### PR TITLE
chore(docs): audit doc/code drift after P1-3/P1-4d/P2-6/P2-7 merges

### DIFF
--- a/commands/mpl-run-finalize.md
+++ b/commands/mpl-run-finalize.md
@@ -633,57 +633,19 @@ Profile data enables:
 2. **Optimize Phase 0 step combinations**: statistics on which step combinations are most efficient
 3. **Detect abnormal runs**: warn on excessive token usage (2x+ the average), excessive micro-fixes (5+)
 
-### 5.4.5: Manifest Generation (F-FC-1, v0.8.5)
+### 5.4.5: Manifest Generation — REMOVED (v0.17)
 
-Generate `.mpl/manifest.json` to track all `.mpl/` artifacts for freshness checking in future runs.
-This file is consumed by Step 0.0.5 (Artifact Freshness Check) in the next MPL execution.
+The pre-v0.17 manifest generation (F-FC-1, v0.8.5) wrote `.mpl/manifest.json`
+for the Step 0.0.5 Artifact Freshness Check. Step 0.0.5 was deleted in v0.17
+(#55) along with `field_classification` / `freshness_ratio` / `pp_proximity`
+state fields, leaving manifest.json as a write-only orphan referencing
+defunct Phase 0 Enhanced artifacts (`phase0/api-contracts.md` etc., collapsed
+to a single `raw-scan.md` in #56). The whole step is removed; nothing now
+reads or writes `.mpl/manifest.json`.
 
-**NOTE**: This is separate from `.mpl/cache/phase0/manifest.json` (Phase 0 cache-specific).
-
-```pseudocode
-commit_hash = Bash("git rev-parse HEAD").trim()
-
-tracked_artifacts = []
-
-// 1. Phase 0 Enhanced artifacts
-phase0_files = ["phase0/api-contracts.md", "phase0/examples.md",
-                "phase0/type-policy.md", "phase0/error-spec.md",
-                "phase0/summary.md", "phase0/complexity-report.json"]
-for each file in phase0_files:
-  path = ".mpl/mpl/" + file
-  if file_exists(path):
-    hash = Bash("shasum -a 256 {path}").split(" ")[0]
-    tracked_artifacts.push({ path, hash, timestamp: file_mtime(path), source: "mpl", category: "phase0" })
-
-// 2. Core artifacts
-core_files = [
-  { path: ".mpl/mpl/decomposition.yaml", category: "decomposition" },
-  { path: ".mpl/pivot-points.md", category: "interview" },
-  { path: ".mpl/mpl/phase-decisions.md", category: "decisions" },
-  { path: ".mpl/mpl/RUNBOOK.md", category: "runbook" },
-  { path: ".mpl/mpl/codebase-analysis.json", category: "analysis" },
-  { path: ".mpl/mpl/interview-snapshot.md", category: "interview" },
-  { path: ".mpl/mpl/verification-plan.md", category: "verification" }
-]
-for each entry in core_files:
-  if file_exists(entry.path):
-    hash = Bash("shasum -a 256 {entry.path}").split(" ")[0]
-    tracked_artifacts.push({ path: entry.path, hash, timestamp: file_mtime(entry.path), source: "mpl", category: entry.category })
-
-// 3. Write manifest (memory files excluded — append-only files cause false staleness)
-manifest = {
-  version: "0.9.2",
-  generated_at: new Date().toISOString(),
-  commit_hash: commit_hash,
-  pp_proximity: state.pp_proximity,
-  field_classification: state.field_classification || "field-1",
-  artifact_count: tracked_artifacts.length,
-  artifacts: tracked_artifacts
-}
-
-Write(".mpl/manifest.json", JSON.stringify(manifest, null, 2))
-Announce: "[MPL] Manifest generated: {tracked_artifacts.length} artifacts tracked at commit {commit_hash.slice(0,7)}."
-```
+> If a future workflow needs artifact provenance, build it on top of
+> `.mpl/mpl/baseline.yaml` (#59) — that file is already the v0.17 ground-truth
+> snapshot for delta calculation and rollback.
 
 ### 5.5: Completion Report
 

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -2,8 +2,8 @@
 
 All fields for `.mpl/config.json`. Single source of truth for configuration.
 
-> **Version**: v0.16.0
-> **Last updated**: 2026-04-20
+> **Version**: v0.16.0 (v0.17 cleanup pending — `session_cache` added; manifest/field_classification marked removed)
+> **Last updated**: 2026-04-26
 
 ---
 
@@ -170,51 +170,31 @@ Semantics:
 |-------|------|---------|-------------|--------|
 | `context_rotation.backend` | `"kitty"` \| `"tmux"` \| `"osascript"` | auto-detect | Terminal backend for session rotation | `hooks/lib/mpl-rotator.mjs` |
 
-## Manifest & Field Classification (v0.8.5)
+## Manifest & Field Classification — REMOVED (v0.17)
 
-### `.mpl/manifest.json` Schema
+Pre-v0.17 generated `.mpl/manifest.json` at finalize (5.4.5) for the Step 0.0.5
+Artifact Freshness Check + Field Classification. v0.17 (#55) deleted Step 0.0.5
+along with `field_classification` / `freshness_ratio` / `pp_proximity` state
+fields, which orphaned the manifest write. The schema and classification table
+were removed from this doc on the same audit pass.
 
-Generated at Step 5.4.5 (Finalize), consumed at Step 0.0.5 (Triage).
-Separate from `.mpl/cache/phase0/manifest.json` (Phase 0 cache-specific).
+For v0.17 ground-truth provenance use `.mpl/mpl/baseline.yaml` (#59) — it is
+the immutable post-Phase-0 snapshot consumed by delta calculation and rollback.
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `version` | string | Manifest schema version (e.g., `"0.9.0"`) |
-| `generated_at` | string (ISO 8601) | When manifest was generated |
-| `commit_hash` | string | Git HEAD at generation time |
-| `pp_proximity` | `"pp_core"` \| `"pp_adjacent"` \| `"non_pp"` | Last run's PP-proximity classification |
-| `field_classification` | string | Last run's field classification |
-| `artifact_count` | number | Number of tracked artifacts |
-| `artifacts` | ArtifactEntry[] | Artifact metadata list |
-
-### ArtifactEntry
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `path` | string | File path relative to project root |
-| `hash` | string | SHA-256 content hash |
-| `timestamp` | string (ISO 8601) | File last modified time |
-| `source` | `"mpl"` \| `"cep"` | Generator (mpl = MPL pipeline, cep = Context Extraction Pipeline) |
-| `category` | string | `"phase0"` \| `"decomposition"` \| `"interview"` \| `"decisions"` \| `"runbook"` \| `"analysis"` \| `"verification"` |
-
-### Field Classification (`state.json → field_classification`)
-
-| Value | Condition | MPL Scope | Phase 0 (v0.8.5) | Phase 0 (v0.9.0 planned) |
-|-------|-----------|-----------|-------------------|--------------------------|
-| `field-1` | No source or no manifest | ✅ Greenfield | full | full |
-| `field-2` | Source + tests (>30%), no .mpl/ | ✅ Well-Documented | full | full + Gate 0.8 baseline |
-| `field-3` | Source + minimal tests, no .mpl/ | ⚠️ WARNING | full | full + WARNING |
-| `field-4-fresh` | .mpl/ + freshness ≥ 0.8 | ✅ AI-Built | full | cache hit + Delta PP |
-| `field-4-stale` | .mpl/ + freshness 0.4~0.8 | ✅ AI-Built | full | partial re-execution |
-| `field-4-degraded` | .mpl/ + freshness < 0.4 | ⚠️ WARNING | full | full + WARNING |
-
-**Note**: Memory files (`.mpl/memory/*`) are excluded from freshness calculation — append-only files would cause false staleness.
 
 ## E2E Testing (v0.8.3)
 
 | Field | Type | Default | Description | Source |
 |-------|------|---------|-------------|--------|
 | `e2e_timeout` | number | `60000` | Timeout per E2E scenario in milliseconds | `mpl-run-finalize.md` Step 5.0 |
+
+## MCP Session Cache (P1-3b, #79)
+
+Per-project override for the global `~/.mpl/cache/sessions.json` TTL. The cache backs `mpl_score_ambiguity`, `mpl_classify_feature_scope`, and `mpl_diagnose_e2e_failure` — extending the resumed-session prompt cache across MCP server restarts.
+
+| Field | Type | Default | Description | Source |
+|-------|------|---------|-------------|--------|
+| `session_cache.ttl_minutes` | number (>0) | `30` | Per-project override of the session-cache freshness window. Precedence: explicit `ttl_ms` (test only) > project config > global cache config > 30. | `mcp-server/src/lib/session-cache.ts` |
 
 ---
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -76,14 +76,22 @@ mpl-init → mpl-decompose → phase2-sprint → phase3-gate → phase5-finalize
 
 ### 3.2 Full Flow Summary Table
 
+> **v0.17 status note**: rows below preserved as historical record; the
+> v0.17 simplification (#55) removed Step -1 (moved to `hooks/mpl-lsp-warmup.mjs`),
+> Step 0.0.5 (artifact freshness + field classification), and Step 0 Triage
+> (interview_depth + pp_proximity scoring). Step 1 PP Interview is now Stage 1
+> inside `commands/mpl-run-phase0.md` Step 1 Interview Block; Steps 1-D / 1-E
+> are absorbed into Stage 1.9 Interview Snapshot. See `commands/mpl-run-phase0.md`
+> for the canonical v0.17 flow.
+
 | Step | Name | Core Agent | Artifact |
 |------|------|-------------|--------|
-| -1 | LSP Warm-up | (orchestrator, non-blocking) | lsp_servers list, cold start elimination |
-| 0.0.5 | Artifact Freshness + Field Classification (v0.8.5) | (orchestrator) | field_classification, freshness_ratio, `.mpl/manifest.json` (read) |
-| 0 | Triage | (orchestrator) | interview_depth (light/light+scan/full), pp_proximity |
+| -1 | LSP Warm-up *(v0.17: hook)* | `hooks/mpl-lsp-warmup.mjs` (UserPromptSubmit) | `state.lsp_servers` |
+| 0.0.5 | Artifact Freshness + Field Classification *(v0.17: REMOVED)* | — | (was: `.mpl/manifest.json`) |
+| 0 | Triage *(v0.17: REMOVED)* | — | (was: interview_depth, pp_proximity) |
 | 1 | PP Interview | mpl-interviewer | `.mpl/pivot-points.md` |
-| 1-D | PP Confirmation | (orchestrator) | PP final confirmation with user |
-| 1-E | Interview Snapshot Save | (orchestrator) | `.mpl/mpl/interview-snapshot.md` |
+| 1-D | PP Confirmation *(v0.17: absorbed into Stage 1.9)* | (orchestrator) | PP final confirmation with user |
+| 1-E | Interview Snapshot Save *(v0.17: Stage 1.9)* | (orchestrator) | `.mpl/mpl/interview-snapshot.md` |
 | 2 | Codebase Analysis | (orchestrator) | `.mpl/mpl/codebase-analysis.json` |
 | 2.4 | Architecture Decision Checklist | (orchestrator) | Key architecture decisions documented |
 | 2.5 | Phase 0 Enhanced | (orchestrator) | `.mpl/mpl/phase0/*.md` |
@@ -839,7 +847,13 @@ Roadmap: `docs/roadmap/pending-features.md` → "E2E Execution Fix" section
 
 Audit report: `analysis/mpl-internal-consistency-audit.md`
 
-### v0.8.5 — Artifact Freshness Check + Field Classification (2026-03-27)
+### v0.8.5 — Artifact Freshness Check + Field Classification (2026-03-27) — REMOVED in v0.17 (#55)
+
+> **REMOVED in v0.17**: Step 0.0.5, manifest.json generation, and the
+> field-1/2/3/4 classification system were deleted in #55. The whole
+> "what kind of project is this?" branching was found to add Phase 0
+> complexity without changing observed behavior. Use `.mpl/mpl/baseline.yaml`
+> (#59) for ground-truth provenance instead.
 
 Foundation for Field 4 (AI-Built Maintenance) support. Detects .mpl/ artifact existence and freshness, classifies projects into 6 field types.
 


### PR DESCRIPTION
## Summary
Three targeted doc fixes uncovered while auditing references to fields/files that v0.17 (#55-78) and the four newly-merged PRs (#80/#82/#84/#87) made dead or stale.

- **`commands/mpl-run-finalize.md`** — replace Step 5.4.5 manifest.json generation with a removal note. The pre-v0.17 step wrote `.mpl/manifest.json` for Step 0.0.5 Artifact Freshness Check, but Step 0.0.5 itself was deleted in #55. Nothing reads the file anymore; we were running a write-only orphan that also referenced defunct phase0 artifact paths (`api-contracts.md` etc., collapsed to `raw-scan.md` in #56).
- **`docs/config-schema.md`** — same removal note for the matching Manifest & Field Classification schema section. Add new **MCP Session Cache** entry documenting the `session_cache.ttl_minutes` override (P1-3b / #79).
- **`docs/design.md`** — annotate Section 3.2 Full Flow Summary table rows for Step -1 / 0.0.5 / 0 / 1-D / 1-E with their v0.17 dispositions (REMOVED, hook-relocated, Stage 1.9-absorbed). Add a v0.17 REMOVED banner to the v0.8.5 version-history entry.

## Why
Pure dead-code/dead-doc cleanup. The four merged PRs introduced new APIs (P2-6 schema_version, P1-3b session_cache, P1-4d AP-CHAIN-01 enforcement, P2-7 generic runCachedQuery) that are correctly documented inline at their use sites — but two pre-v0.17 sections in the central docs were still describing flows that the simplification deleted. Removing/marking them is cheaper than letting future readers chase ghosts.

## Out of scope (deferred)
- `docs/roadmap/*` (overview, pending-features, sprints, adaptive-router-plan) — large, mostly observability of past plans
- Agent `.md` files referencing `pp_score` / `interview_depth` / `phase0_grade` inside `Failure_Modes` blocks — historical drift descriptions; rewriting risks losing context
- `design.md` sections beyond 3.2 — broader narrative may need a v0.17 rewrite, not just markers

## Test plan
- [x] `node --test hooks/__tests__/*.test.mjs` → 317 pass (unchanged)
- [x] No code changes; doc-only PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)