### PR TITLE
feat(#59): Branch Main State Snapshot (baseline.yaml + write-guard hook)

### DIFF
--- a/commands/mpl-run-phase0.md
+++ b/commands/mpl-run-phase0.md
@@ -451,11 +451,9 @@ while true:
 
 ---
 
-## Step 2.9: Branch Main State Snapshot
+## Step 2.9: Branch Main State Snapshot (#59)
 
-> **Status**: Stub for issue #59. Full implementation (baseline.yaml schema, write-guard hook, worktree mode option) pending.
-
-Immediately after Stage 2 closes (threshold_met OR override), record the immutable ground-truth snapshot that downstream delta calculation and rollback depend on.
+Immediately after Stage 2 closes (`threshold_met` OR `override`), record the immutable ground-truth snapshot that downstream delta calculation and rollback depend on.
 
 ### User Confirmation Gate
 
@@ -464,53 +462,108 @@ AskUserQuestion({
   question: "Phase 0 완료. 기능이 확정되었습니다. Baseline을 기록하고 decomposition으로 진행할까요?",
   header: "Phase 0 승인",
   options: [
-    { label: "Approve & Snapshot", description: "baseline.yaml 기록, Decomposer 진입" },
+    { label: "Approve & Snapshot", description: "baseline.yaml 기록 후 Decomposer 진입" },
     { label: "Modify PPs",         description: "Stage 1 재진입 (PP 수정)" },
     { label: "Re-interview",       description: "Stage 1 전체 재실행" }
   ]
 })
 ```
 
-"Approve"가 아니면 해당 Stage로 복귀. "Approve"면 아래 snapshot 기록.
+If the answer is not "Approve", return to the chosen Stage. On "Approve", perform the snapshot below.
 
-### Snapshot (v0.17 minimal — full schema pending #59)
+### Snapshot
 
-```yaml
-# .mpl/mpl/baseline.yaml
-created_at: "{ISO timestamp}"
-pipeline_id: "{from state}"
-git:
-  base_sha: "{git rev-parse HEAD}"
-  base_branch: "{git rev-parse --abbrev-ref HEAD}"
-  working_tree_clean: {git status --porcelain empty?}
-artifacts:
-  pivot_points: { path, sha256 }
-  core_scenarios: { path, sha256 }
-  design_intent: { path, sha256 }
-  user_contract: { path, sha256 }
-  codebase_analysis: { path, sha256, skipped: boolean }
-  raw_scan: { path, sha256 }
-ambiguity:
-  final_score: {state.ambiguity_score}
-  threshold_met: {boolean}
-  override: {state.ambiguity_override or null}
-  rounds: {history.length}
-spec:
-  user_request_hash: "{sha256 of user_request}"
-  resolved_spec_hash: "{sha256 of accumulated Stage 1+2 responses}"
-```
-
-**Immutability**: write once. `mpl-sentinel-pp-file.mjs` extends to block overwrite (see #59 for full guard).
-
-**Transition**:
+Use `hooks/lib/mpl-baseline.mjs` helpers:
 
 ```
+import { buildBaseline, writeBaseline, baselineExists } from "hooks/lib/mpl-baseline.mjs"
+
+state = readState(cwd)
+baseline = buildBaseline(cwd, {
+  pipelineId: state.pipeline_id,
+  userRequest: state.user_request,
+  accumulatedResponses: state.stage2_accumulated_responses,
+  ambiguity: {
+    final_score: state.ambiguity_score,
+    threshold_met: state.ambiguity_score !== null && state.ambiguity_score <= 0.2,
+    override: state.ambiguity_override ?? null,
+    rounds: (state.ambiguity_history ?? []).length,
+  },
+  codebaseSkipped: state.codebase_skipped ?? false,
+})
+
+// Re-interview path: if baseline already exists, drop the renewal flag
+// so mpl-baseline-guard permits the overwrite, then delete it after write.
+if baselineExists(cwd):
+  Bash("touch .mpl/mpl/.baseline-renewal")
+writeBaseline(cwd, baseline)
+if existed:
+  Bash("rm -f .mpl/mpl/.baseline-renewal")
+
 mpl_state_write(cwd, {
   current_phase: "mpl-decompose",
-  baseline_snapshot_at: now_iso()
+  baseline_snapshot_at: new Date().toISOString(),
 })
-Announce: "[MPL] Step 2.9 baseline.yaml recorded. Advancing to decomposition."
+Announce: "[MPL #59] Step 2.9 baseline.yaml recorded. git_base_sha=${baseline.git.base_sha.slice(0,7)}, artifacts=${countNonNull(baseline.artifacts)}. Advancing to decomposition."
 ```
+
+### Schema
+
+```yaml
+# .mpl/mpl/baseline.yaml (immutable after first write)
+created_at: "ISO timestamp"
+pipeline_id: "mpl-{feature}-{date}"
+git:
+  base_sha: "full SHA or null if not a git repo"
+  base_branch: "branch name or null"
+  working_tree_clean: boolean
+artifacts:
+  pivot_points:      { path, sha256 } | null
+  core_scenarios:    { path, sha256 } | null
+  design_intent:     { path, sha256 } | null
+  user_contract:     { path, sha256 } | null
+  codebase_analysis: { path, sha256, skipped: boolean }
+  raw_scan:          { path, sha256 } | null
+ambiguity:
+  final_score: number | null
+  threshold_met: boolean
+  override: { active, reason, by } | null
+  rounds: number
+spec:
+  user_request_hash:  "sha256 of user_request (normalized)"
+  resolved_spec_hash: "sha256 of Stage 1 + Stage 2 accumulated responses (normalized)"
+```
+
+### Immutability (write-guard)
+
+`hooks/mpl-baseline-guard.mjs` is a PreToolUse Edit|Write hook that:
+1. Allows the first write (no `.mpl/mpl/baseline.yaml` yet).
+2. Blocks subsequent writes **unless** `.mpl/mpl/.baseline-renewal` sentinel file exists.
+3. Deny response explains the correct workflow: drop the sentinel, write, remove the sentinel.
+
+The orchestrator uses this dance during Phase 0 re-interview to legitimately refresh the baseline. All other agents cannot overwrite baseline — prevents silent drift corruption.
+
+### Consumers
+
+| Consumer | Usage |
+|---|---|
+| Decomposer | Reads baseline for delta target (ground truth vs current state) |
+| Seed Generator | Includes baseline hashes in seed for cache validation |
+| 4.7 Partial Rollback | Uses `git.base_sha` as reset target on circuit break |
+| 5.1.5 Scope Drift Detection | Compares current artifact hashes against baseline to detect unauthorized drift |
+| Finalize 5.4 Metrics | Reports baseline-relative change volume |
+
+### Branch Mode (optional)
+
+`.mpl/config.json` may opt into worktree isolation:
+
+```json
+{ "branch_mode": "worktree" }
+```
+
+When set, Step 2.9 also runs `git worktree add` so the entire pipeline executes in an isolated directory. Default is `"snapshot"` — baseline records git SHA only, user manages branches.
+
+Worktree mode integrates with existing 4.1.5 Worktree Isolation logic (`commands/mpl-run-execute-context.md`).
 
 ---
 

--- a/hooks/__tests__/mpl-baseline.test.mjs
+++ b/hooks/__tests__/mpl-baseline.test.mjs
@@ -1,0 +1,172 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { execSync } from 'child_process';
+
+import {
+  sha256File,
+  sha256String,
+  buildBaseline,
+  serializeBaseline,
+  writeBaseline,
+  baselineExists,
+  renewalAuthorized,
+  BASELINE_FILE,
+  RENEWAL_FLAG_FILE,
+} from '../lib/mpl-baseline.mjs';
+
+function createTempRepo() {
+  const dir = mkdtempSync(join(tmpdir(), 'mpl-baseline-'));
+  execSync('git init -q', { cwd: dir });
+  execSync('git -c user.email=t@t -c user.name=t commit -q --allow-empty -m init', { cwd: dir });
+  return dir;
+}
+
+describe('sha256String normalization', () => {
+  it('strips CRLF and trims', () => {
+    const a = sha256String('hello\r\nworld\r\n');
+    const b = sha256String('hello\nworld');
+    const c = sha256String('  hello\nworld  ');
+    assert.equal(a, b);
+    assert.equal(b, c);
+  });
+
+  it('handles null/undefined gracefully', () => {
+    assert.equal(sha256String(null), sha256String(''));
+    assert.equal(sha256String(undefined), sha256String(''));
+  });
+});
+
+describe('sha256File', () => {
+  let dir;
+  beforeEach(() => { dir = createTempRepo(); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  it('returns sha for existing file', () => {
+    writeFileSync(join(dir, 'foo.txt'), 'hello');
+    const hash = sha256File(dir, 'foo.txt');
+    assert.ok(hash);
+    assert.equal(hash.length, 64);
+  });
+
+  it('returns null for missing file', () => {
+    assert.equal(sha256File(dir, 'nope.txt'), null);
+  });
+});
+
+describe('buildBaseline', () => {
+  let dir;
+  beforeEach(() => { dir = createTempRepo(); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  it('captures git base_sha and artifact hashes', () => {
+    mkdirSync(join(dir, '.mpl'), { recursive: true });
+    writeFileSync(join(dir, '.mpl/pivot-points.md'), '## PP-1\nAuth is immutable');
+
+    const b = buildBaseline(dir, {
+      pipelineId: 'mpl-test',
+      userRequest: 'build auth',
+      accumulatedResponses: 'round 1: yes',
+      ambiguity: { final_score: 0.18, threshold_met: true, override: null, rounds: 3 },
+      codebaseSkipped: false,
+    });
+
+    assert.equal(b.pipeline_id, 'mpl-test');
+    assert.ok(b.git.base_sha);
+    assert.equal(b.git.base_branch.length > 0, true);
+    assert.ok(b.artifacts.pivot_points);
+    assert.equal(b.artifacts.pivot_points.sha256.length, 64);
+    assert.equal(b.artifacts.core_scenarios, null);  // file absent
+    assert.equal(b.ambiguity.final_score, 0.18);
+    assert.equal(b.ambiguity.threshold_met, true);
+    assert.equal(b.spec.user_request_hash.length, 64);
+  });
+
+  it('marks codebase as skipped for greenfield', () => {
+    const b = buildBaseline(dir, {
+      pipelineId: 'mpl-green',
+      userRequest: 'new project',
+      accumulatedResponses: '',
+      ambiguity: { final_score: 0.19, threshold_met: true, override: null, rounds: 1 },
+      codebaseSkipped: true,
+    });
+
+    assert.equal(b.artifacts.codebase_analysis.skipped, true);
+    assert.equal(b.artifacts.codebase_analysis.sha256, null);
+  });
+
+  it('records override when present', () => {
+    const b = buildBaseline(dir, {
+      pipelineId: 'mpl-override',
+      userRequest: 'x',
+      accumulatedResponses: '',
+      ambiguity: {
+        final_score: 0.35, threshold_met: false, rounds: 5,
+        override: { active: true, reason: 'stagnated', by: 'user_halt' }
+      },
+      codebaseSkipped: true,
+    });
+    assert.equal(b.ambiguity.override.active, true);
+    assert.equal(b.ambiguity.override.reason, 'stagnated');
+  });
+});
+
+describe('serializeBaseline', () => {
+  it('produces YAML-ish output with all sections', () => {
+    const b = {
+      created_at: '2026-04-22T00:00:00.000Z',
+      pipeline_id: 'mpl-x',
+      git: { base_sha: 'abc123', base_branch: 'main', working_tree_clean: true },
+      artifacts: {
+        pivot_points: { path: '.mpl/pivot-points.md', sha256: 'h1' },
+        core_scenarios: null,
+        design_intent: null,
+        user_contract: null,
+        codebase_analysis: { path: '.mpl/mpl/codebase-analysis.json', sha256: null, skipped: true },
+        raw_scan: null,
+      },
+      ambiguity: { final_score: 0.18, threshold_met: true, override: null, rounds: 3 },
+      spec: { user_request_hash: 'req-h', resolved_spec_hash: 'res-h' },
+    };
+
+    const yaml = serializeBaseline(b);
+    assert.ok(yaml.includes('pipeline_id: "mpl-x"'));
+    assert.ok(yaml.includes('base_sha: "abc123"'));
+    assert.ok(yaml.includes('working_tree_clean: true'));
+    assert.ok(yaml.includes('pivot_points:'));
+    assert.ok(yaml.includes('skipped: true'));
+    assert.ok(yaml.includes('final_score: 0.18'));
+    assert.ok(yaml.includes('user_request_hash: "req-h"'));
+  });
+});
+
+describe('writeBaseline + baselineExists + renewalAuthorized', () => {
+  let dir;
+  beforeEach(() => { dir = createTempRepo(); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  it('writes file and reports existence', () => {
+    assert.equal(baselineExists(dir), false);
+
+    const b = buildBaseline(dir, {
+      pipelineId: 'mpl-write',
+      userRequest: 'x', accumulatedResponses: '',
+      ambiguity: { final_score: 0.1, threshold_met: true, override: null, rounds: 1 },
+      codebaseSkipped: true,
+    });
+    writeBaseline(dir, b);
+
+    assert.equal(baselineExists(dir), true);
+    const written = readFileSync(join(dir, BASELINE_FILE), 'utf-8');
+    assert.ok(written.includes('pipeline_id: "mpl-write"'));
+  });
+
+  it('renewalAuthorized toggles on sentinel presence', () => {
+    assert.equal(renewalAuthorized(dir), false);
+    mkdirSync(join(dir, '.mpl/mpl'), { recursive: true });
+    writeFileSync(join(dir, RENEWAL_FLAG_FILE), '');
+    assert.equal(renewalAuthorized(dir), true);
+  });
+});

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -62,6 +62,16 @@
         ]
       },
       {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/mpl-baseline-guard.mjs\"",
+            "timeout": 3
+          }
+        ]
+      },
+      {
         "matcher": "Task|Agent",
         "hooks": [
           {

--- a/hooks/lib/mpl-baseline.mjs
+++ b/hooks/lib/mpl-baseline.mjs
@@ -1,0 +1,216 @@
+#!/usr/bin/env node
+/**
+ * MPL Baseline — Branch Main State Snapshot (#59)
+ *
+ * `.mpl/mpl/baseline.yaml` records the immutable ground-truth checkpoint taken
+ * immediately after Stage 2 Ambiguity Resolution closes. Downstream consumers
+ * (Decomposer, Seed Generator, 4.7 partial rollback, 5.1.5 scope drift)
+ * reference baseline for delta calculation and rollback target.
+ *
+ * Schema:
+ *   created_at: ISO timestamp (write-once)
+ *   pipeline_id: state.pipeline_id
+ *   git:
+ *     base_sha: git rev-parse HEAD
+ *     base_branch: git rev-parse --abbrev-ref HEAD
+ *     working_tree_clean: boolean (git status --porcelain empty?)
+ *   artifacts:
+ *     pivot_points:       { path, sha256 }
+ *     core_scenarios:     { path, sha256 }
+ *     design_intent:      { path, sha256 }
+ *     user_contract:      { path, sha256 }   # null if skip-mode
+ *     codebase_analysis:  { path, sha256, skipped: boolean }
+ *     raw_scan:           { path, sha256 }
+ *   ambiguity:
+ *     final_score: number
+ *     threshold_met: boolean
+ *     override: { active, reason, by } | null
+ *     rounds: number
+ *   spec:
+ *     user_request_hash: sha256(user_request)
+ *     resolved_spec_hash: sha256(Stage 1 + Stage 2 user_responses)
+ *
+ * Immutability: once written, `mpl-baseline-guard.mjs` (PreToolUse Edit|Write)
+ * blocks subsequent writes to baseline.yaml. Only Phase 0 re-interview may
+ * overwrite, and the guard accepts writes only when the sentinel flag
+ * `.mpl/mpl/.baseline-renewal` exists.
+ */
+
+import { existsSync, readFileSync, statSync, mkdirSync, writeFileSync } from 'fs';
+import { join, resolve } from 'path';
+import { execSync } from 'child_process';
+import { createHash } from 'crypto';
+
+const BASELINE_PATH = '.mpl/mpl/baseline.yaml';
+const RENEWAL_FLAG = '.mpl/mpl/.baseline-renewal';
+
+/**
+ * Compute SHA-256 of a file's contents. Returns null if the file does not exist.
+ */
+export function sha256File(cwd, relPath) {
+  const abs = resolve(cwd, relPath);
+  if (!existsSync(abs)) return null;
+  const buf = readFileSync(abs);
+  return createHash('sha256').update(buf).digest('hex');
+}
+
+/**
+ * Compute SHA-256 of a string (normalized: trim + LF).
+ */
+export function sha256String(s) {
+  const normalized = String(s ?? '').replace(/\r\n/g, '\n').trim();
+  return createHash('sha256').update(normalized, 'utf-8').digest('hex');
+}
+
+/**
+ * Shell out to git. Returns trimmed stdout or null on error.
+ */
+function git(cwd, args) {
+  try {
+    return execSync(`git ${args}`, {
+      cwd, stdio: ['ignore', 'pipe', 'ignore'], encoding: 'utf-8'
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build a baseline snapshot object from the current project state.
+ *
+ * @param {string} cwd
+ * @param {object} opts
+ * @param {string} opts.pipelineId
+ * @param {string} opts.userRequest
+ * @param {string} opts.accumulatedResponses - concatenated Stage 1 + Stage 2 user responses
+ * @param {object} opts.ambiguity - { final_score, threshold_met, override, rounds }
+ * @param {boolean} opts.codebaseSkipped - true if Step 2 was skipped (greenfield)
+ * @returns {object} baseline snapshot
+ */
+export function buildBaseline(cwd, {
+  pipelineId,
+  userRequest,
+  accumulatedResponses,
+  ambiguity,
+  codebaseSkipped,
+}) {
+  const baseSha = git(cwd, 'rev-parse HEAD');
+  const baseBranch = git(cwd, 'rev-parse --abbrev-ref HEAD');
+  const porcelain = git(cwd, 'status --porcelain');
+  const workingTreeClean = porcelain === '';
+
+  const artifactFor = (relPath) => {
+    const hash = sha256File(cwd, relPath);
+    return hash ? { path: relPath, sha256: hash } : null;
+  };
+
+  const codebaseHash = sha256File(cwd, '.mpl/mpl/codebase-analysis.json');
+
+  return {
+    created_at: new Date().toISOString(),
+    pipeline_id: pipelineId,
+    git: {
+      base_sha: baseSha,
+      base_branch: baseBranch,
+      working_tree_clean: workingTreeClean,
+    },
+    artifacts: {
+      pivot_points: artifactFor('.mpl/pivot-points.md'),
+      core_scenarios: artifactFor('.mpl/mpl/core-scenarios.yaml'),
+      design_intent: artifactFor('.mpl/mpl/phase0/design-intent.yaml'),
+      user_contract: artifactFor('.mpl/requirements/user-contract.md'),
+      codebase_analysis: codebaseSkipped
+        ? { path: '.mpl/mpl/codebase-analysis.json', sha256: null, skipped: true }
+        : (codebaseHash
+            ? { path: '.mpl/mpl/codebase-analysis.json', sha256: codebaseHash, skipped: false }
+            : { path: '.mpl/mpl/codebase-analysis.json', sha256: null, skipped: true }),
+      raw_scan: artifactFor('.mpl/mpl/phase0/raw-scan.md'),
+    },
+    ambiguity: {
+      final_score: ambiguity?.final_score ?? null,
+      threshold_met: ambiguity?.threshold_met ?? false,
+      override: ambiguity?.override ?? null,
+      rounds: ambiguity?.rounds ?? 0,
+    },
+    spec: {
+      user_request_hash: sha256String(userRequest),
+      resolved_spec_hash: sha256String(accumulatedResponses),
+    },
+  };
+}
+
+/**
+ * Serialize baseline to simple YAML (no external dep). We control the shape,
+ * so a hand-rolled emitter is sufficient and cheap.
+ */
+export function serializeBaseline(b) {
+  const lines = [];
+  lines.push(`created_at: "${b.created_at}"`);
+  lines.push(`pipeline_id: "${b.pipeline_id ?? ''}"`);
+  lines.push('git:');
+  lines.push(`  base_sha: ${b.git.base_sha ? `"${b.git.base_sha}"` : 'null'}`);
+  lines.push(`  base_branch: ${b.git.base_branch ? `"${b.git.base_branch}"` : 'null'}`);
+  lines.push(`  working_tree_clean: ${Boolean(b.git.working_tree_clean)}`);
+  lines.push('artifacts:');
+  for (const [k, v] of Object.entries(b.artifacts)) {
+    if (v === null) {
+      lines.push(`  ${k}: null`);
+      continue;
+    }
+    lines.push(`  ${k}:`);
+    lines.push(`    path: "${v.path}"`);
+    lines.push(`    sha256: ${v.sha256 ? `"${v.sha256}"` : 'null'}`);
+    if (typeof v.skipped === 'boolean') {
+      lines.push(`    skipped: ${v.skipped}`);
+    }
+  }
+  lines.push('ambiguity:');
+  lines.push(`  final_score: ${b.ambiguity.final_score ?? 'null'}`);
+  lines.push(`  threshold_met: ${Boolean(b.ambiguity.threshold_met)}`);
+  if (b.ambiguity.override) {
+    lines.push('  override:');
+    for (const [k, v] of Object.entries(b.ambiguity.override)) {
+      const value = typeof v === 'string' ? `"${v}"` : v;
+      lines.push(`    ${k}: ${value}`);
+    }
+  } else {
+    lines.push('  override: null');
+  }
+  lines.push(`  rounds: ${b.ambiguity.rounds ?? 0}`);
+  lines.push('spec:');
+  lines.push(`  user_request_hash: "${b.spec.user_request_hash}"`);
+  lines.push(`  resolved_spec_hash: "${b.spec.resolved_spec_hash}"`);
+  lines.push('');
+  return lines.join('\n');
+}
+
+/**
+ * Write baseline.yaml to disk. Caller must ensure renewal flag is set when
+ * overwriting an existing baseline (the PreToolUse guard enforces this for
+ * non-orchestrator writers).
+ */
+export function writeBaseline(cwd, baseline) {
+  const abs = resolve(cwd, BASELINE_PATH);
+  mkdirSync(resolve(cwd, '.mpl/mpl'), { recursive: true });
+  writeFileSync(abs, serializeBaseline(baseline), 'utf-8');
+  return abs;
+}
+
+/**
+ * Check whether a baseline already exists on disk.
+ */
+export function baselineExists(cwd) {
+  return existsSync(resolve(cwd, BASELINE_PATH));
+}
+
+/**
+ * Check renewal flag. Returns true if `.mpl/mpl/.baseline-renewal` exists.
+ * Orchestrator drops this file before Phase 0 re-interview to authorize a
+ * baseline overwrite.
+ */
+export function renewalAuthorized(cwd) {
+  return existsSync(resolve(cwd, RENEWAL_FLAG));
+}
+
+export const BASELINE_FILE = BASELINE_PATH;
+export const RENEWAL_FLAG_FILE = RENEWAL_FLAG;

--- a/hooks/mpl-baseline-guard.mjs
+++ b/hooks/mpl-baseline-guard.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+/**
+ * MPL Baseline Guard — PreToolUse blocker for immutable baseline.yaml (#59)
+ *
+ * Blocks Edit/Write operations on `.mpl/mpl/baseline.yaml` after it has been
+ * written, unless the renewal sentinel `.mpl/mpl/.baseline-renewal` exists.
+ *
+ * The baseline snapshot captured at Step 2.9 is ground truth for downstream
+ * delta calculation (Decomposer) and rollback target (4.7 partial rollback).
+ * Silent overwrites would corrupt both. Orchestrator initiates renewal
+ * explicitly by dropping the flag before Phase 0 re-interview.
+ */
+
+import { dirname, join, resolve } from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+import { existsSync } from 'fs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const { isMplActive } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-state.mjs')).href
+);
+const { baselineExists, renewalAuthorized, BASELINE_FILE, RENEWAL_FLAG_FILE } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-baseline.mjs')).href
+);
+const { readStdin } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'stdin.mjs')).href
+);
+
+function normalizeRel(cwd, filePath) {
+  if (!filePath) return '';
+  const abs = resolve(filePath);
+  const cwdAbs = resolve(cwd);
+  if (abs.startsWith(cwdAbs + '/')) {
+    return abs.slice(cwdAbs.length + 1);
+  }
+  return filePath.replace(/\\/g, '/');
+}
+
+async function main() {
+  const input = await readStdin();
+
+  let data;
+  try {
+    data = JSON.parse(input);
+  } catch {
+    console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+    return;
+  }
+
+  const toolName = data.tool_name || data.toolName || '';
+  if (!['Edit', 'edit', 'Write', 'write'].includes(toolName)) {
+    console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+    return;
+  }
+
+  const cwd = data.cwd || data.directory || process.cwd();
+  if (!isMplActive(cwd)) {
+    console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+    return;
+  }
+
+  const toolInput = data.tool_input || data.toolInput || {};
+  const filePath = toolInput.file_path || toolInput.filePath || '';
+  if (!filePath) {
+    console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+    return;
+  }
+
+  const rel = normalizeRel(cwd, filePath);
+  if (rel !== BASELINE_FILE) {
+    console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+    return;
+  }
+
+  // Baseline does not yet exist → first write is allowed (Step 2.9 initial snapshot).
+  if (!baselineExists(cwd)) {
+    console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+    return;
+  }
+
+  // Baseline exists → allow only when renewal sentinel is present.
+  if (renewalAuthorized(cwd)) {
+    console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+    return;
+  }
+
+  const reason = [
+    `[MPL Baseline Guard] Blocked write to ${BASELINE_FILE}.`,
+    '',
+    `This file is the immutable ground-truth snapshot recorded at Step 2.9 after`,
+    `Stage 2 Ambiguity Resolution closed. Downstream consumers (Decomposer,`,
+    `Seed Generator, 4.7 Partial Rollback) treat it as the pipeline's baseline.`,
+    'Silently overwriting it would corrupt delta calculation and rollback.',
+    '',
+    'To legitimately rewrite the baseline (Phase 0 re-interview), drop the',
+    `renewal sentinel first:`,
+    '',
+    `  touch ${RENEWAL_FLAG_FILE}`,
+    '',
+    'Then retry the write. The orchestrator removes the flag after successful',
+    'baseline rewrite.',
+  ].join('\n');
+
+  console.log(JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      permissionDecision: 'deny',
+      permissionDecisionReason: reason
+    }
+  }));
+}
+
+main().catch(() => {
+  console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+});


### PR DESCRIPTION
## Summary

Closes #59. Introduces Step 2.9 Branch Main State Snapshot — the immutable ground-truth checkpoint recorded after Phase 0 Stage 2 Ambiguity closes. Final piece of the v0.17 refactor (all of #55-#60 now complete).

## New artifacts

### `hooks/lib/mpl-baseline.mjs` (216L)

- `buildBaseline()` — gather git SHA/branch/clean-flag, per-artifact SHA-256 hashes, ambiguity state, spec hashes
- `serializeBaseline()` — hand-rolled YAML emitter (no yaml dep)
- `writeBaseline()`, `baselineExists()`, `renewalAuthorized()`
- `sha256File()`, `sha256String()` (normalized per MPL cache-hash convention)

### `hooks/mpl-baseline-guard.mjs` (117L)

PreToolUse Edit|Write hook:
- First write: allow (Step 2.9 initial snapshot)
- Subsequent writes: deny unless `.mpl/mpl/.baseline-renewal` sentinel exists
- Orchestrator drops sentinel before Phase 0 re-interview → write → remove sentinel

Deny reason shows the recovery workflow inline.

## Updated

### `commands/mpl-run-phase0.md` Step 2.9

Stub → full implementation:
- User confirmation gate (Approve & Snapshot / Modify PPs / Re-interview)
- buildBaseline + writeBaseline invocation with renewal-flag dance
- Full schema documented
- Consumer table (Decomposer / Seed Gen / 4.7 rollback / 5.1.5 drift / 5.4 metrics)
- Optional `branch_mode: "worktree"` config

### `hooks/hooks.json`

Register `mpl-baseline-guard.mjs` under PreToolUse Edit|Write matcher.

## Tests

`hooks/__tests__/mpl-baseline.test.mjs` (10 new tests):
- sha256String normalization (CRLF / trim / null)
- sha256File present/absent
- buildBaseline: git info, artifact hashes, greenfield skip, override capture
- serializeBaseline: YAML sanity
- writeBaseline + baselineExists + renewalAuthorized

**Result**: 283/283 pass (273 existing + 10 new).

## Schema

```yaml
created_at: ISO timestamp
pipeline_id: string
git: { base_sha, base_branch, working_tree_clean }
artifacts:
  pivot_points:      { path, sha256 } | null
  core_scenarios:    { path, sha256 } | null
  design_intent:     { path, sha256 } | null
  user_contract:     { path, sha256 } | null
  codebase_analysis: { path, sha256, skipped: boolean }
  raw_scan:          { path, sha256 } | null
ambiguity:
  final_score: number | null
  threshold_met: boolean
  override: { active, reason, by } | null
  rounds: number
spec:
  user_request_hash: sha256 of user_request (normalized)
  resolved_spec_hash: sha256 of Stage 1+2 accumulated responses
```

## v0.17 refactor summary

All 6 target issues merged:

| # | Title | Status |
|---|---|---|
| #55 | Phase 0 simplification — rewrite phase0.md | Merged (PR #61) |
| #56 | phase0-analyzer reduction (raw scan only) | Merged (PR #62) |
| #57 | Decomposer absorbs synthesis | Merged (PR #63) |
| #58 | Seed generator unified dispatch | Merged (PR #64) |
| #60 | F-22 routing pattern removal | Merged (PR #65) |
| #59 | Baseline snapshot + write-guard | **THIS PR** |

## References

- Issue #59
- Target flow: `.mpl/scratch/mpl-flow-diagram.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)