### PR TITLE
feat(#50): Intent Invariants — teleological drift defense via mechanical G2 verification

### DIFF
--- a/agents/mpl-decomposer.md
+++ b/agents/mpl-decomposer.md
@@ -210,6 +210,28 @@ disallowedTools: Write,Edit,Bash,Task,WebFetch,WebSearch,NotebookEdit
 
       EXPERIMENTAL semantics: pattern matches are recorded as metrics only. They do NOT affect pipeline pass/fail until the CB testbed benchmark promotes to HARD per AD-0005 pre-registered threshold (≥3/5 detection rate).
 
+    Step 9.7: Intent Invariants Mapping (#50, 2026-04-20 debate 합의)
+      Read `.mpl/mpl/phase0/design-intent.yaml` top-level `invariants:` array (may be empty or missing — graceful skip).
+      For each phase, filter invariants matching this phase:
+        - `invariant.applies_to_phases` is empty → applies to all phases
+        - `invariant.applies_to_phases` contains this phase's id → apply
+        - otherwise → skip
+
+      For each matching invariant, **verbatim copy** (NO translation/rewording) the tuple
+        `{ id, statement, verify }` into the phase's `verification_plan.invariants[]` slot.
+
+      **배달부 원칙 (debate 합의)**: statement/verify 문자열은 사용자 확정 verbatim.
+      Decomposer는 번역·재해석·요약 금지. 단순히 `applies_to_phases`로 필터링하고 복사할 뿐이다.
+      이 원칙을 어기면 Intent Invariants 전체의 목적(teleological ground truth)이 무너진다.
+
+      If design-intent.yaml does not exist OR invariants field is missing/empty,
+      each phase emits `verification_plan.invariants: []` (G2 invariant 검증은 no-op).
+
+      Consumer: `commands/mpl-run-execute-gates.md` Hard 2 Regression Suite step
+      appends `verify` commands to the accumulated regression execution for phases
+      where `applies_to_phases` matches. Violations increment
+      `invariant_violation_count` (metric per-phase, aggregated at finalize).
+
     Step 10: Risk assessment (pre-mortem)
       - For each phase: most likely failure cause?
       - For each PP: trace compliance. Where could drift occur?
@@ -302,6 +324,15 @@ disallowedTools: Write,Edit,Bash,Task,WebFetch,WebSearch,NotebookEdit
             - criterion: string
               severity: "HIGH" | "MED" | "LOW"
               reason: string         # why automation is insufficient
+          invariants:                 # #50 (2026-04-20): teleological invariants from design-intent.yaml
+            - id: string              # verbatim from design-intent (e.g., INV-1)
+              statement: string       # verbatim user-confirmed why/constraint
+              verify: string          # verbatim bash command or test selector
+            # Verbatim copy from design-intent.yaml filtered by applies_to_phases.
+            # Empty list [] when no invariants apply to this phase (or design-intent has none).
+            # Consumer: commands/mpl-run-execute-gates.md Hard 2 appends `verify` to
+            # regression suite execution. Violations → invariant_violation_count metric.
+            # See Reasoning_Steps Step 9.7.
 
         estimated_complexity: "S" | "M" | "L"
         estimated_todos: number

--- a/agents/mpl-phase-runner.md
+++ b/agents/mpl-phase-runner.md
@@ -168,11 +168,21 @@ disallowedTools: []
     ```
 
     Discoveries: if implementation touches files outside declared impact, report as a discovery with PP conflict assessment and recommendation.
+
+    **Intent Invariant violations (#50, 2026-04-20 debate 합의)**: if during implementation you find code that violates an active `verification_plan.invariants[]` entry (applicable to this phase), you MUST report it as a Discovery with:
+      - `type: "invariant_violation"`
+      - `invariant_id` (verbatim INV-N reference)
+      - `invariant_statement` (verbatim statement)
+      - `evidence`: minimal code snippet / command output showing the violation
+      - `recommendation`: remediation path
+    Do NOT commit invariant-violating code silently. The Discovery is the single legitimate path to surface an invariant conflict; anything else is drift (MAST FM-1.1 / FM-2.3).
+    This Discovery increments the `discovery_from_intent_conflict` metric (aggregated at finalize).
   </Output_Schema>
 
   <Failure_Modes_To_Avoid>
     1. **Scope creep**: implementing features from other phases or modifying files outside declared impact.
     2. **False verification**: claiming criteria pass without running commands. Always run and record real evidence.
     3. **Weak state summary**: omitting required sections. The next phase has no other source of truth.
+    4. **Silent invariant violation (#50)**: committing code that violates a `verification_plan.invariants[]` entry without Discovery report. Teleological invariants are verbatim user-confirmed ground truth — never rationalize around them.
   </Failure_Modes_To_Avoid>
 </Agent_Prompt>

--- a/commands/mpl-run-execute-gates.md
+++ b/commands/mpl-run-execute-gates.md
@@ -161,9 +161,9 @@ if total_checks == 0:
 Hard 1 passes when: all lint tools + type check + all build tools succeed AND at least one check ran.
 Report: `[MPL] Hard 1: Build + Lint + Type PASSED ({total_checks} checks).`
 
-#### Hard 2: Full Test Suite + Regression ($0, mechanical, binary)
+#### Hard 2: Full Test Suite + Regression + Intent Invariants ($0, mechanical, binary)
 
-Run the full test suite **including accumulated regression tests**:
+Run the full test suite **including accumulated regression tests and Intent Invariants (#50)**:
 - Execute all test commands (pytest, npm test, etc.)
 - **Additionally run regression suite** if `.mpl/regression-suite.json` exists:
   ```
@@ -176,8 +176,41 @@ Run the full test suite **including accumulated regression tests**:
     else:
       announce: "[MPL] Hard 2: Regression suite PASSED ({regression_suite.total_assertions} assertions)"
   ```
-- Combined pass_rate (current + regression) must be >= 95% to pass
-- If pass_rate < 95%: enter fix loop (see 4.6)
+- **Intent Invariants verification (#50, 2026-04-20 debate 합의)**:
+  ```
+  # Verbatim — no translation/interpretation
+  phase_invariants = decomposition.phases[current_phase_id].verification_plan.invariants or []
+  invariant_violation_count = 0
+  invariant_results = []
+
+  for inv in phase_invariants:
+    inv_result = Bash(inv.verify, timeout=60000)
+    passed = (inv_result.exit_code == 0)
+    invariant_results.push({
+      id: inv.id,
+      statement: inv.statement,
+      verify: inv.verify,
+      passed: passed,
+      stderr: inv_result.stderr if not passed else null
+    })
+    if not passed:
+      invariant_violation_count += 1
+
+  # Record metric to phase verification record (consumed by finalize aggregation)
+  writePhaseMetric(current_phase_id, {
+    invariant_violation_count: invariant_violation_count,
+    invariant_results: invariant_results
+  })
+
+  if invariant_violation_count > 0:
+    announce: "[MPL #50] Hard 2: Intent Invariants FAILED ({invariant_violation_count}/{phase_invariants.length} violations). Violated: {invariant_results.filter(!passed).map(.id).join(', ')}"
+    → include invariant violations in fix loop context with statement + stderr
+  else if phase_invariants.length > 0:
+    announce: "[MPL #50] Hard 2: Intent Invariants PASSED ({phase_invariants.length} verified)"
+  # phase_invariants empty → silent no-op (bugfix/simple tasks)
+  ```
+- Combined pass_rate (current tests + regression + invariants) must be >= 95% to pass. **Invariant violations count as hard failures** (not averaged) — any violation blocks Hard 2.
+- If any test/regression/invariant fails: enter fix loop (see 4.6)
 
 ### Common Rationalizations (AD-0006, AD-0004, F-40 Test Agent Dispatch)
 

--- a/commands/mpl-run-finalize.md
+++ b/commands/mpl-run-finalize.md
@@ -756,8 +756,33 @@ Save to `.mpl/mpl/metrics.json`:
     "hard3_status": "NOT_EVALUATED", "hard3_exit_code": null, "hard3_command": null
   },
   "verification_plan": { "a_items": 0, "s_items": 0, "h_items": 0 },
+  "intent_invariants": {
+    // #50 (2026-04-20 debate 합의): teleological invariant tracking.
+    // Aggregated from each phase's verification record (written by Hard 2, G2).
+    "total_declared": 2,                  // sum of verification_plan.invariants[].length across phases (dedup by id)
+    "total_violations": 0,                // sum of invariant_violation_count across phases (Hard 2 runs)
+    "discovery_from_intent_conflict": 0,  // count of discoveries where type == "invariant_violation"
+    "violated_ids": [],                   // [ "INV-2", ... ] — ids that failed in any phase (empty if clean)
+    "by_phase": {                         // per-phase breakdown for debugging
+      // "phase-1": { declared: 1, violations: 0, discoveries: 0 },
+      // "phase-2": { declared: 1, violations: 0, discoveries: 0 }
+    }
+  },
   "triage": { "interview_depth": "full", "prompt_density": 3 }
 }
+```
+
+**Intent Invariant aggregation rule (#50)**:
+```
+total_declared = sum over phases: count of unique invariant.id in phase.verification_plan.invariants
+total_violations = sum over phases: phase.hard2_result.invariant_violation_count
+discovery_from_intent_conflict = count of state.discoveries where type == "invariant_violation"
+violated_ids = unique set of invariant.id values that had invariant_violation_count > 0 in any phase
+
+# Graceful defaults when no invariants declared
+if total_declared == 0:
+  intent_invariants = { "total_declared": 0, "total_violations": 0, "discovery_from_intent_conflict": 0, "violated_ids": [], "by_phase": {} }
+  # (no-op for bugfix/simple tasks — matches optional field semantics)
 ```
 
 Generate full run profile at `.mpl/mpl/profile/run-summary.json`:

--- a/commands/mpl-run-phase0-analysis.md
+++ b/commands/mpl-run-phase0-analysis.md
@@ -309,6 +309,66 @@ Task(subagent_type="mpl-phase0-analyzer", model="sonnet",
    the file with an empty `core_scenarios: []` — doctor audit `[h]` flags this
    but does not FAIL (some projects are library-only without user-facing flows).
 
+3.6. **Intent Invariants Derivation (#50, 2026-04-20 debate 합의)**: teleological 불변식을 설정한다.
+
+   **목적**: Subagent drift 방지 (MAST FM-1.1/2.2/2.3). Intent는 push 텍스트가 아닌 **mechanical invariant** — G2 Gate에서 기계 검증되는 teleological 검사.
+
+   **Runs only if**: 사용자가 PP 확인 단계를 통과. Simple grade는 생략 가능(기본 empty).
+
+   **Authoring rule (Option C — LLM draft + 사용자 명시 confirm)**:
+   - LLM이 Phase 0 맥락(PP, core_scenarios, user_request) 기반으로 **2-3개 draft 제안**
+   - 사용자는 각 draft에 대해 **edit / delete / confirm 중 하나를 반드시 명시적으로 수행** (기본 수락 금지)
+   - 최종 `statement`는 사용자 확정 문구의 verbatim
+
+   ```
+   # LLM draft 생성 (orchestrator inline, 저비용)
+   invariant_drafts = draft_invariants_from_context({
+     user_request,
+     pivot_points: confirmed_pps,
+     core_scenarios,
+     max_drafts: 3
+   })
+   # 각 draft는 { id: "INV-N", statement, verify (추정 command), applies_to_phases (추정) }
+
+   confirmed_invariants = []
+   for draft in invariant_drafts:
+     AskUserQuestion(
+       question: "불변식 후보 {draft.id}: "{draft.statement}" — 검증: `{draft.verify}` — 적용 phase: {draft.applies_to_phases or '전체'}. 어떻게 처리할까요?",
+       header: "INV-{N}",
+       options: [
+         { label: "Confirm (verbatim)",
+           description: "문구와 verify 명령어를 그대로 채택" },
+         { label: "Edit — 문구 수정",
+           description: "statement 또는 verify 를 사용자가 재입력" },
+         { label: "Delete — 이 불변식 제외",
+           description: "해당 draft를 버림" }
+       ]
+     )
+     if answer == "Confirm":
+       confirmed_invariants.push(draft)
+     elif answer == "Edit":
+       # 추가 free-text prompt로 statement / verify / applies_to_phases 재수집
+       confirmed_invariants.push({ id: draft.id, statement: <user>, verify: <user>, applies_to_phases: <user> })
+     # Delete: 아무것도 push 안 함
+
+   # 빈 배열 허용 — 모두 delete 시 invariants: []
+   ```
+
+   **결과 저장**: `.mpl/mpl/phase0/design-intent.yaml` 파일이 존재하면 해당 파일의 최상위 `invariants:` 필드를 갱신. 존재하지 않으면 최소 구조로 새로 작성:
+
+   ```yaml
+   design_intent: {}   # per-phase design intent는 별도 단계에서 채워짐
+   invariants:
+     - id: INV-1
+       statement: "..."
+       verify: "..."
+       applies_to_phases: [...]
+   ```
+
+   announce: `[MPL #50] Intent invariants: {confirmed_invariants.length}개 확정 (draft {invariant_drafts.length}개 중). 빈 배열이면 G2 invariant 검증은 no-op 스킵.`
+
+   **Immutability**: `invariants`는 Phase 0 재실행 전까지 불변. Decomposer/G2/Worker는 verbatim 소비만 허용(번역/재해석 금지).
+
 4. **Verification Command Capture (AD-0006, v0.15.0)**: establish the verification contract for gate-recorder hook consumption.
 
    ```

--- a/docs/schemas/design-intent.md
+++ b/docs/schemas/design-intent.md
@@ -2,12 +2,16 @@
 
 **생성 시점**: Phase 0 (opus 강화)
 **경로**: `.mpl/mpl/phase0/design-intent.yaml`
-**소비자**: Seed Generator (chain-seed 생성 시 input으로 사용)
-**관련**: #34 Phase 0 opus 강화, `[[specification-over-debugging]]` 원칙
+**소비자**: Seed Generator (chain-seed 생성 시 input), Decomposer (invariants verbatim 매핑), G2 Gate (invariants verify 실행)
+**관련**: #34 Phase 0 opus 강화, #50 Intent Invariants (2026-04-20 debate 합의), `[[specification-over-debugging]]` 원칙
 
 ## 개요
 
 Phase 0 opus가 모든 phase의 **자연어 설계 의도**를 1회 선언. Seed Generator는 이 artifact를 참조하여 chain-seed를 생성. Per-phase opus 호출(Seed JIT) 대신 **Phase 0에 집중 투자**.
+
+파일은 두 개의 top-level 섹션을 갖는다:
+- `design_intent`: per-phase 자연어 설계 의도 (Seed Generator 소비)
+- `invariants`: 프로젝트 전역 **teleological 불변식** (Decomposer verbatim 매핑 + G2 기계 검증)
 
 ## 스키마
 
@@ -21,6 +25,12 @@ design_intent:
     acceptance_criteria: [string]  # 사람이 읽는 완료 기준 (Seed가 machine-verifiable로 구체화)
     non_goals: [string]            # 이 phase가 하지 않는 것 (scope 경계)
     ambiguity_notes: [string]      # 해결 안 된 설계 질문 (있으면 Seed가 resolve 시도)
+
+invariants:                        # optional, 0-3개, 빈 배열 허용
+  - id: string                     # INV-1, INV-2 … 고유 ID
+    statement: string              # 사용자 확정 verbatim 문구 (teleological why/constraint)
+    verify: string                 # bash command 또는 test selector (기계 검증 가능)
+    applies_to_phases: [phase_id]  # 빈 배열이면 전 phase 적용
 ```
 
 ## 작성 원칙
@@ -29,6 +39,14 @@ design_intent:
 2. **WHY 중심**: "왜 이 phase가 있는지", "왜 이 순서인지"
 3. **Test-ready hints**: probing_hints는 Test Agent의 adversarial test 재료
 4. **Non-goals 명시**: scope creep 방지
+
+### Invariants 작성 원칙 (#50)
+
+1. **Teleological 불변식만**: "구현 완료 기준"(AC, Seed 영역)이 아닌 "목적이 살아있는지"를 묻는 검증. 예: 결제 금액 음수 불가, PII 로그 금지, 특정 엔드포인트 latency < 200ms
+2. **Verbatim 보존**: `statement`는 사용자 확정 문구 그대로. Decomposer/Runner는 번역/재해석 금지
+3. **기계 검증 가능**: `verify`는 반드시 실행 가능한 bash/test selector. 사람이 읽어야 하는 체크는 invariant 아님 (probing_hint로)
+4. **0-3개 제한**: 많을수록 signal 희석. 진짜 위배되면 안 되는 핵심만
+5. **optional**: 빈 배열 허용. bugfix/간단 작업은 `invariants: []`로 no-op 스킵
 
 ## 예시
 
@@ -73,6 +91,16 @@ design_intent:
       - "실패 → error message 표시 (credential 구체 정보 노출 금지)"
     non_goals:
       - "Password reset UI (별도 phase)"
+
+invariants:
+  - id: INV-1
+    statement: "인증 응답에 password hash가 절대 포함되지 않는다"
+    verify: "pytest tests/security/test_no_password_leak.py -q"
+    applies_to_phases: [phase-api-auth, phase-ui-login]
+  - id: INV-2
+    statement: "로그인 실패 응답에 credential 구체 정보가 노출되지 않는다"
+    verify: "pytest tests/security/test_generic_error_message.py -q"
+    applies_to_phases: []  # 전 phase 적용
 ```
 
 ## Seed Generator와의 역할 분담
@@ -96,3 +124,13 @@ Phase 0이 재실행되지 않는 한 불변. Discovery Agent가 architectural_d
 - 모든 phase가 design_intent에 등장
 - 필수 필드 (rationale, acceptance_criteria)
 - probing_hints / risk_notes 존재 (empty list 허용)
+- `invariants` 항목이 있으면 각각 `id`, `statement`, `verify` 필수. `applies_to_phases`는 array(빈 배열 허용). `applies_to_phases`에 등장하는 phase id는 모두 design_intent에 존재해야 함.
+- `invariants` 길이 > 3이면 warn (signal 희석 경고)
+
+## Invariants 소비 경로 (#50)
+
+1. **Phase 0 (생성)**: `mpl-phase0-analyzer` 또는 `mpl-interviewer`가 Phase 0 맥락 기반으로 draft 2-3개 제안 → 사용자가 edit/delete/confirm 명시적 수행(기본 수락 금지)
+2. **Decomposer (매핑)**: `applies_to_phases` 필터링 + `verify` 커맨드를 `phase.verification_plan.hard`에 verbatim append (배달부 역할, 번역 금지)
+3. **G2 Gate (검증)**: Hard 2 Regression Suite가 invariant.verify 자동 실행, 위반 시 Fix Loop
+4. **Worker AC**: 구현 중 invariant 위배 코드 발견 시 Discovery 보고 의무 (invariant-violating code commit 금지)
+5. **Finalize (메트릭)**: `invariant_violation_count`, `discovery_from_intent_conflict` 집계


### PR DESCRIPTION
## Summary

Closes #50. Implements the 6-axis **Intent Invariants** consensus from the 2026-04-20 4-perspective debate (converged 3:0) — teleological drift defense against MAST FM-1.1/2.2/2.3 without any Phase Runner prompt changes.

**핵심 원칙**: Intent는 push 텍스트가 아닌 **mechanical invariant**. Pull 모델 + G2 기계 검증 완전 준수.

## 6-Axis Implementation

| 축 | 역할 | 구현 위치 |
|---|---|---|
| 1. Schema | `design_intent.yaml`에 optional `invariants[]` (0-3개) | `docs/schemas/design-intent.md` |
| 2. Authoring (Option C) | Phase 0 interview — LLM draft 2-3개 → 사용자 **명시** confirm/edit/delete (기본 수락 금지) | `commands/mpl-run-phase0-analysis.md` Step 3.6 |
| 3. Decomposer 배달부 | `applies_to_phases` 필터 + verbatim 복사 (번역/해석 금지) | `agents/mpl-decomposer.md` Step 9.7 |
| 4. G2 기계 검증 | Hard 2에서 각 `verify` 실행 + `invariant_violation_count` 기록 | `commands/mpl-run-execute-gates.md` Hard 2 |
| 5. AC 의무 | Worker에 invariant 위반 Discovery 보고 의무 (한 줄) | `agents/mpl-phase-runner.md` |
| 6. Metrics | `invariant_violation_count`, `discovery_from_intent_conflict` 집계 | `commands/mpl-run-finalize.md` Step 5.4 |

## Debate Consensus Rationale

- **(a)** 최소안/심화안 둘 다 거부 → 제3안 채택 (schema + mechanical verification)
- **(b)** 별도 "Task Intent" 섹션 **없음** — `verification_plan` 내부 편입
- **(c)** PP proximity 조건부 주입 **없음** → `applies_to_phases` 필터 방식
- **(d)** Seed(functional AC) vs invariants(teleological) 슬롯 분리, 해석 경로 1개

## Implementation Notes

- Bugfix/simple phases remain **no-op**: empty `invariants[]` → G2 invariant 검증 skip, zeroed metrics
- Phase Runner dispatch 프롬프트 **0줄 변경** (Pull 모델 준수)
- Decomposer는 배달부 — statement/verify 문자열은 사용자 확정 verbatim 그대로
- 현재 `verification_plan.invariants[]` 별도 슬롯으로 편입 (토론에서 제안된 `.hard` 편입 대비 메트릭 집계 단순화 이점)

## Test plan

- [ ] `.mpl/mpl/phase0/design-intent.yaml` 없을 때 graceful skip 확인
- [ ] `invariants: []` empty 배열일 때 G2 Hard 2 no-op 확인
- [ ] invariant violation 발생 시 Hard 2 블록 + fix loop context 포함 확인
- [ ] `applies_to_phases` 필터 동작 (명시 phase / 빈 배열=전체) 확인
- [ ] Phase 0 interview에서 Option C 암묵 수락 방지 (Confirm/Edit/Delete 명시 선택) 확인
- [ ] finalize에서 `intent_invariants` metrics block 생성 확인

## References

- Debate record: \`~/project/decision/2026-04-20-mpl-task-intent-invariants.md\`
- Origin paper: NeurIPS 2025 *Why Do Multi-Agent LLM Systems Fail?* (arXiv:2503.13657v3) — FM-1.1/2.2/2.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)