### PR TITLE
feat(#77): WS-4 — AP-ID normalization across 6 agent Failure_Modes

### DIFF
--- a/agents/mpl-decomposer.md
+++ b/agents/mpl-decomposer.md
@@ -496,10 +496,10 @@ disallowedTools: Write,Edit,Bash,Task,WebFetch,WebSearch,NotebookEdit
   </Output_Schema>
 
   <Failure_Modes>
-    1. **Scope reduction**: Covering only a subset of the request. If the spec has 10 features, ALL 10 must appear. Never omit features to fit a phase count limit.
-    2. **Horizontal decomposition of multi-layer project**: Splitting by layer (all types -> all backend -> all UI) instead of vertical slices causes cross-layer contract failures.
-    3. **Missing interfaces**: Phases that cannot communicate because requires/produces are undefined. Every phase's requires must be satisfied by prior phases' produces.
-    4. **Synthesis drift from raw scan (v0.17 #57)**: Inventing type-policy or error-spec facts that the raw scan did not produce. Type rules should trace back to raw-scan Type Hints or PP tech stack; error categories to Error Throw Sites or PP conventions. If the raw scan is empty (greenfield + no PP spec), the phase's `type_policy`/`error_spec` may be minimal — that is honest output. Do not fabricate to "fill the field".
-    5. **Skipping synthesis fields as absent** (v0.17 #57): `type_policy` and `error_spec` are REQUIRED on every phase. Emit `applies: false` + empty subfields when the phase legitimately has no type/error surface (pure docs / migrations). Omission is a validation error.
+    - **AP-DECOMP-01 · Scope reduction**: covering only a subset of the request. If the spec has 10 features, ALL 10 must appear. Never omit features to fit a phase count limit — phase count is output, not input constraint.
+    - **AP-DECOMP-02 · Horizontal decomposition of multi-layer project**: splitting by layer (all types → all backend → all UI) instead of vertical slices. Horizontal phases cannot be verified independently and amplify cross-layer contract failures at integration time.
+    - **AP-DECOMP-03 · Missing interfaces**: phases that cannot communicate because `requires`/`produces` are undefined. Every phase's `requires` must be satisfied by a prior phase's `produces`. Orphan phases indicate decomposition error, not harmless slack.
+    - **AP-DECOMP-04 · Synthesis drift from raw scan (v0.17 #57)**: inventing type-policy or error-spec facts the raw scan did not produce. Type rules must trace back to raw-scan Type Hints or PP tech stack; error categories to Error Throw Sites or PP conventions. If the raw scan is empty (greenfield + no PP spec), `type_policy`/`error_spec` may be minimal — that is honest output. Do not fabricate to "fill the field".
+    - **AP-DECOMP-05 · Skipping synthesis fields as absent (v0.17 #57)**: `type_policy` and `error_spec` are REQUIRED on every phase. Emit `applies: false` with empty subfields when the phase legitimately has no type/error surface (pure docs/migrations). Omission is a validation error — absence and "not applicable" are distinct states.
   </Failure_Modes>
 </Agent_Prompt>

--- a/agents/mpl-doctor.md
+++ b/agents/mpl-doctor.md
@@ -250,9 +250,9 @@ disallowedTools: Write, Edit, Task
   </Output_Schema>
 
   <Failure_Modes_To_Avoid>
-    - Assuming PASS without checking: always read/run before reporting.
-    - Reporting tool unavailability as FAIL: LSP tools are optional, report as WARN with fallback.
-    - Missing fallback info: every WARN must include what fallback MPL will use.
-    - Over-alarming: standalone mode is fully functional, not broken.
+    - **AP-DOC-01 · Assuming PASS without checking**: always read files / run commands before reporting a category as PASS. Self-report PASS without evidence is the same failure shape as AP-VERIFY-01 / AP-RUNNER-02 — verification must rest on observation.
+    - **AP-DOC-02 · Reporting tool unavailability as FAIL**: LSP and ast_grep are optional. A missing optional tool is a WARN with a fallback pointer, not a FAIL. FAIL is reserved for broken MPL installation state.
+    - **AP-DOC-03 · Missing fallback info**: every WARN must name the concrete fallback MPL will use (e.g., "ast_grep missing → Grep fallback per docs/standalone.md"). WARN without a resolution path is noise, not actionable guidance.
+    - **AP-DOC-04 · Over-alarming**: standalone mode is fully functional, not broken. Flagging the absence of optional tools as installation problems produces false urgency and reduces audit signal-to-noise.
   </Failure_Modes_To_Avoid>
 </Agent_Prompt>

--- a/agents/mpl-interviewer.md
+++ b/agents/mpl-interviewer.md
@@ -344,8 +344,8 @@ disallowedTools: Write, Edit, Bash, Task
   </Output_Schema>
 
   <Failure_Modes_To_Avoid>
-    - **Leading questions**: suggesting answers instead of eliciting genuine constraints.
-    - **PP inflation**: 3-5 is typical; more than 7 indicates over-specification.
-    - **Vague criteria**: accepting "it should feel good" as a judgment criterion.
+    - **AP-INT-01 · Leading questions**: suggesting answers instead of eliciting genuine constraints. Leading phrasing anchors the user on the interviewer's hypothesis; PPs derived from leading questions are the interviewer's opinion, not the user's constraint.
+    - **AP-INT-02 · PP inflation**: 3-5 PPs is typical; more than 7 indicates over-specification. Excess PPs increase conflict surface for later phases and collapse the distinction between "constraint" and "preference".
+    - **AP-INT-03 · Vague criteria**: accepting "it should feel good" or similar non-observable phrasing as a judgment criterion. Every PP needs a criterion that lets a later phase mechanically verify compliance — ambiguous acceptance erodes the gate model.
   </Failure_Modes_To_Avoid>
 </Agent_Prompt>

--- a/agents/mpl-phase-runner.md
+++ b/agents/mpl-phase-runner.md
@@ -180,9 +180,9 @@ disallowedTools: []
   </Output_Schema>
 
   <Failure_Modes_To_Avoid>
-    1. **Scope creep**: implementing features from other phases or modifying files outside declared impact.
-    2. **False verification**: claiming criteria pass without running commands. Always run and record real evidence.
-    3. **Weak state summary**: omitting required sections. The next phase has no other source of truth.
-    4. **Silent invariant violation (#50)**: committing code that violates a `verification_plan.invariants[]` entry without Discovery report. Teleological invariants are verbatim user-confirmed ground truth — never rationalize around them.
+    - **AP-RUNNER-01 · Scope creep**: implementing features from other phases or modifying files outside declared impact. The `impact` block is the full bound; edits beyond it break phase isolation and compose badly with the state-summary-only knowledge transfer model.
+    - **AP-RUNNER-02 · False verification**: claiming `success_criteria` pass without running commands. Always run the actual command and record real evidence (exit code + output tail) — self-report without execution is the dominant verification-failure shape.
+    - **AP-RUNNER-03 · Weak state summary**: omitting required sections. The next phase has no other source of truth about what happened here; missing sections force later phases to re-discover context and drift.
+    - **AP-RUNNER-04 · Silent invariant violation (#50)**: committing code that violates a `verification_plan.invariants[]` entry without filing a Discovery. Teleological invariants are verbatim user-confirmed ground truth — rationalizing around them defeats the mechanical enforcement model.
   </Failure_Modes_To_Avoid>
 </Agent_Prompt>

--- a/agents/mpl-phase0-analyzer.md
+++ b/agents/mpl-phase0-analyzer.md
@@ -314,10 +314,10 @@ disallowedTools: Edit, Task
   </Output>
 
   <Failure_Modes_To_Avoid>
-    - Synthesizing type policy, error categories, or complexity grades. All synthesis moved to decomposer (#57). Your role is extraction.
-    - Gating passes on "complexity" — passes are cheap and unconditional.
-    - Inferring intent from absence. If a pattern is not found, record "0 hits", not "probably not needed".
-    - Writing files outside `{output_dir}` or `{cache_dir}`.
+    - **AP-SCAN-01 · Synthesizing policy or grades (v0.17 #57)**: type policy, error categories, and complexity grades are decomposer synthesis tasks. Your role is extraction only. Emitting synthesized rules here creates two sources of truth for the same concept.
+    - **AP-SCAN-02 · Gating passes on "complexity"**: passes are cheap and unconditional. Conditionally skipping passes re-introduces grade-based behavior the v0.17 refactor removed; every pass runs on every project regardless of size.
+    - **AP-SCAN-03 · Inferring intent from absence**: if a pattern is not found, record "0 hits", not "probably not needed". Negative findings are data; swallowing them as "irrelevant" hides greenfield signals the decomposer needs.
+    - **AP-SCAN-04 · Writing outside `{output_dir}` / `{cache_dir}`**: the agent's write surface is those two directories only. Writes elsewhere break cache invalidation assumptions and conflict with orchestrator-owned artifacts.
   </Failure_Modes_To_Avoid>
 
   <Semantic_Memory_Shortcuts>

--- a/agents/mpl-seed-generator.md
+++ b/agents/mpl-seed-generator.md
@@ -167,10 +167,10 @@ disallowedTools: Write,Edit,Bash,Task,WebFetch,WebSearch,NotebookEdit
   </Output_Schema>
 
   <Failure_Modes>
-    1. **Partial chain**: Designing only some phases of the chain. ALL phases must have a complete entry.
-    2. **Contract mismatch**: Producer phase declares `returns: {token: string}` but consumer phase's contract_snippet says `params: {jwt: string}`. Symbol/key names must match exactly.
-    3. **Invented contracts**: Making up caller/callee pairs not backed by Decomposer edges. If unsure, use `ambiguity_notes`.
-    4. **Non-machine-verifiable acceptance_criteria**: Pushing "looks good" or "works correctly" to a_items/s_items. These MUST go to h_items with reason.
-    5. **Regeneration mode confusion**: Regenerating all phases when only `affected_phases` should change. Preserve untouched phases exactly.
+    - **AP-SEED-01 · Partial chain (chain mode)**: designing only some phases of the chain. ALL phases in the chain must have a complete entry. Partial output breaks baton-pass and forces re-dispatch — defeats the batch-scope advantage. Inline mode (#58) is exempt: one call = one phase by design.
+    - **AP-SEED-02 · Contract mismatch**: producer phase declares `returns: {token: string}` but consumer phase's `contract_snippet` says `params: {jwt: string}`. Symbol/key names must match exactly — `sentinel-s0` hook will flag mismatches at runtime, but catching them here avoids a re-dispatch cycle.
+    - **AP-SEED-03 · Invented contracts**: making up caller/callee pairs not backed by Decomposer edges. If unsure, use `ambiguity_notes`; fabricated contracts pass SEED-03 validation but fail at integration.
+    - **AP-SEED-04 · Non-machine-verifiable acceptance_criteria**: pushing "looks good" or "works correctly" to `a_items`/`s_items`. Those MUST go to `h_items` with reason — a/s items are mechanical gates, not aspirational criteria.
+    - **AP-SEED-05 · Regeneration mode confusion**: regenerating all phases when only `affected_phases` should change. Preserve untouched phases exactly — regenerating already-validated phases invalidates downstream state-summary trails.
   </Failure_Modes>
 </Agent_Prompt>


### PR DESCRIPTION
## Summary

Closes #77. Apply the AP-ID convention (introduced in #54 for test-agent + 3 command files) across the remaining 6 agents. Pure documentation alignment — no behavior change.

## AP-ID assignments (25 new globally unique IDs)

| Agent | Namespace | Count |
|---|---|---|
| mpl-decomposer | AP-DECOMP-01..05 | 5 |
| mpl-phase-runner | AP-RUNNER-01..04 | 4 |
| mpl-interviewer | AP-INT-01..03 | 3 |
| mpl-doctor | AP-DOC-01..04 | 4 |
| mpl-seed-generator | AP-SEED-01..05 | 5 |
| mpl-phase0-analyzer | AP-SCAN-01..04 | 4 |

## Format

```
- **AP-{NS}-{NN} · {short name}**: {what the failure looks like}.
  {Why it's wrong / cross-reference to related AP-IDs or issues.}
```

1-2 sentence rationale per item. Full empirical blocks reserved for cases with actual data (AP-VERIFY-01's 29-run dataset is the exception, not the template).

## Cross-references

- `AP-DOC-01` cites `AP-VERIFY-01` and `AP-RUNNER-02` as the same "self-report without evidence" shape — demonstrates the convention's value for linking related failures.
- `AP-SEED-01` explicitly exempts inline mode (#58) from "partial chain" failures since inline generates one phase per call by design.

## Rationale for proceeding without measurement

Effect measurement for `AP-VERIFY-01` is absent. Proceeding on convention grounds:
1. Uniform citation format — hooks / discovery records can cite `AP-RUNNER-02` instead of free-text
2. Reduces cognitive load across agents
3. Future central catalog buildable without reformatting (locally-anchored per #54 debate)
4. Prevents free-text drift (different agents phrasing same failure differently)

## Non-goals

- No central catalog built
- No empirical blocks added without data
- No behavior change — documentation only

## Test plan

- [x] All 6 agents use AP-{NS}-NN format
- [x] AP-IDs globally unique (grep verified)
- [x] 283/283 hook tests pass

## References

- Issue #77
- P1-4c from `~/project/wiki/scratch/2026-04-21/mpl-session-remaining.md`
- #54 established the convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)