### PR TITLE
feat(0.16): Stage 3 — Tier C E2E gate + auto-recovery loop

### DIFF
--- a/agents/mpl-decomposer.md
+++ b/agents/mpl-decomposer.md
@@ -32,6 +32,8 @@ disallowedTools: Write,Edit,Bash,Task,WebFetch,WebSearch,NotebookEdit
     7. **Success criteria types**: command, test, file_exists, grep, description. Must be machine-verifiable.
 
     8. **Vertical slice for multi-layer projects**: If 2+ layers detected (frontend/backend/DB/IPC), decompose by feature, not by layer. Each phase implements ONE feature across ALL layers. Scaffold/infrastructure phases remain horizontal.
+
+    9. **APPEND-MODE (0.16 S3-4)**: When the dispatch prompt begins with `APPEND-MODE:`, do NOT re-generate the full decomposition. Instead, keep every existing phase in `.mpl/mpl/decomposition.yaml` intact (ids, contract_files, covers, verification_plan all unchanged) and append 1-3 new phases derived from the supplied `append_phases` hints. Rules: (a) new phase ids must not collide with existing — use the pattern `{anchor}b`, `{anchor}c`, etc. (e.g., `phase-3b` after `phase-3`); (b) each appended phase MUST include `covers:[UC-N]` per 0.16 Tier B and `test_agent_required:true`; (c) preserve `execution_tiers` ordering by inserting the new phase ids immediately after their anchor; (d) emit the FULL updated decomposition.yaml (existing + appended), not a diff. Trigger: Finalize Step 5.0.4 auto-recovery (Classification A) passes `append_phases` from `mpl_diagnose_e2e_failure`.
   </Rules>
 
   <Reasoning_Steps>

--- a/agents/mpl-decomposer.md
+++ b/agents/mpl-decomposer.md
@@ -27,6 +27,8 @@ disallowedTools: Write,Edit,Bash,Task,WebFetch,WebSearch,NotebookEdit
 
     6. **PP respect**: No phase may violate a CONFIRMED Pivot Point. Note conflicts and adjust.
 
+    6a. **UC coverage mandatory (0.16 Tier B)**: Each phase MUST declare `covers: [UC-NN]` — a REQUIRED field that enumerates which user_cases from `.mpl/requirements/user-contract.md` this phase advances. UC-NN entries MUST exist as `included` in user-contract.md. Single literal `["internal"]` is the only escape, reserved for pure plumbing/refactor/infra phases with no user-visible behavior. When `.mpl/requirements/user-contract.md` is absent (legacy graceful-skip mode), `covers: ["internal"]` is accepted everywhere. The hook `mpl-require-covers.mjs` blocks the write when the field is missing or empty, and warns when the ratio of `internal`-only phases exceeds `internal_todo_warn_threshold` (default 0.4).
+
     7. **Success criteria types**: command, test, file_exists, grep, description. Must be machine-verifiable.
 
     8. **Vertical slice for multi-layer projects**: If 2+ layers detected (frontend/backend/DB/IPC), decompose by feature, not by layer. Each phase implements ONE feature across ALL layers. Scaffold/infrastructure phases remain horizontal.
@@ -233,6 +235,16 @@ disallowedTools: Write,Edit,Bash,Task,WebFetch,WebSearch,NotebookEdit
         pp_proximity: string        # pp_core|pp_adjacent|non_pp
         scope: string               # 1-2 sentence scope
         rationale: string           # why this position
+
+        covers:                     # 0.16 Tier B: which UCs this phase advances (REQUIRED)
+          - string                  # UC-NN id from .mpl/requirements/user-contract.md, or "internal"
+          # Consumer: Test Agent expands E2E scenarios per UC; Hook `mpl-require-covers.mjs`
+          # blocks decomposition writes when this field is missing or empty.
+          # Escape: single literal "internal" for pure plumbing/refactor/infra phases with
+          # no user-visible behavior. When >`internal_todo_warn_threshold` (default 0.4) of
+          # phases carry `covers: [internal]`, the hook emits a warn (not block).
+          # If no user-contract.md exists (legacy project, graceful skip mode), the hook
+          # accepts any non-empty covers (including `["internal"]`) and only warns on ratio.
 
         impact:
           create:

--- a/agents/mpl-interviewer.md
+++ b/agents/mpl-interviewer.md
@@ -16,7 +16,7 @@ disallowedTools: Write, Edit, Bash, Task
 
     You are NOT responsible for:
     - Implementing anything, writing code, or making architectural decisions
-    - Ambiguity Scoring or Requirements Structuring (that's Stage 2: mpl-ambiguity-resolver)
+    - Ambiguity Scoring or Requirements Structuring (that's Stage 2: orchestrator-driven loop via mpl_score_ambiguity MCP tool)
     Your role boundary: define WHAT and WHY via PP discovery. Never prescribe HOW.
   </Role>
 
@@ -38,7 +38,7 @@ disallowedTools: Write, Edit, Bash, Task
     - Pre-Research data provided for all technical choice questions
     - PP Conformance checked after each round
     - Output is a complete, refined PP specification ready for .mpl/pivot-points.md
-    - user_responses_summary generated for Stage 2 (mpl-ambiguity-resolver) handoff
+    - user_responses_summary generated for Stage 2 (orchestrator inline + mpl_score_ambiguity MCP tool) handoff
     - NOTE: Ambiguity Scoring is NOT this agent's responsibility — Stage 2 handles it via mpl_score_ambiguity MCP tool
   </Success_Criteria>
 
@@ -123,7 +123,7 @@ disallowedTools: Write, Edit, Bash, Task
     ## Round-Based Convergence (Stage 1)
 
     Stage 1 exits based on rounds, NOT ambiguity score.
-    Ambiguity scoring is performed by Stage 2 (mpl-ambiguity-resolver) using the mpl_score_ambiguity MCP tool.
+    Ambiguity scoring is performed in Stage 2 by the orchestrator inline loop via the mpl_score_ambiguity MCP tool.
 
     **Exit conditions** (any triggers exit):
     - Max rounds reached (light: 2, full: 4)

--- a/commands/mpl-run-finalize.md
+++ b/commands/mpl-run-finalize.md
@@ -52,40 +52,18 @@ After Gate System passes, run final E2E validation using a **3-tier source hiera
 
      final = state.e2e_results[s.id]
      if not final or final.exit_code != 0:
-       # Still failing — HITL AskUserQuestion per AD-0008
-       AskUserQuestion(
-         question: "E2E {s.id} ({s.title}) 실패. 어떻게 처리할까요?",
-         header: "E2E 실패 — {s.id}",
-         options: [
-           { label: "재시도",
-             description: "스크립트 또는 환경 수정 후 같은 test_command로 재실행" },
-           { label: "Override 추가",
-             description: ".mpl/config/e2e-scenario-override.json에 사유와 함께 bypass 등록 (환경 이슈 등). 다음 런부터 자동 적용." },
-           { label: "파이프라인 실패 처리",
-             description: "finalize_done=false 유지. 사용자가 수동으로 scenario 수정 후 finalize 재시도." }
-         ]
-       )
+       # 0.16 S3-3: attempt automated recovery before HITL fallback.
+       # Collect the failure and defer handling until all required scenarios
+       # have run — the diagnostician needs the full failure picture, not a
+       # per-scenario slice.
+       failures.append(s.id)
+       continue
 
-       if choice == "재시도":
-         Bash(s.test_command) again → re-check
-       if choice == "Override 추가":
-         # AD-0008 R-2: persist environment-level learning
-         Read(".mpl/config/e2e-scenario-override.json") or {}
-         Ask follow-up free-text: "override 사유 (20자 이상, 환경/시점 포함)"
-         Write override with shape:
-           {
-             [s.id]: {
-               reason: <user_input>,
-               test_command_hash: sha1(s.test_command),
-               recorded_at: now_iso(),
-               source: "hitl_failure_resolution"
-             }
-           }
-         announce: "[MPL AD-0008] Override added. Future runs auto-skip {s.id} unless test_command changes."
-         continue to next scenario
-       if choice == "파이프라인 실패":
-         announce: "[MPL AD-0008] Finalize held. state.finalize_done remains false. Fix {s.id} then re-run /mpl:mpl-finalize."
-         return from Step 5 WITHOUT setting finalize_done
+   # 0.16 S3-3: if any failure collected, go to Step 5.0.4 Automated Recovery.
+   # That step either resolves all failures (loop back to "for s in required")
+   # or halts the pipeline via circuit breaker → falls through to HITL.
+   if failures:
+     goto Step 5.0.4
 
 3. Report:
    "[MPL AD-0008] E2E Scenarios: {passed}/{required.length} passed, {overridden} overridden, {failed_resolved_via_override} resolved via HITL override."
@@ -99,6 +77,198 @@ remain failing without override will be blocked.
 ```
 
 - MED/LOW H-items are NOT re-asked here — they are aggregated in Step 5.1.8 (T-10, v3.9)
+
+### 5.0.3: Playwright Trace Collection (0.16 S3-6)
+
+When an E2E scenario fails, the diagnostician (Step 5.0.4) needs a trace
+excerpt to classify accurately. This step wires up Playwright trace output
+so the orchestrator can pass meaningful context to `mpl_diagnose_e2e_failure`.
+
+**Auto-wrap policy** (applied inside Step 5.0 loop before `Bash(test_command)`):
+
+```
+if test_command matches /playwright/ AND test_command does not contain "--trace":
+  # Inject trace flags — non-intrusive; Playwright writes zip files
+  traceDir = ".mpl/e2e-traces"
+  Bash("mkdir -p " + traceDir)
+  wrapped = test_command + " --trace on --trace-dir " + traceDir + "/" + s.id
+  Bash(wrapped, timeout=config.e2e_timeout or 60000)
+
+elif test_command matches /pytest/ OR /jest/:
+  # Other frameworks: no automatic trace injection. Diagnostician will
+  # fall back to stderr_tail. Projects can configure project-level
+  # trace via .mpl/config.json { "e2e_trace_cmd_prefix": "..." }.
+  Bash(test_command)
+
+else:
+  Bash(test_command)
+```
+
+**Trace path recording** (post-execution, by orchestrator or gate-recorder):
+
+```
+# Look for the most recent trace zip under the expected directory
+trace_path = ".mpl/e2e-traces/" + s.id + "/trace.zip"
+if File.exists(trace_path):
+  mpl_state_write({
+    e2e_results: {
+      [s.id]: { ...existing, trace_path }
+    }
+  })
+```
+
+**Storage contract**:
+
+- Directory: `.mpl/e2e-traces/<scenario_id>/` (per scenario, isolated)
+- `.gitignore` in user projects must exclude `.mpl/e2e-traces/` —
+  `/mpl:mpl-doctor` warns when this line is missing and offers auto-patch.
+- Trace files are MB-sized; only the `trace_path` string lives in state.json.
+  The diagnostician reads up to 4KB from the trace file when building its
+  `trace_excerpt` input (Step 5.0.4).
+
+### 5.0.4: Automated E2E Recovery Loop (0.16 S3-3)
+
+Triggered from Step 5.0 step 2 when `failures[]` is non-empty. This step
+replaces the old "fail → HITL 3 options" path. HITL still runs, but only
+as the fallback when the circuit breaker halts recovery.
+
+**Pre-check — Tier C UC coverage** (fast fail before spending an LLM call):
+
+```
+contract = Read(".mpl/requirements/user-contract.md")
+included_ucs = parseIncluded(contract)
+covered = union(scenarios[*].covers)
+missing = included_ucs - covered
+
+if missing.size > 0:
+  announce: "[MPL 0.16 Tier C] {missing.size} UC(s) not covered by any scenario: {missing}. " +
+            "Diagnostician WILL NOT be called — fix the contract first."
+  → fall through to HITL (existing 3-option AskUserQuestion).
+```
+
+**Recovery loop** (when UC coverage is complete):
+
+```
+state.e2e_recovery.iter default 0
+state.e2e_recovery.max_iter default 2
+
+while state.e2e_recovery.iter < state.e2e_recovery.max_iter AND failures not empty:
+  # 1. Prepare diagnostic context
+  trace_excerpt = ""
+  for fid in failures:
+    tp = state.e2e_results[fid].trace_path
+    if tp and File.exists(tp):
+      trace_excerpt += "\n[" + fid + "]\n" + Bash("head -c 2000 " + tp)
+    else:
+      trace_excerpt += "\n[" + fid + "] (no trace)\n" + state.e2e_results[fid].stderr_tail or ""
+
+  # 2. Call the MCP tool (opus, session auth, PROMPT_VERSION frozen)
+  diag = mpl_diagnose_e2e_failure({
+    cwd,
+    scenarios: Read(".mpl/mpl/e2e-scenarios.yaml"),
+    e2e_results: JSON.stringify(state.e2e_results),
+    trace_excerpt: trace_excerpt.slice(0, 4000),
+    user_contract: Read(".mpl/requirements/user-contract.md"),
+    decomposition: Read(".mpl/mpl/decomposition.yaml"),
+    prev_iter: state.e2e_recovery.iter,
+  })
+
+  # 3. Persist diagnosis (Q9: resume reads this inline)
+  mpl_state_write({
+    e2e_recovery: {
+      iter: state.e2e_recovery.iter + diag.iter_hint,
+      max_iter: state.e2e_recovery.max_iter,
+      last_classification: diag.classification,
+      last_diagnosis: diag,
+    }
+  })
+
+  announce: "[MPL 0.16 S3] Diagnosis iter {iter+1}/{max}: classification={diag.classification} " +
+            "confidence={diag.confidence} — {diag.root_cause}"
+
+  # 4. Dispatch fix per classification
+  switch diag.classification:
+    case "A":   # spec gap → decomposer appends phases
+      Task(subagent_type="mpl-decomposer", prompt=`
+        APPEND-MODE: existing decomposition.yaml remains; append the phases
+        below without modifying existing phase ids. Each appended phase MUST
+        include covers:[UC-N] per 0.16 Tier B and test_agent_required:true.
+
+        Append hints (from mpl_diagnose_e2e_failure):
+        ${JSON.stringify(diag.append_phases, null, 2)}
+
+        After appending, re-emit the full decomposition.yaml.
+      `)
+      # After decomposer completes, re-enter Phase Execution for the new
+      # phases (mpl-run-execute.md Step 4), then return here.
+
+    case "B":   # test bug → test-agent rewrites the test
+      Task(subagent_type="mpl-test-agent", prompt=`
+        The following E2E scenario failed; the diagnostician believes the TEST
+        is wrong, not the implementation. Review and fix the test.
+
+        Scenario: ${failures[0]}
+        Root cause: ${diag.root_cause}
+        Fix strategy: ${diag.fix_strategy}
+        Trace excerpt: ${diag.trace_excerpt}
+      `)
+
+    case "C":   # missing capability → Phase 0 Step 1.5 minimal re-run
+      announce: "[MPL 0.16 S3] Classification C — missing UC detected. " +
+                "Returning to Phase 0 Step 1.5 (minimal mode) to append the UC."
+      mpl_state_write({ current_phase: "mpl-init", user_contract_set: false })
+      # orchestrator re-enters Phase 0 Step 1.5 inline loop; on completion
+      # it must preserve existing UCs (prev_contract) and only add the missing
+      # one. After Step 1.5 convergence, re-enter Phase Execution for any new
+      # phases spawned by the new UC, then return here.
+
+    case "D":   # flake → single rerun with trace on
+      announce: "[MPL 0.16 S3] Classification D — flake. Rerunning with trace on."
+      for fid in failures:
+        Bash("<scenario test_command for fid> --trace on")  # see Step 5.6 (S3-6)
+
+  # 5. Re-run originally failing scenarios to see if fix worked
+  new_failures = []
+  for fid in failures:
+    Bash(state.e2e_results[fid].test_command)  # gate-recorder updates results
+    if state.e2e_results[fid].exit_code != 0:
+      new_failures.append(fid)
+  failures = new_failures
+
+# loop exit: either failures empty (success) or iter >= max_iter
+```
+
+**Circuit breaker (iter >= max_iter, failures remain)**:
+
+```
+mpl_state_write({
+  e2e_recovery: { ...state.e2e_recovery, halted: true, halt_reason: "e2e_circuit_breaker" }
+})
+
+announce: "[MPL 0.16 S3] Circuit breaker: recovery iter={max_iter} reached, " +
+          "{failures.size} scenario(s) still failing. Entering HITL."
+
+# Fall through to the original 3-option AskUserQuestion (재시도 / Override 추가 /
+# 파이프라인 실패 처리) — now informed by state.e2e_recovery.last_diagnosis so
+# the user sees the diagnostician's verdict alongside the options.
+AskUserQuestion(
+  question: "E2E 자동복구 실패 (iter={state.e2e_recovery.iter}/{state.e2e_recovery.max_iter}). " +
+            "마지막 진단: {state.e2e_recovery.last_diagnosis.classification} — " +
+            "{state.e2e_recovery.last_diagnosis.root_cause}. 어떻게 할까요?",
+  header: "E2E 자동복구 실패",
+  options: [ /* same 3 options as original Step 5.0 */ ]
+)
+```
+
+**Resume behavior (Q9)**: when `/mpl:mpl resume` re-enters after a halt,
+`mpl-run-finalize-resume.md` reads `state.e2e_recovery.last_diagnosis`
+directly from state.json and inlines the summary into the orchestrator
+prompt. No MCP round-trip.
+
+**Exp12 measurement**: every diagnostician call increments
+`state.e2e_recovery.iter` by `iter_hint`; the pipeline summary writes
+`{classification, confidence, iter}` into `.mpl/metrics/e2e-recovery.jsonl`
+for Stage 4 data-driven promotion analysis.
 
 ### 5.0.5: AD Final Verification
 

--- a/commands/mpl-run-phase0.md
+++ b/commands/mpl-run-phase0.md
@@ -545,6 +545,125 @@ PP States: **CONFIRMED** (hard constraint, auto-reject on conflict) / **PROVISIO
 
 ---
 
+## Step 1.5: User Contract Interview (orchestrator inline + MCP) [0.16 Tier A']
+
+**Purpose**: Capture the mutable user feature scope (UCs) into
+`.mpl/requirements/user-contract.md`, strictly separated from the immutable
+Pivot Points. This step directly addresses ygg-exp11's "user-feature 포착 0건"
+gap by making user delta a first-class output.
+
+**Pattern**: Same as Stage 2 Ambiguity Resolution — orchestrator drives the
+loop inline; no subagent dispatch. The orchestrator calls
+`mpl_classify_feature_scope` MCP tool and interleaves `AskUserQuestion` between
+iterations. Max 4 iterations.
+
+**Activation**: After Step 1 (PP Discovery) completes and `pivot-points.md` is
+written, BEFORE Step 1-B.
+
+**Skip condition**: Legacy projects (pre-0.16) with no `.mpl/requirements/`
+directory — the orchestrator skips Step 1.5 and writes a graceful-skip
+`user-contract.md` containing `user_cases: []` and spec-auto-extracted
+`scenarios`. The user can re-run Step 1.5 manually via `/mpl:mpl` in a later
+session.
+
+### Orchestrator Loop (inline, no subagent)
+
+```
+// Preconditions: .mpl/pivot-points.md exists and is CONFIRMED
+Read .mpl/pivot-points.md
+Read the spec/PRD text (from user or spec file)
+
+iteration = 1
+max_iterations = 4
+accumulated_user_responses = ""  // concatenated as "round N: Q: .. A: .."
+prev_contract = null             // set on iteration 2+ if .mpl/requirements/user-contract.md exists
+
+loop:
+  // 1. Call the classifier MCP tool
+  result = mpl_classify_feature_scope({
+    cwd,
+    spec_text,
+    pivot_points: <contents of .mpl/pivot-points.md>,
+    user_responses: accumulated_user_responses,
+    prev_contract,
+    round: iteration,
+  })
+
+  // 2. Check convergence
+  if result.convergence == true:
+    break
+
+  // 3. Ask the user the classifier's next_question
+  if result.next_question == null:
+    // Classifier says not converged but no question — treat as unrecoverable,
+    // write a best-effort contract and break
+    break
+
+  answer = AskUserQuestion({
+    question: formatQuestion(result.next_question),
+    header: shortHeaderFor(result.next_question.kind),
+    options: optionsFrom(result.next_question.payload),
+  })
+
+  accumulated_user_responses += `\nround ${iteration}: Q: ${formatQuestion(result.next_question)} A: ${answer}`
+  iteration += 1
+
+  if iteration > max_iterations:
+    break
+
+// 4. Persist
+Write .mpl/requirements/user-contract.md from result (YAML per
+  docs/schemas/user-contract.md)
+
+mpl_state_write({
+  user_contract_set: true,
+  user_contract_path: ".mpl/requirements/user-contract.md",
+  user_contract_iterations: iteration,
+})
+
+Announce: `[MPL] Step 1.5 complete. user_cases=${result.user_cases.length} deferred=${result.deferred.length} cut=${result.cut.length} scenarios=${result.scenarios.length} iterations=${iteration}.`
+```
+
+### `formatQuestion` / `optionsFrom` (orchestrator helpers)
+
+These are orchestrator-local formatting rules, NOT embedded in the MCP tool.
+
+- `formatQuestion(nq)`: `nq.payload.question` if provided, else a template derived from `nq.kind`:
+  - `clarify` → `"Clarify: ${payload.focus || 'the UC scope'}"`
+  - `priority` → `"Priority ordering for: ${payload.uc_ids?.join(', ')}"`
+  - `conflict` → `"PP conflict on ${payload.uc_id} vs ${payload.pp_id} — how to resolve?"`
+- `optionsFrom(payload)`: if `payload.options` is an array of `{label, description}`, pass through;
+  otherwise provide 3-4 generated options per kind (see `agents/mpl-interviewer.md` Hypothesis-as-Options pattern).
+  ALWAYS append a catch-all `"Other (enter manually)"` option.
+
+### Convergence Fallback
+
+If iteration == max_iterations and convergence == false:
+1. Write the current (incomplete) classification as user-contract.md with a top-level
+   frontmatter field `schema_version: 1` and `converged: false`.
+2. Record unresolved items as `ambiguity_hints[]` so Stage 2 Ambiguity Resolution
+   can pick them up.
+3. Announce: `[MPL] Step 1.5 stopped at max_iterations=4 without convergence. ${result.ambiguity_hints.length} unresolved hints forwarded to Stage 2.`
+
+### Downstream Consumers
+
+| Output | Consumer | Usage |
+|--------|----------|-------|
+| `.mpl/requirements/user-contract.md` | Decomposer (Step 3), Test Agent, Hooks | UC list + scenarios + skip_allowed |
+| `user_contract_set` in state | `mpl-phase-controller` hook | Gate before decomposer dispatch |
+| `scenarios[*]` | Test Agent (Step 3-B) | E2E scenario seeds |
+| `pp_conflict[]` | Step 1-D PP Confirmation | Re-question for UC-dropped vs uc_reshaped vs pp_reaffirmed |
+| `ambiguity_hints[]` | Stage 2 Ambiguity Resolution (Step 2) | Targeted questions |
+
+### Field Boundary Guards
+
+- `mpl-validate-pp-schema.mjs` (0.16 S1-3) blocks any Write/Edit on
+  `.mpl/pivot-points.md` that introduces UC-scoped schema.
+- `mpl-require-covers.mjs` (0.16 S1-5) blocks decomposition.yaml writes that
+  don't reference UC ids from user-contract.md (or use the `"internal"` escape).
+
+---
+
 ## Step 1-B: Pre-Execution Analysis (Gap + Tradeoff)
 
 After PPs are confirmed, run unified pre-execution analysis to identify gaps AND assess risks in a single agent call.

--- a/commands/mpl-run.md
+++ b/commands/mpl-run.md
@@ -166,7 +166,7 @@ Only load the file needed for the current stage — this saves ~60-70% of contex
 
 | File | Steps | Contents | ~Tokens |
 |------|-------|----------|---------|
-| `mpl-run-phase0.md` | -1 ~ 1-E | LSP Warm-up, Triage, PP Interview, Pre-Execution Analysis | ~6K |
+| `mpl-run-phase0.md` | -1 ~ 1-E | LSP Warm-up, Triage, PP Interview, **Step 1.5 User Contract Interview (0.16)**, Pre-Execution Analysis | ~7K |
 | `mpl-run-phase0-analysis.md` | 2 ~ 2.5 | Codebase Analysis, Architecture Decisions, Phase 0 Enhanced | ~8K |
 | `mpl-run-phase0-memory.md` | 0.1.5b-c | 4-Tier Adaptive Memory, Routing Pattern Loading | ~2K |
 | `mpl-run-decompose.md` | 3 ~ 3-B | Phase Decomposition, Verification Planning (Critic absorbed into Decomposer) | ~3K |

--- a/docs/roadmap/0.16-exp12-plan.md
+++ b/docs/roadmap/0.16-exp12-plan.md
@@ -1,0 +1,153 @@
+# MPL 0.16 exp12 Measurement Plan
+
+**Purpose**: validate 0.16 Tier A'/B/C design against ygg-exp11 baseline using the
+Yggdrasil spec (or equivalent). Feeds Stage 4 data-driven decision on whether to
+promote `mpl_diagnose_e2e_failure` to an agent file, keep as MCP tool, or sunset.
+
+Related:
+- Resume plan v2 §3 Stage 3 (S3-7) + Stage 4 (S4-1..5)
+- Decision `~/project/decision/2026-04-19-mpl-0.16-implementation-plan.md`
+- Baseline: `~/project/harness_lab/analysis/mpl-exp11-opus47-evaluation.md`
+
+## Experimental Design
+
+| Aspect | exp11 baseline | exp12 target |
+|---|---|---|
+| MPL version | 0.14.1 | 0.16.0-rc |
+| Spec | Yggdrasil (Tauri + React + Rust) | Same (for fair comparison) |
+| Model | opus-4.7 | opus-4.7 |
+| Run mode | `full` | `full` |
+| Measured phases | 80 (12 planned, 80 total) | expect similar count |
+
+**Independent variables**: 0.16 changes only (Tier A'/B/C enforcement, auto-recovery).
+**Confound control**: same Yggdrasil spec, same model, same hardware. Rerun at
+least twice (N=2) per configuration to detect non-determinism.
+
+## Primary Metrics
+
+Emit all metrics to `.mpl/metrics/exp12-summary.md` and the JSONL files below.
+
+### Metric 1 — User feature capture (Tier A' effectiveness)
+
+| Item | Baseline (exp11) | exp12 target |
+|---|---|---|
+| `user_cases[*].user_delta != ""` count | 0 | ≥ 1 (hard target) |
+| `user_contract_iterations` | n/a | ≤ 4 |
+| `pp_conflict` entries | n/a | logged where UC ↔ PP collision exists |
+
+**Source**: `.mpl/requirements/user-contract.md` after Phase 0 completes.
+
+### Metric 2 — E2E skip elimination (Tier C effectiveness)
+
+| Item | Baseline (exp11) | exp12 target |
+|---|---|---|
+| `implementation-skip` count | 42 / 80 | **0** |
+| `@skip_reason` with allowed env token | n/a | all skips classified |
+| Missing UC coverage Hard fails | n/a | 0 at finalize_done write |
+
+**Source**: `state.e2e_skip_reasons[]` + `state.e2e_results[*].exit_code` +
+`mpl-require-e2e` hook block events.
+
+### Metric 3 — Author ≠ verifier separation (pre-existing AD-0007/0008)
+
+| Item | Baseline (exp11) | exp12 target |
+|---|---|---|
+| phase-runner : test-agent dispatch ratio | 83 : 1 | ≤ 3 : 1 |
+| `test_agent_required=true` phases with no test-agent dispatch | 63 / 63 | 0 |
+
+**Source**: `state.test_agent_dispatched[*]` via `mpl-require-test-agent` hook.
+
+### Metric 4 — Diagnostician behavior (Stage 4 promotion inputs)
+
+Write `.mpl/metrics/e2e-recovery.jsonl` one line per diagnose call:
+
+```jsonl
+{"ts": "...", "classification": "A", "confidence": 0.87, "iter": 1, "prompt_version": "v1-..."}
+```
+
+Aggregated measures:
+
+| Item | Value | Stage 4 threshold |
+|---|---|---|
+| Total diagnose calls across run | — | ≥ 3 / phase for promotion consideration |
+| `classification` histogram {A,B,C,D} | — | B+D share for accuracy labeling |
+| Circuit breaker halts (`halted: true`) | — | ideally 0; counts as bug if > 1 |
+
+### Metric 5 — B/D classification accuracy (Q8 — auxiliary LLM labeling)
+
+For each diagnose call in `.mpl/metrics/e2e-recovery.jsonl`, produce a
+ground-truth label via an independent opus call (temp 0.1, **separate**
+`PROMPT_VERSION = 'v1-labeler-2026-04-19'`):
+
+```
+input: same scenarios/e2e_results/trace_excerpt passed to the classifier
+task:  "Classify this failure as A / B / C / D. Output JSON only."
+```
+
+Metric: agreement rate between classifier output and labeler output.
+
+| Threshold | Stage 4 decision |
+|---|---|
+| agreement ≥ 70% AND calls ≥ 3/phase AND hash consistent | ELIGIBLE for promotion to agent file — escalate to debate |
+| agreement < 70% | sunset trigger — remove `mpl_diagnose_e2e_failure` tool |
+| calls < 3/phase | sunset trigger (unused) |
+
+## Secondary Metrics
+
+- Internal-TODO ratio (`mpl-require-covers` warns fired) — exp12 expected < 40%
+- Feature classifier call count per run — budget target ≤ 6 total
+- `user_contract_set=false` blocks by `mpl-ambiguity-gate` — should fire 0 times
+  on clean runs; non-zero means orchestrator skipped Step 1.5
+
+## Protocol
+
+1. **Pre-flight**:
+   - Check out 0.16 release candidate (or branch stack S1+S2+S3 merged)
+   - Fresh Yggdrasil workspace (no prior `.mpl/`)
+   - Verify MCP server is installed and responding: `mpl_classify_feature_scope`,
+     `mpl_diagnose_e2e_failure`, `mpl_score_ambiguity`
+
+2. **Run**:
+   ```
+   /mpl:mpl <Yggdrasil spec prompt>
+   # let it run full pipeline through finalize
+   ```
+
+3. **Post-flight collection**:
+   ```
+   cp .mpl/requirements/user-contract.md analysis/exp12/
+   cp .mpl/state.json analysis/exp12/
+   cp .mpl/metrics/e2e-recovery.jsonl analysis/exp12/
+   cp .mpl/metrics/phases.jsonl analysis/exp12/
+   ```
+
+4. **Labeling pass** (Metric 5):
+   Script in `harness_lab/analysis/` that iterates each diagnose call and
+   calls the labeler prompt via Agent SDK. Emits
+   `analysis/exp12/labeler-agreement.md`.
+
+5. **Comparison report**:
+   `analysis/mpl-0.16-exp12-vs-exp11.md` — side-by-side of the 5 primary
+   metrics, with pass/fail verdict against the target column above.
+
+## Pass Criteria (for 0.16 release)
+
+All of the following must hold on at least one clean run:
+
+- [ ] Metric 1: user_delta ≥ 1, user_contract_iterations ≤ 4
+- [ ] Metric 2: implementation-skip = 0, Tier C block events = 0 at finalize_done
+- [ ] Metric 3: test-agent dispatch ratio ≤ 3:1
+- [ ] Metric 4: 0 circuit-breaker halts; diagnose calls emit valid JSON each time
+- [ ] Metric 5: agreement rate computed (required even if low — it's the sunset/promotion signal)
+
+## Sunset / Promotion Decision (Stage 4)
+
+After exp12 completes, open a follow-up debate using the 4-agent pattern
+(Architect / Contrarian / Simplifier / Evaluator) with the measurement summary
+as input. The debate decides:
+
+| Outcome | Action |
+|---|---|
+| Promote to agent | New `mpl-e2e-diagnostician` agent file; sunset MCP tool |
+| Keep MCP tool | No change; continue in Stage 4.1 maintenance |
+| Sunset MCP tool | Remove `mcp-server/src/tools/e2e-diagnose.ts` + Finalize Step 5.0.4; fall back to HITL |

--- a/docs/schemas/e2e-contract.md
+++ b/docs/schemas/e2e-contract.md
@@ -1,0 +1,176 @@
+# E2E Contract Annotation Schema (`@contract`, `@skip_reason`)
+
+**적용 파일**: E2E 테스트 파일 (Playwright/Vitest/pytest 등)
+**소비자**: Hook `mpl-require-e2e.mjs` (Tier C gate), MCP tool `mpl_diagnose_e2e_failure` (trace 분석)
+**생성자**: 개발자가 테스트 파일 작성 시 직접 기재 (orchestrator/Test Agent가 초안 생성 가능)
+**관련**: 0.16 S1-6, `user-contract.md` §scenarios
+
+## 개요
+
+모든 E2E 테스트는 어떤 UC(user case)를 검증하는지 `@contract` 애노테이션으로 선언해야 한다. 미선언 테스트는 기본(strict) 모드에서 Hard fail — missing coverage 로 처리된다.
+
+**strict 디폴트 + opt-out** (Q10 확정):
+- 기본값: `@contract` 없는 E2E 테스트는 Hard fail
+- `.mpl/config.json` `e2e_contract_strict: false` 설정 시 warn 으로 degrade
+- Legacy 프로젝트 upgrade 시 `mpl-doctor` 가 opt-out 가이드 출력
+
+## Annotation 형식
+
+### 표기 방법
+
+언어/프레임워크별 형식. 모두 동등하게 인식된다.
+
+| Language | Style | Example |
+|---|---|---|
+| TypeScript/JavaScript | JSDoc 블록 주석 바로 위 테스트 | `/** @contract UC-01 */\ntest('login', …)` |
+| TypeScript/JavaScript | `// @contract UC-01` 한 줄 | `// @contract UC-01, UC-03\ntest('login', …)` |
+| Python (pytest) | 데코레이터 위 주석 | `# @contract UC-01\ndef test_login():` |
+| Python (pytest) | docstring 첫 줄 | `def test_login():\n    """@contract UC-01"""` |
+| Go | 함수 위 주석 | `// @contract UC-01\nfunc TestLogin(t *testing.T) { … }` |
+| Rust | 함수 위 주석 | `// @contract UC-01\n#[test]\nfn login_works() { … }` |
+
+다중 UC 한 테스트에서 검증 가능: `@contract UC-01, UC-03` 또는 `@contract UC-01 UC-03` (쉼표/공백 모두 허용).
+
+### 정규식
+
+Hook 은 테스트 파일 내에서 다음 패턴을 scan:
+
+```regex
+@contract\s+([A-Z]+-\d{2,}(?:\s*,\s*[A-Z]+-\d{2,})*)
+```
+
+매치된 전체 그룹 1을 쉼표/공백 분리 후 UC-NN 토큰 리스트로 수집.
+
+### Annotation 위치 규칙
+
+1. **테스트 함수/블록 바로 앞** (즉시 선행) 에 위치해야 인식됨.
+2. 파일 상단의 모듈 주석에서의 `@contract` 는 **파일 전체 fallback** 으로 처리 — 해당 파일 내 모든 테스트가 그 UC를 cover 한다고 가정. 여러 테스트를 일일이 애노테이션하기 귀찮은 smoke 테스트 파일에 유용.
+3. 테스트-레벨 애노테이션이 있으면 그것이 우선. 파일-레벨 fallback 은 누락된 테스트에만 적용.
+
+## @skip_reason Annotation
+
+환경/네트워크/flaky 등 **정당 사유** 로 테스트를 skip 한 경우 기록한다. `skipIf`/`@pytest.mark.skip` 같은 언어별 메커니즘과 별도로 **항상 주석으로 표기**해야 한다.
+
+### 표기 방법
+
+```ts
+// @contract UC-01
+// @skip_reason ENV_API_DOWN
+test.skip('integration with payment API', …);
+```
+
+```python
+# @contract UC-05
+# @skip_reason FLAKY_NETWORK
+@pytest.mark.skip(reason="network flake, revisit")
+def test_external_webhook(): …
+```
+
+### 허용 값
+
+`user-contract.md` 의 `scenarios[*].skip_allowed` 목록과 교차 참조한다. 해당 시나리오에 정의된 값만 허용되며, 그 외는 **implementation-skip** 으로 취급되어 Hard fail.
+
+표준 값(권장):
+
+| 값 | 의미 |
+|---|---|
+| `ENV_API_DOWN` | 외부 API/서비스 가용 불가 (3rd-party 장애 포함) |
+| `FLAKY_NETWORK` | 네트워크 타임아웃/지연 이슈 (CI 환경 한정) |
+| `DEPENDENCY_MISSING` | 로컬 환경에 도구/바이너리 부재 (Docker/GPU 등) |
+| `RATE_LIMIT` | 호출 속도 제한으로 CI 반복 실행 불가 |
+| `OS_INCOMPATIBLE` | 특정 OS에서만 실행 가능한 테스트 |
+
+**프로젝트 확장**: 위 외 값을 쓰려면 `user-contract.md scenarios[*].skip_allowed` 에 먼저 등록해야 한다.
+
+### implementation-skip 금지
+
+다음 사유로는 skip 할 수 없다. 발견 시 Hard fail.
+
+- "TODO: not implemented yet"
+- "refactor later"
+- "known bug" (이건 xfail/pending 으로 다른 마커 사용)
+- 사유 미기재 skip (`skip()` 만 호출)
+
+`@skip_reason` 없이 skip 이 실행된 경우 hook 이 테스트 출력에서 감지하고 **Hard fail**.
+
+## Hook 검증 로직
+
+`mpl-require-e2e.mjs` (S3-1 수정 예정) 가 finalize Step 5.0 전/후 호출될 때 수행:
+
+1. `.mpl/requirements/user-contract.md` 에서 `user_cases[status=included]` 의 UC-NN 전체 수집 → **expected coverage set**
+2. E2E 테스트 파일 전체(`*.spec.*`, `*_test.*`, `test_*.*` 등) scan → `@contract` 애노테이션 수집 → **actual coverage set**
+3. 차집합 (expected − actual) 이 비어있지 않으면:
+   - `e2e_contract_strict: true` (디폴트) → Hard fail + 미커버 UC 목록 출력
+   - `e2e_contract_strict: false` → warn
+4. `@skip_reason` 이 `scenarios[*].skip_allowed` 에 없거나, skip 이 실행됐는데 `@skip_reason` 이 없으면 → Hard fail (strict) / warn (opt-out)
+5. 정당 skip 카운트는 `state.e2e_skip_reasons[UC-NN][reason]++` 로 누적 (exp12 관측용)
+
+## Producer 힌트 (Test Agent)
+
+Test Agent 가 E2E 시나리오를 확장할 때:
+
+```
+1. user-contract.md scenarios[*].steps 를 기반으로 테스트 본문 생성
+2. 테스트 함수 바로 앞에 `@contract UC-01, UC-03` 삽입 (covers: 리스트)
+3. scenarios[*].skip_allowed 가 비어있으면 @skip_reason 을 쓰지 않음
+4. 다중 UC cover 테스트는 가급적 rationale 주석 1줄 추가
+```
+
+## 예시
+
+### TypeScript (Playwright)
+
+```ts
+// e2e/auth.spec.ts
+
+/** @contract UC-01 */
+test('user can log in with valid credentials', async ({ page }) => {
+  await page.goto('/login');
+  await page.fill('#email', 'user@example.com');
+  await page.fill('#password', 'pass');
+  await page.click('text=Sign in');
+  await expect(page).toHaveURL('/dashboard');
+});
+
+// @contract UC-02, UC-03
+// @skip_reason ENV_API_DOWN
+test.skip('password reset via email link', async ({ page }) => {
+  // requires MailHog which is down in this CI stage
+});
+```
+
+### Python (pytest)
+
+```python
+# @contract UC-01
+def test_login_ok(client):
+    r = client.post("/login", json={"email": "u@e.com", "password": "p"})
+    assert r.status_code == 200
+
+# @contract UC-04
+# @skip_reason DEPENDENCY_MISSING
+@pytest.mark.skip(reason="Docker not available on local dev")
+def test_container_startup(docker_client):
+    ...
+```
+
+## 파일-레벨 Fallback 예시
+
+```ts
+// e2e/smoke/home.spec.ts
+/**
+ * @contract UC-10
+ * 홈 스모크 — 모든 테스트가 UC-10 의 일부.
+ */
+
+test('home loads', ...);       // inherits @contract UC-10
+test('nav renders', ...);      // inherits
+test('auth CTA present', ...); // inherits
+```
+
+## 관련 문서
+
+- `docs/schemas/user-contract.md` (Tier A' — UC id와 scenarios)
+- `agents/mpl-decomposer.md` Rule 6a (Tier B — covers 필드)
+- Resume Plan v2 §3 S1-6, S3-1
+- Decision `~/project/decision/2026-04-19-mpl-0.16-implementation-plan.md` (Tier C)

--- a/docs/schemas/user-contract.md
+++ b/docs/schemas/user-contract.md
@@ -1,0 +1,171 @@
+# User Contract Schema (`user-contract.md`)
+
+**생성 시점**: Phase 0 Step 1.5 (PP Discovery 완료 후, orchestrator inline loop + `mpl_classify_feature_scope` MCP tool)
+**경로**: `.mpl/requirements/user-contract.md`
+**소비자**: Decomposer (TODO `covers` 매핑), Test Agent (UC→E2E 커버리지), Hook `mpl-require-covers`, Hook `mpl-require-e2e` (@contract)
+**재생성**: Finalize E2E fail classification C (missing capability) 시 축소 모드 재실행 (누락 UC만 append)
+**관련**: 0.16 Resume Plan S1-2, Decision `2026-04-19-mpl-0.16-implementation-plan.md` Tier A'
+
+## 개요
+
+사용자가 원하는 가변(mutable) 기능 scope를 명세한다. **PP(불변)와는 파일이 분리**되며, UC는 included/deferred/cut 로 분류되어 협상 가능.
+
+핵심 원칙:
+1. **UC는 가변**. Phase 진행 중 deferred/cut 로 이동 가능 (사용자 승인 필요).
+2. **PP 참조는 read-only**. UC가 PP를 변경하지 않음. 충돌 시 `pp_conflict_log`에 기록 후 사용자 재질문.
+3. **모든 included UC는 covers_pp 최소 1개** (spec 외 feature도 어떤 PP 원칙 하에서 실행되는지 명시).
+4. 순수 배관 작업은 UC 부여하지 않고 TODO에서 `covers: [internal]` 로 표시 (Tier B 스키마 참조).
+
+## 스키마
+
+```yaml
+schema_version: 1
+created_at: string                 # ISO 8601, orchestrator 작성 시각
+iterations: number                 # MCP classify tool 호출 횟수 (최대 4)
+
+user_cases:
+  - id: "UC-01"                    # 형식 "UC-" + zero-padded 2자리 이상
+    title: string                  # 한 줄 (≤ 80 chars)
+    user_delta: string             # spec에 없지만 사용자가 추가 요구한 것. spec-only UC는 "" (empty)
+    priority: "P0" | "P1" | "P2"   # P0=출시 필수, P1=핵심, P2=개선
+    status: "included"             # 이 섹션은 included만. deferred/cut는 아래로 이동.
+    covers_pp: ["PP-A", "PP-B"]    # 이 UC가 어떤 PP 원칙 하에 실행되는지 (최소 1개)
+    acceptance_hint: string        # Test Agent가 E2E scenario로 확장할 힌트 (optional)
+
+deferred_cases:                    # 다음 릴리즈 이후로 미룬 UC
+  - id: "UC-09"
+    title: string
+    reason: string                 # 왜 미뤘는지 (용량/우선순위/리스크/의존성)
+    revisit_at: string             # "post-v0.17" | "after-UC-03" | "on-user-request"
+    source_round: number           # classify loop 몇 번째 iteration에서 deferred 판정
+
+cut_cases:                         # 영구 제외된 UC (out-of-scope 확정)
+  - id: "UC-12"
+    title: string
+    reason: string                 # 왜 잘랐는지 (PP 충돌/기술 불가/사용자 철회)
+    source_round: number
+
+scenarios:                         # E2E 시나리오 설계 힌트 (Decomposer/Test Agent 소비)
+  - id: "SC-01"
+    title: string
+    covers: ["UC-01", "UC-03"]     # 이 시나리오가 검증하는 UC 목록 (≥ 1)
+    covers_pp: ["PP-A"]            # 연관 PP (derived from covers UC의 covers_pp union)
+    steps:
+      - string                     # 순차 단계 (자연어 또는 Gherkin)
+    skip_allowed:                  # 어떤 조건에서 skip 허용인지 (strict 디폴트는 skip 불가)
+      - "ENV_API_DOWN"
+      - "FLAKY_NETWORK"
+
+pp_conflict_log:                   # UC와 PP 충돌 판정 기록 (MCP tool 출력 반영)
+  - uc_id: "UC-05"
+    pp_id: "PP-B"
+    conflict_type: "direct" | "boundary" | "performance"
+    resolution: "uc_dropped" | "uc_reshaped" | "pp_reaffirmed"
+    round: number
+    note: string
+
+ambiguity_hints:                   # MCP tool이 Stage 2 Ambiguity Resolution에 넘기는 힌트
+  - uc_id: "UC-07"
+    dimension: "specificity" | "priority" | "dependency" | "boundary" | "success_criteria"
+    suggestion: string
+```
+
+## 필드 설명
+
+### `user_cases[*].user_delta`
+
+Spec 문서 외에 **사용자가 인터뷰 중 새로 제시한 요구사항**을 기록. 이것이 ygg-exp11에서 "user-feature 포착 0건" gap을 직접 해결하는 필드.
+
+- 값이 빈 문자열 `""` → spec에서 추출한 UC (delta 없음)
+- 값이 있는 경우 → orchestrator가 `AskUserQuestion` 응답에서 이 UC가 새로 드러난 출처 문장을 요약
+
+### `user_cases[*].covers_pp`
+
+Decomposer와 Test Agent가 PP 준수 검증 시 UC→PP 매핑을 이용. **최소 1개 필수** — PP와 무관한 UC는 존재할 수 없다는 원칙(MPL coherence 보장).
+
+매핑이 어려운 경우 `pp_conflict_log`에 기록하고 사용자 재질문.
+
+### `scenarios[*].skip_allowed`
+
+Tier C E2E gate에서 `@skip_reason` 값이 이 배열에 포함되면 환경 skip으로 인정 (카운터만 증가, Hard fail 아님). strict 디폴트이므로 비어 있으면 어떤 skip도 허용되지 않음.
+
+### `pp_conflict_log[*].resolution`
+
+- `uc_dropped` → UC가 cut_cases 로 이동
+- `uc_reshaped` → UC title/delta 수정 후 included 유지
+- `pp_reaffirmed` → PP 유지, UC 쪽이 잘라냄 (PP는 불변 원칙 재확인)
+
+## Producer Input
+
+`mpl_classify_feature_scope` MCP tool 입력:
+
+```json
+{
+  "spec_text": "string (raw spec or PRD content)",
+  "pivot_points": "string (pivot-points.md content)",
+  "user_responses": [
+    { "question": "...", "answer": "..." }
+  ],
+  "prev_contract": "string | null (prior iteration's user-contract.md, if any)",
+  "cwd": "string"
+}
+```
+
+MCP tool 출력 (orchestrator가 받아 user-contract.md 로 직렬화):
+
+```json
+{
+  "user_cases": [...],
+  "deferred": [...],
+  "cut": [...],
+  "scenarios": [...],
+  "pp_conflict": [...],
+  "ambiguity_hints": [...],
+  "next_question": { "kind": "clarify|priority|conflict", "payload": {...} } | null,
+  "convergence": boolean
+}
+```
+
+`convergence == true` 일 때까지 orchestrator가 `AskUserQuestion` → MCP tool 재호출 루프 (최대 4 iteration).
+
+## Consumer Contract
+
+### Decomposer 소비
+
+- 각 node (TODO/phase) 는 `covers: [UC-N]` 필드 필수 (Tier B 스키마 참조)
+- 순수 배관 작업은 `covers: [internal]` (단일 escape)
+- Decomposer prompt는 user-contract.md 의 `user_cases[*].id` 전체를 read-only 참조로 받음
+
+### Test Agent 소비
+
+- 각 UC에 대해 최소 1개의 E2E scenario 필요 (Tier C 스키마 참조)
+- `scenarios[*].steps` 를 Gherkin으로 확장
+- `acceptance_hint` 를 추가 검증 조건으로 활용
+
+### Hook 소비
+
+- `mpl-require-covers.mjs` — TODO `covers` 값이 user_cases[*].id 또는 `[internal]` 인지 검증
+- `mpl-require-e2e.mjs` — included user_cases 전체에 대해 @contract(UC-N) 커버리지 diff 계산
+- `mpl-validate-pp-schema.mjs` (S1-3 신설) — pivot-points.md 에 UC 필드가 섞여 들어가지 않는지 guard
+
+## 불변/가변 경계 규칙
+
+| 파일 | 분류 | 변경 조건 |
+|------|------|----------|
+| `.mpl/pivot-points.md` | **불변** | PP Discovery 완료 후 수정 금지 (Step 1-D PP Confirmation에서만 재협상) |
+| `.mpl/requirements/user-contract.md` | **가변** | Step 1.5 재실행, Finalize classification C 축소 모드, 사용자 명시 요청 시 |
+
+**교차 참조 금지**: user-contract.md 가 PP를 수정하거나, pivot-points.md 가 UC를 포함하면 Hook이 block.
+
+## Backward Compatibility
+
+- 기존 0.15.x 프로젝트 업그레이드 시 `.mpl/requirements/user-contract.md` 부재 → orchestrator가 graceful skip 모드 (light contract: UC 0개, scenarios는 spec에서 자동 추출)
+- 이 경우 `iterations: 0`, `user_cases: []`, `scenarios: [...auto-extracted]`
+- `mpl-doctor` 가 업그레이드 프롬프트 제공: "user-contract.md 가 없습니다. `/mpl:mpl` 재실행으로 Step 1.5 를 수행하시겠습니까?"
+
+## 관련 문서
+
+- Decision: `~/project/decision/2026-04-19-mpl-0.16-implementation-plan.md` (Tier A')
+- Resume Plan: `~/project/wiki/scratch/2026-04-19/mpl-0.16-implementation-resume-plan.md` §3 S1-2
+- Tier B 스키마: `docs/schemas/decomposition.md` (S1-4에서 `covers` 필드 추가)
+- Tier C 스키마: `docs/schemas/e2e-contract.md` (S1-6에서 신설)

--- a/hooks/__tests__/mpl-require-covers.test.mjs
+++ b/hooks/__tests__/mpl-require-covers.test.mjs
@@ -1,0 +1,173 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  targetsDecompositionFile,
+  parsePhaseCovers,
+  validatePhase,
+  computeInternalRatio,
+} from '../mpl-require-covers.mjs';
+
+describe('targetsDecompositionFile', () => {
+  it('matches .mpl/mpl/decomposition.yaml', () => {
+    assert.equal(
+      targetsDecompositionFile('/repo/.mpl/mpl/decomposition.yaml'),
+      true,
+    );
+  });
+  it('does not match unrelated files', () => {
+    assert.equal(
+      targetsDecompositionFile('/repo/.mpl/mpl/chain-assignment.yaml'),
+      false,
+    );
+    assert.equal(
+      targetsDecompositionFile('/repo/.mpl/requirements/user-contract.md'),
+      false,
+    );
+  });
+  it('returns false for null/empty', () => {
+    assert.equal(targetsDecompositionFile(null), false);
+    assert.equal(targetsDecompositionFile(''), false);
+  });
+});
+
+describe('parsePhaseCovers', () => {
+  it('parses inline array form', () => {
+    const yaml = `
+phases:
+  - id: "phase-1"
+    covers: [UC-01, UC-02]
+  - id: "phase-2"
+    covers: ["internal"]
+`;
+    const out = parsePhaseCovers(yaml);
+    assert.equal(out.length, 2);
+    assert.deepEqual(out[0].covers, ['UC-01', 'UC-02']);
+    assert.deepEqual(out[1].covers, ['internal']);
+  });
+
+  it('parses block list form', () => {
+    const yaml = `
+phases:
+  - id: "phase-1"
+    name: "x"
+    covers:
+      - "UC-01"
+      - "UC-05"
+    impact:
+      create: []
+  - id: "phase-2"
+    covers:
+      - internal
+`;
+    const out = parsePhaseCovers(yaml);
+    assert.equal(out.length, 2);
+    assert.deepEqual(out[0].covers, ['UC-01', 'UC-05']);
+    assert.deepEqual(out[1].covers, ['internal']);
+  });
+
+  it('records null covers when field missing', () => {
+    const yaml = `
+phases:
+  - id: "phase-1"
+    name: "no covers"
+    impact:
+      create: []
+`;
+    const out = parsePhaseCovers(yaml);
+    assert.equal(out.length, 1);
+    assert.equal(out[0].covers, null);
+  });
+
+  it('records empty array when covers is []', () => {
+    const yaml = `
+phases:
+  - id: "phase-1"
+    covers: []
+`;
+    const out = parsePhaseCovers(yaml);
+    assert.deepEqual(out[0].covers, []);
+  });
+
+  it('handles null/empty input', () => {
+    assert.deepEqual(parsePhaseCovers(null), []);
+    assert.deepEqual(parsePhaseCovers(''), []);
+  });
+});
+
+describe('validatePhase', () => {
+  it('flags missing covers', () => {
+    const issues = validatePhase({ id: 'phase-1', covers: null }, { allowLegacy: false });
+    assert.ok(issues.some((i) => i.kind === 'missing'));
+  });
+  it('flags empty covers', () => {
+    const issues = validatePhase({ id: 'phase-1', covers: [] }, { allowLegacy: false });
+    assert.ok(issues.some((i) => i.kind === 'empty'));
+  });
+  it('accepts valid UC-NN', () => {
+    const issues = validatePhase({ id: 'p', covers: ['UC-01', 'UC-15'] }, { allowLegacy: false });
+    assert.equal(issues.length, 0);
+  });
+  it('accepts internal escape', () => {
+    const issues = validatePhase({ id: 'p', covers: ['internal'] }, { allowLegacy: false });
+    assert.equal(issues.length, 0);
+  });
+  it('rejects invalid entry', () => {
+    const issues = validatePhase({ id: 'p', covers: ['bogus'] }, { allowLegacy: false });
+    assert.ok(issues.some((i) => i.kind === 'invalid_entry' && i.entry === 'bogus'));
+  });
+  it('rejects single-digit UC (requires UC-NN 2+ digits)', () => {
+    const issues = validatePhase({ id: 'p', covers: ['UC-1'] }, { allowLegacy: false });
+    assert.ok(issues.some((i) => i.kind === 'invalid_entry'));
+  });
+  it('legacy mode downgrades invalid entries but still blocks missing/empty', () => {
+    const legacyOk = validatePhase({ id: 'p', covers: ['bogus'] }, { allowLegacy: true });
+    assert.equal(legacyOk.length, 0);
+    const legacyMissing = validatePhase({ id: 'p', covers: null }, { allowLegacy: true });
+    assert.ok(legacyMissing.some((i) => i.kind === 'missing'));
+  });
+});
+
+describe('computeInternalRatio', () => {
+  it('returns 0 for all-UC phases', () => {
+    const r = computeInternalRatio([
+      { id: 'a', covers: ['UC-01'] },
+      { id: 'b', covers: ['UC-02'] },
+    ]);
+    assert.equal(r, 0);
+  });
+  it('returns 1 for all-internal phases', () => {
+    const r = computeInternalRatio([
+      { id: 'a', covers: ['internal'] },
+      { id: 'b', covers: ['internal'] },
+    ]);
+    assert.equal(r, 1);
+  });
+  it('returns mixed ratio', () => {
+    const r = computeInternalRatio([
+      { id: 'a', covers: ['UC-01'] },
+      { id: 'b', covers: ['internal'] },
+      { id: 'c', covers: ['internal'] },
+      { id: 'd', covers: ['UC-02'] },
+    ]);
+    assert.equal(r, 0.5);
+  });
+  it('phase with UC + internal mix counts as NOT internal-only', () => {
+    const r = computeInternalRatio([
+      { id: 'a', covers: ['UC-01', 'internal'] },
+      { id: 'b', covers: ['internal'] },
+    ]);
+    assert.equal(r, 0.5);
+  });
+  it('ignores phases with null/empty covers', () => {
+    const r = computeInternalRatio([
+      { id: 'a', covers: ['UC-01'] },
+      { id: 'b', covers: null },
+      { id: 'c', covers: [] },
+    ]);
+    assert.equal(r, 0);
+  });
+  it('returns 0 when no valid phases', () => {
+    assert.equal(computeInternalRatio([]), 0);
+    assert.equal(computeInternalRatio([{ id: 'a', covers: null }]), 0);
+  });
+});

--- a/hooks/__tests__/mpl-require-e2e.test.mjs
+++ b/hooks/__tests__/mpl-require-e2e.test.mjs
@@ -1,0 +1,152 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  parseUserContractText,
+  computeUncoveredUcs,
+} from '../mpl-require-e2e.mjs';
+
+describe('parseUserContractText', () => {
+  it('extracts included UC ids with explicit status', () => {
+    const text = `
+schema_version: 1
+user_cases:
+  - id: "UC-01"
+    status: included
+  - id: "UC-02"
+    status: included
+scenarios: []
+`;
+    const r = parseUserContractText(text);
+    assert.deepEqual(r.included_uc_ids, ['UC-01', 'UC-02']);
+  });
+
+  it('defaults UC status to included when unspecified', () => {
+    const text = `
+user_cases:
+  - id: "UC-05"
+    title: "x"
+  - id: "UC-06"
+    title: "y"
+`;
+    const r = parseUserContractText(text);
+    assert.deepEqual(r.included_uc_ids, ['UC-05', 'UC-06']);
+  });
+
+  it('excludes deferred and cut UCs', () => {
+    const text = `
+user_cases:
+  - id: "UC-01"
+    status: included
+  - id: "UC-02"
+    status: deferred
+  - id: "UC-03"
+    status: cut
+`;
+    const r = parseUserContractText(text);
+    assert.deepEqual(r.included_uc_ids, ['UC-01']);
+  });
+
+  it('parses scenarios with inline covers and skip_allowed', () => {
+    const text = `
+scenarios:
+  - id: "SC-01"
+    covers: [UC-01, UC-02]
+    skip_allowed: [ENV_API_DOWN]
+  - id: "SC-02"
+    covers: ["UC-03"]
+    skip_allowed: []
+`;
+    const r = parseUserContractText(text);
+    assert.equal(r.scenarios.length, 2);
+    assert.deepEqual(r.scenarios[0].covers, ['UC-01', 'UC-02']);
+    assert.deepEqual(r.scenarios[0].skip_allowed, ['ENV_API_DOWN']);
+    assert.deepEqual(r.scenarios[1].covers, ['UC-03']);
+    assert.deepEqual(r.scenarios[1].skip_allowed, []);
+  });
+
+  it('parses scenarios with block covers list', () => {
+    const text = `
+scenarios:
+  - id: "SC-01"
+    covers:
+      - "UC-01"
+      - "UC-02"
+    skip_allowed:
+      - ENV_API_DOWN
+      - FLAKY_NETWORK
+`;
+    const r = parseUserContractText(text);
+    assert.equal(r.scenarios.length, 1);
+    assert.deepEqual(r.scenarios[0].covers, ['UC-01', 'UC-02']);
+    assert.deepEqual(r.scenarios[0].skip_allowed, ['ENV_API_DOWN', 'FLAKY_NETWORK']);
+  });
+
+  it('handles multiple sections together', () => {
+    const text = `
+schema_version: 1
+user_cases:
+  - id: "UC-01"
+    status: included
+  - id: "UC-02"
+    status: included
+deferred_cases:
+  - id: "UC-09"
+    reason: "later"
+scenarios:
+  - id: "SC-01"
+    covers: [UC-01]
+  - id: "SC-02"
+    covers: [UC-02]
+`;
+    const r = parseUserContractText(text);
+    assert.deepEqual(r.included_uc_ids, ['UC-01', 'UC-02']);
+    assert.equal(r.scenarios.length, 2);
+  });
+
+  it('returns empty for null/empty input', () => {
+    assert.deepEqual(parseUserContractText(''), { included_uc_ids: [], scenarios: [] });
+    assert.deepEqual(parseUserContractText(null), { included_uc_ids: [], scenarios: [] });
+  });
+});
+
+describe('computeUncoveredUcs', () => {
+  it('returns uncovered UCs when scenarios do not cover all', () => {
+    const uncovered = computeUncoveredUcs(
+      ['UC-01', 'UC-02', 'UC-03'],
+      [{ id: 'SC-1', covers: ['UC-01'] }],
+    );
+    assert.deepEqual(uncovered, ['UC-02', 'UC-03']);
+  });
+
+  it('returns empty when all UCs are covered', () => {
+    const uncovered = computeUncoveredUcs(
+      ['UC-01', 'UC-02'],
+      [
+        { id: 'SC-1', covers: ['UC-01'] },
+        { id: 'SC-2', covers: ['UC-02'] },
+      ],
+    );
+    assert.deepEqual(uncovered, []);
+  });
+
+  it('counts cross-scenario coverage (union)', () => {
+    const uncovered = computeUncoveredUcs(
+      ['UC-01', 'UC-02'],
+      [{ id: 'SC-1', covers: ['UC-01', 'UC-02'] }],
+    );
+    assert.deepEqual(uncovered, []);
+  });
+
+  it('handles scenarios with missing covers field', () => {
+    const uncovered = computeUncoveredUcs(
+      ['UC-01'],
+      [{ id: 'SC-1' }], // no covers field
+    );
+    assert.deepEqual(uncovered, ['UC-01']);
+  });
+
+  it('returns empty when no included UCs', () => {
+    const uncovered = computeUncoveredUcs([], [{ id: 'SC-1', covers: ['UC-01'] }]);
+    assert.deepEqual(uncovered, []);
+  });
+});

--- a/hooks/__tests__/mpl-validate-pp-schema.test.mjs
+++ b/hooks/__tests__/mpl-validate-pp-schema.test.mjs
@@ -1,0 +1,130 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  targetsPivotPointsFile,
+  extractProposedContent,
+  detectUcLeakage,
+  formatBlockReason,
+} from '../mpl-validate-pp-schema.mjs';
+
+describe('targetsPivotPointsFile', () => {
+  it('matches .mpl/pivot-points.md at repo root', () => {
+    assert.equal(targetsPivotPointsFile('/repo/.mpl/pivot-points.md'), true);
+  });
+
+  it('matches nested .mpl/pivot-points.md', () => {
+    assert.equal(targetsPivotPointsFile('/work/project/.mpl/pivot-points.md'), true);
+  });
+
+  it('matches relative path', () => {
+    assert.equal(targetsPivotPointsFile('.mpl/pivot-points.md'), true);
+  });
+
+  it('does not match user-contract.md', () => {
+    assert.equal(targetsPivotPointsFile('/repo/.mpl/requirements/user-contract.md'), false);
+  });
+
+  it('does not match other pivot-points references', () => {
+    assert.equal(targetsPivotPointsFile('/repo/docs/pivot-points.md'), false);
+    assert.equal(targetsPivotPointsFile('/repo/.mpl/pivot-points-backup.md'), false);
+  });
+
+  it('returns false for null/undefined/empty', () => {
+    assert.equal(targetsPivotPointsFile(null), false);
+    assert.equal(targetsPivotPointsFile(undefined), false);
+    assert.equal(targetsPivotPointsFile(''), false);
+  });
+});
+
+describe('extractProposedContent', () => {
+  it('returns content for Write', () => {
+    assert.equal(extractProposedContent({ content: 'body' }, 'Write'), 'body');
+  });
+
+  it('returns new_string for Edit', () => {
+    assert.equal(extractProposedContent({ new_string: 'new body' }, 'Edit'), 'new body');
+  });
+
+  it('returns empty for unknown tool', () => {
+    assert.equal(extractProposedContent({ content: 'x' }, 'Bash'), '');
+  });
+
+  it('handles missing fields', () => {
+    assert.equal(extractProposedContent({}, 'Write'), '');
+    assert.equal(extractProposedContent({}, 'Edit'), '');
+    assert.equal(extractProposedContent(null, 'Write'), '');
+  });
+});
+
+describe('detectUcLeakage', () => {
+  it('detects user_cases: YAML key', () => {
+    const hits = detectUcLeakage('user_cases:\n  - id: UC-01');
+    assert.ok(hits.length >= 1);
+    assert.ok(hits.some((h) => h.name === 'user_cases:'));
+  });
+
+  it('detects deferred_cases: YAML key', () => {
+    const hits = detectUcLeakage('deferred_cases:\n  - id: X');
+    assert.ok(hits.some((h) => h.name === 'deferred_cases:'));
+  });
+
+  it('detects cut_cases: YAML key', () => {
+    const hits = detectUcLeakage('cut_cases:\n  - id: X');
+    assert.ok(hits.some((h) => h.name === 'cut_cases:'));
+  });
+
+  it('detects nested user_delta: field', () => {
+    const hits = detectUcLeakage('  user_delta: "added by user"');
+    assert.ok(hits.some((h) => h.name === 'user_delta:'));
+  });
+
+  it('detects covers_pp: field', () => {
+    const hits = detectUcLeakage('  covers_pp: [PP-1]');
+    assert.ok(hits.some((h) => h.name === 'covers_pp:'));
+  });
+
+  it('detects UC-NN identifiers', () => {
+    const hits = detectUcLeakage('This phase covers UC-01 and UC-15.');
+    assert.ok(hits.some((h) => h.name === 'UC-NN identifier'));
+  });
+
+  it('does NOT flag plain PP content', () => {
+    const clean = `# Pivot Points
+
+## PP-1: Auth tokens must use secure storage
+All token handling in \`src/auth/token.ts\` must use SecureStore.
+
+## PP-2: Append-only migrations
+Files in \`migrations/*.sql\` never modify existing entries.
+`;
+    assert.deepEqual(detectUcLeakage(clean), []);
+  });
+
+  it('does NOT flag single-digit UC-like strings (PP-1 style)', () => {
+    // PP-1 is fine, UC-1 is also intentionally NOT matched (require 2+ digits)
+    const hits = detectUcLeakage('See UC-1 in legacy doc.');
+    assert.deepEqual(hits, []);
+  });
+
+  it('returns empty for empty or null input', () => {
+    assert.deepEqual(detectUcLeakage(''), []);
+    assert.deepEqual(detectUcLeakage(null), []);
+    assert.deepEqual(detectUcLeakage(undefined), []);
+  });
+});
+
+describe('formatBlockReason', () => {
+  it('includes detected marker names', () => {
+    const reason = formatBlockReason([
+      { name: 'user_cases:' },
+      { name: 'UC-NN identifier' },
+    ]);
+    assert.ok(reason.includes('user_cases:'));
+    assert.ok(reason.includes('UC-NN identifier'));
+  });
+
+  it('points to user-contract.md as correct location', () => {
+    const reason = formatBlockReason([{ name: 'user_cases:' }]);
+    assert.ok(reason.includes('user-contract.md'));
+  });
+});

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -52,6 +52,16 @@
         ]
       },
       {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/mpl-require-covers.mjs\"",
+            "timeout": 3
+          }
+        ]
+      },
+      {
         "matcher": "Task|Agent",
         "hooks": [
           {

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -42,6 +42,16 @@
         ]
       },
       {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/mpl-validate-pp-schema.mjs\"",
+            "timeout": 3
+          }
+        ]
+      },
+      {
         "matcher": "Task|Agent",
         "hooks": [
           {

--- a/hooks/mpl-ambiguity-gate.mjs
+++ b/hooks/mpl-ambiguity-gate.mjs
@@ -14,6 +14,7 @@
 
 import { dirname, join } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
+import { existsSync, readFileSync } from 'fs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -21,6 +22,22 @@ const __dirname = dirname(__filename);
 const { isMplActive, readState, writeState } = await import(
   pathToFileURL(join(__dirname, 'lib', 'mpl-state.mjs')).href
 );
+
+/**
+ * 0.16 Tier A' opt-out: legacy projects can disable the user-contract
+ * gate via .mpl/config.json { "user_contract_required": false }. Default true.
+ */
+function isUserContractRequired(cwd) {
+  try {
+    const cfgPath = join(cwd, '.mpl', 'config.json');
+    if (!existsSync(cfgPath)) return true;
+    const cfg = JSON.parse(readFileSync(cfgPath, 'utf-8'));
+    if (cfg && cfg.user_contract_required === false) return false;
+  } catch {
+    // fall through
+  }
+  return true;
+}
 
 const { readStdin } = await import(
   pathToFileURL(join(__dirname, 'lib', 'stdin.mjs')).href
@@ -67,6 +84,24 @@ async function main() {
     console.log(JSON.stringify({
       continue: false,
       reason: '[MPL] ⛔ Decomposer BLOCKED: Cannot read MPL state. Ensure .mpl/state.json exists.'
+    }));
+    return;
+  }
+
+  // 0.16 Tier A': Step 1.5 User Contract Interview must complete before decomposition.
+  // Gate is additive to ambiguity score — BOTH must pass. Legacy projects that pre-date
+  // 0.16 can opt out via .mpl/config.json { "user_contract_required": false }.
+  const contractRequired = isUserContractRequired(cwd);
+  const contractSet = state.user_contract_set === true;
+  if (contractRequired && !contractSet) {
+    writeState(cwd, { current_phase: 'mpl-init' });
+    console.log(JSON.stringify({
+      continue: false,
+      reason: '[MPL] ⛔ Decomposer BLOCKED: user_contract_set is false. ' +
+        'Run Phase 0 Step 1.5 first: orchestrator inline loop calling mpl_classify_feature_scope MCP tool ' +
+        'to produce .mpl/requirements/user-contract.md, then mpl_state_write({user_contract_set:true}). ' +
+        'See commands/mpl-run-phase0.md Step 1.5. ' +
+        'To opt out in legacy projects: set user_contract_required=false in .mpl/config.json.'
     }));
     return;
   }

--- a/hooks/mpl-require-covers.mjs
+++ b/hooks/mpl-require-covers.mjs
@@ -1,0 +1,246 @@
+#!/usr/bin/env node
+/**
+ * MPL Require Covers Hook (PreToolUse on Write|Edit)
+ *
+ * Validates the Tier B schema on `.mpl/mpl/decomposition.yaml` writes:
+ *   - Every phase MUST have non-empty `covers: [...]`.
+ *   - Each entry MUST be either `internal` (escape) or match `UC-\d{2,}`.
+ *   - Emits a warn (not block) when the ratio of `["internal"]`-only phases
+ *     exceeds the configured threshold (default 0.4).
+ *
+ * Config: `.mpl/config.json` may set `internal_todo_warn_threshold` (0..1).
+ *
+ * Legacy graceful-skip mode: when `.mpl/requirements/user-contract.md` is
+ * absent, the hook accepts `["internal"]` anywhere without checking UC-NN
+ * existence, and only enforces the ratio warn.
+ *
+ * Non-blocking on any error.
+ */
+
+import { dirname, join } from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+import { existsSync, readFileSync } from 'fs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const DEFAULT_WARN_THRESHOLD = 0.4;
+const UC_ID_RE = /^UC-\d{2,}$/;
+
+export function targetsDecompositionFile(filePath) {
+  if (!filePath || typeof filePath !== 'string') return false;
+  return /(^|\/)\.mpl\/mpl\/decomposition\.yaml$/.test(filePath);
+}
+
+/**
+ * Minimal YAML parse: extract every phase's `id` and `covers` list.
+ * Returns [{ id, covers: [string] }, ...]
+ *
+ * Handles:
+ *   - `- id: "phase-1"` phase entry
+ *   - `covers:` key on same or nested line, followed by list items or inline
+ */
+export function parsePhaseCovers(yamlText) {
+  if (!yamlText || typeof yamlText !== 'string') return [];
+
+  const lines = yamlText.split('\n').map((l) => l.replace(/\r$/, ''));
+  const phases = [];
+  let cur = null;
+  let inCovers = false;
+  let coversIndent = -1;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    // Phase start
+    const phaseMatch = line.match(/^\s*-\s+id:\s*["']?(phase-[\w-]+)["']?/);
+    if (phaseMatch) {
+      if (cur) phases.push(cur);
+      cur = { id: phaseMatch[1], covers: null }; // null = field missing
+      inCovers = false;
+      continue;
+    }
+    if (!cur) continue;
+
+    // covers: inline array form: `covers: [UC-01, UC-02]` or `covers: ["internal"]`
+    const inlineMatch = line.match(/^(\s*)covers\s*:\s*\[(.*)\]\s*$/);
+    if (inlineMatch) {
+      const items = inlineMatch[2]
+        .split(',')
+        .map((s) => s.trim().replace(/^["']|["']$/g, ''))
+        .filter(Boolean);
+      cur.covers = items;
+      inCovers = false;
+      continue;
+    }
+
+    // covers: start of nested list form
+    const blockMatch = line.match(/^(\s*)covers\s*:\s*$/);
+    if (blockMatch) {
+      coversIndent = blockMatch[1].length;
+      cur.covers = [];
+      inCovers = true;
+      continue;
+    }
+
+    if (inCovers) {
+      // list item under covers: `  - "UC-01"` or `  - internal`
+      const itemMatch = line.match(/^(\s*)-\s+["']?([^"'\s#]+)["']?/);
+      if (itemMatch && itemMatch[1].length > coversIndent) {
+        cur.covers.push(itemMatch[2]);
+        continue;
+      }
+      // Non-item line with indent <= coversIndent = covers block ended
+      if (line.trim() !== '' && !line.startsWith(' '.repeat(coversIndent + 1))) {
+        inCovers = false;
+      }
+    }
+  }
+
+  if (cur) phases.push(cur);
+  return phases;
+}
+
+export function validatePhase(phase, { allowLegacy }) {
+  const issues = [];
+  if (phase.covers === null) {
+    issues.push({ kind: 'missing', phase: phase.id });
+    return issues;
+  }
+  if (!Array.isArray(phase.covers) || phase.covers.length === 0) {
+    issues.push({ kind: 'empty', phase: phase.id });
+    return issues;
+  }
+  for (const entry of phase.covers) {
+    if (entry === 'internal') continue;
+    if (UC_ID_RE.test(entry)) continue;
+    issues.push({ kind: 'invalid_entry', phase: phase.id, entry });
+  }
+  // legacy mode downgrades UC format errors to warns (allow `internal` everywhere)
+  if (allowLegacy) {
+    return issues.filter((i) => i.kind !== 'invalid_entry');
+  }
+  return issues;
+}
+
+export function computeInternalRatio(phases) {
+  const total = phases.filter(
+    (p) => Array.isArray(p.covers) && p.covers.length > 0,
+  ).length;
+  if (total === 0) return 0;
+  const internalOnly = phases.filter(
+    (p) =>
+      Array.isArray(p.covers) &&
+      p.covers.length > 0 &&
+      p.covers.every((c) => c === 'internal'),
+  ).length;
+  return internalOnly / total;
+}
+
+export function loadWarnThreshold(cwd) {
+  const path = join(cwd, '.mpl', 'config.json');
+  if (!existsSync(path)) return DEFAULT_WARN_THRESHOLD;
+  try {
+    const cfg = JSON.parse(readFileSync(path, 'utf-8'));
+    const t = cfg.internal_todo_warn_threshold;
+    if (typeof t === 'number' && t > 0 && t <= 1) return t;
+  } catch {
+    // fall through
+  }
+  return DEFAULT_WARN_THRESHOLD;
+}
+
+export function isLegacyMode(cwd) {
+  const path = join(cwd, '.mpl', 'requirements', 'user-contract.md');
+  return !existsSync(path);
+}
+
+function extractProposedContent(toolInput, toolName) {
+  if (!toolInput) return '';
+  if (toolName === 'Write') return toolInput.content || '';
+  if (toolName === 'Edit') return toolInput.new_string || '';
+  return '';
+}
+
+const isMain = import.meta.url === pathToFileURL(process.argv[1] || '').href;
+
+if (isMain) {
+  const { readStdin } = await import(
+    pathToFileURL(join(__dirname, 'lib', 'stdin.mjs')).href
+  );
+
+  const ok = () =>
+    console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+  const okWithWarn = (msg) =>
+    console.log(
+      JSON.stringify({
+        continue: true,
+        suppressOutput: false,
+        systemMessage: msg,
+      }),
+    );
+  const block = (reason) =>
+    console.log(JSON.stringify({ continue: false, decision: 'block', reason }));
+
+  try {
+    const raw = await readStdin();
+    if (!raw) { ok(); process.exit(0); }
+
+    let input;
+    try { input = JSON.parse(raw); } catch { ok(); process.exit(0); }
+
+    const toolName = input.tool_name || '';
+    if (toolName !== 'Write' && toolName !== 'Edit') { ok(); process.exit(0); }
+
+    const toolInput = input.tool_input || {};
+    const target = toolInput.file_path || '';
+    if (!targetsDecompositionFile(target)) { ok(); process.exit(0); }
+
+    const content = extractProposedContent(toolInput, toolName);
+    if (!content) { ok(); process.exit(0); }
+
+    const cwd = input.cwd || process.cwd();
+    const legacy = isLegacyMode(cwd);
+    const phases = parsePhaseCovers(content);
+
+    if (phases.length === 0) { ok(); process.exit(0); }
+
+    const allIssues = [];
+    for (const p of phases) {
+      const issues = validatePhase(p, { allowLegacy: legacy });
+      allIssues.push(...issues);
+    }
+    if (allIssues.length > 0) {
+      const summary = allIssues
+        .slice(0, 10)
+        .map((i) => {
+          if (i.kind === 'missing')
+            return `${i.phase}: covers field missing`;
+          if (i.kind === 'empty')
+            return `${i.phase}: covers is empty`;
+          return `${i.phase}: invalid covers entry "${i.entry}" (must match UC-NN or "internal")`;
+        })
+        .join('; ');
+      const more = allIssues.length > 10 ? ` (+${allIssues.length - 10} more)` : '';
+      block(
+        `Tier B schema violation in decomposition.yaml: ${summary}${more}. ` +
+          `See docs/schemas/user-contract.md for UC ids.`,
+      );
+      process.exit(0);
+    }
+
+    // warn on internal ratio
+    const threshold = loadWarnThreshold(cwd);
+    const ratio = computeInternalRatio(phases);
+    if (ratio > threshold) {
+      okWithWarn(
+        `[MPL Tier B] internal-only phases ${(ratio * 100).toFixed(0)}% > threshold ${(threshold * 100).toFixed(0)}%. ` +
+          `Consider whether more phases could covers a user UC. Override via .mpl/config.json internal_todo_warn_threshold.`,
+      );
+    } else {
+      ok();
+    }
+  } catch {
+    ok();
+  }
+}

--- a/hooks/mpl-require-e2e.mjs
+++ b/hooks/mpl-require-e2e.mjs
@@ -34,12 +34,14 @@ import { existsSync, readFileSync } from 'fs';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
+const isMain = import.meta.url === pathToFileURL(process.argv[1] || '').href;
+
 const { readState, isMplActive } = await import(
   pathToFileURL(join(__dirname, 'lib', 'mpl-state.mjs')).href
 );
-const { readStdin } = await import(
-  pathToFileURL(join(__dirname, 'lib', 'stdin.mjs')).href
-);
+const { readStdin } = isMain
+  ? await import(pathToFileURL(join(__dirname, 'lib', 'stdin.mjs')).href)
+  : { readStdin: async () => '' };
 
 function ok() {
   console.log(JSON.stringify({ continue: true, suppressOutput: true }));
@@ -122,6 +124,171 @@ function loadOverride(cwd) {
 }
 
 /**
+ * 0.16 Tier C: read .mpl/config.json { e2e_contract_strict: false } to
+ * degrade the missing-UC-coverage check from block to warn. Default true (strict).
+ */
+export function isE2EContractStrict(cwd) {
+  try {
+    const cfgPath = join(cwd, '.mpl', 'config.json');
+    if (!existsSync(cfgPath)) return true;
+    const cfg = JSON.parse(readFileSync(cfgPath, 'utf-8'));
+    if (cfg && cfg.e2e_contract_strict === false) return false;
+  } catch {
+    // fall through
+  }
+  return true;
+}
+
+/**
+ * 0.16 Tier A'/C: parse .mpl/requirements/user-contract.md to extract the
+ * included UC ids and the scenario→UC mapping. File is YAML-shaped even though
+ * it carries an .md extension (pragmatic convention — see Plan v2 Q5).
+ *
+ * Returns { included_uc_ids: [string], scenarios: [{id, covers, skip_allowed}] }.
+ * Missing file → empty result (graceful skip mode).
+ */
+export function parseUserContract(cwd) {
+  const path = join(cwd, '.mpl', 'requirements', 'user-contract.md');
+  if (!existsSync(path)) return { included_uc_ids: [], scenarios: [] };
+
+  let text;
+  try {
+    text = readFileSync(path, 'utf-8');
+  } catch {
+    return { included_uc_ids: [], scenarios: [] };
+  }
+
+  return parseUserContractText(text);
+}
+
+export function parseUserContractText(text) {
+  if (!text || typeof text !== 'string') return { included_uc_ids: [], scenarios: [] };
+
+  const lines = text.split('\n').map((l) => l.replace(/\r$/, ''));
+
+  let section = null; // "user_cases" | "scenarios" | null
+  let sectionIndent = -1;
+  const included = [];
+  const scenarios = [];
+  let curScenario = null;
+  let inListField = null; // "covers" | "skip_allowed"
+  let listIndent = -1;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (line.trim() === '') continue;
+
+    // Top-level section detection
+    const topMatch = line.match(/^(user_cases|deferred_cases|cut_cases|scenarios)\s*:\s*$/);
+    if (topMatch) {
+      if (curScenario) scenarios.push(curScenario);
+      curScenario = null;
+      section = topMatch[1];
+      sectionIndent = 0;
+      inListField = null;
+      continue;
+    }
+
+    // Top-level unrelated keys terminate the section
+    if (/^[a-zA-Z_]/.test(line) && !line.startsWith(' ')) {
+      if (curScenario) scenarios.push(curScenario);
+      curScenario = null;
+      section = null;
+      inListField = null;
+      continue;
+    }
+
+    if (section === 'user_cases') {
+      const idMatch = line.match(/^\s*-\s+id:\s*["']?(UC-\d{2,})["']?/);
+      if (idMatch) {
+        // Peek forward for status: "included"; safer to accept-all-then-filter via default
+        // We stream-parse: assume status defaults to "included" unless explicitly set.
+        included.push({ id: idMatch[1], status: 'included' });
+        continue;
+      }
+      const statusMatch = line.match(/^\s+status:\s*["']?(included|deferred|cut)["']?/);
+      if (statusMatch && included.length > 0) {
+        included[included.length - 1].status = statusMatch[1];
+        continue;
+      }
+    }
+
+    if (section === 'scenarios') {
+      const idMatch = line.match(/^\s*-\s+id:\s*["']?(SC-[\w-]+|E2E-[\w-]+)["']?/);
+      if (idMatch) {
+        if (curScenario) scenarios.push(curScenario);
+        curScenario = { id: idMatch[1], covers: [], skip_allowed: [] };
+        inListField = null;
+        continue;
+      }
+      if (!curScenario) continue;
+
+      // Inline arrays
+      const inlineCovers = line.match(/^\s+covers\s*:\s*\[(.*)\]\s*$/);
+      if (inlineCovers) {
+        curScenario.covers = inlineCovers[1]
+          .split(',')
+          .map((s) => s.trim().replace(/^["']|["']$/g, ''))
+          .filter(Boolean);
+        inListField = null;
+        continue;
+      }
+      const inlineSkip = line.match(/^\s+skip_allowed\s*:\s*\[(.*)\]\s*$/);
+      if (inlineSkip) {
+        curScenario.skip_allowed = inlineSkip[1]
+          .split(',')
+          .map((s) => s.trim().replace(/^["']|["']$/g, ''))
+          .filter(Boolean);
+        inListField = null;
+        continue;
+      }
+
+      // Block list form
+      const blockCovers = line.match(/^(\s+)covers\s*:\s*$/);
+      if (blockCovers) {
+        inListField = 'covers';
+        listIndent = blockCovers[1].length;
+        continue;
+      }
+      const blockSkip = line.match(/^(\s+)skip_allowed\s*:\s*$/);
+      if (blockSkip) {
+        inListField = 'skip_allowed';
+        listIndent = blockSkip[1].length;
+        continue;
+      }
+
+      if (inListField) {
+        const itemMatch = line.match(/^(\s*)-\s+["']?([^"'\s#]+)["']?/);
+        if (itemMatch && itemMatch[1].length > listIndent) {
+          curScenario[inListField].push(itemMatch[2]);
+          continue;
+        }
+        // leaving list
+        inListField = null;
+      }
+    }
+  }
+  if (curScenario) scenarios.push(curScenario);
+
+  return {
+    included_uc_ids: included.filter((u) => u.status === 'included').map((u) => u.id),
+    scenarios,
+  };
+}
+
+/**
+ * 0.16 Tier C: compute which `included` UCs have no scenario covering them.
+ * Returns array of uncovered UC ids.
+ */
+export function computeUncoveredUcs(includedUcIds, scenarios) {
+  const covered = new Set();
+  for (const s of scenarios) {
+    for (const uc of s.covers || []) covered.add(uc);
+  }
+  return includedUcIds.filter((id) => !covered.has(id));
+}
+
+/**
  * Detect whether the incoming tool input writes `finalize_done: true` to
  * `.mpl/state.json`. Handles Edit (old_string/new_string) and Write (content).
  * False positives are acceptable — the hook only blocks when scenarios are
@@ -140,11 +307,11 @@ function isFinalizeDoneWrite(toolInput) {
   return /"finalize_done"\s*:\s*true/.test(newText);
 }
 
-try {
+async function runHook() {
   const raw = await readStdin();
   if (!raw.trim()) {
     ok();
-    process.exit(0);
+    return;
   }
 
   let data;
@@ -152,25 +319,25 @@ try {
     data = JSON.parse(raw);
   } catch {
     ok();
-    process.exit(0);
+    return;
   }
 
   const cwd = data.cwd || data.directory || process.cwd();
   if (!isMplActive(cwd)) {
     ok();
-    process.exit(0);
+    return;
   }
 
   const toolName = String(data.tool_name || data.toolName || '');
   if (!['Write', 'write', 'Edit', 'edit'].includes(toolName)) {
     ok();
-    process.exit(0);
+    return;
   }
 
   const toolInput = data.tool_input || data.toolInput || {};
   if (!isFinalizeDoneWrite(toolInput)) {
     ok();
-    process.exit(0);
+    return;
   }
 
   // A finalize_done: true write is imminent. Validate E2E coverage.
@@ -179,7 +346,7 @@ try {
   if (required.length === 0) {
     // No declared E2E scenarios — nothing to enforce. Allow.
     ok();
-    process.exit(0);
+    return;
   }
 
   const state = readState(cwd) || {};
@@ -216,18 +383,48 @@ try {
     }
   }
 
-  if (unresolved.length === 0) {
-    ok();
-    process.exit(0);
+  if (unresolved.length > 0) {
+    block(
+      `[MPL AD-0008] Cannot set finalize_done=true — ${unresolved.length} required E2E scenario(s) missing or failing: ${unresolved.join(', ')}. ` +
+        `Each required scenario's test_command must be executed (gate-recorder writes state.e2e_results automatically) AND exit 0, ` +
+        `OR explicitly overridden via .mpl/config/e2e-scenario-override.json with a user reason. ` +
+        `Re-run the scenarios or use /mpl:mpl-finalize Step 5.0 HITL to record overrides before retrying finalize.`
+    );
+    return;
   }
 
-  block(
-    `[MPL AD-0008] Cannot set finalize_done=true — ${unresolved.length} required E2E scenario(s) missing or failing: ${unresolved.join(', ')}. ` +
-      `Each required scenario's test_command must be executed (gate-recorder writes state.e2e_results automatically) AND exit 0, ` +
-      `OR explicitly overridden via .mpl/config/e2e-scenario-override.json with a user reason. ` +
-      `Re-run the scenarios or use /mpl:mpl-finalize Step 5.0 HITL to record overrides before retrying finalize.`
-  );
-} catch {
-  // Hook must never wedge the pipeline.
+  // 0.16 Tier C: UC coverage gate.
+  const contract = parseUserContract(cwd);
+  if (contract.included_uc_ids.length > 0) {
+    const uncovered = computeUncoveredUcs(contract.included_uc_ids, contract.scenarios);
+    if (uncovered.length > 0) {
+      if (isE2EContractStrict(cwd)) {
+        block(
+          `[MPL 0.16 Tier C] Cannot set finalize_done=true — ${uncovered.length} included UC(s) have no E2E scenario coverage: ${uncovered.join(', ')}. ` +
+            `Add scenarios to .mpl/requirements/user-contract.md (each scenario's covers[] must list the UC) ` +
+            `or opt out of strict mode via .mpl/config.json { "e2e_contract_strict": false }.`
+        );
+        return;
+      }
+      console.log(
+        JSON.stringify({
+          continue: true,
+          suppressOutput: false,
+          systemMessage:
+            `[MPL 0.16 Tier C WARN] ${uncovered.length} UC(s) without E2E scenario coverage: ${uncovered.join(', ')}. ` +
+            `Strict mode is disabled; add coverage or re-enable e2e_contract_strict=true before the next run.`,
+        }),
+      );
+      return;
+    }
+  }
+
   ok();
+}
+
+if (isMain) {
+  runHook().catch(() => {
+    // Hook must never wedge the pipeline.
+    ok();
+  });
 }

--- a/hooks/mpl-validate-pp-schema.mjs
+++ b/hooks/mpl-validate-pp-schema.mjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+/**
+ * MPL Validate PP Schema Hook (PreToolUse on Write|Edit)
+ *
+ * Guards `.mpl/pivot-points.md` (immutable PP file) from UC-scoped schema
+ * leakage. Pivot Points are design invariants; User Cases are mutable feature
+ * scope. They MUST live in separate files.
+ *
+ *   - pivot-points.md               → PP (immutable)
+ *   - requirements/user-contract.md → UC (mutable, 0.16 Tier A')
+ *
+ * If a Write or Edit targets pivot-points.md and the proposed content contains
+ * UC-specific schema keys or UC-N identifiers, the hook blocks the write.
+ *
+ * This is the reverse of common drift: during interviews or fix loops the
+ * orchestrator may mistakenly try to persist UC discoveries into the PP file.
+ * The hook is the structural guard.
+ *
+ * Non-blocking on any error.
+ */
+
+import { dirname, join } from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const UC_SCHEMA_PATTERNS = [
+  { re: /^user_cases\s*:/m, name: 'user_cases:' },
+  { re: /^deferred_cases\s*:/m, name: 'deferred_cases:' },
+  { re: /^cut_cases\s*:/m, name: 'cut_cases:' },
+  { re: /^\s{2,}user_delta\s*:/m, name: 'user_delta:' },
+  { re: /^\s{2,}covers_pp\s*:/m, name: 'covers_pp:' },
+  { re: /\bUC-\d{2,}\b/, name: 'UC-NN identifier' },
+];
+
+export function targetsPivotPointsFile(filePath) {
+  if (!filePath || typeof filePath !== 'string') return false;
+  return /(^|\/)\.mpl\/pivot-points\.md$/.test(filePath);
+}
+
+export function extractProposedContent(toolInput, toolName) {
+  if (!toolInput) return '';
+  if (toolName === 'Write') return toolInput.content || '';
+  if (toolName === 'Edit') return toolInput.new_string || '';
+  return '';
+}
+
+export function detectUcLeakage(content) {
+  if (!content || typeof content !== 'string') return [];
+  return UC_SCHEMA_PATTERNS.filter((p) => p.re.test(content));
+}
+
+export function formatBlockReason(hits) {
+  const names = hits.map((h) => h.name).join(', ');
+  return [
+    `Blocked: .mpl/pivot-points.md (immutable PP file) must not contain UC-scoped schema.`,
+    `Detected markers: ${names}.`,
+    `UCs belong in .mpl/requirements/user-contract.md (0.16 Tier A').`,
+    `If you are trying to persist user feature discoveries, write them to the user-contract file instead.`,
+  ].join(' ');
+}
+
+// Skip execution during tests (when imported as a module)
+const isMain =
+  import.meta.url === pathToFileURL(process.argv[1] || '').href;
+
+if (isMain) {
+  const { readStdin } = await import(
+    pathToFileURL(join(__dirname, 'lib', 'stdin.mjs')).href
+  );
+
+  const ok = () =>
+    console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+  const block = (reason) =>
+    console.log(JSON.stringify({ continue: false, decision: 'block', reason }));
+
+  try {
+    const raw = await readStdin();
+    if (!raw) ok();
+    else {
+      let input;
+      try {
+        input = JSON.parse(raw);
+      } catch {
+        ok();
+        process.exit(0);
+      }
+      const toolName = input.tool_name || '';
+      if (toolName !== 'Write' && toolName !== 'Edit') ok();
+      else {
+        const toolInput = input.tool_input || {};
+        const target = toolInput.file_path || '';
+        if (!targetsPivotPointsFile(target)) ok();
+        else {
+          const content = extractProposedContent(toolInput, toolName);
+          if (!content) ok();
+          else {
+            const hits = detectUcLeakage(content);
+            if (hits.length === 0) ok();
+            else block(formatBlockReason(hits));
+          }
+        }
+      }
+    }
+  } catch {
+    ok();
+  }
+}

--- a/mcp-server/__tests__/e2e-diagnoser.test.mjs
+++ b/mcp-server/__tests__/e2e-diagnoser.test.mjs
@@ -1,0 +1,118 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  PROMPT_VERSION,
+  parseDiagnosis,
+  neutralDiagnosis,
+} from '../dist/lib/e2e-diagnoser.js';
+
+describe('PROMPT_VERSION', () => {
+  it('is a frozen version string', () => {
+    assert.equal(typeof PROMPT_VERSION, 'string');
+    assert.ok(PROMPT_VERSION.length > 0);
+  });
+});
+
+describe('parseDiagnosis', () => {
+  const validA = {
+    classification: 'A',
+    root_cause: 'No /reset-password route exists in src/auth/router.ts',
+    fix_strategy: 'Append phase to add POST /reset-password handler; see append_phases.',
+    iter_hint: 1,
+    trace_excerpt: '404 Not Found at POST /reset-password (line 47 of reset.spec.ts)',
+    append_phases: [
+      {
+        position: 'after',
+        anchor_phase: 'phase-3',
+        proposed_id: 'phase-3b',
+        goal: 'Add reset-password endpoint',
+        covers: ['UC-05'],
+      },
+    ],
+    confidence: 0.9,
+  };
+
+  it('parses a valid A diagnosis', () => {
+    const r = parseDiagnosis(JSON.stringify(validA));
+    assert.ok(r);
+    assert.equal(r.classification, 'A');
+    assert.equal(r.iter_hint, 1);
+    assert.equal(r.append_phases.length, 1);
+    assert.equal(r.prompt_version, PROMPT_VERSION);
+  });
+
+  it('parses JSON embedded in surrounding text', () => {
+    const r = parseDiagnosis(`Preamble...\n${JSON.stringify(validA)}\nEnd.`);
+    assert.ok(r);
+    assert.equal(r.classification, 'A');
+  });
+
+  it('rejects invalid classification values', () => {
+    const bad = { ...validA, classification: 'Z' };
+    assert.equal(parseDiagnosis(JSON.stringify(bad)), null);
+  });
+
+  it('rejects missing required fields', () => {
+    const noRoot = { ...validA };
+    delete noRoot.root_cause;
+    assert.equal(parseDiagnosis(JSON.stringify(noRoot)), null);
+
+    const noAppend = { ...validA };
+    delete noAppend.append_phases;
+    assert.equal(parseDiagnosis(JSON.stringify(noAppend)), null);
+  });
+
+  it('clamps iter_hint to 0..2', () => {
+    const high = { ...validA, iter_hint: 99 };
+    const rh = parseDiagnosis(JSON.stringify(high));
+    assert.equal(rh.iter_hint, 2);
+    const low = { ...validA, iter_hint: -5 };
+    const rl = parseDiagnosis(JSON.stringify(low));
+    assert.equal(rl.iter_hint, 0);
+  });
+
+  it('clamps confidence to 0..1', () => {
+    const over = { ...validA, confidence: 2.5 };
+    assert.equal(parseDiagnosis(JSON.stringify(over)).confidence, 1);
+    const under = { ...validA, confidence: -0.5 };
+    assert.equal(parseDiagnosis(JSON.stringify(under)).confidence, 0);
+  });
+
+  it('truncates trace_excerpt to 400 chars', () => {
+    const long = { ...validA, trace_excerpt: 'x'.repeat(1000) };
+    const r = parseDiagnosis(JSON.stringify(long));
+    assert.equal(r.trace_excerpt.length, 400);
+  });
+
+  it('accepts all four classifications A/B/C/D', () => {
+    for (const k of ['A', 'B', 'C', 'D']) {
+      const payload = { ...validA, classification: k, append_phases: [] };
+      const r = parseDiagnosis(JSON.stringify(payload));
+      assert.ok(r);
+      assert.equal(r.classification, k);
+    }
+  });
+
+  it('returns null for malformed JSON', () => {
+    assert.equal(parseDiagnosis('{unclosed'), null);
+    assert.equal(parseDiagnosis(''), null);
+  });
+});
+
+describe('neutralDiagnosis', () => {
+  it('defaults to D (flake) to avoid false phase appends', () => {
+    const r = neutralDiagnosis();
+    assert.equal(r.classification, 'D');
+    assert.equal(r.append_phases.length, 0);
+    assert.equal(r.confidence, 0);
+  });
+
+  it('sets iter_hint to 1 (count against budget)', () => {
+    const r = neutralDiagnosis();
+    assert.equal(r.iter_hint, 1);
+  });
+
+  it('carries the frozen PROMPT_VERSION', () => {
+    assert.equal(neutralDiagnosis().prompt_version, PROMPT_VERSION);
+  });
+});

--- a/mcp-server/__tests__/feature-classifier.test.mjs
+++ b/mcp-server/__tests__/feature-classifier.test.mjs
@@ -1,0 +1,130 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  PROMPT_VERSION,
+  parseClassification,
+  neutralResult,
+} from '../dist/lib/feature-classifier.js';
+
+describe('PROMPT_VERSION', () => {
+  it('is a frozen version string', () => {
+    assert.equal(typeof PROMPT_VERSION, 'string');
+    assert.ok(PROMPT_VERSION.length > 0);
+  });
+});
+
+describe('parseClassification', () => {
+  const validPayload = {
+    user_cases: [
+      {
+        id: 'UC-01',
+        title: 'User can log in',
+        user_delta: '',
+        priority: 'P0',
+        status: 'included',
+        covers_pp: ['PP-1'],
+        acceptance_hint: '',
+      },
+    ],
+    deferred: [],
+    cut: [],
+    scenarios: [
+      {
+        id: 'SC-01',
+        title: 'Login happy path',
+        covers: ['UC-01'],
+        covers_pp: ['PP-1'],
+        steps: ['visit /login', 'enter creds', 'assert /dashboard'],
+        skip_allowed: [],
+      },
+    ],
+    pp_conflict: [],
+    ambiguity_hints: [],
+    next_question: null,
+    convergence: true,
+  };
+
+  it('parses a valid JSON payload', () => {
+    const result = parseClassification(JSON.stringify(validPayload));
+    assert.ok(result);
+    assert.equal(result.convergence, true);
+    assert.equal(result.user_cases.length, 1);
+    assert.equal(result.user_cases[0].id, 'UC-01');
+    assert.equal(result.scenarios[0].id, 'SC-01');
+    assert.equal(result.prompt_version, PROMPT_VERSION);
+  });
+
+  it('parses JSON embedded in surrounding text', () => {
+    const wrapped = `Some preamble...\n${JSON.stringify(validPayload)}\nTrailing.`;
+    const result = parseClassification(wrapped);
+    assert.ok(result);
+    assert.equal(result.user_cases.length, 1);
+  });
+
+  it('returns null on empty input', () => {
+    assert.equal(parseClassification(''), null);
+    assert.equal(parseClassification(null), null);
+  });
+
+  it('returns null when required arrays are missing', () => {
+    const missingScenarios = { ...validPayload };
+    delete missingScenarios.scenarios;
+    assert.equal(parseClassification(JSON.stringify(missingScenarios)), null);
+  });
+
+  it('returns null when array field is not an array', () => {
+    const bad = { ...validPayload, user_cases: 'not-an-array' };
+    assert.equal(parseClassification(JSON.stringify(bad)), null);
+  });
+
+  it('returns null when convergence is missing or not boolean', () => {
+    const noConv = { ...validPayload };
+    delete noConv.convergence;
+    assert.equal(parseClassification(JSON.stringify(noConv)), null);
+
+    const badConv = { ...validPayload, convergence: 'yes' };
+    assert.equal(parseClassification(JSON.stringify(badConv)), null);
+  });
+
+  it('accepts non-null next_question object', () => {
+    const withQ = {
+      ...validPayload,
+      convergence: false,
+      next_question: { kind: 'clarify', payload: { uc_id: 'UC-01' } },
+    };
+    const result = parseClassification(JSON.stringify(withQ));
+    assert.ok(result);
+    assert.equal(result.next_question.kind, 'clarify');
+  });
+
+  it('rejects malformed JSON', () => {
+    assert.equal(parseClassification('{unclosed'), null);
+    assert.equal(parseClassification('not json at all'), null);
+  });
+});
+
+describe('neutralResult', () => {
+  it('returns a structurally valid fallback', () => {
+    const r = neutralResult();
+    assert.equal(r.prompt_version, PROMPT_VERSION);
+    assert.ok(Array.isArray(r.user_cases));
+    assert.ok(Array.isArray(r.deferred));
+    assert.ok(Array.isArray(r.cut));
+    assert.ok(Array.isArray(r.scenarios));
+    assert.ok(Array.isArray(r.pp_conflict));
+    assert.ok(Array.isArray(r.ambiguity_hints));
+    assert.equal(r.convergence, false);
+  });
+
+  it('emits a classifier_unavailable next_question', () => {
+    const r = neutralResult();
+    assert.ok(r.next_question);
+    assert.equal(r.next_question.kind, 'clarify');
+    assert.equal(r.next_question.payload.reason, 'classifier_unavailable');
+  });
+
+  it('records at least one ambiguity hint so orchestrator knows to degrade', () => {
+    const r = neutralResult();
+    assert.ok(r.ambiguity_hints.length >= 1);
+  });
+});

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
-    "start": "node dist/index.js"
+    "start": "node dist/index.js",
+    "test": "npm run build && node --test __tests__/*.test.mjs"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.81",

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -3,9 +3,11 @@
  * MPL MCP Server — Tier 1: Deterministic Scoring + Active State Access
  *
  * Tools:
- *   mpl_score_ambiguity  — 5D ambiguity scoring via LLM API (temp 0.1) + code computation
- *   mpl_state_read       — Read pipeline state (active agent access)
- *   mpl_state_write      — Update pipeline state (atomic, deep-merge)
+ *   mpl_score_ambiguity         — 5D ambiguity scoring via LLM API (temp 0.1) + code computation
+ *   mpl_state_read              — Read pipeline state (active agent access)
+ *   mpl_state_write             — Update pipeline state (atomic, deep-merge)
+ *   mpl_classify_feature_scope  — 0.16 Tier A': classify user cases (included/deferred/cut) +
+ *                                 scenarios + PP conflict ledger (called inline during Phase 0 Step 1.5)
  *
  * Transport: stdio (Claude Code standard)
  */
@@ -19,6 +21,10 @@ import {
 
 import { scoreAmbiguityTool, handleScoreAmbiguity } from './tools/scoring.js';
 import { stateReadTool, handleStateRead, stateWriteTool, handleStateWrite } from './tools/state.js';
+import {
+  classifyFeatureScopeTool,
+  handleClassifyFeatureScope,
+} from './tools/feature-scope.js';
 
 const server = new Server(
   { name: 'mpl-server', version: '0.6.6' },
@@ -27,7 +33,7 @@ const server = new Server(
 
 // Register tools
 server.setRequestHandler(ListToolsRequestSchema, async () => ({
-  tools: [scoreAmbiguityTool, stateReadTool, stateWriteTool],
+  tools: [scoreAmbiguityTool, stateReadTool, stateWriteTool, classifyFeatureScopeTool],
 }));
 
 // Handle tool calls
@@ -43,6 +49,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
     case 'mpl_state_write':
       return handleStateWrite(args as Parameters<typeof handleStateWrite>[0]);
+
+    case 'mpl_classify_feature_scope':
+      return handleClassifyFeatureScope(
+        args as Parameters<typeof handleClassifyFeatureScope>[0],
+      );
 
     default:
       return {

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -8,6 +8,8 @@
  *   mpl_state_write             — Update pipeline state (atomic, deep-merge)
  *   mpl_classify_feature_scope  — 0.16 Tier A': classify user cases (included/deferred/cut) +
  *                                 scenarios + PP conflict ledger (called inline during Phase 0 Step 1.5)
+ *   mpl_diagnose_e2e_failure    — 0.16 Tier C: classify E2E failure as A/B/C/D + fix strategy
+ *                                 (called conditionally from Finalize; circuit breaker iter<=2)
  *
  * Transport: stdio (Claude Code standard)
  */
@@ -25,6 +27,10 @@ import {
   classifyFeatureScopeTool,
   handleClassifyFeatureScope,
 } from './tools/feature-scope.js';
+import {
+  diagnoseE2EFailureTool,
+  handleDiagnoseE2EFailure,
+} from './tools/e2e-diagnose.js';
 
 const server = new Server(
   { name: 'mpl-server', version: '0.6.6' },
@@ -33,7 +39,13 @@ const server = new Server(
 
 // Register tools
 server.setRequestHandler(ListToolsRequestSchema, async () => ({
-  tools: [scoreAmbiguityTool, stateReadTool, stateWriteTool, classifyFeatureScopeTool],
+  tools: [
+    scoreAmbiguityTool,
+    stateReadTool,
+    stateWriteTool,
+    classifyFeatureScopeTool,
+    diagnoseE2EFailureTool,
+  ],
 }));
 
 // Handle tool calls
@@ -53,6 +65,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     case 'mpl_classify_feature_scope':
       return handleClassifyFeatureScope(
         args as Parameters<typeof handleClassifyFeatureScope>[0],
+      );
+
+    case 'mpl_diagnose_e2e_failure':
+      return handleDiagnoseE2EFailure(
+        args as Parameters<typeof handleDiagnoseE2EFailure>[0],
       );
 
     default:

--- a/mcp-server/src/lib/e2e-diagnoser.ts
+++ b/mcp-server/src/lib/e2e-diagnoser.ts
@@ -1,0 +1,211 @@
+/**
+ * E2E Failure Diagnoser — LLM-driven root cause + fix strategy classifier.
+ *
+ * Invoked from Finalize only when:
+ *   (a) All required scenarios executed AND
+ *   (b) Tier C UC coverage is complete AND
+ *   (c) At least one scenario failed (exit_code != 0)
+ *
+ * Classification taxonomy:
+ *   A = spec gap             (decomposer must append mini-phases)
+ *   B = test bug             (test-agent re-dispatch; implementation is fine)
+ *   C = missing capability   (Step 1.5 re-run in minimal mode; new UC emerged)
+ *   D = flake                (rerun once with --trace on)
+ *
+ * PROMPT_VERSION is frozen inline so exp12 agreement-rate (auxiliary LLM
+ * labeling per Q8) can gate sunset vs file-promotion decisions in Stage 4.
+ */
+
+export const PROMPT_VERSION = 'v1-2026-04-19';
+
+const MAX_RETRIES = 2;
+
+let cachedSessionId: string | null = null;
+
+export type Classification = 'A' | 'B' | 'C' | 'D';
+
+export interface AppendPhaseHint {
+  position: 'after' | 'before';
+  anchor_phase: string;
+  proposed_id: string;
+  goal: string;
+  covers: string[];
+}
+
+export interface DiagnosisResult {
+  prompt_version: string;
+  classification: Classification;
+  root_cause: string;
+  fix_strategy: string;
+  iter_hint: number;
+  trace_excerpt: string;
+  append_phases: AppendPhaseHint[];
+  confidence: number;
+}
+
+export interface DiagnoserInput {
+  scenarios: string;
+  e2e_results: string;
+  trace_excerpt: string;
+  user_contract: string;
+  decomposition: string;
+  prev_iter: number;
+}
+
+const DIAGNOSE_PROMPT = `You are the MPL E2E Failure Diagnoser.
+
+GOAL: Given a failing E2E run context, classify the root cause and propose a fix
+strategy. You do NOT write code. You produce a structured verdict that the
+orchestrator and decomposer will act on.
+
+CLASSIFICATION RULES (pick exactly one):
+- A = spec gap               (implementation is missing behavior required by the
+                              failing scenario; new phase(s) must be appended.
+                              Fill append_phases with 1-3 hints.)
+- B = test bug               (implementation behavior is correct; the test
+                              itself is wrong — wrong selector, wrong assertion,
+                              wrong setup. Point to the specific test.)
+- C = missing capability     (the scenario exercises a UC that was not declared
+                              in user-contract.md — Step 1.5 must re-run in
+                              minimal mode to append the missing UC.)
+- D = flake                  (non-deterministic environmental failure:
+                              timing, network jitter, resource contention.
+                              Rerun once with trace on.)
+
+FIELDS:
+- root_cause: 1-2 sentences, concrete, referencing specific files/symbols/lines
+  from the provided context.
+- fix_strategy: 1-3 sentences, actionable. For A reference append_phases.
+  For B name the test file. For C name the uncovered UC. For D state the
+  timing/env signal.
+- iter_hint: suggested iter bump for circuit breaker (0, 1, or 2). D typically
+  iter=0 (doesn't count against budget). A/B/C typically iter=1.
+- trace_excerpt: 200-char max excerpt quoting the most damning trace line(s).
+- append_phases: ONLY populated when classification=A. Otherwise empty array.
+- confidence: 0.0..1.0, your confidence in the classification.
+
+RESPOND ONLY WITH VALID JSON (no markdown, no prose):
+{
+  "classification": "A|B|C|D",
+  "root_cause": "",
+  "fix_strategy": "",
+  "iter_hint": 1,
+  "trace_excerpt": "",
+  "append_phases": [],
+  "confidence": 0.85
+}`;
+
+function buildUserMessage(input: DiagnoserInput): string {
+  return [
+    `Scenarios YAML:\n${input.scenarios}`,
+    `E2E Results JSON:\n${input.e2e_results}`,
+    `Trace Excerpt:\n${input.trace_excerpt}`,
+    `User Contract:\n${input.user_contract}`,
+    `Decomposition YAML:\n${input.decomposition}`,
+    `Previous iter: ${input.prev_iter}`,
+  ].join('\n\n');
+}
+
+export function parseDiagnosis(text: string): DiagnosisResult | null {
+  try {
+    const match = text.match(/\{[\s\S]*\}/);
+    if (!match) return null;
+    const p = JSON.parse(match[0]);
+
+    if (!['A', 'B', 'C', 'D'].includes(p.classification)) return null;
+    if (typeof p.root_cause !== 'string') return null;
+    if (typeof p.fix_strategy !== 'string') return null;
+    if (typeof p.iter_hint !== 'number') return null;
+    if (typeof p.trace_excerpt !== 'string') return null;
+    if (!Array.isArray(p.append_phases)) return null;
+    if (typeof p.confidence !== 'number') return null;
+
+    return {
+      prompt_version: PROMPT_VERSION,
+      classification: p.classification as Classification,
+      root_cause: p.root_cause,
+      fix_strategy: p.fix_strategy,
+      iter_hint: Math.max(0, Math.min(2, Math.floor(p.iter_hint))),
+      trace_excerpt: p.trace_excerpt.slice(0, 400),
+      append_phases: p.append_phases,
+      confidence: Math.max(0, Math.min(1, p.confidence)),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function neutralDiagnosis(): DiagnosisResult {
+  return {
+    prompt_version: PROMPT_VERSION,
+    classification: 'D',
+    root_cause:
+      'Diagnoser LLM unavailable — defaulting to flake classification to avoid falsely appending phases.',
+    fix_strategy:
+      'Rerun once. If failure reproduces, escalate to manual review; do NOT auto-append phases under uncertainty.',
+    iter_hint: 1,
+    trace_excerpt: '',
+    append_phases: [],
+    confidence: 0,
+  };
+}
+
+export async function diagnoseE2EFailure(
+  input: DiagnoserInput,
+): Promise<DiagnosisResult> {
+  const fullPrompt = `${DIAGNOSE_PROMPT}\n\nINPUT:\n${buildUserMessage(input)}`;
+
+  let queryFn:
+    | typeof import('@anthropic-ai/claude-agent-sdk').query
+    | null = null;
+  try {
+    const sdk = await import('@anthropic-ai/claude-agent-sdk');
+    queryFn = sdk.query;
+  } catch {
+    return neutralDiagnosis();
+  }
+
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      const opts: Record<string, unknown> = {
+        model: 'opus',
+        maxTurns: 1,
+        systemPrompt:
+          'You are a JSON-only E2E failure diagnoser. Output only valid JSON per the schema.',
+        allowedTools: [],
+      };
+      if (cachedSessionId) opts.sessionId = cachedSessionId;
+
+      const q = queryFn({ prompt: fullPrompt, options: opts });
+      let responseText = '';
+      for await (const event of q) {
+        if (event.type === 'result' && event.subtype === 'success') {
+          responseText = (event as { result: string }).result;
+          const sid = (event as { sessionId?: string }).sessionId;
+          if (sid) cachedSessionId = sid;
+        } else if (event.type === 'assistant') {
+          const msg = event.message as {
+            content?: Array<{ type: string; text?: string }>;
+          };
+          if (msg.content) {
+            for (const block of msg.content) {
+              if (block.type === 'text' && block.text) {
+                responseText += block.text;
+              }
+            }
+          }
+        } else if ((event as { sessionId?: string }).sessionId) {
+          const sid = (event as { sessionId?: string }).sessionId;
+          if (sid) cachedSessionId = sid;
+        }
+      }
+
+      const parsed = parseDiagnosis(responseText);
+      if (parsed) return parsed;
+    } catch {
+      if (attempt === MAX_RETRIES) return neutralDiagnosis();
+    }
+  }
+
+  return neutralDiagnosis();
+}

--- a/mcp-server/src/lib/feature-classifier.ts
+++ b/mcp-server/src/lib/feature-classifier.ts
@@ -1,0 +1,272 @@
+/**
+ * Feature Scope Classifier — LLM-driven UC classification for 0.16 Tier A'.
+ *
+ * Uses the Claude Agent SDK (session auth, no API key) following the same
+ * pattern as llm-scorer.ts. Given spec + pivot points + user responses,
+ * classifies features into included / deferred / cut, extracts scenarios,
+ * records PP conflicts, and suggests the next clarifying question.
+ *
+ * PROMPT_VERSION is frozen inline — changing the prompt requires bumping
+ * the version so exp12 measurements can detect prompt drift.
+ */
+
+export const PROMPT_VERSION = 'v1-2026-04-19';
+
+const MAX_RETRIES = 2;
+
+let cachedSessionId: string | null = null;
+
+export interface UserCase {
+  id: string;
+  title: string;
+  user_delta: string;
+  priority: 'P0' | 'P1' | 'P2';
+  status: 'included';
+  covers_pp: string[];
+  acceptance_hint?: string;
+}
+
+export interface DeferredCase {
+  id: string;
+  title: string;
+  reason: string;
+  revisit_at: string;
+  source_round: number;
+}
+
+export interface CutCase {
+  id: string;
+  title: string;
+  reason: string;
+  source_round: number;
+}
+
+export interface ScenarioSpec {
+  id: string;
+  title: string;
+  covers: string[];
+  covers_pp: string[];
+  steps: string[];
+  skip_allowed: string[];
+}
+
+export interface PpConflict {
+  uc_id: string;
+  pp_id: string;
+  conflict_type: 'direct' | 'boundary' | 'performance';
+  resolution: 'uc_dropped' | 'uc_reshaped' | 'pp_reaffirmed';
+  round: number;
+  note: string;
+}
+
+export interface AmbiguityHint {
+  uc_id: string;
+  dimension:
+    | 'specificity'
+    | 'priority'
+    | 'dependency'
+    | 'boundary'
+    | 'success_criteria';
+  suggestion: string;
+}
+
+export interface NextQuestion {
+  kind: 'clarify' | 'priority' | 'conflict';
+  payload: Record<string, unknown>;
+}
+
+export interface ClassificationResult {
+  prompt_version: string;
+  user_cases: UserCase[];
+  deferred: DeferredCase[];
+  cut: CutCase[];
+  scenarios: ScenarioSpec[];
+  pp_conflict: PpConflict[];
+  ambiguity_hints: AmbiguityHint[];
+  next_question: NextQuestion | null;
+  convergence: boolean;
+}
+
+const CLASSIFY_PROMPT = `You are the MPL Feature Scope Classifier (0.16 Tier A').
+
+GOAL: Produce a deterministic JSON classification of user-facing features for the
+input spec + Pivot Points + user responses. Do NOT implement anything. Do NOT
+prescribe architecture. Only classify scope.
+
+RULES:
+1. Every included user_case MUST list at least one covers_pp id (PP-N) drawn from
+   the supplied Pivot Points. If no PP matches, record it as pp_conflict with
+   resolution "pp_reaffirmed" and move the candidate to cut or deferred.
+2. user_delta is the key field: non-empty iff the UC was NOT derivable from the
+   spec alone (i.e., surfaced via user responses). Spec-only UCs use "".
+3. Use UC-NN ids with 2+ digits (UC-01, UC-15). Prefer stable ids across
+   iterations — if prev_contract shows a UC, keep that id.
+4. deferred_cases have a reason and revisit_at ("post-v0.17" / "after-UC-03" /
+   "on-user-request"). cut_cases are permanent out-of-scope.
+5. scenarios are E2E test seeds. Each scenario covers at least 1 UC. covers_pp
+   is the union of covers[*].covers_pp.
+6. skip_allowed: list environmental skip reasons that are acceptable for this
+   scenario (ENV_API_DOWN, FLAKY_NETWORK, DEPENDENCY_MISSING, RATE_LIMIT,
+   OS_INCOMPATIBLE). Empty array means strict (no skip allowed).
+7. next_question: set to null only when convergence is true. Otherwise propose
+   ONE targeted question to close the highest-uncertainty gap.
+8. convergence: true only when every included UC has covers_pp, no unresolved
+   pp_conflict exists, and no ambiguity_hint has dimension "priority" or
+   "boundary".
+
+RESPOND ONLY WITH VALID JSON (no markdown, no prose):
+{
+  "user_cases": [{ "id": "UC-01", "title": "", "user_delta": "", "priority": "P0|P1|P2", "status": "included", "covers_pp": ["PP-1"], "acceptance_hint": "" }],
+  "deferred": [{ "id": "UC-0X", "title": "", "reason": "", "revisit_at": "", "source_round": 1 }],
+  "cut": [{ "id": "UC-0X", "title": "", "reason": "", "source_round": 1 }],
+  "scenarios": [{ "id": "SC-01", "title": "", "covers": ["UC-01"], "covers_pp": ["PP-1"], "steps": [""], "skip_allowed": [] }],
+  "pp_conflict": [{ "uc_id": "UC-0X", "pp_id": "PP-X", "conflict_type": "direct|boundary|performance", "resolution": "uc_dropped|uc_reshaped|pp_reaffirmed", "round": 1, "note": "" }],
+  "ambiguity_hints": [{ "uc_id": "UC-0X", "dimension": "specificity|priority|dependency|boundary|success_criteria", "suggestion": "" }],
+  "next_question": null,
+  "convergence": false
+}`;
+
+function buildUserMessage(input: ClassifierInput): string {
+  let msg = `Spec:\n${input.spec_text || '(empty)'}\n\nPivot Points:\n${input.pivot_points}\n\nUser Responses:\n${input.user_responses}`;
+  if (input.prev_contract) {
+    msg += `\n\nPrevious Iteration Contract (for id stability):\n${input.prev_contract}`;
+  }
+  msg += `\n\nRound: ${input.round}`;
+  return msg;
+}
+
+export interface ClassifierInput {
+  spec_text: string;
+  pivot_points: string;
+  user_responses: string;
+  prev_contract?: string;
+  round: number;
+}
+
+export function parseClassification(text: string): ClassificationResult | null {
+  try {
+    const jsonMatch = text.match(/\{[\s\S]*\}/);
+    if (!jsonMatch) return null;
+    const parsed = JSON.parse(jsonMatch[0]);
+
+    // Structural sanity
+    const requiredArrays = [
+      'user_cases',
+      'deferred',
+      'cut',
+      'scenarios',
+      'pp_conflict',
+      'ambiguity_hints',
+    ];
+    for (const key of requiredArrays) {
+      if (!Array.isArray(parsed[key])) return null;
+    }
+    if (typeof parsed.convergence !== 'boolean') return null;
+    if (parsed.next_question !== null && typeof parsed.next_question !== 'object') {
+      return null;
+    }
+
+    return {
+      prompt_version: PROMPT_VERSION,
+      user_cases: parsed.user_cases,
+      deferred: parsed.deferred,
+      cut: parsed.cut,
+      scenarios: parsed.scenarios,
+      pp_conflict: parsed.pp_conflict,
+      ambiguity_hints: parsed.ambiguity_hints,
+      next_question: parsed.next_question,
+      convergence: parsed.convergence,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function neutralResult(): ClassificationResult {
+  return {
+    prompt_version: PROMPT_VERSION,
+    user_cases: [],
+    deferred: [],
+    cut: [],
+    scenarios: [],
+    pp_conflict: [],
+    ambiguity_hints: [
+      {
+        uc_id: 'UC-00',
+        dimension: 'specificity',
+        suggestion:
+          'LLM classifier unavailable. Provide UC list manually or retry after restoring Agent SDK access.',
+      },
+    ],
+    next_question: {
+      kind: 'clarify',
+      payload: {
+        reason: 'classifier_unavailable',
+        instruction:
+          'Agent SDK not reachable; the orchestrator should degrade to a manual spec-only UC extraction or halt.',
+      },
+    },
+    convergence: false,
+  };
+}
+
+export async function classifyFeatureScope(
+  input: ClassifierInput,
+): Promise<ClassificationResult> {
+  const userMessage = buildUserMessage(input);
+  const fullPrompt = `${CLASSIFY_PROMPT}\n\nINPUT:\n${userMessage}`;
+
+  let queryFn:
+    | typeof import('@anthropic-ai/claude-agent-sdk').query
+    | null = null;
+  try {
+    const sdk = await import('@anthropic-ai/claude-agent-sdk');
+    queryFn = sdk.query;
+  } catch {
+    return neutralResult();
+  }
+
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      const queryOptions: Record<string, unknown> = {
+        model: 'opus',
+        maxTurns: 1,
+        systemPrompt:
+          'You are a JSON-only classification assistant. Output only valid JSON per the schema.',
+        allowedTools: [],
+      };
+      if (cachedSessionId) queryOptions.sessionId = cachedSessionId;
+
+      const q = queryFn({ prompt: fullPrompt, options: queryOptions });
+      let responseText = '';
+      for await (const event of q) {
+        if (event.type === 'result' && event.subtype === 'success') {
+          responseText = (event as { result: string }).result;
+          const sessionId = (event as { sessionId?: string }).sessionId;
+          if (sessionId) cachedSessionId = sessionId;
+        } else if (event.type === 'assistant') {
+          const msg = event.message as {
+            content?: Array<{ type: string; text?: string }>;
+          };
+          if (msg.content) {
+            for (const block of msg.content) {
+              if (block.type === 'text' && block.text) {
+                responseText += block.text;
+              }
+            }
+          }
+        } else if ((event as { sessionId?: string }).sessionId) {
+          const sessionId = (event as { sessionId?: string }).sessionId;
+          if (sessionId) cachedSessionId = sessionId;
+        }
+      }
+
+      const parsed = parseClassification(responseText);
+      if (parsed) return parsed;
+    } catch {
+      if (attempt === MAX_RETRIES) return neutralResult();
+    }
+  }
+
+  return neutralResult();
+}

--- a/mcp-server/src/lib/state-manager.ts
+++ b/mcp-server/src/lib/state-manager.ts
@@ -49,6 +49,10 @@ export interface MplState {
   resume_from_phase: string | null;
   pause_timestamp: string | null;
   budget_at_pause: Record<string, unknown> | null;
+  // 0.16 Tier A' — user contract tracking
+  user_contract_set: boolean;
+  user_contract_path: string | null;
+  user_contract_iterations: number;
   [key: string]: unknown;
 }
 
@@ -92,6 +96,9 @@ const DEFAULT_STATE: MplState = {
   resume_from_phase: null,
   pause_timestamp: null,
   budget_at_pause: null,
+  user_contract_set: false,
+  user_contract_path: null,
+  user_contract_iterations: 0,
 };
 
 function deepMerge(target: Record<string, unknown>, source: Record<string, unknown>): Record<string, unknown> {

--- a/mcp-server/src/lib/state-manager.ts
+++ b/mcp-server/src/lib/state-manager.ts
@@ -53,6 +53,15 @@ export interface MplState {
   user_contract_set: boolean;
   user_contract_path: string | null;
   user_contract_iterations: number;
+  // 0.16 Tier C — E2E recovery circuit breaker + last diagnosis snapshot
+  e2e_recovery: {
+    iter: number;
+    max_iter: number;
+    last_classification: 'A' | 'B' | 'C' | 'D' | null;
+    last_diagnosis: Record<string, unknown> | null;
+    halted: boolean;
+    halt_reason: string | null;
+  };
   [key: string]: unknown;
 }
 
@@ -99,6 +108,14 @@ const DEFAULT_STATE: MplState = {
   user_contract_set: false,
   user_contract_path: null,
   user_contract_iterations: 0,
+  e2e_recovery: {
+    iter: 0,
+    max_iter: 2,
+    last_classification: null,
+    last_diagnosis: null,
+    halted: false,
+    halt_reason: null,
+  },
 };
 
 function deepMerge(target: Record<string, unknown>, source: Record<string, unknown>): Record<string, unknown> {

--- a/mcp-server/src/tools/e2e-diagnose.ts
+++ b/mcp-server/src/tools/e2e-diagnose.ts
@@ -1,0 +1,101 @@
+/**
+ * MCP Tool: mpl_diagnose_e2e_failure
+ *
+ * 0.16 Tier C classifier. Orchestrator calls this conditionally from Finalize
+ * when every required scenario ran but one or more failed AND user-contract UC
+ * coverage is complete. Returns a classification + fix strategy JSON that the
+ * orchestrator then acts on (append phases / re-test-agent / re-Step-1.5 /
+ * rerun).
+ *
+ * Budget: expected cost <= 1 opus call per finalize failure. Circuit breaker
+ * (state.e2e_recovery.iter, max=2) caps total diagnose calls per pipeline.
+ */
+
+import {
+  diagnoseE2EFailure,
+  PROMPT_VERSION,
+} from '../lib/e2e-diagnoser.js';
+
+export const diagnoseE2EFailureTool = {
+  name: 'mpl_diagnose_e2e_failure',
+  description:
+    'Classify a failing E2E run as A=spec gap / B=test bug / C=missing capability / D=flake and return a fix strategy. Called conditionally by Finalize (Tier C UC coverage complete + E2E fail). Max 2 invocations per pipeline (circuit breaker).',
+  inputSchema: {
+    type: 'object' as const,
+    properties: {
+      cwd: { type: 'string', description: 'Project root directory' },
+      scenarios: {
+        type: 'string',
+        description: 'Contents of .mpl/mpl/e2e-scenarios.yaml',
+      },
+      e2e_results: {
+        type: 'string',
+        description:
+          'JSON of state.e2e_results (scenario_id → { exit_code, stdout_tail, stderr_tail, trace_path? })',
+      },
+      trace_excerpt: {
+        type: 'string',
+        description:
+          'Concatenated failing-scenario trace excerpts (best-effort, 4KB max). Orchestrator prepares from trace files.',
+      },
+      user_contract: {
+        type: 'string',
+        description: 'Contents of .mpl/requirements/user-contract.md',
+      },
+      decomposition: {
+        type: 'string',
+        description: 'Contents of .mpl/mpl/decomposition.yaml',
+      },
+      prev_iter: {
+        type: 'number',
+        description:
+          'state.e2e_recovery.iter before this call. Used for iter_hint bookkeeping.',
+      },
+    },
+    required: [
+      'cwd',
+      'scenarios',
+      'e2e_results',
+      'trace_excerpt',
+      'user_contract',
+      'decomposition',
+      'prev_iter',
+    ],
+  },
+};
+
+export async function handleDiagnoseE2EFailure(args: {
+  cwd: string;
+  scenarios: string;
+  e2e_results: string;
+  trace_excerpt: string;
+  user_contract: string;
+  decomposition: string;
+  prev_iter: number;
+}) {
+  const prev_iter = Math.max(0, Math.min(2, Math.floor(args.prev_iter)));
+  const result = await diagnoseE2EFailure({
+    scenarios: args.scenarios,
+    e2e_results: args.e2e_results,
+    trace_excerpt: args.trace_excerpt,
+    user_contract: args.user_contract,
+    decomposition: args.decomposition,
+    prev_iter,
+  });
+
+  const ordered = {
+    prompt_version: PROMPT_VERSION,
+    prev_iter,
+    classification: result.classification,
+    root_cause: result.root_cause,
+    fix_strategy: result.fix_strategy,
+    iter_hint: result.iter_hint,
+    trace_excerpt: result.trace_excerpt,
+    append_phases: result.append_phases,
+    confidence: result.confidence,
+  };
+
+  return {
+    content: [{ type: 'text' as const, text: JSON.stringify(ordered, null, 2) }],
+  };
+}

--- a/mcp-server/src/tools/feature-scope.ts
+++ b/mcp-server/src/tools/feature-scope.ts
@@ -1,0 +1,95 @@
+/**
+ * MCP Tool: mpl_classify_feature_scope
+ *
+ * Orchestrator-driven Feature Scope classification for 0.16 Tier A'.
+ * Called during Phase 0 Step 1.5 (inline loop, after PP Discovery).
+ *
+ * Returns a structured classification:
+ *   - user_cases (included), deferred, cut
+ *   - scenarios (E2E test seeds)
+ *   - pp_conflict (UC ↔ PP conflict ledger)
+ *   - ambiguity_hints (for Stage 2 Ambiguity Resolution)
+ *   - next_question (null iff convergence)
+ *   - convergence (boolean)
+ *
+ * Pattern: deterministic return shape; LLM call (opus, session auth) handled
+ * inside lib/feature-classifier.ts. Matches mpl_score_ambiguity style.
+ */
+
+import {
+  classifyFeatureScope,
+  PROMPT_VERSION,
+} from '../lib/feature-classifier.js';
+
+export const classifyFeatureScopeTool = {
+  name: 'mpl_classify_feature_scope',
+  description:
+    'Classify user-facing feature scope into included/deferred/cut UCs + scenarios + PP conflict ledger. Orchestrator calls this inline during Phase 0 Step 1.5 until convergence.',
+  inputSchema: {
+    type: 'object' as const,
+    properties: {
+      cwd: { type: 'string', description: 'Project root directory' },
+      spec_text: {
+        type: 'string',
+        description: 'Raw spec / PRD content',
+      },
+      pivot_points: {
+        type: 'string',
+        description: 'Pivot Points markdown content (read-only — classifier must not modify PPs)',
+      },
+      user_responses: {
+        type: 'string',
+        description:
+          'Concatenated user responses from Step 1.5 interview rounds (format: round N: Q: .. A: ..)',
+      },
+      prev_contract: {
+        type: 'string',
+        description:
+          'Previous iteration user-contract.md content, for UC id stability (optional)',
+      },
+      round: {
+        type: 'number',
+        description:
+          'Current iteration number (1..4). Recorded in source_round fields.',
+      },
+    },
+    required: ['cwd', 'spec_text', 'pivot_points', 'user_responses', 'round'],
+  },
+};
+
+export async function handleClassifyFeatureScope(args: {
+  cwd: string;
+  spec_text: string;
+  pivot_points: string;
+  user_responses: string;
+  prev_contract?: string;
+  round: number;
+}) {
+  const round = Math.max(1, Math.min(4, Math.floor(args.round)));
+
+  const result = await classifyFeatureScope({
+    spec_text: args.spec_text,
+    pivot_points: args.pivot_points,
+    user_responses: args.user_responses,
+    prev_contract: args.prev_contract,
+    round,
+  });
+
+  // Ensure deterministic field order at the top level for caller parsing stability
+  const ordered = {
+    prompt_version: PROMPT_VERSION,
+    round,
+    user_cases: result.user_cases,
+    deferred: result.deferred,
+    cut: result.cut,
+    scenarios: result.scenarios,
+    pp_conflict: result.pp_conflict,
+    ambiguity_hints: result.ambiguity_hints,
+    next_question: result.next_question,
+    convergence: result.convergence,
+  };
+
+  return {
+    content: [{ type: 'text' as const, text: JSON.stringify(ordered, null, 2) }],
+  };
+}


### PR DESCRIPTION
## Summary

0.16 Stage 3 — complete E2E contract enforcement and automated failure recovery. Closes the final gap identified in ygg-exp11 (42/80 skip-committed scenarios, no structural way to recover from E2E fail without HITL).

Two commits on this branch:
- `f4c6c38`: Tier C UC coverage gate + `mpl_diagnose_e2e_failure` MCP tool + circuit-breaker state fields
- `c8b1722`: Finalize Step 5.0.4 auto-recovery + decomposer APPEND-MODE + Playwright trace + exp12 plan

### Primary changes

| Task | Change |
|---|---|
| **S3-1** | `mpl-require-e2e.mjs` extended with Tier C UC-coverage diff gate (strict default + opt-out). 12 new unit tests. |
| **S3-2** | New MCP tool `mpl_diagnose_e2e_failure` (classifier A/B/C/D + fix_strategy + append_phases). 13 new unit tests. |
| **S3-3** | Finalize Step 5.0.4 inserts an automated recovery loop before the existing HITL fallback. Circuit breaker iter=2 stores `last_diagnosis` for inline resume (Q9). |
| **S3-4** | Decomposer APPEND-MODE (Rule 9) consumes `append_phases` from the diagnostician to spawn mini-phases without rewriting existing ones. |
| **S3-5** | `state.e2e_recovery = { iter, max_iter=2, last_classification, last_diagnosis, halted, halt_reason }`. |
| **S3-6** | Step 5.0.3 auto-wraps Playwright test commands with `--trace on`, writes to `.mpl/e2e-traces/<scenario_id>/`, records `trace_path` in state. |
| **S3-7** | `docs/roadmap/0.16-exp12-plan.md` defines 5 primary metrics with baseline vs target columns, plus Q8 auxiliary-LLM labeling protocol for Stage 4 sunset/promotion. |

## Context

- Base branch: `feat/0.16-s2-feature-mcp` (PR #46) — depends on state fields + `mpl_classify_feature_scope`
- Debate decision: `~/project/decision/2026-04-19-mpl-0.16-implementation-plan.md`
- Resume plan: `~/project/wiki/scratch/2026-04-19/mpl-0.16-implementation-resume-plan.md` §3 Stage 3

## Test plan

- [x] `cd mcp-server && npm test` — 25/25 pass (12 feature + 13 diagnoser)
- [x] `cd mcp-server && npm run build` — clean TypeScript compile
- [x] `npm test` (hooks) — 272/273 pass (1 pre-existing `mpl-state` failure unrelated)
- [x] `mpl-require-e2e.test.mjs` — 12/12 pass (parseUserContractText, computeUncoveredUcs)
- [x] `e2e-diagnoser.test.mjs` — 13/13 pass (parseDiagnosis clamping + neutralDiagnosis fallback)
- [ ] End-to-end: exp12 on Yggdrasil spec — scheduled for Stage 4 gate

## Next (Stage 4 — conditional, post-exp12)

- Run exp12 per `docs/roadmap/0.16-exp12-plan.md`
- Collect B/D agreement rate via auxiliary LLM labeling (Q8)
- 4-agent debate: promote `mpl_diagnose_e2e_failure` to agent file, keep as MCP tool, or sunset
- `/mpl:mpl-version-bump` to 0.16.0 + migration guide

🤖 Generated with [Claude Code](https://claude.com/claude-code)