### PR TITLE
feat(0.16): Stage 3 — Tier C E2E gate + auto-recovery loop (rebased)

### DIFF
--- a/agents/mpl-decomposer.md
+++ b/agents/mpl-decomposer.md
@@ -32,6 +32,8 @@ disallowedTools: Write,Edit,Bash,Task,WebFetch,WebSearch,NotebookEdit
     7. **Success criteria types**: command, test, file_exists, grep, description. Must be machine-verifiable.
 
     8. **Vertical slice for multi-layer projects**: If 2+ layers detected (frontend/backend/DB/IPC), decompose by feature, not by layer. Each phase implements ONE feature across ALL layers. Scaffold/infrastructure phases remain horizontal.
+
+    9. **APPEND-MODE (0.16 S3-4)**: When the dispatch prompt begins with `APPEND-MODE:`, do NOT re-generate the full decomposition. Instead, keep every existing phase in `.mpl/mpl/decomposition.yaml` intact (ids, contract_files, covers, verification_plan all unchanged) and append 1-3 new phases derived from the supplied `append_phases` hints. Rules: (a) new phase ids must not collide with existing — use the pattern `{anchor}b`, `{anchor}c`, etc. (e.g., `phase-3b` after `phase-3`); (b) each appended phase MUST include `covers:[UC-N]` per 0.16 Tier B and `test_agent_required:true`; (c) preserve `execution_tiers` ordering by inserting the new phase ids immediately after their anchor; (d) emit the FULL updated decomposition.yaml (existing + appended), not a diff. Trigger: Finalize Step 5.0.4 auto-recovery (Classification A) passes `append_phases` from `mpl_diagnose_e2e_failure`.
   </Rules>
 
   <Reasoning_Steps>

--- a/commands/mpl-run-finalize.md
+++ b/commands/mpl-run-finalize.md
@@ -52,40 +52,18 @@ After Gate System passes, run final E2E validation using a **3-tier source hiera
 
      final = state.e2e_results[s.id]
      if not final or final.exit_code != 0:
-       # Still failing — HITL AskUserQuestion per AD-0008
-       AskUserQuestion(
-         question: "E2E {s.id} ({s.title}) 실패. 어떻게 처리할까요?",
-         header: "E2E 실패 — {s.id}",
-         options: [
-           { label: "재시도",
-             description: "스크립트 또는 환경 수정 후 같은 test_command로 재실행" },
-           { label: "Override 추가",
-             description: ".mpl/config/e2e-scenario-override.json에 사유와 함께 bypass 등록 (환경 이슈 등). 다음 런부터 자동 적용." },
-           { label: "파이프라인 실패 처리",
-             description: "finalize_done=false 유지. 사용자가 수동으로 scenario 수정 후 finalize 재시도." }
-         ]
-       )
+       # 0.16 S3-3: attempt automated recovery before HITL fallback.
+       # Collect the failure and defer handling until all required scenarios
+       # have run — the diagnostician needs the full failure picture, not a
+       # per-scenario slice.
+       failures.append(s.id)
+       continue
 
-       if choice == "재시도":
-         Bash(s.test_command) again → re-check
-       if choice == "Override 추가":
-         # AD-0008 R-2: persist environment-level learning
-         Read(".mpl/config/e2e-scenario-override.json") or {}
-         Ask follow-up free-text: "override 사유 (20자 이상, 환경/시점 포함)"
-         Write override with shape:
-           {
-             [s.id]: {
-               reason: <user_input>,
-               test_command_hash: sha1(s.test_command),
-               recorded_at: now_iso(),
-               source: "hitl_failure_resolution"
-             }
-           }
-         announce: "[MPL AD-0008] Override added. Future runs auto-skip {s.id} unless test_command changes."
-         continue to next scenario
-       if choice == "파이프라인 실패":
-         announce: "[MPL AD-0008] Finalize held. state.finalize_done remains false. Fix {s.id} then re-run /mpl:mpl-finalize."
-         return from Step 5 WITHOUT setting finalize_done
+   # 0.16 S3-3: if any failure collected, go to Step 5.0.4 Automated Recovery.
+   # That step either resolves all failures (loop back to "for s in required")
+   # or halts the pipeline via circuit breaker → falls through to HITL.
+   if failures:
+     goto Step 5.0.4
 
 3. Report:
    "[MPL AD-0008] E2E Scenarios: {passed}/{required.length} passed, {overridden} overridden, {failed_resolved_via_override} resolved via HITL override."
@@ -99,6 +77,198 @@ remain failing without override will be blocked.
 ```
 
 - MED/LOW H-items are NOT re-asked here — they are aggregated in Step 5.1.8 (T-10, v3.9)
+
+### 5.0.3: Playwright Trace Collection (0.16 S3-6)
+
+When an E2E scenario fails, the diagnostician (Step 5.0.4) needs a trace
+excerpt to classify accurately. This step wires up Playwright trace output
+so the orchestrator can pass meaningful context to `mpl_diagnose_e2e_failure`.
+
+**Auto-wrap policy** (applied inside Step 5.0 loop before `Bash(test_command)`):
+
+```
+if test_command matches /playwright/ AND test_command does not contain "--trace":
+  # Inject trace flags — non-intrusive; Playwright writes zip files
+  traceDir = ".mpl/e2e-traces"
+  Bash("mkdir -p " + traceDir)
+  wrapped = test_command + " --trace on --trace-dir " + traceDir + "/" + s.id
+  Bash(wrapped, timeout=config.e2e_timeout or 60000)
+
+elif test_command matches /pytest/ OR /jest/:
+  # Other frameworks: no automatic trace injection. Diagnostician will
+  # fall back to stderr_tail. Projects can configure project-level
+  # trace via .mpl/config.json { "e2e_trace_cmd_prefix": "..." }.
+  Bash(test_command)
+
+else:
+  Bash(test_command)
+```
+
+**Trace path recording** (post-execution, by orchestrator or gate-recorder):
+
+```
+# Look for the most recent trace zip under the expected directory
+trace_path = ".mpl/e2e-traces/" + s.id + "/trace.zip"
+if File.exists(trace_path):
+  mpl_state_write({
+    e2e_results: {
+      [s.id]: { ...existing, trace_path }
+    }
+  })
+```
+
+**Storage contract**:
+
+- Directory: `.mpl/e2e-traces/<scenario_id>/` (per scenario, isolated)
+- `.gitignore` in user projects must exclude `.mpl/e2e-traces/` —
+  `/mpl:mpl-doctor` warns when this line is missing and offers auto-patch.
+- Trace files are MB-sized; only the `trace_path` string lives in state.json.
+  The diagnostician reads up to 4KB from the trace file when building its
+  `trace_excerpt` input (Step 5.0.4).
+
+### 5.0.4: Automated E2E Recovery Loop (0.16 S3-3)
+
+Triggered from Step 5.0 step 2 when `failures[]` is non-empty. This step
+replaces the old "fail → HITL 3 options" path. HITL still runs, but only
+as the fallback when the circuit breaker halts recovery.
+
+**Pre-check — Tier C UC coverage** (fast fail before spending an LLM call):
+
+```
+contract = Read(".mpl/requirements/user-contract.md")
+included_ucs = parseIncluded(contract)
+covered = union(scenarios[*].covers)
+missing = included_ucs - covered
+
+if missing.size > 0:
+  announce: "[MPL 0.16 Tier C] {missing.size} UC(s) not covered by any scenario: {missing}. " +
+            "Diagnostician WILL NOT be called — fix the contract first."
+  → fall through to HITL (existing 3-option AskUserQuestion).
+```
+
+**Recovery loop** (when UC coverage is complete):
+
+```
+state.e2e_recovery.iter default 0
+state.e2e_recovery.max_iter default 2
+
+while state.e2e_recovery.iter < state.e2e_recovery.max_iter AND failures not empty:
+  # 1. Prepare diagnostic context
+  trace_excerpt = ""
+  for fid in failures:
+    tp = state.e2e_results[fid].trace_path
+    if tp and File.exists(tp):
+      trace_excerpt += "\n[" + fid + "]\n" + Bash("head -c 2000 " + tp)
+    else:
+      trace_excerpt += "\n[" + fid + "] (no trace)\n" + state.e2e_results[fid].stderr_tail or ""
+
+  # 2. Call the MCP tool (opus, session auth, PROMPT_VERSION frozen)
+  diag = mpl_diagnose_e2e_failure({
+    cwd,
+    scenarios: Read(".mpl/mpl/e2e-scenarios.yaml"),
+    e2e_results: JSON.stringify(state.e2e_results),
+    trace_excerpt: trace_excerpt.slice(0, 4000),
+    user_contract: Read(".mpl/requirements/user-contract.md"),
+    decomposition: Read(".mpl/mpl/decomposition.yaml"),
+    prev_iter: state.e2e_recovery.iter,
+  })
+
+  # 3. Persist diagnosis (Q9: resume reads this inline)
+  mpl_state_write({
+    e2e_recovery: {
+      iter: state.e2e_recovery.iter + diag.iter_hint,
+      max_iter: state.e2e_recovery.max_iter,
+      last_classification: diag.classification,
+      last_diagnosis: diag,
+    }
+  })
+
+  announce: "[MPL 0.16 S3] Diagnosis iter {iter+1}/{max}: classification={diag.classification} " +
+            "confidence={diag.confidence} — {diag.root_cause}"
+
+  # 4. Dispatch fix per classification
+  switch diag.classification:
+    case "A":   # spec gap → decomposer appends phases
+      Task(subagent_type="mpl-decomposer", prompt=`
+        APPEND-MODE: existing decomposition.yaml remains; append the phases
+        below without modifying existing phase ids. Each appended phase MUST
+        include covers:[UC-N] per 0.16 Tier B and test_agent_required:true.
+
+        Append hints (from mpl_diagnose_e2e_failure):
+        ${JSON.stringify(diag.append_phases, null, 2)}
+
+        After appending, re-emit the full decomposition.yaml.
+      `)
+      # After decomposer completes, re-enter Phase Execution for the new
+      # phases (mpl-run-execute.md Step 4), then return here.
+
+    case "B":   # test bug → test-agent rewrites the test
+      Task(subagent_type="mpl-test-agent", prompt=`
+        The following E2E scenario failed; the diagnostician believes the TEST
+        is wrong, not the implementation. Review and fix the test.
+
+        Scenario: ${failures[0]}
+        Root cause: ${diag.root_cause}
+        Fix strategy: ${diag.fix_strategy}
+        Trace excerpt: ${diag.trace_excerpt}
+      `)
+
+    case "C":   # missing capability → Phase 0 Step 1.5 minimal re-run
+      announce: "[MPL 0.16 S3] Classification C — missing UC detected. " +
+                "Returning to Phase 0 Step 1.5 (minimal mode) to append the UC."
+      mpl_state_write({ current_phase: "mpl-init", user_contract_set: false })
+      # orchestrator re-enters Phase 0 Step 1.5 inline loop; on completion
+      # it must preserve existing UCs (prev_contract) and only add the missing
+      # one. After Step 1.5 convergence, re-enter Phase Execution for any new
+      # phases spawned by the new UC, then return here.
+
+    case "D":   # flake → single rerun with trace on
+      announce: "[MPL 0.16 S3] Classification D — flake. Rerunning with trace on."
+      for fid in failures:
+        Bash("<scenario test_command for fid> --trace on")  # see Step 5.6 (S3-6)
+
+  # 5. Re-run originally failing scenarios to see if fix worked
+  new_failures = []
+  for fid in failures:
+    Bash(state.e2e_results[fid].test_command)  # gate-recorder updates results
+    if state.e2e_results[fid].exit_code != 0:
+      new_failures.append(fid)
+  failures = new_failures
+
+# loop exit: either failures empty (success) or iter >= max_iter
+```
+
+**Circuit breaker (iter >= max_iter, failures remain)**:
+
+```
+mpl_state_write({
+  e2e_recovery: { ...state.e2e_recovery, halted: true, halt_reason: "e2e_circuit_breaker" }
+})
+
+announce: "[MPL 0.16 S3] Circuit breaker: recovery iter={max_iter} reached, " +
+          "{failures.size} scenario(s) still failing. Entering HITL."
+
+# Fall through to the original 3-option AskUserQuestion (재시도 / Override 추가 /
+# 파이프라인 실패 처리) — now informed by state.e2e_recovery.last_diagnosis so
+# the user sees the diagnostician's verdict alongside the options.
+AskUserQuestion(
+  question: "E2E 자동복구 실패 (iter={state.e2e_recovery.iter}/{state.e2e_recovery.max_iter}). " +
+            "마지막 진단: {state.e2e_recovery.last_diagnosis.classification} — " +
+            "{state.e2e_recovery.last_diagnosis.root_cause}. 어떻게 할까요?",
+  header: "E2E 자동복구 실패",
+  options: [ /* same 3 options as original Step 5.0 */ ]
+)
+```
+
+**Resume behavior (Q9)**: when `/mpl:mpl resume` re-enters after a halt,
+`mpl-run-finalize-resume.md` reads `state.e2e_recovery.last_diagnosis`
+directly from state.json and inlines the summary into the orchestrator
+prompt. No MCP round-trip.
+
+**Exp12 measurement**: every diagnostician call increments
+`state.e2e_recovery.iter` by `iter_hint`; the pipeline summary writes
+`{classification, confidence, iter}` into `.mpl/metrics/e2e-recovery.jsonl`
+for Stage 4 data-driven promotion analysis.
 
 ### 5.0.5: AD Final Verification
 

--- a/docs/roadmap/0.16-exp12-plan.md
+++ b/docs/roadmap/0.16-exp12-plan.md
@@ -1,0 +1,153 @@
+# MPL 0.16 exp12 Measurement Plan
+
+**Purpose**: validate 0.16 Tier A'/B/C design against ygg-exp11 baseline using the
+Yggdrasil spec (or equivalent). Feeds Stage 4 data-driven decision on whether to
+promote `mpl_diagnose_e2e_failure` to an agent file, keep as MCP tool, or sunset.
+
+Related:
+- Resume plan v2 §3 Stage 3 (S3-7) + Stage 4 (S4-1..5)
+- Decision `~/project/decision/2026-04-19-mpl-0.16-implementation-plan.md`
+- Baseline: `~/project/harness_lab/analysis/mpl-exp11-opus47-evaluation.md`
+
+## Experimental Design
+
+| Aspect | exp11 baseline | exp12 target |
+|---|---|---|
+| MPL version | 0.14.1 | 0.16.0-rc |
+| Spec | Yggdrasil (Tauri + React + Rust) | Same (for fair comparison) |
+| Model | opus-4.7 | opus-4.7 |
+| Run mode | `full` | `full` |
+| Measured phases | 80 (12 planned, 80 total) | expect similar count |
+
+**Independent variables**: 0.16 changes only (Tier A'/B/C enforcement, auto-recovery).
+**Confound control**: same Yggdrasil spec, same model, same hardware. Rerun at
+least twice (N=2) per configuration to detect non-determinism.
+
+## Primary Metrics
+
+Emit all metrics to `.mpl/metrics/exp12-summary.md` and the JSONL files below.
+
+### Metric 1 — User feature capture (Tier A' effectiveness)
+
+| Item | Baseline (exp11) | exp12 target |
+|---|---|---|
+| `user_cases[*].user_delta != ""` count | 0 | ≥ 1 (hard target) |
+| `user_contract_iterations` | n/a | ≤ 4 |
+| `pp_conflict` entries | n/a | logged where UC ↔ PP collision exists |
+
+**Source**: `.mpl/requirements/user-contract.md` after Phase 0 completes.
+
+### Metric 2 — E2E skip elimination (Tier C effectiveness)
+
+| Item | Baseline (exp11) | exp12 target |
+|---|---|---|
+| `implementation-skip` count | 42 / 80 | **0** |
+| `@skip_reason` with allowed env token | n/a | all skips classified |
+| Missing UC coverage Hard fails | n/a | 0 at finalize_done write |
+
+**Source**: `state.e2e_skip_reasons[]` + `state.e2e_results[*].exit_code` +
+`mpl-require-e2e` hook block events.
+
+### Metric 3 — Author ≠ verifier separation (pre-existing AD-0007/0008)
+
+| Item | Baseline (exp11) | exp12 target |
+|---|---|---|
+| phase-runner : test-agent dispatch ratio | 83 : 1 | ≤ 3 : 1 |
+| `test_agent_required=true` phases with no test-agent dispatch | 63 / 63 | 0 |
+
+**Source**: `state.test_agent_dispatched[*]` via `mpl-require-test-agent` hook.
+
+### Metric 4 — Diagnostician behavior (Stage 4 promotion inputs)
+
+Write `.mpl/metrics/e2e-recovery.jsonl` one line per diagnose call:
+
+```jsonl
+{"ts": "...", "classification": "A", "confidence": 0.87, "iter": 1, "prompt_version": "v1-..."}
+```
+
+Aggregated measures:
+
+| Item | Value | Stage 4 threshold |
+|---|---|---|
+| Total diagnose calls across run | — | ≥ 3 / phase for promotion consideration |
+| `classification` histogram {A,B,C,D} | — | B+D share for accuracy labeling |
+| Circuit breaker halts (`halted: true`) | — | ideally 0; counts as bug if > 1 |
+
+### Metric 5 — B/D classification accuracy (Q8 — auxiliary LLM labeling)
+
+For each diagnose call in `.mpl/metrics/e2e-recovery.jsonl`, produce a
+ground-truth label via an independent opus call (temp 0.1, **separate**
+`PROMPT_VERSION = 'v1-labeler-2026-04-19'`):
+
+```
+input: same scenarios/e2e_results/trace_excerpt passed to the classifier
+task:  "Classify this failure as A / B / C / D. Output JSON only."
+```
+
+Metric: agreement rate between classifier output and labeler output.
+
+| Threshold | Stage 4 decision |
+|---|---|
+| agreement ≥ 70% AND calls ≥ 3/phase AND hash consistent | ELIGIBLE for promotion to agent file — escalate to debate |
+| agreement < 70% | sunset trigger — remove `mpl_diagnose_e2e_failure` tool |
+| calls < 3/phase | sunset trigger (unused) |
+
+## Secondary Metrics
+
+- Internal-TODO ratio (`mpl-require-covers` warns fired) — exp12 expected < 40%
+- Feature classifier call count per run — budget target ≤ 6 total
+- `user_contract_set=false` blocks by `mpl-ambiguity-gate` — should fire 0 times
+  on clean runs; non-zero means orchestrator skipped Step 1.5
+
+## Protocol
+
+1. **Pre-flight**:
+   - Check out 0.16 release candidate (or branch stack S1+S2+S3 merged)
+   - Fresh Yggdrasil workspace (no prior `.mpl/`)
+   - Verify MCP server is installed and responding: `mpl_classify_feature_scope`,
+     `mpl_diagnose_e2e_failure`, `mpl_score_ambiguity`
+
+2. **Run**:
+   ```
+   /mpl:mpl <Yggdrasil spec prompt>
+   # let it run full pipeline through finalize
+   ```
+
+3. **Post-flight collection**:
+   ```
+   cp .mpl/requirements/user-contract.md analysis/exp12/
+   cp .mpl/state.json analysis/exp12/
+   cp .mpl/metrics/e2e-recovery.jsonl analysis/exp12/
+   cp .mpl/metrics/phases.jsonl analysis/exp12/
+   ```
+
+4. **Labeling pass** (Metric 5):
+   Script in `harness_lab/analysis/` that iterates each diagnose call and
+   calls the labeler prompt via Agent SDK. Emits
+   `analysis/exp12/labeler-agreement.md`.
+
+5. **Comparison report**:
+   `analysis/mpl-0.16-exp12-vs-exp11.md` — side-by-side of the 5 primary
+   metrics, with pass/fail verdict against the target column above.
+
+## Pass Criteria (for 0.16 release)
+
+All of the following must hold on at least one clean run:
+
+- [ ] Metric 1: user_delta ≥ 1, user_contract_iterations ≤ 4
+- [ ] Metric 2: implementation-skip = 0, Tier C block events = 0 at finalize_done
+- [ ] Metric 3: test-agent dispatch ratio ≤ 3:1
+- [ ] Metric 4: 0 circuit-breaker halts; diagnose calls emit valid JSON each time
+- [ ] Metric 5: agreement rate computed (required even if low — it's the sunset/promotion signal)
+
+## Sunset / Promotion Decision (Stage 4)
+
+After exp12 completes, open a follow-up debate using the 4-agent pattern
+(Architect / Contrarian / Simplifier / Evaluator) with the measurement summary
+as input. The debate decides:
+
+| Outcome | Action |
+|---|---|
+| Promote to agent | New `mpl-e2e-diagnostician` agent file; sunset MCP tool |
+| Keep MCP tool | No change; continue in Stage 4.1 maintenance |
+| Sunset MCP tool | Remove `mcp-server/src/tools/e2e-diagnose.ts` + Finalize Step 5.0.4; fall back to HITL |

--- a/hooks/__tests__/mpl-require-e2e.test.mjs
+++ b/hooks/__tests__/mpl-require-e2e.test.mjs
@@ -1,0 +1,152 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  parseUserContractText,
+  computeUncoveredUcs,
+} from '../mpl-require-e2e.mjs';
+
+describe('parseUserContractText', () => {
+  it('extracts included UC ids with explicit status', () => {
+    const text = `
+schema_version: 1
+user_cases:
+  - id: "UC-01"
+    status: included
+  - id: "UC-02"
+    status: included
+scenarios: []
+`;
+    const r = parseUserContractText(text);
+    assert.deepEqual(r.included_uc_ids, ['UC-01', 'UC-02']);
+  });
+
+  it('defaults UC status to included when unspecified', () => {
+    const text = `
+user_cases:
+  - id: "UC-05"
+    title: "x"
+  - id: "UC-06"
+    title: "y"
+`;
+    const r = parseUserContractText(text);
+    assert.deepEqual(r.included_uc_ids, ['UC-05', 'UC-06']);
+  });
+
+  it('excludes deferred and cut UCs', () => {
+    const text = `
+user_cases:
+  - id: "UC-01"
+    status: included
+  - id: "UC-02"
+    status: deferred
+  - id: "UC-03"
+    status: cut
+`;
+    const r = parseUserContractText(text);
+    assert.deepEqual(r.included_uc_ids, ['UC-01']);
+  });
+
+  it('parses scenarios with inline covers and skip_allowed', () => {
+    const text = `
+scenarios:
+  - id: "SC-01"
+    covers: [UC-01, UC-02]
+    skip_allowed: [ENV_API_DOWN]
+  - id: "SC-02"
+    covers: ["UC-03"]
+    skip_allowed: []
+`;
+    const r = parseUserContractText(text);
+    assert.equal(r.scenarios.length, 2);
+    assert.deepEqual(r.scenarios[0].covers, ['UC-01', 'UC-02']);
+    assert.deepEqual(r.scenarios[0].skip_allowed, ['ENV_API_DOWN']);
+    assert.deepEqual(r.scenarios[1].covers, ['UC-03']);
+    assert.deepEqual(r.scenarios[1].skip_allowed, []);
+  });
+
+  it('parses scenarios with block covers list', () => {
+    const text = `
+scenarios:
+  - id: "SC-01"
+    covers:
+      - "UC-01"
+      - "UC-02"
+    skip_allowed:
+      - ENV_API_DOWN
+      - FLAKY_NETWORK
+`;
+    const r = parseUserContractText(text);
+    assert.equal(r.scenarios.length, 1);
+    assert.deepEqual(r.scenarios[0].covers, ['UC-01', 'UC-02']);
+    assert.deepEqual(r.scenarios[0].skip_allowed, ['ENV_API_DOWN', 'FLAKY_NETWORK']);
+  });
+
+  it('handles multiple sections together', () => {
+    const text = `
+schema_version: 1
+user_cases:
+  - id: "UC-01"
+    status: included
+  - id: "UC-02"
+    status: included
+deferred_cases:
+  - id: "UC-09"
+    reason: "later"
+scenarios:
+  - id: "SC-01"
+    covers: [UC-01]
+  - id: "SC-02"
+    covers: [UC-02]
+`;
+    const r = parseUserContractText(text);
+    assert.deepEqual(r.included_uc_ids, ['UC-01', 'UC-02']);
+    assert.equal(r.scenarios.length, 2);
+  });
+
+  it('returns empty for null/empty input', () => {
+    assert.deepEqual(parseUserContractText(''), { included_uc_ids: [], scenarios: [] });
+    assert.deepEqual(parseUserContractText(null), { included_uc_ids: [], scenarios: [] });
+  });
+});
+
+describe('computeUncoveredUcs', () => {
+  it('returns uncovered UCs when scenarios do not cover all', () => {
+    const uncovered = computeUncoveredUcs(
+      ['UC-01', 'UC-02', 'UC-03'],
+      [{ id: 'SC-1', covers: ['UC-01'] }],
+    );
+    assert.deepEqual(uncovered, ['UC-02', 'UC-03']);
+  });
+
+  it('returns empty when all UCs are covered', () => {
+    const uncovered = computeUncoveredUcs(
+      ['UC-01', 'UC-02'],
+      [
+        { id: 'SC-1', covers: ['UC-01'] },
+        { id: 'SC-2', covers: ['UC-02'] },
+      ],
+    );
+    assert.deepEqual(uncovered, []);
+  });
+
+  it('counts cross-scenario coverage (union)', () => {
+    const uncovered = computeUncoveredUcs(
+      ['UC-01', 'UC-02'],
+      [{ id: 'SC-1', covers: ['UC-01', 'UC-02'] }],
+    );
+    assert.deepEqual(uncovered, []);
+  });
+
+  it('handles scenarios with missing covers field', () => {
+    const uncovered = computeUncoveredUcs(
+      ['UC-01'],
+      [{ id: 'SC-1' }], // no covers field
+    );
+    assert.deepEqual(uncovered, ['UC-01']);
+  });
+
+  it('returns empty when no included UCs', () => {
+    const uncovered = computeUncoveredUcs([], [{ id: 'SC-1', covers: ['UC-01'] }]);
+    assert.deepEqual(uncovered, []);
+  });
+});

--- a/hooks/mpl-require-e2e.mjs
+++ b/hooks/mpl-require-e2e.mjs
@@ -34,12 +34,14 @@ import { existsSync, readFileSync } from 'fs';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
+const isMain = import.meta.url === pathToFileURL(process.argv[1] || '').href;
+
 const { readState, isMplActive } = await import(
   pathToFileURL(join(__dirname, 'lib', 'mpl-state.mjs')).href
 );
-const { readStdin } = await import(
-  pathToFileURL(join(__dirname, 'lib', 'stdin.mjs')).href
-);
+const { readStdin } = isMain
+  ? await import(pathToFileURL(join(__dirname, 'lib', 'stdin.mjs')).href)
+  : { readStdin: async () => '' };
 
 function ok() {
   console.log(JSON.stringify({ continue: true, suppressOutput: true }));
@@ -122,6 +124,171 @@ function loadOverride(cwd) {
 }
 
 /**
+ * 0.16 Tier C: read .mpl/config.json { e2e_contract_strict: false } to
+ * degrade the missing-UC-coverage check from block to warn. Default true (strict).
+ */
+export function isE2EContractStrict(cwd) {
+  try {
+    const cfgPath = join(cwd, '.mpl', 'config.json');
+    if (!existsSync(cfgPath)) return true;
+    const cfg = JSON.parse(readFileSync(cfgPath, 'utf-8'));
+    if (cfg && cfg.e2e_contract_strict === false) return false;
+  } catch {
+    // fall through
+  }
+  return true;
+}
+
+/**
+ * 0.16 Tier A'/C: parse .mpl/requirements/user-contract.md to extract the
+ * included UC ids and the scenario→UC mapping. File is YAML-shaped even though
+ * it carries an .md extension (pragmatic convention — see Plan v2 Q5).
+ *
+ * Returns { included_uc_ids: [string], scenarios: [{id, covers, skip_allowed}] }.
+ * Missing file → empty result (graceful skip mode).
+ */
+export function parseUserContract(cwd) {
+  const path = join(cwd, '.mpl', 'requirements', 'user-contract.md');
+  if (!existsSync(path)) return { included_uc_ids: [], scenarios: [] };
+
+  let text;
+  try {
+    text = readFileSync(path, 'utf-8');
+  } catch {
+    return { included_uc_ids: [], scenarios: [] };
+  }
+
+  return parseUserContractText(text);
+}
+
+export function parseUserContractText(text) {
+  if (!text || typeof text !== 'string') return { included_uc_ids: [], scenarios: [] };
+
+  const lines = text.split('\n').map((l) => l.replace(/\r$/, ''));
+
+  let section = null; // "user_cases" | "scenarios" | null
+  let sectionIndent = -1;
+  const included = [];
+  const scenarios = [];
+  let curScenario = null;
+  let inListField = null; // "covers" | "skip_allowed"
+  let listIndent = -1;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (line.trim() === '') continue;
+
+    // Top-level section detection
+    const topMatch = line.match(/^(user_cases|deferred_cases|cut_cases|scenarios)\s*:\s*$/);
+    if (topMatch) {
+      if (curScenario) scenarios.push(curScenario);
+      curScenario = null;
+      section = topMatch[1];
+      sectionIndent = 0;
+      inListField = null;
+      continue;
+    }
+
+    // Top-level unrelated keys terminate the section
+    if (/^[a-zA-Z_]/.test(line) && !line.startsWith(' ')) {
+      if (curScenario) scenarios.push(curScenario);
+      curScenario = null;
+      section = null;
+      inListField = null;
+      continue;
+    }
+
+    if (section === 'user_cases') {
+      const idMatch = line.match(/^\s*-\s+id:\s*["']?(UC-\d{2,})["']?/);
+      if (idMatch) {
+        // Peek forward for status: "included"; safer to accept-all-then-filter via default
+        // We stream-parse: assume status defaults to "included" unless explicitly set.
+        included.push({ id: idMatch[1], status: 'included' });
+        continue;
+      }
+      const statusMatch = line.match(/^\s+status:\s*["']?(included|deferred|cut)["']?/);
+      if (statusMatch && included.length > 0) {
+        included[included.length - 1].status = statusMatch[1];
+        continue;
+      }
+    }
+
+    if (section === 'scenarios') {
+      const idMatch = line.match(/^\s*-\s+id:\s*["']?(SC-[\w-]+|E2E-[\w-]+)["']?/);
+      if (idMatch) {
+        if (curScenario) scenarios.push(curScenario);
+        curScenario = { id: idMatch[1], covers: [], skip_allowed: [] };
+        inListField = null;
+        continue;
+      }
+      if (!curScenario) continue;
+
+      // Inline arrays
+      const inlineCovers = line.match(/^\s+covers\s*:\s*\[(.*)\]\s*$/);
+      if (inlineCovers) {
+        curScenario.covers = inlineCovers[1]
+          .split(',')
+          .map((s) => s.trim().replace(/^["']|["']$/g, ''))
+          .filter(Boolean);
+        inListField = null;
+        continue;
+      }
+      const inlineSkip = line.match(/^\s+skip_allowed\s*:\s*\[(.*)\]\s*$/);
+      if (inlineSkip) {
+        curScenario.skip_allowed = inlineSkip[1]
+          .split(',')
+          .map((s) => s.trim().replace(/^["']|["']$/g, ''))
+          .filter(Boolean);
+        inListField = null;
+        continue;
+      }
+
+      // Block list form
+      const blockCovers = line.match(/^(\s+)covers\s*:\s*$/);
+      if (blockCovers) {
+        inListField = 'covers';
+        listIndent = blockCovers[1].length;
+        continue;
+      }
+      const blockSkip = line.match(/^(\s+)skip_allowed\s*:\s*$/);
+      if (blockSkip) {
+        inListField = 'skip_allowed';
+        listIndent = blockSkip[1].length;
+        continue;
+      }
+
+      if (inListField) {
+        const itemMatch = line.match(/^(\s*)-\s+["']?([^"'\s#]+)["']?/);
+        if (itemMatch && itemMatch[1].length > listIndent) {
+          curScenario[inListField].push(itemMatch[2]);
+          continue;
+        }
+        // leaving list
+        inListField = null;
+      }
+    }
+  }
+  if (curScenario) scenarios.push(curScenario);
+
+  return {
+    included_uc_ids: included.filter((u) => u.status === 'included').map((u) => u.id),
+    scenarios,
+  };
+}
+
+/**
+ * 0.16 Tier C: compute which `included` UCs have no scenario covering them.
+ * Returns array of uncovered UC ids.
+ */
+export function computeUncoveredUcs(includedUcIds, scenarios) {
+  const covered = new Set();
+  for (const s of scenarios) {
+    for (const uc of s.covers || []) covered.add(uc);
+  }
+  return includedUcIds.filter((id) => !covered.has(id));
+}
+
+/**
  * Detect whether the incoming tool input writes `finalize_done: true` to
  * `.mpl/state.json`. Handles Edit (old_string/new_string) and Write (content).
  * False positives are acceptable — the hook only blocks when scenarios are
@@ -140,11 +307,11 @@ function isFinalizeDoneWrite(toolInput) {
   return /"finalize_done"\s*:\s*true/.test(newText);
 }
 
-try {
+async function runHook() {
   const raw = await readStdin();
   if (!raw.trim()) {
     ok();
-    process.exit(0);
+    return;
   }
 
   let data;
@@ -152,25 +319,25 @@ try {
     data = JSON.parse(raw);
   } catch {
     ok();
-    process.exit(0);
+    return;
   }
 
   const cwd = data.cwd || data.directory || process.cwd();
   if (!isMplActive(cwd)) {
     ok();
-    process.exit(0);
+    return;
   }
 
   const toolName = String(data.tool_name || data.toolName || '');
   if (!['Write', 'write', 'Edit', 'edit'].includes(toolName)) {
     ok();
-    process.exit(0);
+    return;
   }
 
   const toolInput = data.tool_input || data.toolInput || {};
   if (!isFinalizeDoneWrite(toolInput)) {
     ok();
-    process.exit(0);
+    return;
   }
 
   // A finalize_done: true write is imminent. Validate E2E coverage.
@@ -179,7 +346,7 @@ try {
   if (required.length === 0) {
     // No declared E2E scenarios — nothing to enforce. Allow.
     ok();
-    process.exit(0);
+    return;
   }
 
   const state = readState(cwd) || {};
@@ -216,18 +383,48 @@ try {
     }
   }
 
-  if (unresolved.length === 0) {
-    ok();
-    process.exit(0);
+  if (unresolved.length > 0) {
+    block(
+      `[MPL AD-0008] Cannot set finalize_done=true — ${unresolved.length} required E2E scenario(s) missing or failing: ${unresolved.join(', ')}. ` +
+        `Each required scenario's test_command must be executed (gate-recorder writes state.e2e_results automatically) AND exit 0, ` +
+        `OR explicitly overridden via .mpl/config/e2e-scenario-override.json with a user reason. ` +
+        `Re-run the scenarios or use /mpl:mpl-finalize Step 5.0 HITL to record overrides before retrying finalize.`
+    );
+    return;
   }
 
-  block(
-    `[MPL AD-0008] Cannot set finalize_done=true — ${unresolved.length} required E2E scenario(s) missing or failing: ${unresolved.join(', ')}. ` +
-      `Each required scenario's test_command must be executed (gate-recorder writes state.e2e_results automatically) AND exit 0, ` +
-      `OR explicitly overridden via .mpl/config/e2e-scenario-override.json with a user reason. ` +
-      `Re-run the scenarios or use /mpl:mpl-finalize Step 5.0 HITL to record overrides before retrying finalize.`
-  );
-} catch {
-  // Hook must never wedge the pipeline.
+  // 0.16 Tier C: UC coverage gate.
+  const contract = parseUserContract(cwd);
+  if (contract.included_uc_ids.length > 0) {
+    const uncovered = computeUncoveredUcs(contract.included_uc_ids, contract.scenarios);
+    if (uncovered.length > 0) {
+      if (isE2EContractStrict(cwd)) {
+        block(
+          `[MPL 0.16 Tier C] Cannot set finalize_done=true — ${uncovered.length} included UC(s) have no E2E scenario coverage: ${uncovered.join(', ')}. ` +
+            `Add scenarios to .mpl/requirements/user-contract.md (each scenario's covers[] must list the UC) ` +
+            `or opt out of strict mode via .mpl/config.json { "e2e_contract_strict": false }.`
+        );
+        return;
+      }
+      console.log(
+        JSON.stringify({
+          continue: true,
+          suppressOutput: false,
+          systemMessage:
+            `[MPL 0.16 Tier C WARN] ${uncovered.length} UC(s) without E2E scenario coverage: ${uncovered.join(', ')}. ` +
+            `Strict mode is disabled; add coverage or re-enable e2e_contract_strict=true before the next run.`,
+        }),
+      );
+      return;
+    }
+  }
+
   ok();
+}
+
+if (isMain) {
+  runHook().catch(() => {
+    // Hook must never wedge the pipeline.
+    ok();
+  });
 }

--- a/mcp-server/__tests__/e2e-diagnoser.test.mjs
+++ b/mcp-server/__tests__/e2e-diagnoser.test.mjs
@@ -1,0 +1,118 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  PROMPT_VERSION,
+  parseDiagnosis,
+  neutralDiagnosis,
+} from '../dist/lib/e2e-diagnoser.js';
+
+describe('PROMPT_VERSION', () => {
+  it('is a frozen version string', () => {
+    assert.equal(typeof PROMPT_VERSION, 'string');
+    assert.ok(PROMPT_VERSION.length > 0);
+  });
+});
+
+describe('parseDiagnosis', () => {
+  const validA = {
+    classification: 'A',
+    root_cause: 'No /reset-password route exists in src/auth/router.ts',
+    fix_strategy: 'Append phase to add POST /reset-password handler; see append_phases.',
+    iter_hint: 1,
+    trace_excerpt: '404 Not Found at POST /reset-password (line 47 of reset.spec.ts)',
+    append_phases: [
+      {
+        position: 'after',
+        anchor_phase: 'phase-3',
+        proposed_id: 'phase-3b',
+        goal: 'Add reset-password endpoint',
+        covers: ['UC-05'],
+      },
+    ],
+    confidence: 0.9,
+  };
+
+  it('parses a valid A diagnosis', () => {
+    const r = parseDiagnosis(JSON.stringify(validA));
+    assert.ok(r);
+    assert.equal(r.classification, 'A');
+    assert.equal(r.iter_hint, 1);
+    assert.equal(r.append_phases.length, 1);
+    assert.equal(r.prompt_version, PROMPT_VERSION);
+  });
+
+  it('parses JSON embedded in surrounding text', () => {
+    const r = parseDiagnosis(`Preamble...\n${JSON.stringify(validA)}\nEnd.`);
+    assert.ok(r);
+    assert.equal(r.classification, 'A');
+  });
+
+  it('rejects invalid classification values', () => {
+    const bad = { ...validA, classification: 'Z' };
+    assert.equal(parseDiagnosis(JSON.stringify(bad)), null);
+  });
+
+  it('rejects missing required fields', () => {
+    const noRoot = { ...validA };
+    delete noRoot.root_cause;
+    assert.equal(parseDiagnosis(JSON.stringify(noRoot)), null);
+
+    const noAppend = { ...validA };
+    delete noAppend.append_phases;
+    assert.equal(parseDiagnosis(JSON.stringify(noAppend)), null);
+  });
+
+  it('clamps iter_hint to 0..2', () => {
+    const high = { ...validA, iter_hint: 99 };
+    const rh = parseDiagnosis(JSON.stringify(high));
+    assert.equal(rh.iter_hint, 2);
+    const low = { ...validA, iter_hint: -5 };
+    const rl = parseDiagnosis(JSON.stringify(low));
+    assert.equal(rl.iter_hint, 0);
+  });
+
+  it('clamps confidence to 0..1', () => {
+    const over = { ...validA, confidence: 2.5 };
+    assert.equal(parseDiagnosis(JSON.stringify(over)).confidence, 1);
+    const under = { ...validA, confidence: -0.5 };
+    assert.equal(parseDiagnosis(JSON.stringify(under)).confidence, 0);
+  });
+
+  it('truncates trace_excerpt to 400 chars', () => {
+    const long = { ...validA, trace_excerpt: 'x'.repeat(1000) };
+    const r = parseDiagnosis(JSON.stringify(long));
+    assert.equal(r.trace_excerpt.length, 400);
+  });
+
+  it('accepts all four classifications A/B/C/D', () => {
+    for (const k of ['A', 'B', 'C', 'D']) {
+      const payload = { ...validA, classification: k, append_phases: [] };
+      const r = parseDiagnosis(JSON.stringify(payload));
+      assert.ok(r);
+      assert.equal(r.classification, k);
+    }
+  });
+
+  it('returns null for malformed JSON', () => {
+    assert.equal(parseDiagnosis('{unclosed'), null);
+    assert.equal(parseDiagnosis(''), null);
+  });
+});
+
+describe('neutralDiagnosis', () => {
+  it('defaults to D (flake) to avoid false phase appends', () => {
+    const r = neutralDiagnosis();
+    assert.equal(r.classification, 'D');
+    assert.equal(r.append_phases.length, 0);
+    assert.equal(r.confidence, 0);
+  });
+
+  it('sets iter_hint to 1 (count against budget)', () => {
+    const r = neutralDiagnosis();
+    assert.equal(r.iter_hint, 1);
+  });
+
+  it('carries the frozen PROMPT_VERSION', () => {
+    assert.equal(neutralDiagnosis().prompt_version, PROMPT_VERSION);
+  });
+});

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -8,6 +8,8 @@
  *   mpl_state_write             — Update pipeline state (atomic, deep-merge)
  *   mpl_classify_feature_scope  — 0.16 Tier A': classify user cases (included/deferred/cut) +
  *                                 scenarios + PP conflict ledger (called inline during Phase 0 Step 1.5)
+ *   mpl_diagnose_e2e_failure    — 0.16 Tier C: classify E2E failure as A/B/C/D + fix strategy
+ *                                 (called conditionally from Finalize; circuit breaker iter<=2)
  *
  * Transport: stdio (Claude Code standard)
  */
@@ -25,6 +27,10 @@ import {
   classifyFeatureScopeTool,
   handleClassifyFeatureScope,
 } from './tools/feature-scope.js';
+import {
+  diagnoseE2EFailureTool,
+  handleDiagnoseE2EFailure,
+} from './tools/e2e-diagnose.js';
 
 const server = new Server(
   { name: 'mpl-server', version: '0.6.6' },
@@ -33,7 +39,13 @@ const server = new Server(
 
 // Register tools
 server.setRequestHandler(ListToolsRequestSchema, async () => ({
-  tools: [scoreAmbiguityTool, stateReadTool, stateWriteTool, classifyFeatureScopeTool],
+  tools: [
+    scoreAmbiguityTool,
+    stateReadTool,
+    stateWriteTool,
+    classifyFeatureScopeTool,
+    diagnoseE2EFailureTool,
+  ],
 }));
 
 // Handle tool calls
@@ -53,6 +65,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     case 'mpl_classify_feature_scope':
       return handleClassifyFeatureScope(
         args as Parameters<typeof handleClassifyFeatureScope>[0],
+      );
+
+    case 'mpl_diagnose_e2e_failure':
+      return handleDiagnoseE2EFailure(
+        args as Parameters<typeof handleDiagnoseE2EFailure>[0],
       );
 
     default:

--- a/mcp-server/src/lib/e2e-diagnoser.ts
+++ b/mcp-server/src/lib/e2e-diagnoser.ts
@@ -1,0 +1,211 @@
+/**
+ * E2E Failure Diagnoser — LLM-driven root cause + fix strategy classifier.
+ *
+ * Invoked from Finalize only when:
+ *   (a) All required scenarios executed AND
+ *   (b) Tier C UC coverage is complete AND
+ *   (c) At least one scenario failed (exit_code != 0)
+ *
+ * Classification taxonomy:
+ *   A = spec gap             (decomposer must append mini-phases)
+ *   B = test bug             (test-agent re-dispatch; implementation is fine)
+ *   C = missing capability   (Step 1.5 re-run in minimal mode; new UC emerged)
+ *   D = flake                (rerun once with --trace on)
+ *
+ * PROMPT_VERSION is frozen inline so exp12 agreement-rate (auxiliary LLM
+ * labeling per Q8) can gate sunset vs file-promotion decisions in Stage 4.
+ */
+
+export const PROMPT_VERSION = 'v1-2026-04-19';
+
+const MAX_RETRIES = 2;
+
+let cachedSessionId: string | null = null;
+
+export type Classification = 'A' | 'B' | 'C' | 'D';
+
+export interface AppendPhaseHint {
+  position: 'after' | 'before';
+  anchor_phase: string;
+  proposed_id: string;
+  goal: string;
+  covers: string[];
+}
+
+export interface DiagnosisResult {
+  prompt_version: string;
+  classification: Classification;
+  root_cause: string;
+  fix_strategy: string;
+  iter_hint: number;
+  trace_excerpt: string;
+  append_phases: AppendPhaseHint[];
+  confidence: number;
+}
+
+export interface DiagnoserInput {
+  scenarios: string;
+  e2e_results: string;
+  trace_excerpt: string;
+  user_contract: string;
+  decomposition: string;
+  prev_iter: number;
+}
+
+const DIAGNOSE_PROMPT = `You are the MPL E2E Failure Diagnoser.
+
+GOAL: Given a failing E2E run context, classify the root cause and propose a fix
+strategy. You do NOT write code. You produce a structured verdict that the
+orchestrator and decomposer will act on.
+
+CLASSIFICATION RULES (pick exactly one):
+- A = spec gap               (implementation is missing behavior required by the
+                              failing scenario; new phase(s) must be appended.
+                              Fill append_phases with 1-3 hints.)
+- B = test bug               (implementation behavior is correct; the test
+                              itself is wrong — wrong selector, wrong assertion,
+                              wrong setup. Point to the specific test.)
+- C = missing capability     (the scenario exercises a UC that was not declared
+                              in user-contract.md — Step 1.5 must re-run in
+                              minimal mode to append the missing UC.)
+- D = flake                  (non-deterministic environmental failure:
+                              timing, network jitter, resource contention.
+                              Rerun once with trace on.)
+
+FIELDS:
+- root_cause: 1-2 sentences, concrete, referencing specific files/symbols/lines
+  from the provided context.
+- fix_strategy: 1-3 sentences, actionable. For A reference append_phases.
+  For B name the test file. For C name the uncovered UC. For D state the
+  timing/env signal.
+- iter_hint: suggested iter bump for circuit breaker (0, 1, or 2). D typically
+  iter=0 (doesn't count against budget). A/B/C typically iter=1.
+- trace_excerpt: 200-char max excerpt quoting the most damning trace line(s).
+- append_phases: ONLY populated when classification=A. Otherwise empty array.
+- confidence: 0.0..1.0, your confidence in the classification.
+
+RESPOND ONLY WITH VALID JSON (no markdown, no prose):
+{
+  "classification": "A|B|C|D",
+  "root_cause": "",
+  "fix_strategy": "",
+  "iter_hint": 1,
+  "trace_excerpt": "",
+  "append_phases": [],
+  "confidence": 0.85
+}`;
+
+function buildUserMessage(input: DiagnoserInput): string {
+  return [
+    `Scenarios YAML:\n${input.scenarios}`,
+    `E2E Results JSON:\n${input.e2e_results}`,
+    `Trace Excerpt:\n${input.trace_excerpt}`,
+    `User Contract:\n${input.user_contract}`,
+    `Decomposition YAML:\n${input.decomposition}`,
+    `Previous iter: ${input.prev_iter}`,
+  ].join('\n\n');
+}
+
+export function parseDiagnosis(text: string): DiagnosisResult | null {
+  try {
+    const match = text.match(/\{[\s\S]*\}/);
+    if (!match) return null;
+    const p = JSON.parse(match[0]);
+
+    if (!['A', 'B', 'C', 'D'].includes(p.classification)) return null;
+    if (typeof p.root_cause !== 'string') return null;
+    if (typeof p.fix_strategy !== 'string') return null;
+    if (typeof p.iter_hint !== 'number') return null;
+    if (typeof p.trace_excerpt !== 'string') return null;
+    if (!Array.isArray(p.append_phases)) return null;
+    if (typeof p.confidence !== 'number') return null;
+
+    return {
+      prompt_version: PROMPT_VERSION,
+      classification: p.classification as Classification,
+      root_cause: p.root_cause,
+      fix_strategy: p.fix_strategy,
+      iter_hint: Math.max(0, Math.min(2, Math.floor(p.iter_hint))),
+      trace_excerpt: p.trace_excerpt.slice(0, 400),
+      append_phases: p.append_phases,
+      confidence: Math.max(0, Math.min(1, p.confidence)),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function neutralDiagnosis(): DiagnosisResult {
+  return {
+    prompt_version: PROMPT_VERSION,
+    classification: 'D',
+    root_cause:
+      'Diagnoser LLM unavailable — defaulting to flake classification to avoid falsely appending phases.',
+    fix_strategy:
+      'Rerun once. If failure reproduces, escalate to manual review; do NOT auto-append phases under uncertainty.',
+    iter_hint: 1,
+    trace_excerpt: '',
+    append_phases: [],
+    confidence: 0,
+  };
+}
+
+export async function diagnoseE2EFailure(
+  input: DiagnoserInput,
+): Promise<DiagnosisResult> {
+  const fullPrompt = `${DIAGNOSE_PROMPT}\n\nINPUT:\n${buildUserMessage(input)}`;
+
+  let queryFn:
+    | typeof import('@anthropic-ai/claude-agent-sdk').query
+    | null = null;
+  try {
+    const sdk = await import('@anthropic-ai/claude-agent-sdk');
+    queryFn = sdk.query;
+  } catch {
+    return neutralDiagnosis();
+  }
+
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      const opts: Record<string, unknown> = {
+        model: 'opus',
+        maxTurns: 1,
+        systemPrompt:
+          'You are a JSON-only E2E failure diagnoser. Output only valid JSON per the schema.',
+        allowedTools: [],
+      };
+      if (cachedSessionId) opts.sessionId = cachedSessionId;
+
+      const q = queryFn({ prompt: fullPrompt, options: opts });
+      let responseText = '';
+      for await (const event of q) {
+        if (event.type === 'result' && event.subtype === 'success') {
+          responseText = (event as { result: string }).result;
+          const sid = (event as { sessionId?: string }).sessionId;
+          if (sid) cachedSessionId = sid;
+        } else if (event.type === 'assistant') {
+          const msg = event.message as {
+            content?: Array<{ type: string; text?: string }>;
+          };
+          if (msg.content) {
+            for (const block of msg.content) {
+              if (block.type === 'text' && block.text) {
+                responseText += block.text;
+              }
+            }
+          }
+        } else if ((event as { sessionId?: string }).sessionId) {
+          const sid = (event as { sessionId?: string }).sessionId;
+          if (sid) cachedSessionId = sid;
+        }
+      }
+
+      const parsed = parseDiagnosis(responseText);
+      if (parsed) return parsed;
+    } catch {
+      if (attempt === MAX_RETRIES) return neutralDiagnosis();
+    }
+  }
+
+  return neutralDiagnosis();
+}

--- a/mcp-server/src/lib/state-manager.ts
+++ b/mcp-server/src/lib/state-manager.ts
@@ -53,6 +53,15 @@ export interface MplState {
   user_contract_set: boolean;
   user_contract_path: string | null;
   user_contract_iterations: number;
+  // 0.16 Tier C — E2E recovery circuit breaker + last diagnosis snapshot
+  e2e_recovery: {
+    iter: number;
+    max_iter: number;
+    last_classification: 'A' | 'B' | 'C' | 'D' | null;
+    last_diagnosis: Record<string, unknown> | null;
+    halted: boolean;
+    halt_reason: string | null;
+  };
   [key: string]: unknown;
 }
 
@@ -99,6 +108,14 @@ const DEFAULT_STATE: MplState = {
   user_contract_set: false,
   user_contract_path: null,
   user_contract_iterations: 0,
+  e2e_recovery: {
+    iter: 0,
+    max_iter: 2,
+    last_classification: null,
+    last_diagnosis: null,
+    halted: false,
+    halt_reason: null,
+  },
 };
 
 function deepMerge(target: Record<string, unknown>, source: Record<string, unknown>): Record<string, unknown> {

--- a/mcp-server/src/tools/e2e-diagnose.ts
+++ b/mcp-server/src/tools/e2e-diagnose.ts
@@ -1,0 +1,101 @@
+/**
+ * MCP Tool: mpl_diagnose_e2e_failure
+ *
+ * 0.16 Tier C classifier. Orchestrator calls this conditionally from Finalize
+ * when every required scenario ran but one or more failed AND user-contract UC
+ * coverage is complete. Returns a classification + fix strategy JSON that the
+ * orchestrator then acts on (append phases / re-test-agent / re-Step-1.5 /
+ * rerun).
+ *
+ * Budget: expected cost <= 1 opus call per finalize failure. Circuit breaker
+ * (state.e2e_recovery.iter, max=2) caps total diagnose calls per pipeline.
+ */
+
+import {
+  diagnoseE2EFailure,
+  PROMPT_VERSION,
+} from '../lib/e2e-diagnoser.js';
+
+export const diagnoseE2EFailureTool = {
+  name: 'mpl_diagnose_e2e_failure',
+  description:
+    'Classify a failing E2E run as A=spec gap / B=test bug / C=missing capability / D=flake and return a fix strategy. Called conditionally by Finalize (Tier C UC coverage complete + E2E fail). Max 2 invocations per pipeline (circuit breaker).',
+  inputSchema: {
+    type: 'object' as const,
+    properties: {
+      cwd: { type: 'string', description: 'Project root directory' },
+      scenarios: {
+        type: 'string',
+        description: 'Contents of .mpl/mpl/e2e-scenarios.yaml',
+      },
+      e2e_results: {
+        type: 'string',
+        description:
+          'JSON of state.e2e_results (scenario_id → { exit_code, stdout_tail, stderr_tail, trace_path? })',
+      },
+      trace_excerpt: {
+        type: 'string',
+        description:
+          'Concatenated failing-scenario trace excerpts (best-effort, 4KB max). Orchestrator prepares from trace files.',
+      },
+      user_contract: {
+        type: 'string',
+        description: 'Contents of .mpl/requirements/user-contract.md',
+      },
+      decomposition: {
+        type: 'string',
+        description: 'Contents of .mpl/mpl/decomposition.yaml',
+      },
+      prev_iter: {
+        type: 'number',
+        description:
+          'state.e2e_recovery.iter before this call. Used for iter_hint bookkeeping.',
+      },
+    },
+    required: [
+      'cwd',
+      'scenarios',
+      'e2e_results',
+      'trace_excerpt',
+      'user_contract',
+      'decomposition',
+      'prev_iter',
+    ],
+  },
+};
+
+export async function handleDiagnoseE2EFailure(args: {
+  cwd: string;
+  scenarios: string;
+  e2e_results: string;
+  trace_excerpt: string;
+  user_contract: string;
+  decomposition: string;
+  prev_iter: number;
+}) {
+  const prev_iter = Math.max(0, Math.min(2, Math.floor(args.prev_iter)));
+  const result = await diagnoseE2EFailure({
+    scenarios: args.scenarios,
+    e2e_results: args.e2e_results,
+    trace_excerpt: args.trace_excerpt,
+    user_contract: args.user_contract,
+    decomposition: args.decomposition,
+    prev_iter,
+  });
+
+  const ordered = {
+    prompt_version: PROMPT_VERSION,
+    prev_iter,
+    classification: result.classification,
+    root_cause: result.root_cause,
+    fix_strategy: result.fix_strategy,
+    iter_hint: result.iter_hint,
+    trace_excerpt: result.trace_excerpt,
+    append_phases: result.append_phases,
+    confidence: result.confidence,
+  };
+
+  return {
+    content: [{ type: 'text' as const, text: JSON.stringify(ordered, null, 2) }],
+  };
+}


### PR DESCRIPTION
Replaces #47 (auto-closed when its base branch deleted during stacked merge).

## Summary

0.16 Stage 3 — complete E2E contract enforcement and automated failure recovery.

### Commits

- `f4c6c38` (now `9e57d6a~1`): Tier C UC coverage gate + `mpl_diagnose_e2e_failure` MCP tool + circuit-breaker state fields
- `c8b1722` (now `9e57d6a`): Finalize Step 5.0.4 auto-recovery + decomposer APPEND-MODE + Playwright trace + exp12 plan

### Tasks covered

| Task | Change |
|---|---|
| S3-1 | `mpl-require-e2e.mjs` extended with Tier C UC-coverage diff gate (strict default + opt-out). 12 new tests. |
| S3-2 | MCP tool `mpl_diagnose_e2e_failure` (A/B/C/D + fix_strategy + append_phases). 13 new tests. |
| S3-3 | Finalize Step 5.0.4 auto-recovery loop with circuit breaker iter=2 + resume-inline via last_diagnosis (Q9). |
| S3-4 | Decomposer Rule 9 APPEND-MODE for Classification A auto-append. |
| S3-5 | `state.e2e_recovery = { iter, max_iter=2, last_classification, last_diagnosis, halted, halt_reason }`. |
| S3-6 | Step 5.0.3 Playwright trace wrap (`--trace on`, `.mpl/e2e-traces/`). |
| S3-7 | `docs/roadmap/0.16-exp12-plan.md` — 5 primary metrics + Q8 auxiliary-LLM labeling protocol. |

## Test plan

- [x] mcp-server: 25/25 pass (12 feature + 13 diagnoser)
- [x] hooks: 272/273 pass (1 pre-existing mpl-state failure)
- [x] TypeScript build: clean

## Context

- Base: main (Stage 2 #48 merged as `14c922d`)
- Debate decision: `~/project/decision/2026-04-19-mpl-0.16-implementation-plan.md`
- Resume plan: `~/project/wiki/scratch/2026-04-19/mpl-0.16-implementation-resume-plan.md` §3 Stage 3

## Next (Stage 4)

- exp12 on Yggdrasil per `docs/roadmap/0.16-exp12-plan.md`
- Agreement-rate measurement (Q8)
- 4-agent debate: promote / keep / sunset `mpl_diagnose_e2e_failure`
- `/mpl:mpl-version-bump` to 0.16.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)