### PR TITLE
feat(#58): unify mpl-seed-generator dispatch (inline mode now dispatches agent)

### DIFF
--- a/agents/mpl-seed-generator.md
+++ b/agents/mpl-seed-generator.md
@@ -1,24 +1,42 @@
 ---
 name: mpl-seed-generator
-description: Chain-Scoped Seed Generator - designs all phases in a chain with one opus call (#34 Stage 1)
+description: Seed Generator - designs phase execution specs. Two dispatch modes (#58) - chain-scoped batch or inline single-phase. Both emit the same schema.
 model: opus
 disallowedTools: Write,Edit,Bash,Task,WebFetch,WebSearch,NotebookEdit
 ---
 
 <Agent_Prompt>
   <Role>
-    You are the Seed Generator for MPL #34 chain-scoped architecture.
-    You design the detailed execution spec for ALL phases in a single chain with ONE opus call.
-    You reason only from provided inputs. You do NOT implement, verify, or execute.
+    You design detailed per-phase execution specs that Phase Runners consume.
+    You reason only from provided inputs; you do NOT implement, verify, or execute.
 
-    Your output (chain-seed.yaml) is consumed by Phase Runner(s) for the entire chain. Runners do NOT re-invoke you — they work from chain-seed + prev phase handoffs.
-    The only case you are re-invoked is when Discovery Agent returns `architectural_discovery` verdict. In that case you receive a discovery-patch and regenerate only affected phases.
+    **v0.17 (#58) — Two dispatch modes**:
+
+    - **mode=chain** (`chain_seed.enabled: true`): design ALL phases in a single
+      chain with ONE opus call. Output: `chain-seed.yaml`. This is the #34 Stage 1
+      architecture — baton-pass between sibling phases + prompt-cache reuse.
+
+    - **mode=inline** (`chain_seed.enabled: false`, the default): design exactly
+      ONE phase per call. Output: single `phase-seed.yaml` for that phase.
+      Orchestrator invokes you once per phase as execution proceeds.
+
+    Both modes emit the same per-phase schema — downstream consumers (SEED-03
+    validation, SNT-S0 contract-snippet check, Phase Runner context) do NOT
+    distinguish. Only batch scope differs.
+
+    You are re-invoked when:
+    - (chain mode) Discovery Agent returns `architectural_discovery` and you
+      receive a discovery-patch → regenerate only affected phases.
+    - (inline mode) Phase Runner's seed validation (SEED-03/SNT-S0) fails and
+      the orchestrator dispatches a regeneration with validation feedback.
   </Role>
 
   <Rules>
     1. **Read-only access**: Use Read, Glob, Grep to validate assumptions from inputs.
 
-    2. **Chain-scoped design**: Every phase in the chain MUST receive a complete spec. No phase skipped.
+    2. **Mode-aware output**:
+       - chain mode: produce a complete spec for EVERY phase in the chain. No phase skipped.
+       - inline mode: produce EXACTLY ONE phase's spec; do not infer other phases.
 
     3. **Contract consistency**: If phase A's edge declares `phase-B.login` as callee, phase B's contract_snippet MUST include `login` symbol with matching params/returns.
 

--- a/commands/mpl-run-execute.md
+++ b/commands/mpl-run-execute.md
@@ -124,7 +124,14 @@ announce: "[MPL] #34: phase {phase.id} using chain-seed from {chain_id} (no opus
 
 **Discovery-triggered re-generation**: handled in Stage 2. Stage 1 does not regenerate mid-chain.
 
-### 4.0.5.B: Legacy Per-Phase Seed (default when chain_seed.enabled == false)
+### 4.0.5.B: Inline Per-Phase Seed (default when chain_seed.enabled == false)
+
+**v0.17 (#58)**: inline mode now dispatches `mpl-seed-generator` (opus) per phase
+instead of orchestrator-inline field assembly. Chain mode (4.0.5.A) and inline
+mode (4.0.5.B) differ only in scope (multi-phase batch vs single-phase) — both
+produce the same Seed schema through the same agent. This eliminates the
+previous dead-branch problem where the agent was only alive in the default-off
+chain mode.
 
 ```
 if config.phase_seed?.enabled != false:
@@ -144,22 +151,44 @@ if config.phase_seed?.enabled != false:
   if phase_definition.interface_contract.adjacent_contracts?.outbound:
     contract_files["outbound"] = Read(phase_definition.interface_contract.adjacent_contracts.outbound)
 
-  // Inline seed generation (orchestrator generates directly)
-  seed = {
-    goal: phase_definition.goal,
-    acceptance_criteria: phase_definition.acceptance_criteria,
-    todo_structure: derive_todos_from_phase_definition(phase_definition),
-    exit_conditions: phase_definition.success_criteria,
-    contract_snippet: extract_contract_keys(contract_files),
-    phase0_context: phase0_relevant
-  }
+  // Dispatch mpl-seed-generator with mode=inline (single-phase scope)
+  result = Task(subagent_type="mpl-seed-generator", model="opus",
+    prompt="""
+    You are the Inline Seed Generator for MPL (#58, mode=inline).
+    Generate a single phase's seed from the phase definition + contracts.
 
-  save seed to .mpl/mpl/phases/{phase.id}/phase-seed.yaml
-  context.phase_seed = seed
-  announce: "[MPL] Phase Seed generated for {phase.id}: {seed.todo_structure.length} TODOs"
+    ## Mode
+    inline — emit ONE seed for ONE phase. This is NOT a chain batch.
+
+    ## Input
+    - phase_definition: {phase_definition}       # full decomposition.yaml entry for this phase
+    - prior_summaries: {prior_summaries}         # state-summary.md from completed phases
+    - contract_files: {contract_files}           # loaded contract JSON contents
+    - phase0_relevant: {phase0_relevant}         # subset of raw-scan applicable to this phase
+    - baseline: {baseline}                       # .mpl/mpl/baseline.yaml if present (#59 stub)
+    - type_policy: {phase_definition.type_policy}   # from decomposer (#57)
+    - error_spec:  {phase_definition.error_spec}    # from decomposer (#57)
+
+    ## Output
+    Single YAML seed with fields:
+      goal / acceptance_criteria / todo_structure / exit_conditions /
+      contract_snippet / phase0_context
+    Schema is IDENTICAL to chain-scoped seeds (4.0.5.A) — downstream SEED-03
+    validation and SNT-S0 contract-snippet check run unchanged.
+    """
+  )
+
+  save result.seed to .mpl/mpl/phases/{phase.id}/phase-seed.yaml
+  context.phase_seed = result.seed
+  announce: "[MPL] Inline seed generated for {phase.id}: {result.seed.todo_structure.length} TODOs (opus dispatch)"
 else:
-  context.phase_seed = null  // Legacy mode
+  context.phase_seed = null  // Legacy mode (phase_seed.enabled explicitly false)
 ```
+
+**Seed schema parity**: chain-scoped and inline seeds are field-compatible. 4.0.5.1
+Seed validation + 4.1 Context Assembly + 4.2 Phase Runner all consume the same
+shape. Chain mode's advantage is purely batch-scope (one opus call per chain
+rather than per phase) + baton-pass between sibling phases in the same chain.
 
 ### 4.0.5.1: Seed Validation (SEED-03 + SNT-S0, v0.10.0)
 


### PR DESCRIPTION
## Summary

Closes #58. Eliminate the dead-branch problem where `mpl-seed-generator` only dispatched in chain mode (default-off) and inline mode bypassed the agent entirely by assembling fields in orchestrator code.

## Changes

### `commands/mpl-run-execute.md` Section 4.0.5.B

Inline-mode seed generation now dispatches `Task(mpl-seed-generator, mode=inline)` producing a single-phase seed. Schema identical to chain-mode; downstream consumers (SEED-03, SNT-S0, Phase Runner) unchanged.

Prompt now includes type_policy + error_spec (from decomposer #57) and baseline (from #59 stub) as inputs.

### `agents/mpl-seed-generator.md`

Role + Rules updated to document both modes:
- **mode=chain**: all phases in one opus call (#34 Stage 1)
- **mode=inline**: exactly one phase per call (default when `chain_seed.enabled=false`)

Frontmatter description reflects dual-mode operation. Re-invocation triggers documented for both.

## Seed schema parity

Chain and inline emit identical per-phase shape: `{goal, acceptance_criteria, todo_structure, exit_conditions, contract_snippet, phase0_context}`. Only batch scope differs.

## Test plan

- [x] 273/273 hook tests pass
- [ ] E2E: inline mode dispatches Task (verify via state or logs)
- [ ] E2E: chain-mode output unchanged when `chain_seed.enabled=true`
- [ ] E2E: SEED-03 and SNT-S0 validation pass on inline-generated seeds
- [ ] E2E: Phase Runner receives identical context in both modes

## Cost impact

Inline mode now incurs one opus call per phase for seed generation (previously zero — orchestrator assembly only). ~N × ~3K input tokens where N = phase count. Chain mode unchanged.

## References

- Issue #58
- Depends on: #55, #56, #57 (merged)
- Unblocks: #59 uses seed-generator baseline input

🤖 Generated with [Claude Code](https://claude.com/claude-code)