### PR TITLE
feat(#57): decomposer absorbs Phase 0 synthesis (type policy / error spec)

### DIFF
--- a/agents/mpl-decomposer.md
+++ b/agents/mpl-decomposer.md
@@ -7,8 +7,11 @@ disallowedTools: Write,Edit,Bash,Task,WebFetch,WebSearch,NotebookEdit
 
 <Agent_Prompt>
   <Role>
-    You are the Phase Decomposer for MPL v0.12.0. You break a user's request into ordered micro-phases, classify each by PP-proximity, and generate a verification plan (A/S/H) per phase.
-    You reason only from the structured CodebaseAnalysis provided as input. You do NOT implement, verify, or execute.
+    You are the Phase Decomposer for MPL. You break a user's request into ordered micro-phases, classify each by PP-proximity, and generate a verification plan (A/S/H) per phase.
+
+    **v0.17 (#57)**: you now also synthesize **per-phase type policy**, **per-phase error spec**, and (implicitly) **complexity judgment via phase sizing**. These were previously separate artifacts produced by `mpl-phase0-analyzer`; they now live inside the decomposer's output because (a) type policy and error handling are phase-scoped design decisions, not global constants, and (b) you already have all the inputs needed — raw scan + PP tech stack + user contract + interface contracts.
+
+    You reason from the structured CodebaseAnalysis + raw-scan inputs provided. You do NOT implement, verify, or execute.
     Your decomposition MUST cover the ENTIRE user request. Never scope down to a subset.
   </Role>
 
@@ -57,6 +60,48 @@ disallowedTools: Write,Edit,Bash,Task,WebFetch,WebSearch,NotebookEdit
 
     Step 5: Size phases
       - 1-7 TODOs per phase, 1-8 files. 8+ TODOs -> split. 1 TODO -> merge.
+      - Phase count itself expresses project complexity — there is no separate
+        "complexity grade" field. A 2-phase decomposition is a small project;
+        a 15-phase decomposition is a large one. Do NOT under-decompose to make
+        the project "look smaller" or over-decompose to appear thorough.
+
+    Step 5.5: Per-phase Type Policy Synthesis (v0.17, #57)
+      Read raw-scan.md sections: `Type Hints (Path A brownfield)` and `Boundary Pairs`.
+      Read PP `tech_stack` and architectural_layers info.
+
+      For each phase, synthesize `type_policy`:
+        - Phase layer (backend/frontend/sidecar/shared) from `phase_domain`
+        - Naming convention: snake_case (Rust/Python) / camelCase (TS) / per framework rules at boundaries
+        - Null handling: Option<T> (Rust), T | null (TS), None (Python) — per layer
+        - Enum constraints: from raw-scan type hints OR PP schema (greenfield)
+        - Prohibited patterns per layer (e.g., no `any` in TS, no `unwrap()` beyond N count in Rust)
+        - Conversion points: at contract_files boundaries where types transform
+
+      **Greenfield fallback** (no raw-scan type hints): derive from PP tech stack
+      using well-known framework conventions (Tauri v2 → serde + camelCase auto-convert,
+      Next.js → camelCase, FastAPI → snake_case + pydantic, etc.).
+
+      **Empty case**: pure doc/infra phases with no type surface emit
+      `type_policy: { applies: false }`. Do NOT omit the field — explicit false
+      is the signal that the phase was considered.
+
+    Step 5.6: Per-phase Error Spec Synthesis (v0.17, #57)
+      Read raw-scan.md sections: `Error Throw Sites`, `Error Locations`, and the
+      raw strict-mode/unwrap audit counts.
+      Read PP error-handling conventions (if declared).
+
+      For each phase, synthesize `error_spec`:
+        - Error categories raised by this phase (validation / network / auth / resource-not-found / internal)
+        - For each category: how the phase surfaces it (exception type, HTTP status, Result<T,E>)
+        - Error message formatting convention (structured JSON / human string / i18n key)
+        - Strict-mode advisories when raw audit counts exceed thresholds:
+          - Rust: `.unwrap()` count ≥ 10 in source → advisory "audit unwrap calls"
+          - TypeScript: `strict: false` OR `strictNullChecks: false` → advisory "enable strict null"
+          - Go: ≥5 ignored-error sites → advisory "explicit error handling"
+        - Validation order (when multiple validations apply to same input)
+
+      **Empty case**: pure doc/infra/migration phases with no error surface emit
+      `error_spec: { applies: false }`. Same rule as type_policy.
 
     Step 6: Define interface contracts
       - Specify requires/produces for each phase.
@@ -334,6 +379,32 @@ disallowedTools: Write,Edit,Bash,Task,WebFetch,WebSearch,NotebookEdit
             # regression suite execution. Violations → invariant_violation_count metric.
             # See Reasoning_Steps Step 9.7.
 
+        # v0.17 (#57): synthesis absorbed from ex-phase0-analyzer. REQUIRED on every phase.
+        # Consumer: Phase Runner loads these as context for the phase's implementation.
+        type_policy:
+          applies: boolean            # false for doc/infra phases with no type surface
+          layer: string               # "backend" | "frontend" | "sidecar" | "shared" (when applies)
+          naming: string              # naming convention description (when applies)
+          null_handling: string       # per-language null/option convention (when applies)
+          enum_constraints: [string]  # enum types this phase must respect (when applies)
+          prohibited_patterns: [string]  # patterns that would violate policy (when applies)
+          conversion_points: [string] # contract_file boundary_ids where types transform (when applies)
+
+        # v0.17 (#57): synthesis absorbed from ex-phase0-analyzer. REQUIRED on every phase.
+        error_spec:
+          applies: boolean            # false for doc/infra/migration phases
+          categories:                 # which error categories this phase surfaces
+            - name: string            # "validation" | "network" | "auth" | "not_found" | "internal" | custom
+              exception_type: string  # concrete type raised (e.g., "ValidationError", "HTTPException(422)")
+              message_format: string  # "structured_json" | "human_string" | "i18n_key"
+          validation_order: [string]  # ordered list of validation check ids (when applies)
+          strict_mode_advisories: [string]  # advisories emitted when raw audit thresholds exceeded
+          # Raw audit counts that triggered advisories (from raw-scan) — for traceability
+          raw_audit_counts:
+            unwrap_count: number       # Rust .unwrap() count in src/
+            strict_null_enabled: boolean  # TS tsconfig flag
+            ignored_error_count: number   # Go _ = patterns
+
         estimated_complexity: "S" | "M" | "L"
         estimated_todos: number
         estimated_files: number
@@ -428,5 +499,7 @@ disallowedTools: Write,Edit,Bash,Task,WebFetch,WebSearch,NotebookEdit
     1. **Scope reduction**: Covering only a subset of the request. If the spec has 10 features, ALL 10 must appear. Never omit features to fit a phase count limit.
     2. **Horizontal decomposition of multi-layer project**: Splitting by layer (all types -> all backend -> all UI) instead of vertical slices causes cross-layer contract failures.
     3. **Missing interfaces**: Phases that cannot communicate because requires/produces are undefined. Every phase's requires must be satisfied by prior phases' produces.
+    4. **Synthesis drift from raw scan (v0.17 #57)**: Inventing type-policy or error-spec facts that the raw scan did not produce. Type rules should trace back to raw-scan Type Hints or PP tech stack; error categories to Error Throw Sites or PP conventions. If the raw scan is empty (greenfield + no PP spec), the phase's `type_policy`/`error_spec` may be minimal — that is honest output. Do not fabricate to "fill the field".
+    5. **Skipping synthesis fields as absent** (v0.17 #57): `type_policy` and `error_spec` are REQUIRED on every phase. Emit `applies: false` + empty subfields when the phase legitimately has no type/error surface (pure docs / migrations). Omission is a validation error.
   </Failure_Modes>
 </Agent_Prompt>

--- a/commands/mpl-run-decompose.md
+++ b/commands/mpl-run-decompose.md
@@ -63,19 +63,20 @@ Task(subagent_type="mpl-decomposer", model="opus",
      ### Codebase Analysis
      {codebase_analysis JSON from .mpl/mpl/codebase-analysis.json}
 
-     ### Phase 0 Enhanced Artifacts
-     #### Complexity
-     {complexity_report from .mpl/mpl/phase0/complexity-report.json}
-     #### Phase 0 Summary
-     {phase0_summary from .mpl/mpl/phase0/summary.md}
-     #### Detailed Artifacts (if generated)
-     {api_contracts from .mpl/mpl/phase0/api-contracts.md — if exists}
-     {examples from .mpl/mpl/phase0/examples.md — if exists}
-     {type_policy from .mpl/mpl/phase0/type-policy.md — if exists}
-     {error_spec from .mpl/mpl/phase0/error-spec.md — always exists}
+     ### Phase 0 Artifacts
+     #### Raw Scan (v0.17, #56 — single source from mpl-phase0-analyzer)
+     {raw_scan from .mpl/mpl/phase0/raw-scan.md — always exists, may be minimal for greenfield}
+     #### Core Scenarios + Intent Invariants + User Contract
+     {core_scenarios from .mpl/mpl/core-scenarios.yaml}
+     {design_intent from .mpl/mpl/phase0/design-intent.yaml}
+     {user_contract from .mpl/requirements/user-contract.md — if exists}
+     #### Baseline (v0.17 #59 stub)
+     {baseline from .mpl/mpl/baseline.yaml — if exists}
 
-     ### Pre-Execution Analysis (Gap + Tradeoff)
-     {pre_execution_analysis from .mpl/mpl/pre-execution-analysis.md}
+     ### Synthesis Responsibility (v0.17 #57)
+     You (decomposer) now synthesize `type_policy` and `error_spec` per phase inline
+     — previously in phase0-analyzer. Raw scan provides the facts; you decide
+     per-phase rules. See agents/mpl-decomposer.md Step 5.5 / 5.6.
 
      ## Task
      Break the user request into ordered phases that cover the ENTIRE scope of the request.


### PR DESCRIPTION
## Summary

Closes #57. Moves per-phase type policy, per-phase error spec, and complexity judgment into the decomposer. Raw scan (haiku, #56) supplies facts; decomposer (opus) synthesizes rules.

## Agent changes (`agents/mpl-decomposer.md`, 432L → 505L)

### New Reasoning_Steps
- **Step 5.5 — Type Policy Synthesis**: reads raw-scan Type Hints + Boundary Pairs + PP tech_stack. Emits per-phase `{layer, naming, null_handling, enum_constraints, prohibited_patterns, conversion_points}`. Greenfield fallback uses framework conventions (Tauri/Next/FastAPI).
- **Step 5.6 — Error Spec Synthesis**: reads raw-scan Error Throw Sites + strict-mode/unwrap audit + PP conventions. Emits per-phase `{categories[], validation_order, strict_mode_advisories, raw_audit_counts}`.

### Step 5 addendum
Phase count itself expresses complexity. No separate grade field.

### New Output_Schema fields (REQUIRED per phase)
```yaml
type_policy:
  applies: boolean  # false for doc/infra phases
  layer: string
  naming: string
  null_handling: string
  enum_constraints: [string]
  prohibited_patterns: [string]
  conversion_points: [string]

error_spec:
  applies: boolean
  categories:
    - { name, exception_type, message_format }
  validation_order: [string]
  strict_mode_advisories: [string]
  raw_audit_counts: { unwrap_count, strict_null_enabled, ignored_error_count }
```

`applies: false` for phases with no type/error surface. Omission is a validation error.

### New Failure_Modes
- Synthesis drift from raw scan (don't invent facts)
- Skipping synthesis fields (use `applies: false`)

## Orchestrator changes (`commands/mpl-run-decompose.md`)

Input block replaced:

Before: `complexity_report` + `api_contracts` + `examples` + `type_policy` + `error_spec` (5 artifacts).
After: single `raw_scan` + `core_scenarios` + `design_intent` + `user_contract` + `baseline` (#59 stub).

## Tests

- [x] 273/273 hook tests pass
- [ ] E2E: decomposer output contains `type_policy` + `error_spec` per phase
- [ ] E2E: brownfield project → raw audit counts populated
- [ ] E2E: greenfield project → type_policy derived from PP tech stack (Path B equivalent)
- [ ] E2E: pure doc/infra phase → `type_policy: { applies: false }`

## Migration

Pre-v0.17 `decomposition.yaml` files lack the new fields. Re-decomposition required. `complexity-report.json`, `type-policy.md`, `error-spec.md` artifacts no longer written — consumers should read from per-phase decomposition entries instead.

## References

- Issue #57
- Depends on: #55, #56 (merged)
- Unblocks: #58 #59 #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)