### PR TITLE
feat(#81): P1-4d — machine-enforce AP-CHAIN-01 via require-chain-assignment hook

### DIFF
--- a/commands/mpl-run-decompose.md
+++ b/commands/mpl-run-decompose.md
@@ -516,6 +516,12 @@ Before leaving decomposition with `chain_seed.enabled=true`, verify
 `.mpl/mpl/chain-assignment.yaml` exists. If not, Step 3-G did not actually
 run — return to it.
 
+**Machine enforcement (P1-4d)**: `hooks/mpl-require-chain-assignment.mjs`
+(PreToolUse on `Task|Agent` with `subagent_type=mpl-seed-generator`) denies
+the dispatch outright when `chain_seed.enabled=true` and the yaml is absent.
+The prose warning above is preserved for context; the hook makes the prior
+silent-skip path impossible.
+
 
 After decomposition is saved (Step 3) and validated (Step 3-F, 3-B), derive chain structure from phase edges and proximity. Output: `.mpl/mpl/chain-assignment.yaml`.
 

--- a/hooks/__tests__/mpl-require-chain-assignment.test.mjs
+++ b/hooks/__tests__/mpl-require-chain-assignment.test.mjs
@@ -1,0 +1,208 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join, dirname } from 'path';
+import { tmpdir } from 'os';
+import { execSync, spawnSync } from 'child_process';
+import { fileURLToPath } from 'url';
+
+import {
+  isChainSeedEnabled,
+  chainAssignmentExists,
+} from '../mpl-require-chain-assignment.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const HOOK_PATH = join(dirname(__filename), '..', 'mpl-require-chain-assignment.mjs');
+
+function makeProject() {
+  const dir = mkdtempSync(join(tmpdir(), 'mpl-req-chain-'));
+  mkdirSync(join(dir, '.mpl'), { recursive: true });
+  // Minimal active-state file so isMplActive returns true.
+  writeFileSync(
+    join(dir, '.mpl', 'state.json'),
+    JSON.stringify({ current_phase: 'mpl-decompose', pipeline_id: 'mpl-test' }),
+  );
+  return dir;
+}
+
+function writeConfig(dir, cfg) {
+  writeFileSync(join(dir, '.mpl', 'config.json'), JSON.stringify(cfg));
+}
+
+function writeChainAssignment(dir, body = 'chains: []\n') {
+  mkdirSync(join(dir, '.mpl', 'mpl'), { recursive: true });
+  writeFileSync(join(dir, '.mpl', 'mpl', 'chain-assignment.yaml'), body);
+}
+
+function runHook(cwd, payload) {
+  const result = spawnSync('node', [HOOK_PATH], {
+    cwd,
+    input: JSON.stringify(payload),
+    encoding: 'utf-8',
+    timeout: 5000,
+  });
+  return {
+    status: result.status,
+    stdout: result.stdout.trim(),
+    stderr: result.stderr.trim(),
+    parsed: result.stdout.trim() ? JSON.parse(result.stdout.trim()) : null,
+  };
+}
+
+describe('isChainSeedEnabled', () => {
+  let dir;
+  beforeEach(() => { dir = makeProject(); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  it('returns false when config.json is absent', () => {
+    assert.strictEqual(isChainSeedEnabled(dir), false);
+  });
+
+  it('returns false when chain_seed key is missing', () => {
+    writeConfig(dir, { max_fix_loops: 10 });
+    assert.strictEqual(isChainSeedEnabled(dir), false);
+  });
+
+  it('returns false when chain_seed.enabled is false', () => {
+    writeConfig(dir, { chain_seed: { enabled: false } });
+    assert.strictEqual(isChainSeedEnabled(dir), false);
+  });
+
+  it('returns true when chain_seed.enabled is exactly true', () => {
+    writeConfig(dir, { chain_seed: { enabled: true } });
+    assert.strictEqual(isChainSeedEnabled(dir), true);
+  });
+
+  it('returns false on malformed config (graceful)', () => {
+    writeFileSync(join(dir, '.mpl', 'config.json'), 'not json{{{');
+    assert.strictEqual(isChainSeedEnabled(dir), false);
+  });
+
+  it('returns false when chain_seed.enabled is a truthy non-boolean (strict equality)', () => {
+    writeConfig(dir, { chain_seed: { enabled: 1 } });
+    assert.strictEqual(isChainSeedEnabled(dir), false);
+  });
+});
+
+describe('chainAssignmentExists', () => {
+  let dir;
+  beforeEach(() => { dir = makeProject(); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  it('returns false when the file is missing', () => {
+    assert.strictEqual(chainAssignmentExists(dir), false);
+  });
+
+  it('returns true when the file exists', () => {
+    writeChainAssignment(dir);
+    assert.strictEqual(chainAssignmentExists(dir), true);
+  });
+});
+
+describe('mpl-require-chain-assignment hook (AP-CHAIN-01 enforcement)', () => {
+  let dir;
+  beforeEach(() => { dir = makeProject(); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  it('allows when chain_seed.enabled=false (inline mode, AP-SEED-01 exempt)', () => {
+    writeConfig(dir, { chain_seed: { enabled: false } });
+    const r = runHook(dir, {
+      cwd: dir,
+      tool_name: 'Task',
+      tool_input: { subagent_type: 'mpl-seed-generator' },
+    });
+    assert.strictEqual(r.parsed.continue, true);
+    assert.strictEqual(r.parsed.suppressOutput, true);
+  });
+
+  it('allows when chain_seed.enabled=true AND chain-assignment.yaml exists', () => {
+    writeConfig(dir, { chain_seed: { enabled: true } });
+    writeChainAssignment(dir);
+    const r = runHook(dir, {
+      cwd: dir,
+      tool_name: 'Task',
+      tool_input: { subagent_type: 'mpl-seed-generator' },
+    });
+    assert.strictEqual(r.parsed.continue, true);
+  });
+
+  it('denies when chain_seed.enabled=true AND chain-assignment.yaml missing', () => {
+    writeConfig(dir, { chain_seed: { enabled: true } });
+    const r = runHook(dir, {
+      cwd: dir,
+      tool_name: 'Task',
+      tool_input: { subagent_type: 'mpl-seed-generator' },
+    });
+    assert.strictEqual(r.parsed.continue, false);
+    assert.strictEqual(r.parsed.decision, 'block');
+    assert.match(r.parsed.reason, /AP-CHAIN-01/);
+    assert.match(r.parsed.reason, /chain-assignment\.yaml/);
+    assert.match(r.parsed.reason, /Step 3-G/);
+  });
+
+  it('accepts the mpl:mpl-seed-generator plugin-prefixed subagent name', () => {
+    writeConfig(dir, { chain_seed: { enabled: true } });
+    const r = runHook(dir, {
+      cwd: dir,
+      tool_name: 'Task',
+      tool_input: { subagent_type: 'mpl:mpl-seed-generator' },
+    });
+    assert.strictEqual(r.parsed.continue, false);
+    assert.match(r.parsed.reason, /AP-CHAIN-01/);
+  });
+
+  it('ignores dispatches to other subagents', () => {
+    writeConfig(dir, { chain_seed: { enabled: true } });
+    // chain-assignment.yaml deliberately missing — would deny seed-generator,
+    // but non-seed subagents must pass through unconditionally.
+    const r = runHook(dir, {
+      cwd: dir,
+      tool_name: 'Task',
+      tool_input: { subagent_type: 'mpl-decomposer' },
+    });
+    assert.strictEqual(r.parsed.continue, true);
+  });
+
+  it('ignores non-Task/Agent tool calls', () => {
+    writeConfig(dir, { chain_seed: { enabled: true } });
+    const r = runHook(dir, {
+      cwd: dir,
+      tool_name: 'Bash',
+      tool_input: { command: 'echo hi' },
+    });
+    assert.strictEqual(r.parsed.continue, true);
+  });
+
+  it('allows when MPL is inactive (no state.json)', () => {
+    rmSync(join(dir, '.mpl', 'state.json'));
+    writeConfig(dir, { chain_seed: { enabled: true } });
+    const r = runHook(dir, {
+      cwd: dir,
+      tool_name: 'Task',
+      tool_input: { subagent_type: 'mpl-seed-generator' },
+    });
+    assert.strictEqual(r.parsed.continue, true);
+  });
+
+  it('allows on empty stdin (defensive default)', () => {
+    const result = spawnSync('node', [HOOK_PATH], {
+      cwd: dir,
+      input: '',
+      encoding: 'utf-8',
+      timeout: 5000,
+    });
+    const parsed = JSON.parse(result.stdout.trim());
+    assert.strictEqual(parsed.continue, true);
+  });
+
+  it('allows on malformed stdin (never wedges the pipeline)', () => {
+    const result = spawnSync('node', [HOOK_PATH], {
+      cwd: dir,
+      input: 'not json{{{',
+      encoding: 'utf-8',
+      timeout: 5000,
+    });
+    const parsed = JSON.parse(result.stdout.trim());
+    assert.strictEqual(parsed.continue, true);
+  });
+});

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -80,6 +80,16 @@
             "timeout": 3
           }
         ]
+      },
+      {
+        "matcher": "Task|Agent",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/mpl-require-chain-assignment.mjs\"",
+            "timeout": 3
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/hooks/mpl-require-chain-assignment.mjs
+++ b/hooks/mpl-require-chain-assignment.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+/**
+ * MPL Require Chain Assignment Hook (PreToolUse on Task|Agent)
+ *
+ * AP-CHAIN-01 enforcement (was: prose warning in commands/mpl-run-decompose.md).
+ * When `.mpl/config.json` sets `chain_seed.enabled: true`, the Step 3-G chain
+ * derivation MUST have produced `.mpl/mpl/chain-assignment.yaml` before the
+ * orchestrator dispatches `mpl-seed-generator`. If the derivation was silently
+ * skipped (observed in exp10 / AD-0006 §#41 → the "Gated" label was read as
+ * *skippable* rather than *conditional on config*), the seed generator would
+ * fall back to `chains/no-chain/` and the user's explicit activation would be
+ * lost. This hook machine-enforces the invariant by denying the dispatch.
+ *
+ * Matcher: Task|Agent (PreToolUse)
+ * Scope:   subagent_type == "mpl-seed-generator" (or "mpl:mpl-seed-generator")
+ * Pass:    chain_seed.enabled != true → allow (inline mode, AP-SEED-01 exemption)
+ *          chain_seed.enabled == true AND chain-assignment.yaml present → allow
+ * Deny:    chain_seed.enabled == true AND chain-assignment.yaml absent
+ *
+ * Non-blocking on error: any exception swallowed, defaults to allow.
+ */
+
+import { dirname, join } from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+import { existsSync, readFileSync } from 'fs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const { isMplActive } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-state.mjs')).href
+);
+const { readStdin } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'stdin.mjs')).href
+);
+
+const SEED_SUBAGENTS = new Set(['mpl-seed-generator', 'mpl:mpl-seed-generator']);
+
+function ok() {
+  console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+}
+
+function deny(reason) {
+  console.log(JSON.stringify({ continue: false, decision: 'block', reason }));
+}
+
+/**
+ * Read `.mpl/config.json` → `chain_seed.enabled`. Defaults to false when the
+ * file is missing, unreadable, or omits the key — same contract as
+ * commands/mpl-run-decompose.md Step 3-G.
+ */
+export function isChainSeedEnabled(cwd) {
+  try {
+    const configPath = join(cwd, '.mpl', 'config.json');
+    if (!existsSync(configPath)) return false;
+    const cfg = JSON.parse(readFileSync(configPath, 'utf-8'));
+    return cfg?.chain_seed?.enabled === true;
+  } catch {
+    return false;
+  }
+}
+
+export function chainAssignmentExists(cwd) {
+  return existsSync(join(cwd, '.mpl', 'mpl', 'chain-assignment.yaml'));
+}
+
+async function main() {
+  const raw = await readStdin();
+  if (!raw.trim()) {
+    ok();
+    return;
+  }
+
+  let data;
+  try {
+    data = JSON.parse(raw);
+  } catch {
+    ok();
+    return;
+  }
+
+  const cwd = data.cwd || data.directory || process.cwd();
+  if (!isMplActive(cwd)) {
+    ok();
+    return;
+  }
+
+  const toolName = String(data.tool_name || data.toolName || '');
+  if (toolName !== 'Task' && toolName !== 'Agent') {
+    ok();
+    return;
+  }
+
+  const toolInput = data.tool_input || data.toolInput || {};
+  const subagentType = String(toolInput.subagent_type || toolInput.subagentType || '');
+  if (!SEED_SUBAGENTS.has(subagentType)) {
+    ok();
+    return;
+  }
+
+  // Seed Generator dispatch — gate only when chain mode is explicitly enabled.
+  // Inline mode (default) is AP-SEED-01 exempt per #58: one call = one phase
+  // by design, no chain-assignment.yaml expected.
+  if (!isChainSeedEnabled(cwd)) {
+    ok();
+    return;
+  }
+
+  if (chainAssignmentExists(cwd)) {
+    ok();
+    return;
+  }
+
+  deny(
+    '[MPL AP-CHAIN-01] ⛔ Seed Generator BLOCKED: chain_seed.enabled=true but ' +
+      '.mpl/mpl/chain-assignment.yaml is missing. Step 3-G (Chain Derivation) ' +
+      'must run before mpl-seed-generator dispatch — silent fallback to chains/no-chain/ ' +
+      'would discard the user\'s explicit chain-mode activation and break baton-pass/cache reuse. ' +
+      'Fix: return to commands/mpl-run-decompose.md Step 3-G, derive chains from decomposition.yaml ' +
+      'phase edges, and write .mpl/mpl/chain-assignment.yaml (schema: docs/schemas/chain-assignment.md). ' +
+      'Opt-out: set chain_seed.enabled=false in .mpl/config.json for inline mode (AP-SEED-01 exempt per #58).'
+  );
+}
+
+main().catch(() => {
+  // Hook must never wedge the pipeline.
+  ok();
+});


### PR DESCRIPTION
## Summary
- Add `hooks/mpl-require-chain-assignment.mjs` — PreToolUse deny on `Task|Agent(subagent_type=mpl-seed-generator)` when `chain_seed.enabled=true` and `.mpl/mpl/chain-assignment.yaml` is absent. Inline mode (default) passes through (AP-SEED-01 exempt per #58).
- Register the hook in `hooks/hooks.json` alongside `mpl-ambiguity-gate` (same matcher family).
- Add an addendum in `commands/mpl-run-decompose.md` §Step 3-G noting the prose warning is now machine-enforced.
- 17 new tests (unit + subprocess): config precedence, file presence check, positive/negative hook outcomes, plugin-prefixed subagent name, non-seed/non-Task pass-through, defensive fallbacks.

## Why
AP-CHAIN-01 has been a prose warning since its introduction in #54. The Step 3-G "Gated" label is easy to misread as *skippable by default* rather than *conditional on config*, so `chain_seed.enabled=true` runs can still silently fall back to `chains/no-chain/` — discarding the user's explicit chain-mode activation and breaking baton-pass / cache reuse (observed in exp10 / AD-0006 §#41). This hook removes the silent-skip path entirely.

## Test plan
- [x] `node --test hooks/__tests__/mpl-require-chain-assignment.test.mjs` → 17/17 pass
- [x] `node --test hooks/__tests__/*.test.mjs` → 300 pass (was 283, +17, 0 regression)
- [x] Defensive fallbacks verified: empty stdin, malformed stdin, missing state.json, non-Task tool, non-seed subagent — all allow-through
- [x] Config precedence: absent / missing key / explicit false / explicit true / malformed JSON / truthy-non-boolean

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)