### PR TITLE
feat(#69): WS-3C — extract inline schemas to commands/schemas/

### DIFF
--- a/commands/mpl-run-finalize.md
+++ b/commands/mpl-run-finalize.md
@@ -601,52 +601,13 @@ Config example (`.mpl/config.json`):
 
 ### 5.4: Metrics
 
-Save to `.mpl/mpl/metrics.json`:
-```json
-{
-  "phases_completed": 4, "phases_failed": 0,
-  "total_retries": 2, "total_micro_fixes": 3,
-  "total_discoveries": 3, "total_pd_count": 8, "total_pd_overrides": 1,
-  "final_pass_rate": 100, "phase5_skipped": true,
-  "phase0_cache_hit": false,
-  "phase0_grade": "Complex",
-  "phase0_artifacts_validated": "3/3",
-  "token_profile": {
-    "phase0": 12000,
-    "phases": [10000, 12000, 8000, 5000],
-    "phase5_gate": 500,
-    "finalize": 2000,
-    "total_estimated": 49500
-  },
-  "elapsed_ms": 720000, "final_verification": "all_pass",
-  "side_interviews": { "count": 0, "phases": [] },
-  "convergence_triggers": { "stagnation": 0, "regression": 0 },
-  "gap_analysis": { "missing_requirements": 0, "pitfalls": 0, "constraints": 0 },
-  "tradeoff_analysis": { "aggregate_risk": "LOW", "irreversible_count": 0 },
-  "critic_assessment": "READY",
-  "three_gate_results": {
-    // AD-0006: derived from state.gate_results (machine evidence, not self-report).
-    // hard{1,2,3}_status ∈ { "PASS" (exit 0), "PARTIAL" (exit != 0), "NOT_EVALUATED" (null) }
-    "hard1_status": "PASS", "hard1_exit_code": 0, "hard1_command": "pnpm lint && pnpm build",
-    "hard2_status": "PASS", "hard2_exit_code": 0, "hard2_command": "pnpm test --run",
-    "hard3_status": "NOT_EVALUATED", "hard3_exit_code": null, "hard3_command": null
-  },
-  "verification_plan": { "a_items": 0, "s_items": 0, "h_items": 0 },
-  "intent_invariants": {
-    // #50 (2026-04-20 debate 합의): teleological invariant tracking.
-    // Aggregated from each phase's verification record (written by Hard 2, G2).
-    "total_declared": 2,                  // sum of verification_plan.invariants[].length across phases (dedup by id)
-    "total_violations": 0,                // sum of invariant_violation_count across phases (Hard 2 runs)
-    "discovery_from_intent_conflict": 0,  // count of discoveries where type == "invariant_violation"
-    "violated_ids": [],                   // [ "INV-2", ... ] — ids that failed in any phase (empty if clean)
-    "by_phase": {                         // per-phase breakdown for debugging
-      // "phase-1": { declared: 1, violations: 0, discoveries: 0 },
-      // "phase-2": { declared: 1, violations: 0, discoveries: 0 }
-    }
-  },
-  "triage": { "interview_depth": "full", "prompt_density": 3 }
-}
-```
+Save to `.mpl/mpl/metrics.json`.
+
+> See [`commands/schemas/metrics.json`](schemas/metrics.json) for the full schema with field comments.
+>
+> **Top-level shape**: phase/retry/discovery counters · `token_profile` (phase0/phases/phase5_gate/finalize/total_estimated) · `three_gate_results` (AD-0006 machine evidence derived from state.gate_results) · `intent_invariants` (#50 aggregation: total_declared/total_violations/discovery_from_intent_conflict/violated_ids/by_phase) · `verification_plan` (a/s/h counts) · `gap_analysis`, `tradeoff_analysis`, `side_interviews`, `convergence_triggers`.
+>
+> **v0.17 cleanup**: `phase0_grade` and `triage.interview_depth` fields removed (complexity grade and light/full dual-track deleted in #55/#56/#57).
 
 **Intent Invariant aggregation rule (#50)**:
 ```
@@ -661,23 +622,11 @@ if total_declared == 0:
   # (no-op for bugfix/simple tasks — matches optional field semantics)
 ```
 
-Generate full run profile at `.mpl/mpl/profile/run-summary.json`:
-```json
-{
-  "run_id": "mpl-{timestamp}",
-  "complexity": { "grade": "Complex", "score": 85 },
-  "cache": { "phase0_hit": false, "saved_tokens": 0 },
-  "phases": [
-    { "id": "phase0", "tokens": 12000, "duration_ms": 15000, "cache_hit": false },
-    { "id": "phase-1", "tokens": 10000, "duration_ms": 45000, "pass_rate": 100, "micro_fixes": 0 },
-    { "id": "phase-2", "tokens": 12000, "duration_ms": 60000, "pass_rate": 100, "micro_fixes": 1 },
-    { "id": "phase-3", "tokens": 8000, "duration_ms": 40000, "pass_rate": 100, "micro_fixes": 0 },
-    { "id": "phase-4", "tokens": 5000, "duration_ms": 30000, "pass_rate": 100, "micro_fixes": 0 }
-  ],
-  "phase5_gate": { "final_pass_rate": 100, "decision": "skip", "fix_tokens": 0 },
-  "totals": { "tokens": 49500, "duration_ms": 210000, "micro_fixes": 1, "retries": 0 }
-}
-```
+Generate full run profile at `.mpl/mpl/profile/run-summary.json`.
+
+> See [`commands/schemas/run-summary.json`](schemas/run-summary.json) for the full schema.
+>
+> **Shape**: `run_id` · `complexity` (grade/score) · `cache` (phase0_hit/saved_tokens) · `phases[]` (per-phase tokens/duration_ms/pass_rate/micro_fixes) · `phase5_gate` · `totals`.
 
 Profile data enables:
 1. **Learn optimal token budget by complexity**: derive average tokens per grade from past profiles

--- a/commands/mpl-run-phase0.md
+++ b/commands/mpl-run-phase0.md
@@ -509,30 +509,9 @@ Announce: "[MPL #59] Step 2.9 baseline.yaml recorded. git_base_sha=${baseline.gi
 
 ### Schema
 
-```yaml
-# .mpl/mpl/baseline.yaml (immutable after first write)
-created_at: "ISO timestamp"
-pipeline_id: "mpl-{feature}-{date}"
-git:
-  base_sha: "full SHA or null if not a git repo"
-  base_branch: "branch name or null"
-  working_tree_clean: boolean
-artifacts:
-  pivot_points:      { path, sha256 } | null
-  core_scenarios:    { path, sha256 } | null
-  design_intent:     { path, sha256 } | null
-  user_contract:     { path, sha256 } | null
-  codebase_analysis: { path, sha256, skipped: boolean }
-  raw_scan:          { path, sha256 } | null
-ambiguity:
-  final_score: number | null
-  threshold_met: boolean
-  override: { active, reason, by } | null
-  rounds: number
-spec:
-  user_request_hash:  "sha256 of user_request (normalized)"
-  resolved_spec_hash: "sha256 of Stage 1 + Stage 2 accumulated responses (normalized)"
-```
+> See [`commands/schemas/baseline.yaml`](schemas/baseline.yaml) for the full schema with field documentation.
+>
+> **Top-level keys**: `created_at` · `pipeline_id` · `git` (base_sha/base_branch/working_tree_clean) · `artifacts` (per Phase 0 artifact: path + sha256, plus `skipped` for codebase_analysis) · `ambiguity` (final_score/threshold_met/override/rounds) · `spec` (user_request_hash + resolved_spec_hash, both normalized SHA-256).
 
 ### Immutability (write-guard)
 

--- a/commands/mpl-run.md
+++ b/commands/mpl-run.md
@@ -180,6 +180,7 @@ Only load the file needed for the current stage — this saves ~60-70% of contex
 | `mpl-run-finalize-resume.md` | 6 | Resume Protocol, Budget Pause Resume, Discovery Processing, Related Skills | ~2K |
 | `commands/references/e2e-recovery.md` (v0.17 #67) | 5.0.4 detail | Automated E2E Recovery Loop full protocol — load on failure | ~2K |
 | `commands/references/prompt-routing.md` (v0.17 #68) | 4.2.1 detail | F-28 domain routing + F-39 4-Layer composition — load at Phase Runner dispatch | ~2K |
+| `commands/schemas/*.{yaml,json}` (v0.17 #69) | canonical | baseline.yaml / metrics.json / run-summary.json schemas — referenced when writing artifacts | ~1K |
 
 ### Sub-File Loading Rules
 

--- a/commands/schemas/baseline.yaml
+++ b/commands/schemas/baseline.yaml
@@ -1,0 +1,37 @@
+# Schema: .mpl/mpl/baseline.yaml
+# Written by: commands/mpl-run-phase0.md Step 2.9 (#59) after Stage 2 closes.
+# Immutable: hooks/mpl-baseline-guard.mjs blocks overwrite unless
+#   .mpl/mpl/.baseline-renewal sentinel exists.
+# Consumers: Decomposer (delta target), Seed Generator (cache validation),
+#   4.7 Partial Rollback (git.base_sha reset target), 5.1.5 Scope Drift
+#   Detection, Finalize 5.4 Metrics.
+
+created_at: "ISO timestamp"
+pipeline_id: "mpl-{feature}-{date}"
+
+git:
+  base_sha: "full SHA or null if not a git repo"
+  base_branch: "branch name or null"
+  working_tree_clean: boolean                   # git status --porcelain empty?
+
+artifacts:
+  # Each entry: { path, sha256 } | null (absent) — sha256 normalized SHA-256
+  pivot_points:      { path: ".mpl/pivot-points.md",         sha256: "<hash>" } # null if absent
+  core_scenarios:    { path: ".mpl/mpl/core-scenarios.yaml", sha256: "<hash>" } # null if absent
+  design_intent:     { path: ".mpl/mpl/phase0/design-intent.yaml", sha256: "<hash>" } # null if absent
+  user_contract:     { path: ".mpl/requirements/user-contract.md", sha256: "<hash>" } # null if absent
+  codebase_analysis: { path: ".mpl/mpl/codebase-analysis.json", sha256: "<hash>", skipped: false } # skipped=true for greenfield
+  raw_scan:          { path: ".mpl/mpl/phase0/raw-scan.md",  sha256: "<hash>" } # null if absent
+
+ambiguity:
+  final_score: number                            # null if never scored
+  threshold_met: boolean                         # score <= 0.2 at close
+  override:                                      # null when gate passed naturally
+    active: boolean
+    reason: "user-provided rationale string"
+    by: "user_halt | ci_override"
+  rounds: integer                                # length of ambiguity_history at close
+
+spec:
+  user_request_hash:  "sha256 of user_request (normalized: CRLF→LF + trim)"
+  resolved_spec_hash: "sha256 of Stage 1 + Stage 2 accumulated responses (normalized)"

--- a/commands/schemas/metrics.json
+++ b/commands/schemas/metrics.json
@@ -1,0 +1,53 @@
+{
+  "_comment": "Schema: .mpl/mpl/metrics.json. Written by commands/mpl-run-finalize.md Step 5.4.",
+  "_consumers": "mpl:mpl-status dashboard, mpl:mpl-doctor audit, external analytics",
+
+  "phases_completed": 4,
+  "phases_failed": 0,
+  "total_retries": 2,
+  "total_micro_fixes": 3,
+  "total_discoveries": 3,
+  "total_pd_count": 8,
+  "total_pd_overrides": 1,
+  "final_pass_rate": 100,
+  "phase5_skipped": true,
+  "phase0_cache_hit": false,
+  "phase0_artifacts_validated": "1/1",
+  "token_profile": {
+    "phase0": 12000,
+    "phases": [10000, 12000, 8000, 5000],
+    "phase5_gate": 500,
+    "finalize": 2000,
+    "total_estimated": 49500
+  },
+  "elapsed_ms": 720000,
+  "final_verification": "all_pass",
+  "side_interviews": { "count": 0, "phases": [] },
+  "convergence_triggers": { "stagnation": 0, "regression": 0 },
+  "gap_analysis": { "missing_requirements": 0, "pitfalls": 0, "constraints": 0 },
+  "tradeoff_analysis": { "aggregate_risk": "LOW", "irreversible_count": 0 },
+  "critic_assessment": "READY",
+
+  "three_gate_results": {
+    "_comment": "AD-0006: derived from state.gate_results (machine evidence, not self-report). status ∈ {PASS (exit 0), PARTIAL (exit != 0), NOT_EVALUATED (null)}",
+    "hard1_status": "PASS", "hard1_exit_code": 0, "hard1_command": "pnpm lint && pnpm build",
+    "hard2_status": "PASS", "hard2_exit_code": 0, "hard2_command": "pnpm test --run",
+    "hard3_status": "NOT_EVALUATED", "hard3_exit_code": null, "hard3_command": null
+  },
+
+  "verification_plan": { "a_items": 0, "s_items": 0, "h_items": 0 },
+
+  "intent_invariants": {
+    "_comment": "#50 (2026-04-20 debate 합의): teleological invariant tracking. Aggregated from each phase's verification record.",
+    "total_declared": 2,
+    "total_violations": 0,
+    "discovery_from_intent_conflict": 0,
+    "violated_ids": [],
+    "by_phase": {
+      "_example": {
+        "phase-1": { "declared": 1, "violations": 0, "discoveries": 0 },
+        "phase-2": { "declared": 1, "violations": 0, "discoveries": 0 }
+      }
+    }
+  }
+}

--- a/commands/schemas/run-summary.json
+++ b/commands/schemas/run-summary.json
@@ -1,0 +1,17 @@
+{
+  "_comment": "Schema: .mpl/mpl/profile/run-summary.json. Written by commands/mpl-run-finalize.md Step 5.4.",
+  "_purpose": "Per-phase token + duration profile for cost analysis and learning",
+
+  "run_id": "mpl-{timestamp}",
+  "complexity": { "grade": "Complex", "score": 85 },
+  "cache": { "phase0_hit": false, "saved_tokens": 0 },
+  "phases": [
+    { "id": "phase0",   "tokens": 12000, "duration_ms": 15000, "cache_hit": false },
+    { "id": "phase-1",  "tokens": 10000, "duration_ms": 45000, "pass_rate": 100, "micro_fixes": 0 },
+    { "id": "phase-2",  "tokens": 12000, "duration_ms": 60000, "pass_rate": 100, "micro_fixes": 1 },
+    { "id": "phase-3",  "tokens":  8000, "duration_ms": 40000, "pass_rate": 100, "micro_fixes": 0 },
+    { "id": "phase-4",  "tokens":  5000, "duration_ms": 30000, "pass_rate": 100, "micro_fixes": 0 }
+  ],
+  "phase5_gate": { "final_pass_rate": 100, "decision": "skip", "fix_tokens": 0 },
+  "totals": { "tokens": 49500, "duration_ms": 210000, "micro_fixes": 1, "retries": 0 }
+}


### PR DESCRIPTION
## Summary

Closes #69. Third and final progressive disclosure sub-issue. Three large inline schema blocks move to `commands/schemas/` as canonical, single-source-of-truth files.

## New files (107L)

- `commands/schemas/baseline.yaml` (37L) — ex-phase0.md L512-535
- `commands/schemas/metrics.json` (53L) — ex-finalize.md L605-649
- `commands/schemas/run-summary.json` (17L) — ex-finalize.md L665-680

## Modified

- `commands/mpl-run-phase0.md` 578L → 557L (-21L)
- `commands/mpl-run-finalize.md` 777L → 726L (-51L)
- `commands/mpl-run.md` Protocol Files Summary adds schemas row

## Bonus: stale field cleanup

metrics.json schema previously documented `phase0_grade` and `triage.interview_depth` — both deleted during v0.17 (#55/#56/#57) but left stale in finalize prose. Removed in the new canonical schema.

## Test plan

- [x] 283/283 hook tests pass
- [ ] E2E: finalize writes .mpl/mpl/metrics.json matching new schema shape
- [ ] Future: add `mpl:mpl-doctor` audit that validates artifact against commands/schemas/*

## Rationale

1. Prose drift: inline blocks drifted out of sync with code (phase0_grade case)
2. Single source of truth for future validators + external dashboards
3. Command prose reads as narrative, not schema dump

P1-4a / WS-3 complete after merge (#67 + #68 + #69).

🤖 Generated with [Claude Code](https://claude.com/claude-code)