### PR TITLE
feat(0.16): Stage 2 — mpl_classify_feature_scope MCP + orchestrator Step 1.5 (rebased)

### DIFF
--- a/commands/mpl-run-phase0.md
+++ b/commands/mpl-run-phase0.md
@@ -545,6 +545,125 @@ PP States: **CONFIRMED** (hard constraint, auto-reject on conflict) / **PROVISIO
 
 ---
 
+## Step 1.5: User Contract Interview (orchestrator inline + MCP) [0.16 Tier A']
+
+**Purpose**: Capture the mutable user feature scope (UCs) into
+`.mpl/requirements/user-contract.md`, strictly separated from the immutable
+Pivot Points. This step directly addresses ygg-exp11's "user-feature 포착 0건"
+gap by making user delta a first-class output.
+
+**Pattern**: Same as Stage 2 Ambiguity Resolution — orchestrator drives the
+loop inline; no subagent dispatch. The orchestrator calls
+`mpl_classify_feature_scope` MCP tool and interleaves `AskUserQuestion` between
+iterations. Max 4 iterations.
+
+**Activation**: After Step 1 (PP Discovery) completes and `pivot-points.md` is
+written, BEFORE Step 1-B.
+
+**Skip condition**: Legacy projects (pre-0.16) with no `.mpl/requirements/`
+directory — the orchestrator skips Step 1.5 and writes a graceful-skip
+`user-contract.md` containing `user_cases: []` and spec-auto-extracted
+`scenarios`. The user can re-run Step 1.5 manually via `/mpl:mpl` in a later
+session.
+
+### Orchestrator Loop (inline, no subagent)
+
+```
+// Preconditions: .mpl/pivot-points.md exists and is CONFIRMED
+Read .mpl/pivot-points.md
+Read the spec/PRD text (from user or spec file)
+
+iteration = 1
+max_iterations = 4
+accumulated_user_responses = ""  // concatenated as "round N: Q: .. A: .."
+prev_contract = null             // set on iteration 2+ if .mpl/requirements/user-contract.md exists
+
+loop:
+  // 1. Call the classifier MCP tool
+  result = mpl_classify_feature_scope({
+    cwd,
+    spec_text,
+    pivot_points: <contents of .mpl/pivot-points.md>,
+    user_responses: accumulated_user_responses,
+    prev_contract,
+    round: iteration,
+  })
+
+  // 2. Check convergence
+  if result.convergence == true:
+    break
+
+  // 3. Ask the user the classifier's next_question
+  if result.next_question == null:
+    // Classifier says not converged but no question — treat as unrecoverable,
+    // write a best-effort contract and break
+    break
+
+  answer = AskUserQuestion({
+    question: formatQuestion(result.next_question),
+    header: shortHeaderFor(result.next_question.kind),
+    options: optionsFrom(result.next_question.payload),
+  })
+
+  accumulated_user_responses += `\nround ${iteration}: Q: ${formatQuestion(result.next_question)} A: ${answer}`
+  iteration += 1
+
+  if iteration > max_iterations:
+    break
+
+// 4. Persist
+Write .mpl/requirements/user-contract.md from result (YAML per
+  docs/schemas/user-contract.md)
+
+mpl_state_write({
+  user_contract_set: true,
+  user_contract_path: ".mpl/requirements/user-contract.md",
+  user_contract_iterations: iteration,
+})
+
+Announce: `[MPL] Step 1.5 complete. user_cases=${result.user_cases.length} deferred=${result.deferred.length} cut=${result.cut.length} scenarios=${result.scenarios.length} iterations=${iteration}.`
+```
+
+### `formatQuestion` / `optionsFrom` (orchestrator helpers)
+
+These are orchestrator-local formatting rules, NOT embedded in the MCP tool.
+
+- `formatQuestion(nq)`: `nq.payload.question` if provided, else a template derived from `nq.kind`:
+  - `clarify` → `"Clarify: ${payload.focus || 'the UC scope'}"`
+  - `priority` → `"Priority ordering for: ${payload.uc_ids?.join(', ')}"`
+  - `conflict` → `"PP conflict on ${payload.uc_id} vs ${payload.pp_id} — how to resolve?"`
+- `optionsFrom(payload)`: if `payload.options` is an array of `{label, description}`, pass through;
+  otherwise provide 3-4 generated options per kind (see `agents/mpl-interviewer.md` Hypothesis-as-Options pattern).
+  ALWAYS append a catch-all `"Other (enter manually)"` option.
+
+### Convergence Fallback
+
+If iteration == max_iterations and convergence == false:
+1. Write the current (incomplete) classification as user-contract.md with a top-level
+   frontmatter field `schema_version: 1` and `converged: false`.
+2. Record unresolved items as `ambiguity_hints[]` so Stage 2 Ambiguity Resolution
+   can pick them up.
+3. Announce: `[MPL] Step 1.5 stopped at max_iterations=4 without convergence. ${result.ambiguity_hints.length} unresolved hints forwarded to Stage 2.`
+
+### Downstream Consumers
+
+| Output | Consumer | Usage |
+|--------|----------|-------|
+| `.mpl/requirements/user-contract.md` | Decomposer (Step 3), Test Agent, Hooks | UC list + scenarios + skip_allowed |
+| `user_contract_set` in state | `mpl-phase-controller` hook | Gate before decomposer dispatch |
+| `scenarios[*]` | Test Agent (Step 3-B) | E2E scenario seeds |
+| `pp_conflict[]` | Step 1-D PP Confirmation | Re-question for UC-dropped vs uc_reshaped vs pp_reaffirmed |
+| `ambiguity_hints[]` | Stage 2 Ambiguity Resolution (Step 2) | Targeted questions |
+
+### Field Boundary Guards
+
+- `mpl-validate-pp-schema.mjs` (0.16 S1-3) blocks any Write/Edit on
+  `.mpl/pivot-points.md` that introduces UC-scoped schema.
+- `mpl-require-covers.mjs` (0.16 S1-5) blocks decomposition.yaml writes that
+  don't reference UC ids from user-contract.md (or use the `"internal"` escape).
+
+---
+
 ## Step 1-B: Pre-Execution Analysis (Gap + Tradeoff)
 
 After PPs are confirmed, run unified pre-execution analysis to identify gaps AND assess risks in a single agent call.

--- a/commands/mpl-run.md
+++ b/commands/mpl-run.md
@@ -166,7 +166,7 @@ Only load the file needed for the current stage — this saves ~60-70% of contex
 
 | File | Steps | Contents | ~Tokens |
 |------|-------|----------|---------|
-| `mpl-run-phase0.md` | -1 ~ 1-E | LSP Warm-up, Triage, PP Interview, Pre-Execution Analysis | ~6K |
+| `mpl-run-phase0.md` | -1 ~ 1-E | LSP Warm-up, Triage, PP Interview, **Step 1.5 User Contract Interview (0.16)**, Pre-Execution Analysis | ~7K |
 | `mpl-run-phase0-analysis.md` | 2 ~ 2.5 | Codebase Analysis, Architecture Decisions, Phase 0 Enhanced | ~8K |
 | `mpl-run-phase0-memory.md` | 0.1.5b-c | 4-Tier Adaptive Memory, Routing Pattern Loading | ~2K |
 | `mpl-run-decompose.md` | 3 ~ 3-B | Phase Decomposition, Verification Planning (Critic absorbed into Decomposer) | ~3K |

--- a/hooks/mpl-ambiguity-gate.mjs
+++ b/hooks/mpl-ambiguity-gate.mjs
@@ -14,6 +14,7 @@
 
 import { dirname, join } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
+import { existsSync, readFileSync } from 'fs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -21,6 +22,22 @@ const __dirname = dirname(__filename);
 const { isMplActive, readState, writeState } = await import(
   pathToFileURL(join(__dirname, 'lib', 'mpl-state.mjs')).href
 );
+
+/**
+ * 0.16 Tier A' opt-out: legacy projects can disable the user-contract
+ * gate via .mpl/config.json { "user_contract_required": false }. Default true.
+ */
+function isUserContractRequired(cwd) {
+  try {
+    const cfgPath = join(cwd, '.mpl', 'config.json');
+    if (!existsSync(cfgPath)) return true;
+    const cfg = JSON.parse(readFileSync(cfgPath, 'utf-8'));
+    if (cfg && cfg.user_contract_required === false) return false;
+  } catch {
+    // fall through
+  }
+  return true;
+}
 
 const { readStdin } = await import(
   pathToFileURL(join(__dirname, 'lib', 'stdin.mjs')).href
@@ -67,6 +84,24 @@ async function main() {
     console.log(JSON.stringify({
       continue: false,
       reason: '[MPL] ⛔ Decomposer BLOCKED: Cannot read MPL state. Ensure .mpl/state.json exists.'
+    }));
+    return;
+  }
+
+  // 0.16 Tier A': Step 1.5 User Contract Interview must complete before decomposition.
+  // Gate is additive to ambiguity score — BOTH must pass. Legacy projects that pre-date
+  // 0.16 can opt out via .mpl/config.json { "user_contract_required": false }.
+  const contractRequired = isUserContractRequired(cwd);
+  const contractSet = state.user_contract_set === true;
+  if (contractRequired && !contractSet) {
+    writeState(cwd, { current_phase: 'mpl-init' });
+    console.log(JSON.stringify({
+      continue: false,
+      reason: '[MPL] ⛔ Decomposer BLOCKED: user_contract_set is false. ' +
+        'Run Phase 0 Step 1.5 first: orchestrator inline loop calling mpl_classify_feature_scope MCP tool ' +
+        'to produce .mpl/requirements/user-contract.md, then mpl_state_write({user_contract_set:true}). ' +
+        'See commands/mpl-run-phase0.md Step 1.5. ' +
+        'To opt out in legacy projects: set user_contract_required=false in .mpl/config.json.'
     }));
     return;
   }

--- a/mcp-server/__tests__/feature-classifier.test.mjs
+++ b/mcp-server/__tests__/feature-classifier.test.mjs
@@ -1,0 +1,130 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  PROMPT_VERSION,
+  parseClassification,
+  neutralResult,
+} from '../dist/lib/feature-classifier.js';
+
+describe('PROMPT_VERSION', () => {
+  it('is a frozen version string', () => {
+    assert.equal(typeof PROMPT_VERSION, 'string');
+    assert.ok(PROMPT_VERSION.length > 0);
+  });
+});
+
+describe('parseClassification', () => {
+  const validPayload = {
+    user_cases: [
+      {
+        id: 'UC-01',
+        title: 'User can log in',
+        user_delta: '',
+        priority: 'P0',
+        status: 'included',
+        covers_pp: ['PP-1'],
+        acceptance_hint: '',
+      },
+    ],
+    deferred: [],
+    cut: [],
+    scenarios: [
+      {
+        id: 'SC-01',
+        title: 'Login happy path',
+        covers: ['UC-01'],
+        covers_pp: ['PP-1'],
+        steps: ['visit /login', 'enter creds', 'assert /dashboard'],
+        skip_allowed: [],
+      },
+    ],
+    pp_conflict: [],
+    ambiguity_hints: [],
+    next_question: null,
+    convergence: true,
+  };
+
+  it('parses a valid JSON payload', () => {
+    const result = parseClassification(JSON.stringify(validPayload));
+    assert.ok(result);
+    assert.equal(result.convergence, true);
+    assert.equal(result.user_cases.length, 1);
+    assert.equal(result.user_cases[0].id, 'UC-01');
+    assert.equal(result.scenarios[0].id, 'SC-01');
+    assert.equal(result.prompt_version, PROMPT_VERSION);
+  });
+
+  it('parses JSON embedded in surrounding text', () => {
+    const wrapped = `Some preamble...\n${JSON.stringify(validPayload)}\nTrailing.`;
+    const result = parseClassification(wrapped);
+    assert.ok(result);
+    assert.equal(result.user_cases.length, 1);
+  });
+
+  it('returns null on empty input', () => {
+    assert.equal(parseClassification(''), null);
+    assert.equal(parseClassification(null), null);
+  });
+
+  it('returns null when required arrays are missing', () => {
+    const missingScenarios = { ...validPayload };
+    delete missingScenarios.scenarios;
+    assert.equal(parseClassification(JSON.stringify(missingScenarios)), null);
+  });
+
+  it('returns null when array field is not an array', () => {
+    const bad = { ...validPayload, user_cases: 'not-an-array' };
+    assert.equal(parseClassification(JSON.stringify(bad)), null);
+  });
+
+  it('returns null when convergence is missing or not boolean', () => {
+    const noConv = { ...validPayload };
+    delete noConv.convergence;
+    assert.equal(parseClassification(JSON.stringify(noConv)), null);
+
+    const badConv = { ...validPayload, convergence: 'yes' };
+    assert.equal(parseClassification(JSON.stringify(badConv)), null);
+  });
+
+  it('accepts non-null next_question object', () => {
+    const withQ = {
+      ...validPayload,
+      convergence: false,
+      next_question: { kind: 'clarify', payload: { uc_id: 'UC-01' } },
+    };
+    const result = parseClassification(JSON.stringify(withQ));
+    assert.ok(result);
+    assert.equal(result.next_question.kind, 'clarify');
+  });
+
+  it('rejects malformed JSON', () => {
+    assert.equal(parseClassification('{unclosed'), null);
+    assert.equal(parseClassification('not json at all'), null);
+  });
+});
+
+describe('neutralResult', () => {
+  it('returns a structurally valid fallback', () => {
+    const r = neutralResult();
+    assert.equal(r.prompt_version, PROMPT_VERSION);
+    assert.ok(Array.isArray(r.user_cases));
+    assert.ok(Array.isArray(r.deferred));
+    assert.ok(Array.isArray(r.cut));
+    assert.ok(Array.isArray(r.scenarios));
+    assert.ok(Array.isArray(r.pp_conflict));
+    assert.ok(Array.isArray(r.ambiguity_hints));
+    assert.equal(r.convergence, false);
+  });
+
+  it('emits a classifier_unavailable next_question', () => {
+    const r = neutralResult();
+    assert.ok(r.next_question);
+    assert.equal(r.next_question.kind, 'clarify');
+    assert.equal(r.next_question.payload.reason, 'classifier_unavailable');
+  });
+
+  it('records at least one ambiguity hint so orchestrator knows to degrade', () => {
+    const r = neutralResult();
+    assert.ok(r.ambiguity_hints.length >= 1);
+  });
+});

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
-    "start": "node dist/index.js"
+    "start": "node dist/index.js",
+    "test": "npm run build && node --test __tests__/*.test.mjs"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.81",

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -3,9 +3,11 @@
  * MPL MCP Server — Tier 1: Deterministic Scoring + Active State Access
  *
  * Tools:
- *   mpl_score_ambiguity  — 5D ambiguity scoring via LLM API (temp 0.1) + code computation
- *   mpl_state_read       — Read pipeline state (active agent access)
- *   mpl_state_write      — Update pipeline state (atomic, deep-merge)
+ *   mpl_score_ambiguity         — 5D ambiguity scoring via LLM API (temp 0.1) + code computation
+ *   mpl_state_read              — Read pipeline state (active agent access)
+ *   mpl_state_write             — Update pipeline state (atomic, deep-merge)
+ *   mpl_classify_feature_scope  — 0.16 Tier A': classify user cases (included/deferred/cut) +
+ *                                 scenarios + PP conflict ledger (called inline during Phase 0 Step 1.5)
  *
  * Transport: stdio (Claude Code standard)
  */
@@ -19,6 +21,10 @@ import {
 
 import { scoreAmbiguityTool, handleScoreAmbiguity } from './tools/scoring.js';
 import { stateReadTool, handleStateRead, stateWriteTool, handleStateWrite } from './tools/state.js';
+import {
+  classifyFeatureScopeTool,
+  handleClassifyFeatureScope,
+} from './tools/feature-scope.js';
 
 const server = new Server(
   { name: 'mpl-server', version: '0.6.6' },
@@ -27,7 +33,7 @@ const server = new Server(
 
 // Register tools
 server.setRequestHandler(ListToolsRequestSchema, async () => ({
-  tools: [scoreAmbiguityTool, stateReadTool, stateWriteTool],
+  tools: [scoreAmbiguityTool, stateReadTool, stateWriteTool, classifyFeatureScopeTool],
 }));
 
 // Handle tool calls
@@ -43,6 +49,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
     case 'mpl_state_write':
       return handleStateWrite(args as Parameters<typeof handleStateWrite>[0]);
+
+    case 'mpl_classify_feature_scope':
+      return handleClassifyFeatureScope(
+        args as Parameters<typeof handleClassifyFeatureScope>[0],
+      );
 
     default:
       return {

--- a/mcp-server/src/lib/feature-classifier.ts
+++ b/mcp-server/src/lib/feature-classifier.ts
@@ -1,0 +1,272 @@
+/**
+ * Feature Scope Classifier — LLM-driven UC classification for 0.16 Tier A'.
+ *
+ * Uses the Claude Agent SDK (session auth, no API key) following the same
+ * pattern as llm-scorer.ts. Given spec + pivot points + user responses,
+ * classifies features into included / deferred / cut, extracts scenarios,
+ * records PP conflicts, and suggests the next clarifying question.
+ *
+ * PROMPT_VERSION is frozen inline — changing the prompt requires bumping
+ * the version so exp12 measurements can detect prompt drift.
+ */
+
+export const PROMPT_VERSION = 'v1-2026-04-19';
+
+const MAX_RETRIES = 2;
+
+let cachedSessionId: string | null = null;
+
+export interface UserCase {
+  id: string;
+  title: string;
+  user_delta: string;
+  priority: 'P0' | 'P1' | 'P2';
+  status: 'included';
+  covers_pp: string[];
+  acceptance_hint?: string;
+}
+
+export interface DeferredCase {
+  id: string;
+  title: string;
+  reason: string;
+  revisit_at: string;
+  source_round: number;
+}
+
+export interface CutCase {
+  id: string;
+  title: string;
+  reason: string;
+  source_round: number;
+}
+
+export interface ScenarioSpec {
+  id: string;
+  title: string;
+  covers: string[];
+  covers_pp: string[];
+  steps: string[];
+  skip_allowed: string[];
+}
+
+export interface PpConflict {
+  uc_id: string;
+  pp_id: string;
+  conflict_type: 'direct' | 'boundary' | 'performance';
+  resolution: 'uc_dropped' | 'uc_reshaped' | 'pp_reaffirmed';
+  round: number;
+  note: string;
+}
+
+export interface AmbiguityHint {
+  uc_id: string;
+  dimension:
+    | 'specificity'
+    | 'priority'
+    | 'dependency'
+    | 'boundary'
+    | 'success_criteria';
+  suggestion: string;
+}
+
+export interface NextQuestion {
+  kind: 'clarify' | 'priority' | 'conflict';
+  payload: Record<string, unknown>;
+}
+
+export interface ClassificationResult {
+  prompt_version: string;
+  user_cases: UserCase[];
+  deferred: DeferredCase[];
+  cut: CutCase[];
+  scenarios: ScenarioSpec[];
+  pp_conflict: PpConflict[];
+  ambiguity_hints: AmbiguityHint[];
+  next_question: NextQuestion | null;
+  convergence: boolean;
+}
+
+const CLASSIFY_PROMPT = `You are the MPL Feature Scope Classifier (0.16 Tier A').
+
+GOAL: Produce a deterministic JSON classification of user-facing features for the
+input spec + Pivot Points + user responses. Do NOT implement anything. Do NOT
+prescribe architecture. Only classify scope.
+
+RULES:
+1. Every included user_case MUST list at least one covers_pp id (PP-N) drawn from
+   the supplied Pivot Points. If no PP matches, record it as pp_conflict with
+   resolution "pp_reaffirmed" and move the candidate to cut or deferred.
+2. user_delta is the key field: non-empty iff the UC was NOT derivable from the
+   spec alone (i.e., surfaced via user responses). Spec-only UCs use "".
+3. Use UC-NN ids with 2+ digits (UC-01, UC-15). Prefer stable ids across
+   iterations — if prev_contract shows a UC, keep that id.
+4. deferred_cases have a reason and revisit_at ("post-v0.17" / "after-UC-03" /
+   "on-user-request"). cut_cases are permanent out-of-scope.
+5. scenarios are E2E test seeds. Each scenario covers at least 1 UC. covers_pp
+   is the union of covers[*].covers_pp.
+6. skip_allowed: list environmental skip reasons that are acceptable for this
+   scenario (ENV_API_DOWN, FLAKY_NETWORK, DEPENDENCY_MISSING, RATE_LIMIT,
+   OS_INCOMPATIBLE). Empty array means strict (no skip allowed).
+7. next_question: set to null only when convergence is true. Otherwise propose
+   ONE targeted question to close the highest-uncertainty gap.
+8. convergence: true only when every included UC has covers_pp, no unresolved
+   pp_conflict exists, and no ambiguity_hint has dimension "priority" or
+   "boundary".
+
+RESPOND ONLY WITH VALID JSON (no markdown, no prose):
+{
+  "user_cases": [{ "id": "UC-01", "title": "", "user_delta": "", "priority": "P0|P1|P2", "status": "included", "covers_pp": ["PP-1"], "acceptance_hint": "" }],
+  "deferred": [{ "id": "UC-0X", "title": "", "reason": "", "revisit_at": "", "source_round": 1 }],
+  "cut": [{ "id": "UC-0X", "title": "", "reason": "", "source_round": 1 }],
+  "scenarios": [{ "id": "SC-01", "title": "", "covers": ["UC-01"], "covers_pp": ["PP-1"], "steps": [""], "skip_allowed": [] }],
+  "pp_conflict": [{ "uc_id": "UC-0X", "pp_id": "PP-X", "conflict_type": "direct|boundary|performance", "resolution": "uc_dropped|uc_reshaped|pp_reaffirmed", "round": 1, "note": "" }],
+  "ambiguity_hints": [{ "uc_id": "UC-0X", "dimension": "specificity|priority|dependency|boundary|success_criteria", "suggestion": "" }],
+  "next_question": null,
+  "convergence": false
+}`;
+
+function buildUserMessage(input: ClassifierInput): string {
+  let msg = `Spec:\n${input.spec_text || '(empty)'}\n\nPivot Points:\n${input.pivot_points}\n\nUser Responses:\n${input.user_responses}`;
+  if (input.prev_contract) {
+    msg += `\n\nPrevious Iteration Contract (for id stability):\n${input.prev_contract}`;
+  }
+  msg += `\n\nRound: ${input.round}`;
+  return msg;
+}
+
+export interface ClassifierInput {
+  spec_text: string;
+  pivot_points: string;
+  user_responses: string;
+  prev_contract?: string;
+  round: number;
+}
+
+export function parseClassification(text: string): ClassificationResult | null {
+  try {
+    const jsonMatch = text.match(/\{[\s\S]*\}/);
+    if (!jsonMatch) return null;
+    const parsed = JSON.parse(jsonMatch[0]);
+
+    // Structural sanity
+    const requiredArrays = [
+      'user_cases',
+      'deferred',
+      'cut',
+      'scenarios',
+      'pp_conflict',
+      'ambiguity_hints',
+    ];
+    for (const key of requiredArrays) {
+      if (!Array.isArray(parsed[key])) return null;
+    }
+    if (typeof parsed.convergence !== 'boolean') return null;
+    if (parsed.next_question !== null && typeof parsed.next_question !== 'object') {
+      return null;
+    }
+
+    return {
+      prompt_version: PROMPT_VERSION,
+      user_cases: parsed.user_cases,
+      deferred: parsed.deferred,
+      cut: parsed.cut,
+      scenarios: parsed.scenarios,
+      pp_conflict: parsed.pp_conflict,
+      ambiguity_hints: parsed.ambiguity_hints,
+      next_question: parsed.next_question,
+      convergence: parsed.convergence,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function neutralResult(): ClassificationResult {
+  return {
+    prompt_version: PROMPT_VERSION,
+    user_cases: [],
+    deferred: [],
+    cut: [],
+    scenarios: [],
+    pp_conflict: [],
+    ambiguity_hints: [
+      {
+        uc_id: 'UC-00',
+        dimension: 'specificity',
+        suggestion:
+          'LLM classifier unavailable. Provide UC list manually or retry after restoring Agent SDK access.',
+      },
+    ],
+    next_question: {
+      kind: 'clarify',
+      payload: {
+        reason: 'classifier_unavailable',
+        instruction:
+          'Agent SDK not reachable; the orchestrator should degrade to a manual spec-only UC extraction or halt.',
+      },
+    },
+    convergence: false,
+  };
+}
+
+export async function classifyFeatureScope(
+  input: ClassifierInput,
+): Promise<ClassificationResult> {
+  const userMessage = buildUserMessage(input);
+  const fullPrompt = `${CLASSIFY_PROMPT}\n\nINPUT:\n${userMessage}`;
+
+  let queryFn:
+    | typeof import('@anthropic-ai/claude-agent-sdk').query
+    | null = null;
+  try {
+    const sdk = await import('@anthropic-ai/claude-agent-sdk');
+    queryFn = sdk.query;
+  } catch {
+    return neutralResult();
+  }
+
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      const queryOptions: Record<string, unknown> = {
+        model: 'opus',
+        maxTurns: 1,
+        systemPrompt:
+          'You are a JSON-only classification assistant. Output only valid JSON per the schema.',
+        allowedTools: [],
+      };
+      if (cachedSessionId) queryOptions.sessionId = cachedSessionId;
+
+      const q = queryFn({ prompt: fullPrompt, options: queryOptions });
+      let responseText = '';
+      for await (const event of q) {
+        if (event.type === 'result' && event.subtype === 'success') {
+          responseText = (event as { result: string }).result;
+          const sessionId = (event as { sessionId?: string }).sessionId;
+          if (sessionId) cachedSessionId = sessionId;
+        } else if (event.type === 'assistant') {
+          const msg = event.message as {
+            content?: Array<{ type: string; text?: string }>;
+          };
+          if (msg.content) {
+            for (const block of msg.content) {
+              if (block.type === 'text' && block.text) {
+                responseText += block.text;
+              }
+            }
+          }
+        } else if ((event as { sessionId?: string }).sessionId) {
+          const sessionId = (event as { sessionId?: string }).sessionId;
+          if (sessionId) cachedSessionId = sessionId;
+        }
+      }
+
+      const parsed = parseClassification(responseText);
+      if (parsed) return parsed;
+    } catch {
+      if (attempt === MAX_RETRIES) return neutralResult();
+    }
+  }
+
+  return neutralResult();
+}

--- a/mcp-server/src/lib/state-manager.ts
+++ b/mcp-server/src/lib/state-manager.ts
@@ -49,6 +49,10 @@ export interface MplState {
   resume_from_phase: string | null;
   pause_timestamp: string | null;
   budget_at_pause: Record<string, unknown> | null;
+  // 0.16 Tier A' — user contract tracking
+  user_contract_set: boolean;
+  user_contract_path: string | null;
+  user_contract_iterations: number;
   [key: string]: unknown;
 }
 
@@ -92,6 +96,9 @@ const DEFAULT_STATE: MplState = {
   resume_from_phase: null,
   pause_timestamp: null,
   budget_at_pause: null,
+  user_contract_set: false,
+  user_contract_path: null,
+  user_contract_iterations: 0,
 };
 
 function deepMerge(target: Record<string, unknown>, source: Record<string, unknown>): Record<string, unknown> {

--- a/mcp-server/src/tools/feature-scope.ts
+++ b/mcp-server/src/tools/feature-scope.ts
@@ -1,0 +1,95 @@
+/**
+ * MCP Tool: mpl_classify_feature_scope
+ *
+ * Orchestrator-driven Feature Scope classification for 0.16 Tier A'.
+ * Called during Phase 0 Step 1.5 (inline loop, after PP Discovery).
+ *
+ * Returns a structured classification:
+ *   - user_cases (included), deferred, cut
+ *   - scenarios (E2E test seeds)
+ *   - pp_conflict (UC ↔ PP conflict ledger)
+ *   - ambiguity_hints (for Stage 2 Ambiguity Resolution)
+ *   - next_question (null iff convergence)
+ *   - convergence (boolean)
+ *
+ * Pattern: deterministic return shape; LLM call (opus, session auth) handled
+ * inside lib/feature-classifier.ts. Matches mpl_score_ambiguity style.
+ */
+
+import {
+  classifyFeatureScope,
+  PROMPT_VERSION,
+} from '../lib/feature-classifier.js';
+
+export const classifyFeatureScopeTool = {
+  name: 'mpl_classify_feature_scope',
+  description:
+    'Classify user-facing feature scope into included/deferred/cut UCs + scenarios + PP conflict ledger. Orchestrator calls this inline during Phase 0 Step 1.5 until convergence.',
+  inputSchema: {
+    type: 'object' as const,
+    properties: {
+      cwd: { type: 'string', description: 'Project root directory' },
+      spec_text: {
+        type: 'string',
+        description: 'Raw spec / PRD content',
+      },
+      pivot_points: {
+        type: 'string',
+        description: 'Pivot Points markdown content (read-only — classifier must not modify PPs)',
+      },
+      user_responses: {
+        type: 'string',
+        description:
+          'Concatenated user responses from Step 1.5 interview rounds (format: round N: Q: .. A: ..)',
+      },
+      prev_contract: {
+        type: 'string',
+        description:
+          'Previous iteration user-contract.md content, for UC id stability (optional)',
+      },
+      round: {
+        type: 'number',
+        description:
+          'Current iteration number (1..4). Recorded in source_round fields.',
+      },
+    },
+    required: ['cwd', 'spec_text', 'pivot_points', 'user_responses', 'round'],
+  },
+};
+
+export async function handleClassifyFeatureScope(args: {
+  cwd: string;
+  spec_text: string;
+  pivot_points: string;
+  user_responses: string;
+  prev_contract?: string;
+  round: number;
+}) {
+  const round = Math.max(1, Math.min(4, Math.floor(args.round)));
+
+  const result = await classifyFeatureScope({
+    spec_text: args.spec_text,
+    pivot_points: args.pivot_points,
+    user_responses: args.user_responses,
+    prev_contract: args.prev_contract,
+    round,
+  });
+
+  // Ensure deterministic field order at the top level for caller parsing stability
+  const ordered = {
+    prompt_version: PROMPT_VERSION,
+    round,
+    user_cases: result.user_cases,
+    deferred: result.deferred,
+    cut: result.cut,
+    scenarios: result.scenarios,
+    pp_conflict: result.pp_conflict,
+    ambiguity_hints: result.ambiguity_hints,
+    next_question: result.next_question,
+    convergence: result.convergence,
+  };
+
+  return {
+    content: [{ type: 'text' as const, text: JSON.stringify(ordered, null, 2) }],
+  };
+}


### PR DESCRIPTION
Replaces #46 (auto-closed when its base branch deleted during stacked merge).

## Summary

0.16 Stage 2 — Feature Scope Interview as orchestrator-driven inline loop backed by a new MCP tool.

- **New MCP tool**: `mpl_classify_feature_scope` — classifies user cases (included/deferred/cut) + scenarios + PP conflict ledger per iteration. `PROMPT_VERSION` frozen inline.
- **New orchestrator protocol**: Phase 0 Step 1.5 inline loop (max 4 iterations), writes `.mpl/requirements/user-contract.md` on convergence.
- **State additions**: `user_contract_set` / `user_contract_path` / `user_contract_iterations`.
- **Wiring**: `mpl-ambiguity-gate.mjs` now blocks decomposer dispatch unless `user_contract_set=true` (opt-out via `.mpl/config.json user_contract_required:false`).

Agent file count unchanged (0 delta) per debate decision.

## Commits

- `505a8d8` feat(mcp,orchestrator): add mpl_classify_feature_scope tool + Step 1.5 loop
- `cdd1a8b` feat(hooks,docs): wire user_contract_set into ambiguity gate (S2-4)

## Test plan

- [x] mcp-server: 12/12 pass
- [x] hooks: 272/273 pass (1 pre-existing mpl-state failure)
- [x] TypeScript build: clean

## Context

- Base: main (Stage 1 #45 merged as `7ac8b93`)
- Resume plan: `~/project/wiki/scratch/2026-04-19/mpl-0.16-implementation-resume-plan.md` §3 S2

🤖 Generated with [Claude Code](https://claude.com/claude-code)