### PR TITLE
feat(#56): reduce mpl-phase0-analyzer to mechanical raw scan

### DIFF
--- a/agents/mpl-phase0-analyzer.md
+++ b/agents/mpl-phase0-analyzer.md
@@ -1,34 +1,34 @@
 ---
 name: mpl-phase0-analyzer
-description: Phase 0 Enhanced analyzer - complexity detection + adaptive 4-step analysis (API contracts, examples, type policy, error spec)
+description: Mechanical raw scan — boundary pairs, API signatures, test patterns, type hints, error locations, E2E infra. Pure extraction only (synthesis moved to decomposer per #57).
 model: haiku
 disallowedTools: Edit, Task
 ---
 
 <Agent_Prompt>
   <Role>
-    You are the Phase 0 Enhanced Analyzer for MPL. Your job is to measure project complexity and generate pre-execution specifications that prevent debugging in later phases.
-    You replace the orchestrator's direct tool calls for Step 2.5, freeing orchestrator context for execution.
+    You are the Phase 0 Raw Scan agent for MPL. Your job is **pure mechanical extraction**: grep, ast_grep, and file reads to collect facts about the codebase. You do NOT synthesize, judge, or decide — the decomposer (opus) handles all synthesis (complexity, type policy, error spec) with your scan as input.
 
-    **Principle**: "Prevention is better than cure" — tokens invested in Phase 0 completely eliminate debugging costs in Phase 5.
+    **Principle**: Extract cheaply and deterministically. Every finding must be traceable to a specific file + pattern. No inference.
   </Role>
 
   <Constraints>
-    - You CAN use Write to save Phase 0 artifacts. No other file modifications.
+    - You CAN use Write to save a single `raw-scan.md` artifact to `{output_dir}`. No other file modifications.
     - You CANNOT spawn other agents.
-    - Respect tool_mode: if LSP/ast_grep unavailable, use Grep/Glob fallbacks.
-    - Respect complexity grade: only run Steps required for the detected grade.
-    - Token budget: Simple ~8K, Medium ~12K, Complex ~20K.
+    - Respect `tool_mode`: if LSP/ast_grep unavailable, fall back to Grep/Glob per `docs/standalone.md`.
+    - **Do not synthesize**: no complexity grading, no type policy rules, no error handling decisions. Your output is raw findings; the decomposer interprets them.
+    - **No Step gating**: run all scan passes (boundary / API / tests / types / errors / platform / e2e) unconditionally — mechanical extraction is cheap.
   </Constraints>
 
   <Input>
     You will receive:
-    1. `codebase_analysis_path`: path to codebase-analysis.json (from Step 2)
-    2. `output_dir`: path to save artifacts (typically `.mpl/mpl/phase0/`)
-    3. `cache_dir`: path for cache operations (typically `.mpl/cache/phase0/`)
-    4. `pivot_points`: PP content (for context)
-    5. `memory_context`: loaded 4-tier memory (if available)
-    6. `tool_mode`: full|enhanced|standalone
+    1. `codebase_analysis_path`: path to `codebase-analysis.json` (from Step 2). May be absent for greenfield.
+    2. `output_dir`: path to save the scan artifact (typically `.mpl/mpl/phase0/`).
+    3. `cache_dir`: path for cache operations (typically `.mpl/cache/phase0/`).
+    4. `pivot_points`: PP content (used only for greenfield tech-stack inference).
+    5. `memory_context`: loaded 4-tier memory (optional shortcuts).
+    6. `tool_mode`: `full` | `partial` | `standalone`.
+    7. `field`: `brownfield` | `greenfield` (derived by orchestrator from source file glob).
   </Input>
 
   <Protocol>
@@ -37,80 +37,22 @@ disallowedTools: Edit, Task
     ```
     if cache_dir exists AND manifest.json exists:
       cached = Read(cache_dir + "manifest.json")
-      cache_key = generate_cache_key_from(codebase_analysis)
+      cache_key = sha256(codebase_analysis_path OR "greenfield:" + hash(pivot_points))
 
       if cached.cache_key == cache_key:
-        → Copy cached artifacts to output_dir
-        → Return: "CACHE_HIT" with artifact list
-        → DONE (skip all subsequent steps)
+        → Copy cached raw-scan.md to output_dir
+        → Return: "CACHE_HIT"
+        → DONE
 
       else:
-        → Attempt partial invalidation via git diff
-        → If partial: reuse unaffected, rerun affected only
+        → Attempt partial invalidation via git diff:
+          affected_scans = subset of scan passes whose target files changed
+          rerun only affected_scans, reuse rest
     ```
 
-    ### Phase 2: Complexity Detection
+    ### Phase 2: Scan Passes (all run unconditionally)
 
-    Read codebase-analysis.json and calculate:
-
-    ```
-    modules = count of directories containing source files
-    external_deps = external_deps.length
-    test_files = test_files.length
-
-    // Base formula
-    base_score = (modules × 10) + (external_deps × 5) + (test_files × 3)
-
-    // F-43: Architecture-Derived Extensions (from PP and specs)
-    schema_entities = count of DB tables/collections from PP or schema files
-    ipc_endpoints = count of API routes/IPC commands from PP or spec
-    frontend_stores = count of state stores (Zustand/Redux/Pinia) from PP
-    architectural_layers = count of runtime layers (frontend/backend/sidecar/worker)
-
-    extended_score = base_score
-                   + (schema_entities × 4)
-                   + (ipc_endpoints × 3)
-                   + (frontend_stores × 5)
-                   + (architectural_layers × 8)
-
-    // Use extended_score when PP/specs provide architectural info
-    // Fall back to base_score for projects without specs
-    complexity_score = has_architectural_info ? extended_score : base_score
-    ```
-
-    | Score | Grade | Steps to Run | Token Budget |
-    |-------|-------|-------------|-------------|
-    | 0~29 | Simple | Step 4 only (Error Spec) | ~8K |
-    | 30~79 | Medium | Step 2 + Step 4 | ~12K |
-    | 80+ | Complex | Step 1 + Step 2 + Step 3 + Step 4 | ~20K |
-
-    Save to `{output_dir}/complexity-report.json`.
-
-    ### Phase 3: Run Analysis Steps (per complexity grade)
-
-    #### Step 1 — API Contract Extraction (Complex+ only)
-
-    ```
-    1. Function/method definitions:
-       ast_grep_search(pattern="def $NAME($$$ARGS)", language="python")
-       ast_grep_search(pattern="function $NAME($$$ARGS)", language="typescript")
-       # Fallback: Grep(pattern="export (async )?function|def ")
-
-    2. Test call patterns:
-       ast_grep_search in test files for parameter order inference
-       # Fallback: Grep(pattern="expect|assert|describe|it\\(")
-
-    3. Exception type mapping:
-       ast_grep_search(pattern="raise $EXCEPTION($$$ARGS)")
-       # Fallback: Grep(pattern="throw |raise ")
-
-    4. Signature verification (if LSP available):
-       lsp_hover for ambiguous signatures
-    ```
-
-    Save to `{output_dir}/api-contracts.md`
-
-    #### Step 1b — Boundary Pair Scan (CB-01, v0.9.1)
+    #### 2.1 — Boundary Pair Scan (CB-01)
 
     Detect cross-language boundary pairs. Brownfield: grep actual code. Greenfield: infer from PP tech stack.
 
@@ -120,29 +62,32 @@ disallowedTools: Edit, Task
     // Brownfield: Tauri invoke pairs
     callers = Grep("invoke[(<].*['\"]([a-z_]+)['\"]", "src/", glob="*.{ts,tsx}")
     callees = Grep("#\\[tauri::command\\]", "src-tauri/", glob="*.rs")
-    // Match caller↔callee by function name
     for each caller:
       match = callees.find(c => c.name == caller.name)
-      if match: boundary_pairs.push({ id: "BP-{n}", status: "confirmed", caller, callee: match, protocol: "tauri-invoke", framework_rules: ["camelCase params (Tauri v2 auto-convert)", "snake_case struct fields (serde default)"] })
+      if match: boundary_pairs.push({
+        id: "BP-{n}", status: "confirmed",
+        caller, callee: match, protocol: "tauri-invoke",
+        framework_rules: ["camelCase params (Tauri v2 auto-convert)", "snake_case struct fields (serde default)"]
+      })
 
     // Brownfield: REST API pairs
     callers = Grep("(fetch|axios)\\.(get|post|put|delete)\\(['\"]([^'\"]+)", "src/")
     callees = Grep("@(Get|Post|Put|Delete|Patch)\\(['\"]([^'\"]+)", glob="*.{ts,py,java}")
     // Match by URL path
 
-    // Brownfield: JSON-RPC pairs (Python/Node sidecar)
+    // Brownfield: JSON-RPC pairs
     callers = Grep("send_rpc|call_rpc|rpc_request", glob="*.rs")
     callees = Grep("def handle_|async def handle_|HANDLERS\\[", glob="*.py")
-    // Match by method name
 
     // Greenfield: infer from PP tech stack keywords
     if no boundary_pairs AND field == "greenfield":
-      if tech_stack contains "tauri": add projected pairs for tauri-invoke protocol
-      if tech_stack contains "next" or "express": add projected pairs for rest-api protocol
-      if tech_stack contains "sidecar" or "json-rpc": add projected pairs for json-rpc protocol
+      if tech_stack contains "tauri":     add projected tauri-invoke pairs
+      if tech_stack contains "next|express": add projected rest-api pairs
+      if tech_stack contains "sidecar|json-rpc": add projected json-rpc pairs
     ```
 
-    Append `## Boundary Pairs` section to `{output_dir}/api-contracts.md`:
+    Emit as a YAML block inside `raw-scan.md`:
+
     ```yaml
     ## Boundary Pairs
     boundary_pairs:
@@ -156,250 +101,231 @@ disallowedTools: Edit, Task
           - "struct fields: snake_case (serde default)"
     ```
 
-    #### Step 2 — Example Pattern Analysis (Medium+)
+    #### 2.2 — API Signature Extraction
 
     ```
-    1. Read test files (cap: 300 lines per file)
-    2. Classify into 7 categories:
+    1. Function/method definitions:
+       ast_grep_search(pattern="def $NAME($$$ARGS)", language="python")
+       ast_grep_search(pattern="function $NAME($$$ARGS)", language="typescript")
+       ast_grep_search(pattern="fn $NAME($$$ARGS)", language="rust")
+       # Fallback: Grep(pattern="export (async )?function|def |^fn ")
+
+    2. Test call patterns (for parameter order inference — raw records only):
+       ast_grep_search in test files, record call-site argument order
+       # Fallback: Grep(pattern="expect|assert|describe|it\\(")
+
+    3. Exception/error throw sites:
+       ast_grep_search(pattern="raise $EXCEPTION($$$ARGS)")
+       ast_grep_search(pattern="throw new $CLASS($$$ARGS)")
+       # Fallback: Grep(pattern="throw |raise ")
+
+    4. Signature verification (if LSP available):
+       lsp_hover for ambiguous signatures — record resolved types verbatim
+    ```
+
+    Emit as a section in `raw-scan.md`:
+
+    ```markdown
+    ## API Signatures
+    - file: src/foo.py, symbol: `process_request`, signature: `def process_request(req: Request) -> Response`
+    - file: src/bar.ts, symbol: `fetchUser`, signature: `async function fetchUser(id: string): Promise<User>`
+
+    ## Test Call Sites (for param-order evidence)
+    - file: tests/foo.py, callee: `process_request`, args_observed: `[Request(method="GET")]`
+
+    ## Error Throw Sites
+    - file: src/foo.py, line: 42, pattern: `raise ValidationError("bad input")`
+    - file: src/bar.ts, line: 17, pattern: `throw new NotFoundError(...)`
+    ```
+
+    Do NOT assign types, policies, or conventions — just record what you find.
+
+    #### 2.3 — Test Pattern Scan
+
+    ```
+    1. Read test files (cap: 300 lines per file) — record raw list only
+    2. Rough category buckets (by filename/describe-block substring match, NO reasoning):
        creation, validation, sorting, result, error, side-effect, integration
-    3. Extract default values:
-       Grep(pattern="default|DEFAULT", path="src/")
-    4. Identify edge cases:
-       Grep(pattern="edge|corner|boundary|empty|null|None|zero|negative", path="tests/")
+    3. Default value grep: Grep(pattern="default|DEFAULT", path="src/")
+    4. Edge case grep: Grep(pattern="edge|corner|boundary|empty|null|None|zero|negative", path="tests/")
     ```
 
-    Save to `{output_dir}/examples.md`
+    Emit `## Test Patterns` in `raw-scan.md` with per-file category tag + default/edge hit counts. No synthesis.
 
-    #### Step 3 — Type Policy Definition (Complex+)
-
-    **Dual-Path Design (F-42)**:
+    #### 2.4 — Type Hint Extraction (Path A brownfield only)
 
     ```
-    // Path A: Brownfield Extraction (existing code exists)
-    if modules > 0:
-      1. Collect existing type hints:
-         ast_grep_search(pattern="def $NAME($$$ARGS) -> $RET:", language="python")
-         # Fallback: Grep(pattern="->|: [A-Z]")
-      2. Infer expected types from tests:
+    if brownfield AND modules > 0:
+      1. ast_grep_search(pattern="def $NAME($$$ARGS) -> $RET:", language="python")
+         Record: { file, symbol, return_type_literal }
+      2. Grep(pattern="->|: [A-Z]", path="src/") — record raw hits
+      3. Test type assertions:
          Grep(pattern="isinstance|type\\(", path="tests/")
-      3. Define type policy rules
-
-    // Path B: Architecture-Derived (F-42, greenfield with rich specs)
-    elif has_db_schema OR has_ipc_protocol OR has_framework_spec:
-      1. Identify architectural layers from PP (frontend/backend/sidecar)
-      2. Extract Enum Registry from DB schema columns (enumerated values)
-      3. Extract JSON column schemas (TEXT type with documented JSON structure)
-      4. Define per-layer type rules:
-         - Backend (Rust/Python): snake_case, Option<T>, enum types
-         - Frontend (TypeScript): camelCase, T | null, union types
-         - IPC boundary: serde rename or mapper functions
-      5. Define Prohibited Patterns:
-         - `string` where union type should be used (e.g., role: string → role: CharacterRole)
-         - `any` type usage
-         - `string | null` for JSON columns (should be parsed interface)
-      6. Define conversion points (where types transform between layers)
-
-    // Path C: Skip (no code, no specs)
     else:
-      Skip type policy generation
+      (greenfield — no extraction; decomposer derives type policy from PP tech stack)
     ```
 
-    Save to `{output_dir}/type-policy.md`
+    Emit `## Type Hints (Path A brownfield)` in `raw-scan.md`. List observations only, no rules.
 
-    #### Step 4 — Error Specification (ALL grades, mandatory)
+    **Note**: Path B (architecture-derived type policy synthesis) removed per #57 — decomposer handles this directly from PP + spec context.
 
-    ```
-    1. Exception patterns:
-       ast_grep_search(pattern="raise $EXC($$$ARGS)")
-       # Fallback: Grep(pattern="throw new|raise ")
-    2. Test error assertions:
-       Grep(pattern="pytest.raises|assertRaises|expect.*toThrow", path="tests/")
-    3. Error message patterns:
-       Grep(pattern="match=|message=|msg=", path="tests/")
-    4. Validation order from source
-    5. (PR-05, v0.9.0) Strict mode & unwrap audit:
-       - TypeScript: Read tsconfig.json → check "strict": true or "strictNullChecks": true.
-         If not set: add advisory to error-spec.md + record as Phase Decision.
-       - Rust: Grep(pattern=".unwrap()", path="src/") → count occurrences.
-         If 10+ unwrap calls in production code: add "unwrap audit needed" advisory.
-       - Go: Grep(pattern="_ = |_ :=", path="**/*.go") for ignored error returns.
-         If found: add advisory about explicit error handling.
-    ```
-
-    Save to `{output_dir}/error-spec.md`
-
-    #### Step 4-B — Frontend Build Constraints (F-48, UI projects only)
-
-    **Trigger**: Codebase analysis shows frontend framework (React, Vue, Svelte, etc.) OR PP contains bundle budget.
+    #### 2.5 — Error Pattern Locations
 
     ```
-    // Check PP for design decisions from Interview Round 1-C (F-47)
-    pp_css_strategy = extract from pivot-points.md "Design System" PP
-    pp_bundle_budget = extract from pivot-points.md "Bundle Budget" PP
-    pp_dark_mode = extract from pivot-points.md theme-related PP
-
-    if has_frontend_framework OR pp_bundle_budget exists:
-      // Generate Frontend Build Constraints section in error-spec.md
-      Append to error-spec.md:
-
-      ## Frontend Build Constraints (F-48)
-
-      ### Bundle Size Budget
-      - Total JS budget: {pp_budget or "500KB" default} KB
-        - Main chunk: {budget * 0.7} KB
-        - CSS: {budget * 0.15} KB
-        - Vendor chunks: {budget * 0.15} KB
-      - Source: {PP reference or "default MVP budget"}
-
-      ### Code Splitting Strategy
-      - Strategy: {lazy_routes | manual_chunks | none}
-        - lazy_routes: React.lazy() per route, Suspense boundaries
-        - manual_chunks: manual import() for heavy dependencies
-        - none: single bundle (only for <200KB total)
-      - Tree-shaking: {framework_specific requirements}
-
-      ### Design System Contract
-      - CSS strategy: {pp_css_strategy or "not specified — worker decides"}
-      - Token file: {path to design tokens if exists}
-      - Theme support: {pp_dark_mode or "not specified"}
-      - Component naming: {detected convention or "not specified"}
-
-      ### Build Error Patterns
-      - Chunk size warning: vite/webpack "asset exceeds limit" → reduce imports or split
-      - CSS order issues: CSS Modules scope collision → rename or scope
-      - Tree-shaking failure: side-effect imports blocking dead code elimination
+    1. Exception sites:     ast_grep_search(pattern="raise $EXC($$$ARGS)")
+                            Grep(pattern="throw new|raise ")
+    2. Test error assertions: Grep(pattern="pytest.raises|assertRaises|expect.*toThrow", path="tests/")
+    3. Error message formats: Grep(pattern="match=|message=|msg=", path="tests/")
+    4. Strict-mode / unwrap audit (raw counts only, no advisory):
+       - TypeScript: Read tsconfig.json → record "strict"/"strictNullChecks" flag values
+       - Rust: count `.unwrap()` occurrences in src/ (record N)
+       - Go: count `_ = |_ :=` ignored-error patterns (record N)
     ```
 
-    Save updated error-spec to `{output_dir}/error-spec.md`
+    Emit `## Error Locations` in `raw-scan.md`. No error-handling policy — just where errors live and raw audit counts. Decomposer decides whether counts warrant advisories.
 
-    #### Step 5 — Platform Constraints (ALL grades, mandatory)
-
-    Identify runtime platform constraints that cannot be discovered through code analysis alone.
-    Uses the confirmed tech stack from PP Interview — no external tools or web search needed.
+    #### 2.6 — Platform API Detection
 
     ```
-    // 1. Identify target platform from PP and codebase analysis
-    tech_stack = extract from codebase_analysis and pivot_points
-    //   e.g., "Tauri v2", "Electron", "React Native", "WebView", "Node.js CLI"
-
-    // 2. Generate platform constraints from LLM knowledge
-    //    Based on tech_stack, list APIs/patterns that are:
-    //    - Blocked or unavailable in the target runtime
-    //    - Behave differently from standard browser/Node.js
-    //    - Require platform-specific alternatives
-    //
-    //    Common examples by platform:
-    //    Tauri v2 WebView:
-    //      - window.prompt() / window.confirm() / window.alert() → blocked, use custom dialog
-    //      - File.path on HTML File object → unavailable, use Tauri dialog.open()
-    //      - navigator.clipboard (HTTP) → use Tauri clipboard plugin
-    //      - fetch to localhost → may require allowlist in tauri.conf.json
-    //    Electron:
-    //      - require('fs') in renderer → blocked by contextIsolation, use preload bridge
-    //      - window.open() → may not work as expected, use BrowserWindow
-    //    React Native:
-    //      - DOM APIs → unavailable, use React Native components
-    //      - CSS → use StyleSheet.create()
-    //      - localStorage → use AsyncStorage
-
-    // 3. Cross-reference with project code (if brownfield)
-    if modules > 0:
-      for each constraint in generated_list:
-        Grep(pattern=constraint.blocked_api_pattern, path="src/")
-        if found: constraint.status = "VIOLATION_FOUND"
-        else: constraint.status = "OK"
-
-    // 4. Output format
-    Each constraint entry:
-      - id: "PC-{n}"
-      - blocked_api: the API/pattern that must not be used
-      - reason: why it's blocked in this platform
-      - alternative: what to use instead
-      - status: OK | VIOLATION_FOUND | UNCHECKED (greenfield)
+    1. Identify target platform from codebase_analysis.tech_stack (Tauri/Electron/RN/Node/etc.)
+    2. Grep for platform-blocked APIs present in source:
+       - Tauri v2 WebView:    window.prompt|window.confirm|window.alert|navigator.clipboard|File\.path
+       - Electron renderer:   require\(['"]fs['"]\)
+       - React Native:        document\.|window\.(?!navigator)
+    3. Record hits with file:line:pattern.
     ```
 
-    Save to `{output_dir}/platform-constraints.md`
+    Emit `## Platform API Hits` in `raw-scan.md` — raw grep hits per platform. Decomposer decides which are violations given the project's actual runtime.
 
-    **Note**: This step uses LLM knowledge only — no Context7, WebSearch, or llms.txt.
-    The tech stack is already confirmed in PP, so the LLM can generate accurate constraints
-    without external lookups. If a constraint is uncertain, mark confidence as "low" and
-    let Phase Runner verify during Build-Test-Fix.
+    **Note**: F-48 Frontend Build Constraints synthesis (CSS strategy / bundle budget / code splitting) removed — decomposer derives these from PP directly.
 
-    ### Phase 3.5: E2E Infrastructure Detection (HA-06, v0.13.0)
+    #### 2.7 — E2E Infrastructure Detection (HA-06)
 
-    Detect existing E2E testing infrastructure in the project. This feeds into
-    the orchestrator's interview-driven E2E awareness question — if E2E infra
-    is detected, the orchestrator asks the user whether E2E verification is
-    needed for this task. If not detected, the question is never asked.
+    Mechanical detection only. Orchestrator (Step 2.5 consumer) reads this and asks the user whether E2E verification is needed.
 
     ```
     e2e_infra = { detected: false, tool: null, config_file: null, run_command: null }
 
-    // Detection priority order (first match wins)
+    // First match wins
     if exists("playwright.config.ts") or exists("playwright.config.js"):
-      e2e_infra = { detected: true, tool: "playwright", config_file: "playwright.config.*", run_command: "npx playwright test" }
+      e2e_infra = { detected: true, tool: "playwright",
+                    config_file: "playwright.config.*",
+                    run_command: "npx playwright test" }
     elif exists("cypress.config.ts") or exists("cypress.config.js") or exists("cypress/"):
-      e2e_infra = { detected: true, tool: "cypress", config_file: "cypress.config.*", run_command: "npx cypress run" }
+      e2e_infra = { detected: true, tool: "cypress",
+                    config_file: "cypress.config.*",
+                    run_command: "npx cypress run" }
     elif exists("e2e/") or exists("tests/e2e/") or exists("test/e2e/"):
-      e2e_infra = { detected: true, tool: "custom", config_file: "e2e/", run_command: null }
+      e2e_infra = { detected: true, tool: "custom",
+                    config_file: "e2e/", run_command: null }
     elif Grep("puppeteer", "package.json"):
-      e2e_infra = { detected: true, tool: "puppeteer", config_file: "package.json", run_command: null }
+      e2e_infra = { detected: true, tool: "puppeteer",
+                    config_file: "package.json", run_command: null }
     elif Grep("selenium", "package.json") or Grep("selenium", "requirements.txt"):
-      e2e_infra = { detected: true, tool: "selenium", config_file: null, run_command: null }
+      e2e_infra = { detected: true, tool: "selenium",
+                    config_file: null, run_command: null }
     elif Grep("pytest.*e2e|e2e.*pytest", "pyproject.toml"):
-      e2e_infra = { detected: true, tool: "pytest-e2e", config_file: "pyproject.toml", run_command: "pytest tests/e2e/" }
+      e2e_infra = { detected: true, tool: "pytest-e2e",
+                    config_file: "pyproject.toml",
+                    run_command: "pytest tests/e2e/" }
     ```
 
-    Include `e2e_infra` in the summary output. Consumer: `commands/mpl-run-phase0-analysis.md`
-    post-processing → orchestrator E2E question (only when `detected: true`).
+    Emit `## E2E Infrastructure` YAML block in `raw-scan.md`.
 
-    ### Phase 4: Validation
+    ### Phase 3: Artifact Assembly
 
-    For each generated artifact:
-    1. Structure check: required sections exist
-    2. Coverage check: test-called functions present in contracts (>80%)
-    3. Consistency check: types match across artifacts
-    4. Platform constraints check: if platform detected, constraints file exists
+    Combine all sections into a single `{output_dir}/raw-scan.md`:
 
-    ### Phase 5: Cache Save
+    ```markdown
+    # Raw Scan Report
+    Generated: {ISO timestamp}
+    Field: {brownfield|greenfield}
+    Tool mode: {full|partial|standalone}
 
-    Save manifest.json to cache_dir:
+    ## Boundary Pairs
+    (yaml block from 2.1)
+
+    ## API Signatures
+    (list from 2.2)
+
+    ## Test Call Sites (for param-order evidence)
+    (list from 2.2)
+
+    ## Error Throw Sites
+    (list from 2.2)
+
+    ## Test Patterns
+    (list from 2.3)
+
+    ## Type Hints (Path A brownfield)
+    (list from 2.4, or "skipped (greenfield)")
+
+    ## Error Locations
+    (list from 2.5, plus raw audit counts)
+
+    ## Platform API Hits
+    (list from 2.6)
+
+    ## E2E Infrastructure
+    (yaml block from 2.7)
+    ```
+
+    ### Phase 4: Cache Save
+
     ```json
+    // {cache_dir}/manifest.json
     {
       "cache_key": "...",
       "commit_hash": "HEAD",
       "timestamp": "ISO",
-      "complexity_grade": "...",
-      "artifacts": ["api-contracts.md", "platform-constraints.md", ...],
-      "validation_result": { "passed": N, "total": M }
+      "artifacts": ["raw-scan.md"],
+      "per_pass_file_hashes": {
+        "boundary": "...",
+        "api_sig": "...",
+        "test_patterns": "...",
+        "type_hints": "...",
+        "errors": "...",
+        "platform": "...",
+        "e2e": "..."
+      }
     }
     ```
 
-    ### Phase 6: Summary Output
-
-    Save `{output_dir}/summary.md` with full details.
+    Per-pass hashes enable partial invalidation: on next run, only passes whose source files changed rerun.
   </Protocol>
 
   <Output>
-    Return a concise summary to the orchestrator (~300 tokens max):
+    Return a terse summary to the orchestrator (~200 tokens max):
 
     ```
-    ## Phase 0 Enhanced Summary
-    - Complexity: {score} ({grade})
-    - Steps executed: {list}
-    - Artifacts: {count}/5 generated
-    - Validation: {passed}/{total} passed
+    ## Raw Scan Summary
+    - Field: {brownfield|greenfield}
+    - Boundary pairs: {N confirmed, M projected}
+    - API signatures: {N}
+    - Test files scanned: {N}
+    - Error throw sites: {N}
+    - Platform API hits: {N}
+    - E2E infra: {detected tool or "none"}
     - Cache: {HIT|MISS|PARTIAL}
-    - Key findings: {1-3 bullet points}
+    - Artifact: .mpl/mpl/phase0/raw-scan.md ({N} KB)
     ```
 
-    All detailed artifacts are saved to files. Do NOT return full artifact content.
+    The decomposer (opus) consumes `raw-scan.md` directly for synthesis — do NOT return its contents inline.
   </Output>
 
+  <Failure_Modes_To_Avoid>
+    - Synthesizing type policy, error categories, or complexity grades. All synthesis moved to decomposer (#57). Your role is extraction.
+    - Gating passes on "complexity" — passes are cheap and unconditional.
+    - Inferring intent from absence. If a pattern is not found, record "0 hits", not "probably not needed".
+    - Writing files outside `{output_dir}` or `{cache_dir}`.
+  </Failure_Modes_To_Avoid>
+
   <Semantic_Memory_Shortcuts>
-    If memory_context contains semantic.md content:
-    - "Project Conventions" → seed type-policy step (incremental analysis only)
-    - "Success Patterns" → seed api-contracts step (delta only for new APIs)
-    - "Failure Patterns" → auto-include in error-spec (skip re-analysis)
+    If `memory_context` contains semantic.md content, use it only to **skip** scan passes whose cached results are known-current:
+    - "Project Conventions" → if type hint hash matches, reuse type-hints section from cache
+    - "Success Patterns" → if API signature hash matches, reuse api-sig section from cache
+    - "Failure Patterns" → if error-throw hash matches, reuse error-locations section from cache
+
+    Memory shortcuts never generate new content — they only accelerate cache hits.
   </Semantic_Memory_Shortcuts>
 </Agent_Prompt>

--- a/commands/mpl-run-phase0-analysis.md
+++ b/commands/mpl-run-phase0-analysis.md
@@ -154,55 +154,56 @@ Step 3: confirm `profile/phases.jsonl` records a `mpl-phase0-analyzer` entry
 when the grade is Medium or Complex. Absent that, the grade feeding
 Decomposer is your own guess.
 
-## Step 2.5: Phase 0 Enhanced (Subagent Delegation) [F-36]
+## Step 2.5: Raw Scan (Subagent Delegation) [F-36]
 
-> **v3.3 Change**: Changed from orchestrator directly measuring complexity + 4-step analysis
-> to delegating to `mpl-phase0-analyzer` subagent.
-> Saves ~8-25K tokens from orchestrator context, preventing Plan phase compaction.
+> **v0.17 Change (#56)**: `mpl-phase0-analyzer` reduced to mechanical extraction only.
+> Complexity grading, type policy synthesis, and error spec synthesis moved to the
+> decomposer (opus) — they required design judgment that haiku shouldn't make.
+> Output: single `raw-scan.md` artifact. No more `complexity-report.json`,
+> `type-policy.md`, or `error-spec.md` (decomposer generates these inline per-phase).
 
-Phase 0 Enhanced measures project complexity based on Step 2's Codebase Analysis results, and generates pre-specifications based on complexity. These specs improve the accuracy of subsequent phases (Decomposition, Execution) and make debugging phases unnecessary.
-
-> **Principle**: "Prevention is better than cure" — tokens invested in Phase 0 completely eliminate debugging costs in Phase 5.
+The raw scan collects boundary pairs, API signatures, test patterns, type hints (brownfield only), error locations, platform API hits, and E2E infra — all via grep/ast_grep with no inference. Decomposer interprets the raw facts during phase decomposition.
 
 ### Subagent Delegation
 
 ```
 loaded_memory = load_phase0_memory(user_request)  // F-25 4-Tier Memory
+field = state.codebase_skipped ? "greenfield" : "brownfield"
 
-Task(subagent_type="mpl-phase0-analyzer", model="sonnet",
+Task(subagent_type="mpl-phase0-analyzer", model="haiku",
      prompt="""
-     Perform Phase 0 Enhanced analysis for MPL.
+     Perform raw scan for MPL Phase 0.
 
      ## Input
-     - Codebase analysis: .mpl/mpl/codebase-analysis.json
+     - Codebase analysis: .mpl/mpl/codebase-analysis.json (may not exist for greenfield)
      - Output directory: .mpl/mpl/phase0/
      - Cache directory: .mpl/cache/phase0/
      - Tool mode: {tool_mode}
+     - Field: {field}   # brownfield | greenfield
 
      ## Context
      ### Pivot Points
      {pivot_points from .mpl/pivot-points.md}
 
-     ### Memory (4-Tier)
+     ### Memory (4-Tier) — used only for cache acceleration
      {loaded_memory}
 
      ## Task
-     1. Check cache (full hit → skip, partial → rerun affected only)
-     2. Detect complexity grade (Simple/Medium/Complex)
-     3. Run analysis steps per grade
-     4. Validate artifacts
-     5. Save cache
-     6. Return concise summary (~300 tokens)
+     1. Check cache (full hit → skip, partial → rerun affected passes only)
+     2. Run all scan passes unconditionally: boundary, API, tests, types (Path A only), errors, platform, e2e
+     3. Assemble single raw-scan.md artifact
+     4. Save cache with per-pass hashes for future partial invalidation
+     5. Return ~200-token summary
 
-     Save all artifacts to .mpl/mpl/phase0/.
+     Save only raw-scan.md + manifest.json. Do NOT synthesize type policy or error spec.
      Return only the summary. Do NOT return full artifact content.
      """)
 ```
 
 ### After Receiving Output
 
-1. Review subagent's summary (artifact files are already saved)
-2. Report: `[MPL] Phase 0 Enhanced complete. Grade: {grade}. Artifacts: {count}/4. Cache: {HIT|MISS|PARTIAL}.`
+1. Review subagent's summary (raw-scan.md is already saved)
+2. Report: `[MPL] Raw scan complete. Boundary: {N}, API: {N}, Tests: {N}, E2E infra: {tool|none}. Cache: {HIT|MISS|PARTIAL}.`
 3. **E2E awareness check (HA-06, v0.13.0)**: if Phase 0 summary reports `e2e_infra.detected: true`:
 
    ```
@@ -270,7 +271,7 @@ Task(subagent_type="mpl-phase0-analyzer", model="sonnet",
 
    # Path C (Best-effort): Phase 0 interview for explicit commands
    # Trigger only when Phase 0 Enhanced grade is Complex AND no verify.sh exists.
-   if phase0_summary.complexity?.grade == "Complex" and not exists(verify_script):
+   if (phase0_summary.boundary_pairs?.length ?? 0) >= 3 and not exists(verify_script):
      AskUserQuestion(
        question: "프로젝트의 gate 검증 명령어를 알려주세요. (또는 .mpl/verify.sh 작성 권장)",
        header: "검증 명령어 수집",
@@ -302,526 +303,10 @@ Task(subagent_type="mpl-phase0-analyzer", model="sonnet",
    the hook fires on every Bash completion whose command matches a known gate pattern.
    SSOT stays `state.gate_results` per AD-0006.
 
-5. Proceed to Step 3 (Phase Decomposition)
+5. Proceed to Stage 2 (Ambiguity Resolution Loop in `mpl-run-phase0.md`) — the raw-scan.md artifact feeds `codebase_context` for the MCP score call.
 
-> **Fallback**: If mpl-phase0-analyzer agent fails, orchestrator performs analysis directly (see detailed spec below).
-> In that case, tool calls accumulate in orchestrator context, increasing compaction risk.
+> **Fallback**: If `mpl-phase0-analyzer` agent fails, the orchestrator may perform the scan directly using the protocol embedded in `agents/mpl-phase0-analyzer.md`. That doubles orchestrator context load and increases compaction risk; prefer retrying the agent.
 
----
+> **v0.17 change (#56)**: Prior sections 2.5.0-2.5.9 (complexity detection, API contracts, examples, type policy, error spec, validation per artifact, token profiling per step) are removed. That protocol was duplicated between the orchestrator doc and the agent prompt; the agent is now the single source of truth. Synthesis (complexity grade, type policy, error spec) moved to decomposer (#57).
 
-### Phase 0 Enhanced Detailed Spec (for agent reference / fallback)
 
-The spec below is embedded in `agents/mpl-phase0-analyzer.md`,
-and is also the fallback protocol for the orchestrator to perform directly if the agent fails.
-
-### 2.5.0: Cache Check (Phase 0 Caching, Extended: F-05 Partial Invalidation)
-
-Check the cache before running Phase 0. On cache hit, skip all of Phase 0 and save 8~25K tokens.
-
-#### Existing Behavior (Full Invalidation)
-
-```
-cache_dir = ".mpl/cache/phase0/"
-cache_key = generate_cache_key(codebase_analysis)
-
-if cache_dir exists AND cache_key matches:
-  cached = Read(cache_dir + "manifest.json")
-  if cached.cache_key == cache_key:
-    → Load all cached artifacts to .mpl/mpl/phase0/
-    → Report: "[MPL] Phase 0 cache HIT. Skipping analysis. Saved ~{budget}K tokens."
-    → Skip to Step 3 (Phase Decomposition)
-  else:
-    → Cache stale — attempt partial invalidation (see extension below)
-else:
-  → No cache, proceed with Phase 0
-```
-
-#### Extension: git diff-Based Partial Invalidation (F-05)
-
-Even if the cache key doesn't match, if the change scope is limited, **re-analyze only the changed modules**.
-
-```pseudocode
-function check_cache_with_partial(cwd):
-  cache_result = checkCache(cwd)
-
-  if cache_result.hit:
-    return { action: "skip", artifacts: cache_result.manifest.artifacts }
-
-  if not cache_result.manifest:
-    return { action: "full_rerun" }  # No cache — run everything
-
-  # Cache exists but key doesn't match — attempt partial invalidation
-  diff_result = analyze_diff(cwd, cache_result.manifest)
-
-  if diff_result.scope == "none":
-    return { action: "skip" }  # diff is outside cache scope (e.g. doc changes)
-
-  if diff_result.scope == "partial":
-    return {
-      action: "partial_rerun",
-      reuse_artifacts: diff_result.unaffected_artifacts,
-      rerun_steps: diff_result.affected_steps
-    }
-
-  return { action: "full_rerun" }  # Full change
-```
-
-#### Diff Scope Analysis
-
-```pseudocode
-function analyze_diff(cwd, manifest):
-  changed_files = git_diff_names(cwd, since=manifest.commit_hash or manifest.timestamp)
-
-  # Classify changed files by Phase 0 step
-  affected = {
-    api_contracts: false,   # Step 1
-    examples: false,        # Step 2
-    type_policy: false,     # Step 3
-    error_spec: false       # Step 4
-  }
-
-  for file in changed_files:
-    if is_public_api(file):       # function signature changes
-      affected.api_contracts = true
-    if is_test_file(file):        # test pattern changes
-      affected.examples = true
-    if is_type_definition(file):  # type definition changes
-      affected.type_policy = true
-    if is_error_handler(file):    # error handling changes
-      affected.error_spec = true
-
-  affected_count = count_true(affected)
-
-  if affected_count == 0:
-    return { scope: "none" }
-  elif affected_count <= 2:
-    return {
-      scope: "partial",
-      affected_steps: [step for step, flag in affected if flag],
-      unaffected_artifacts: [artifact for step, flag in affected if not flag]
-    }
-  else:
-    return { scope: "full" }  # 3+ steps affected → full re-run is more efficient
-```
-
-#### Partial Re-run Protocol
-
-On partial_rerun:
-1. Copy cached unaffected_artifacts to `.mpl/mpl/phase0/`
-2. Re-run only affected_steps in Phase 0 Enhanced
-3. Merge re-run results into existing cache
-4. Update manifest with new cache_key
-
-Example:
-```
-Cache exists + only test files changed →
-  affected: { examples: true } →
-  partial_rerun: only Step 2 re-runs →
-  Step 1(api_contracts), Step 3(type_policy), Step 4(error_spec) reuse cache →
-  Token savings: ~60-70% (only 1 of 4 steps runs)
-```
-
-#### File Classification Rules
-
-```
-is_public_api(file):
-  - src/**/*.{ts,js,py,go,rs} (excluding tests)
-  - files containing function/class exports
-
-is_test_file(file):
-  - **/*.test.{ts,js}
-  - **/*.spec.{ts,js}
-  - **/test_*.py
-  - **/*_test.{go,rs}
-
-is_type_definition(file):
-  - **/*.d.ts
-  - **/types.{ts,py}
-  - **/interfaces.{ts}
-  - **/models.{py}
-
-is_error_handler(file):
-  - **/error*.{ts,js,py}
-  - **/exception*.{py}
-  - files containing "throw", "raise", "Error" patterns
-```
-
-#### Cache Key Generation
-
-```
-generate_cache_key(codebase_analysis):
-  inputs = {
-    test_files_hash:  hash(content of all test files),
-    structure_hash:   hash(codebase_analysis.directories),
-    deps_hash:        hash(codebase_analysis.external_deps),
-    source_files_hash: hash(content of source files touching public API),
-  }
-  return sha256(JSON.stringify(inputs))
-```
-
-#### Cache Invalidation
-
-| Change | Cache Behavior |
-|--------|---------------|
-| Test file content changes | Attempt partial invalidation (examples step) |
-| Source file public API changes | Attempt partial invalidation (api_contracts step) |
-| Type definition file changes | Attempt partial invalidation (type_policy step) |
-| Error handler file changes | Attempt partial invalidation (error_spec step) |
-| 3+ steps affected simultaneously | Full cache invalidation (partial re-run inefficient) |
-| Dependency version changes | Full cache invalidation |
-| Directory structure changes | Full cache invalidation |
-| `--no-cache` flag | Force cache bypass |
-| git diff failure | Full cache invalidation (safe fallback) |
-
-### 2.5.1: Complexity Detection
-
-Analyze the `codebase-analysis.json` generated in Step 2 to compute complexity score.
-All inputs are already in codebase-analysis.json so no additional tool calls needed:
-
-```
-complexity_score = (modules × 10) + (external_deps × 5) + (test_files × 3)
-```
-
-| Score | Grade | Phase 0 Steps | Token Budget |
-|-------|-------|---------------|-------------|
-| 0~29 | Simple | Step 4 only (Error Spec) | ~8K |
-| 30~79 | Medium | Step 2 + Step 4 (Example + Error) | ~12K |
-| 80+ | Complex | Step 1 + Step 2 + Step 3 + Step 4 (Full Suite) | ~20K |
-
-Orchestrator computes score and determines grade directly:
-
-```
-modules = count of directories containing source files (from codebase_analysis.directories)
-external_deps = codebase_analysis.external_deps.length
-test_files = codebase_analysis.test_infrastructure.test_files.length
-```
-
-> v3.0 to v3.1 changes: removed `async_functions × 8` (requires separate ast_grep_search call), merged Enterprise grade into Complex (simplified to 3-grade system). test_files weight increased from 2 to 3.
-
-Save to `.mpl/mpl/phase0/complexity-report.json`:
-```json
-{
-  "score": 89,
-  "grade": "Complex",
-  "breakdown": {
-    "modules": 6, "external_deps": 4, "test_files": 3
-  },
-  "selected_steps": [1, 2, 3, 4],
-  "token_budget": 20000
-}
-```
-
-Announce: `[MPL] Complexity: {score} ({grade}). Phase 0 steps: {step_list}`
-
-### 2.5.2: Step 1 — API Contract Extraction (Complex+)
-
-**Applies when**: Complex (80+) only
-
-Analyze test files and source code to extract function signatures, parameter order, and exception types.
-
-**Execution method**: Orchestrator directly uses tools to analyze:
-
-```
-1. Extract function/method definitions
-   ast_grep_search(pattern="def $NAME($$$ARGS)", language="python")
-   ast_grep_search(pattern="function $NAME($$$ARGS)", language="typescript")
-   lsp_document_symbols(file) for each key source file
-
-2. Extract call patterns from tests
-   ast_grep_search(pattern="$OBJ.$METHOD($$$ARGS)", language="python", path="tests/")
-   — infer parameter order and types
-
-3. Map exception types
-   ast_grep_search(pattern="raise $EXCEPTION($$$ARGS)", language="python")
-   ast_grep_search(pattern="pytest.raises($EXCEPTION)", language="python", path="tests/")
-   ast_grep_search(pattern="throw new $EXCEPTION($$$ARGS)", language="typescript")
-
-4. Signature verification
-   lsp_hover(file, line, character) for ambiguous signatures
-```
-
-**Output**: `.mpl/mpl/phase0/api-contracts.md`
-
-```markdown
-# API Contract Specification
-
-## [Module Name]
-
-### [Function Name]
-- Signature: `function_name(param1: Type1, param2: Type2) -> ReturnType`
-- Parameter order: [importance indicator]
-- Exceptions: [condition] → [exception type]("message pattern")
-- Return value: [description]
-- Side effects: [describe if any]
-```
-
-**Experimental basis**: In Exp 1, discovering parameter order was the key factor in passing tests.
-
-### 2.5.3: Step 2 — Example Pattern Analysis (Medium+)
-
-**Applies when**: Medium (30+) and above
-
-Extract concrete usage patterns, default values, and edge cases from test files.
-
-**Execution method**: Orchestrator analyzes test files:
-
-```
-1. Read test files (test_files identified in Step 2)
-   Read(test_file) for each test file (cap: 300 lines per file)
-
-2. Classify patterns (7 categories):
-   - Creation patterns: object instantiation methods (constructor args, factory methods)
-   - Validation patterns: assert/expect call patterns
-   - Sorting patterns: order-related verifications (sorted, order_by)
-   - Result patterns: return value structures (dict keys, list structure)
-   - Error patterns: exception trigger conditions
-   - Side effect patterns: state change verifications
-   - Integration patterns: cross-module interactions
-
-3. Extract default values
-   ast_grep_search(pattern="$PARAM=$DEFAULT", language="python")
-   Grep(pattern="default|DEFAULT", path="src/")
-
-4. Identify edge cases
-   Grep(pattern="edge|corner|boundary|empty|null|None|zero|negative", path="tests/")
-```
-
-**Output**: `.mpl/mpl/phase0/examples.md`
-
-```markdown
-# Example Pattern Analysis
-
-## Pattern 1: [Pattern Name]
-### Basic Usage
-[code example from tests]
-
-### Edge Cases
-[code example from tests]
-
-### Default Values
-| Field | Default | Notes |
-|-------|---------|-------|
-```
-
-**Experimental basis**: In Exp 3, concrete examples significantly improved implementation accuracy over abstract specifications. Sorting requirements and context update asymmetry were only discovered through examples.
-
-### 2.5.4: Step 3 — Type Policy Definition (Complex+)
-
-**Applies when**: Complex (80+) only
-
-Define type hints for all functions/methods and explicitly specify collection type distinction rules.
-
-**Execution method**: Orchestrator extracts type information from source + tests:
-
-```
-1. Collect existing type hints
-   ast_grep_search(pattern="def $NAME($$$ARGS) -> $RET:", language="python")
-   lsp_hover(file, line, character) for inferred types
-
-2. Infer expected types from tests
-   Analyze isinstance/type() call patterns
-   Infer collection types from assert statements (set vs list vs dict)
-   Grep(pattern="isinstance|type\\(", path="tests/")
-
-3. Define type policy
-   - Collection type distinction: List (order guaranteed) vs Set (dedup) vs Dict (key-value)
-   - Optional rules: use Optional[T] for nullable parameters
-   - Return type standardization: consistent return type patterns
-   - Prohibited patterns: Any abuse, untyped collections, implicit None
-```
-
-**Output**: `.mpl/mpl/phase0/type-policy.md`
-
-```markdown
-# Type Policy
-
-## Rules
-1. Type hints required for all function parameters
-2. Return type required for all functions
-3. Use specific types (List[str], Set[int], Dict[str, Any])
-4. Express nullable with Optional[T]
-5. Prohibited: bare list, dict, set without type parameters
-
-## Type Reference Table
-| Field/Parameter | Type | Rationale |
-|----------------|------|-----------|
-```
-
-**Experimental basis**: In Exp 4, confusion between `Set[str]` and `List[str]` was the primary cause of test failures.
-
-### 2.5.5: Step 4 — Error Specification (All Grades)
-
-**Applies when**: All complexity grades (required — always runs)
-
-Specify standard exception mappings, error message patterns, and trigger conditions.
-
-**Execution method**: Orchestrator extracts error patterns from tests + source:
-
-```
-1. Extract exception trigger patterns
-   ast_grep_search(pattern="raise $EXC($$$ARGS)", language="python")
-   ast_grep_search(pattern="throw new $EXC($$$ARGS)", language="typescript")
-
-2. Extract error validations from tests
-   ast_grep_search(pattern="pytest.raises($EXC)", language="python", path="tests/")
-   Grep(pattern="with pytest.raises|assertRaises|expect.*toThrow", path="tests/")
-
-3. Extract error message patterns
-   Grep(pattern="match=|message=|msg=", path="tests/")
-   — preserve regex patterns as-is
-
-4. Analyze validation order
-   Check if/raise order in source code — which condition is checked first
-```
-
-**Output**: `.mpl/mpl/phase0/error-spec.md`
-
-```markdown
-# Error Handling Specification
-
-## [Module] Errors
-- Type: [ExceptionType]
-- Condition: [trigger condition]
-- Message: "[pattern with {placeholders}]"
-- Validation order: [priority]
-
-## Prohibited
-- Do not create custom exception classes (use standard exceptions only)
-- Error messages must exactly match the match pattern in tests
-```
-
-**Experimental basis**: In Exp 7, error specification was found to be the "missing puzzle piece." Score jumped from 83% to 100% just by adding the error spec.
-
-### 2.5.6: Phase 0 Output Summary
-
-Summarize all applied step results in `.mpl/mpl/phase0/summary.md`:
-
-```markdown
-# Phase 0 Enhanced Summary
-
-## Complexity
-- Grade: {grade} (score: {score})
-- Breakdown: modules={n}, deps={n}, tests={n}, async={n}
-
-## Applied Steps
-- [x/o] Step 1: API Contract Extraction
-- [x/o] Step 2: Example Pattern Analysis
-- [x/o] Step 3: Type Policy Definition
-- [x] Step 4: Error Specification
-
-## Artifacts
-| Artifact | Path | Status |
-|----------|------|--------|
-| API Contracts | `.mpl/mpl/phase0/api-contracts.md` | generated / skipped |
-| Examples | `.mpl/mpl/phase0/examples.md` | generated / skipped |
-| Type Policy | `.mpl/mpl/phase0/type-policy.md` | generated / skipped |
-| Error Spec | `.mpl/mpl/phase0/error-spec.md` | generated |
-
-## Key Findings
-[auto-generated key findings]
-```
-
-Announce: `[MPL] Phase 0 Enhanced complete. Grade: {grade}. Artifacts: {count}/4 generated. Token budget: {budget}.`
-
-### 2.5.7: Artifact Validation
-
-Automatically validate the quality of Phase 0 artifacts:
-
-```
-for each generated artifact:
-  validate_artifact(artifact):
-    1. Structure check: verify required sections exist
-       - api-contracts.md: "## [Module Name]" + "### [Function Name]" sections exist
-       - examples.md: "## Pattern" section + code blocks exist
-       - type-policy.md: "## Rules" + "## Type Reference Table" sections exist
-       - error-spec.md: "## [Module] Errors" section exists
-    2. Coverage check: verify functions called in tests are included in contract
-       - Extract function call list from tests via ast_grep_search
-       - Compare against function list in api-contracts.md
-       - Missing rate > 20% → warning
-    3. Consistency check: cross-artifact reference consistency
-       - types in api-contracts ↔ types in type-policy match
-       - exceptions in api-contracts ↔ exceptions in error-spec match
-
-  if validation fails:
-    → Report: "[MPL] Phase 0 artifact validation WARNING: {details}"
-    → Attempt auto-fix (re-run failed step with narrower focus)
-    → Max 1 retry per artifact
-
-Report: "[MPL] Phase 0 validation: {passed}/{total} artifacts validated."
-```
-
-### 2.5.8: Cache Save
-
-After Phase 0 execution completes, save results to cache:
-
-```
-cache_dir = ".mpl/cache/phase0/"
-cache_key = generate_cache_key(codebase_analysis)
-commit_hash = git_rev_parse("HEAD")  # used as diff baseline in partial invalidation (F-05)
-
-save_to_cache:
-  1. Create cache_dir if not exists
-  2. Copy all phase0 artifacts to cache_dir
-  3. Write manifest.json:
-     {
-       "cache_key": cache_key,
-       "commit_hash": commit_hash,
-       "timestamp": ISO timestamp,
-       "complexity_grade": complexity_grade,
-       "artifacts": ["api-contracts.md", "examples.md", ...],
-       "validation_result": { passed: N, total: M }
-     }
-  4. Report: "[MPL] Phase 0 artifacts cached. Key: {short_key}."
-```
-
-#### 2.5.8 Extension: Cache Save on Partial Re-run (F-05)
-
-After partial re-run completes:
-1. Merge reused cache artifacts + newly generated artifacts
-2. Generate new cache_key (full hash at current point)
-3. Update manifest.json: add partial_rerun_info field
-   ```json
-   {
-     "cache_key": "new_full_hash",
-     "commit_hash": "current_HEAD",
-     "timestamp": "2026-03-13T...",
-     "complexity_grade": "Complex",
-     "artifacts": ["api-contracts.md", "examples.md", "type-policy.md", "error-spec.md"],
-     "validation_result": { "passed": 4, "total": 4 },
-     "partial_rerun": true,
-     "rerun_steps": ["examples"],
-     "reused_steps": ["api_contracts", "type_policy", "error_spec"],
-     "original_cache_key": "previous_hash"
-   }
-   ```
-4. Report: `"[MPL] Partial cache save. Rerun: {rerun_steps}. Reused: {reused_steps}. New key: {short_key}."`
-
-### 2.5.9: Token Profiling (Phase 0)
-
-Record token usage for Phase 0 execution:
-
-```
-phase0_profile = {
-  "step": "phase0-enhanced",
-  "grade": complexity_grade,
-  "cache_hit": false,
-  "steps_executed": [1, 3, 4],
-  "artifacts_generated": 3,
-  "validation_passed": 3,
-  "estimated_tokens": {
-    "complexity_detection": ~500,
-    "step1_api_contracts": ~5000,
-    "step2_examples": 0,
-    "step3_type_policy": ~3000,
-    "step4_error_spec": ~3000,
-    "validation": ~500,
-    "total": ~12000
-  },
-  "duration_ms": elapsed
-}
-
-Append to .mpl/mpl/profile/phases.jsonl
-```
-
----

--- a/hooks/__tests__/mpl-cache.test.mjs
+++ b/hooks/__tests__/mpl-cache.test.mjs
@@ -150,9 +150,8 @@ describe('saveCache', () => {
   it('should save artifacts and manifest', () => {
     const result = saveCache(tempDir, {
       cacheKey: 'test_key_123',
-      complexityGrade: 'Simple',
       artifacts: {
-        'error-spec.md': '# Error Specification\n\n## Errors',
+        'raw-scan.md': '# Raw Scan\n\n## Boundary Pairs',
         'summary.md': '# Phase 0 Summary',
       }
     });
@@ -161,21 +160,21 @@ describe('saveCache', () => {
     assert.equal(result.artifactCount, 2);
 
     const cacheDir = join(tempDir, '.mpl', 'cache', 'phase0');
-    assert.ok(existsSync(join(cacheDir, 'error-spec.md')));
+    assert.ok(existsSync(join(cacheDir, 'raw-scan.md')));
     assert.ok(existsSync(join(cacheDir, 'summary.md')));
     assert.ok(existsSync(join(cacheDir, 'manifest.json')));
 
     const manifest = JSON.parse(readFileSync(join(cacheDir, 'manifest.json'), 'utf-8'));
     assert.equal(manifest.cache_key, 'test_key_123');
-    assert.equal(manifest.complexity_grade, 'Simple');
-    assert.deepEqual(manifest.artifacts, ['error-spec.md', 'summary.md']);
+    assert.equal(manifest.complexity_grade, undefined);
+    assert.deepEqual(manifest.artifacts, ['raw-scan.md', 'summary.md']);
   });
 
   it('should create cache directory if it does not exist', () => {
     const cacheDir = join(tempDir, '.mpl', 'cache', 'phase0');
     assert.ok(!existsSync(cacheDir));
 
-    saveCache(tempDir, { cacheKey: 'k', complexityGrade: 'Medium', artifacts: { 'a.md': 'content' } });
+    saveCache(tempDir, { cacheKey: 'k', artifacts: { 'a.md': 'content' } });
     assert.ok(existsSync(cacheDir));
   });
 });
@@ -263,7 +262,6 @@ describe('invalidateCache', () => {
   it('should make checkCache return hit=false after invalidation', () => {
     saveCache(tempDir, {
       cacheKey: 'test_key',
-      complexityGrade: 'Simple',
       artifacts: { 'error-spec.md': '# Errors' }
     });
     assert.equal(checkCache(tempDir).hit, true);
@@ -291,7 +289,6 @@ describe('F-05: Partial Cache Invalidation', () => {
       writeFileSync(join(cacheDir, 'manifest.json'), JSON.stringify({
         cache_key: 'test-key',
         timestamp: new Date().toISOString(),
-        complexity_grade: 'Medium',
         artifacts: [],
       }));
 
@@ -307,7 +304,6 @@ describe('F-05: Partial Cache Invalidation', () => {
         cache_key: 'test-key',
         commit_hash: 'deadbeef1234',
         timestamp: new Date().toISOString(),
-        complexity_grade: 'Medium',
         artifacts: [],
       }));
 
@@ -332,8 +328,7 @@ describe('F-05: Partial Cache Invalidation', () => {
 
       const result = partialCacheSave(tempDir, {
         newCacheKey: 'new-key-123',
-        complexityGrade: 'Medium',
-        newArtifacts: { 'examples.md': '# New Examples' },
+          newArtifacts: { 'examples.md': '# New Examples' },
         reusedArtifacts: ['api-contracts.md', 'type-policy.md'],
         originalKey: 'old-key-456',
       });
@@ -355,8 +350,7 @@ describe('F-05: Partial Cache Invalidation', () => {
 
       partialCacheSave(tempDir, {
         newCacheKey: 'key-abc',
-        complexityGrade: 'Simple',
-        newArtifacts: { 'error-spec.md': '# Error Spec' },
+          newArtifacts: { 'error-spec.md': '# Error Spec' },
         reusedArtifacts: ['type-policy.md'],
         originalKey: 'key-old',
       });
@@ -377,8 +371,7 @@ describe('F-05: Partial Cache Invalidation', () => {
 
       partialCacheSave(tempDir, {
         newCacheKey: 'key-xyz',
-        complexityGrade: 'Medium',
-        newArtifacts: { 'examples.md': '# New Examples' },
+          newArtifacts: { 'examples.md': '# New Examples' },
         reusedArtifacts: ['api-contracts.md'],
         originalKey: 'key-prev',
       });
@@ -398,8 +391,7 @@ describe('F-05: Partial Cache Invalidation', () => {
 
       const result = partialCacheSave(tempDir, {
         newCacheKey: 'key-count',
-        complexityGrade: 'Simple',
-        newArtifacts: { 'error-spec.md': '# Errors', 'examples.md': '# Examples' },
+          newArtifacts: { 'error-spec.md': '# Errors', 'examples.md': '# Examples' },
         reusedArtifacts: ['type-policy.md'],
         originalKey: 'key-old',
       });

--- a/hooks/lib/mpl-cache.mjs
+++ b/hooks/lib/mpl-cache.mjs
@@ -111,14 +111,17 @@ export function validateCache(cwd, currentKey) {
 /**
  * Save Phase 0 artifacts to cache.
  *
+ * v0.17 (#56): `complexityGrade` removed. Raw scan has no grade — decomposer
+ * synthesizes complexity directly from raw-scan.md. `complexityGrade` is still
+ * accepted as an ignored parameter for backward-compat with older callers.
+ *
  * @param {string} cwd - Project root directory
  * @param {object} options
  * @param {string} options.cacheKey - Cache key to store
- * @param {string} options.complexityGrade - Complexity grade (Simple/Medium/Complex/Enterprise)
  * @param {object} options.artifacts - Map of filename -> content to cache
  * @returns {{ saved: boolean, cacheDir: string, artifactCount: number }}
  */
-export function saveCache(cwd, { cacheKey, complexityGrade, artifacts }) {
+export function saveCache(cwd, { cacheKey, artifacts }) {
   const cacheDir = join(cwd, CACHE_DIR);
 
   try {
@@ -136,7 +139,6 @@ export function saveCache(cwd, { cacheKey, complexityGrade, artifacts }) {
       cache_key: cacheKey,
       commit_hash: getHeadCommitHash(cwd),
       timestamp: new Date().toISOString(),
-      complexity_grade: complexityGrade,
       artifacts: artifactNames,
     };
     writeFileSync(join(cacheDir, MANIFEST_FILE), JSON.stringify(manifest, null, 2), 'utf-8');
@@ -368,10 +370,9 @@ export function analyzePartialInvalidation(cwd) {
  * @param {Object<string, string>} options.newArtifacts - Newly generated artifacts (filename -> content)
  * @param {string} options.originalKey - Previous cache key
  * @param {string} options.newCacheKey - Newly computed cache key
- * @param {string} options.complexityGrade - Complexity grade
  * @returns {{ saved: boolean, cacheDir: string, artifactCount: number }}
  */
-export function partialCacheSave(cwd, { reusedArtifacts, newArtifacts, originalKey, newCacheKey, complexityGrade }) {
+export function partialCacheSave(cwd, { reusedArtifacts, newArtifacts, originalKey, newCacheKey }) {
   const cacheDir = join(cwd, CACHE_DIR);
 
   try {
@@ -406,7 +407,6 @@ export function partialCacheSave(cwd, { reusedArtifacts, newArtifacts, originalK
       cache_key: newCacheKey,
       commit_hash: getHeadCommitHash(cwd),
       timestamp: new Date().toISOString(),
-      complexity_grade: complexityGrade,
       artifacts: [...new Set(allArtifacts)],
       partial_rerun: true,
       rerun_steps: rerunSteps,


### PR DESCRIPTION
## Summary

Closes #56. Strips all synthesis from `mpl-phase0-analyzer` (haiku), keeping only mechanical extraction passes. Synthesis (complexity, type policy, error spec) will be absorbed by the decomposer in follow-up #57.

**Net +237 / -834 lines** across 4 files.

## Agent prompt (`agents/mpl-phase0-analyzer.md`, 405L → 331L)

### Removed
- Phase 2 Complexity Detection (base_score / extended_score formulas, F-43 Architecture-Derived Extensions)
- Token budget table (~8K/12K/20K) — non-enforcing
- Grade-conditional step gating (`Complex+ only`, `Medium+`) — all passes now unconditional
- F-42 Path B (architecture-derived type policy synthesis) — judgment task for decomposer, not haiku
- Step 4-B Frontend Build Constraints synthesis
- Error Spec category/policy synthesis (keep raw throw locations only)

### Retained (now unconditional)
- Cache with per-pass hashes for partial invalidation
- Boundary Pair Scan (CB-01) — tauri-invoke / REST / JSON-RPC
- API signature extraction (ast_grep + LSP fallback)
- Test pattern rough-categorization
- Type hint extraction (Path A brownfield grep only)
- Error pattern locations + raw strict-mode/unwrap counts
- Platform API hit detection
- E2E infrastructure detection (HA-06)

### Output shape
Before: 4-5 separate artifacts (complexity-report.json + api-contracts.md + examples.md + type-policy.md + error-spec.md).
After: Single consolidated `raw-scan.md`.

## Orchestrator doc (`commands/mpl-run-phase0-analysis.md`, 954L → 312L)

Removed entire 518L "Phase 0 Enhanced Detailed Spec (for agent reference / fallback)" section that duplicated the agent's internal protocol.

Updated Step 2.5 invocation:
- Model: haiku (was sonnet in prose — now aligned with frontmatter)
- Prompt: raw scan task only, no synthesis instructions
- `field` parameter (brownfield/greenfield) derived from `state.codebase_skipped`
- Summary format shows boundary/API/test counts + E2E infra tool (no grade)

Updated AD-0006 Path C trigger: was `phase0_summary.complexity?.grade == "Complex"`, now `(phase0_summary.boundary_pairs?.length ?? 0) >= 3`.

## Hook cache (`hooks/lib/mpl-cache.mjs`)

- `saveCache()`: remove `complexityGrade` from manifest (param accepted for backward-compat, silently ignored)
- `partialCacheSave()`: same treatment
- Tests: removed all `complexityGrade` passes and `complexity_grade` assertions

## Test plan

- [x] 273/273 hook tests pass
- [x] 42/42 mcp-server tests pass
- [ ] E2E: brownfield project → raw-scan.md generated, no complexity-report.json
- [ ] E2E: greenfield project → raw-scan.md with projected boundary pairs, type hints section empty
- [ ] E2E: cache invalidation still works via per-pass hashes
- [ ] E2E: AD-0006 Path C triggers on ≥3 boundary pairs without verify.sh

## References

- Issue #56
- Follow-up: #57 (decomposer synthesis absorption)

🤖 Generated with [Claude Code](https://claude.com/claude-code)