### PR TITLE
release(v0.17.0): simplification + P1/P2 hardening stream

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "mpl",
       "description": "Decomposes tasks into micro-phases with independent plan-execute-verify mini-loops. Orchestrator-Worker separation enforced via hooks.",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "author": {
         "name": "KyubumShin"
       },
@@ -25,5 +25,5 @@
       ]
     }
   ],
-  "version": "0.16.0"
+  "version": "0.17.0"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mpl",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Micro-Phase Loop - Coherence-first autonomous coding pipeline with decomposition, phase execution, and verification",
   "author": {
     "name": "KyubumShin"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# MPL (Micro-Phase Loop) v0.16.0
+# MPL (Micro-Phase Loop) v0.17.0
 
 **Prevention over cure. Specification over debugging.**
 

--- a/README_ko.md
+++ b/README_ko.md
@@ -1,4 +1,4 @@
-# MPL (Micro-Phase Loop) v0.16.0
+# MPL (Micro-Phase Loop) v0.17.0
 
 **예방이 치료보다 낫다. 명세가 디버깅보다 낫다.**
 

--- a/agents/mpl-decomposer.md
+++ b/agents/mpl-decomposer.md
@@ -192,7 +192,7 @@ disallowedTools: Write,Edit,Bash,Task,WebFetch,WebSearch,NotebookEdit
       post-decompose step (commands/mpl-run-decompose.md Step 3-H) extracts and
       writes `.mpl/mpl/e2e-scenarios.yaml`.
 
-    Step 8: PP-proximity classification
+    Step 8: PP-proximity classification *(v0.17 REMOVED — Triage and pp_proximity routing dropped; field still emitted as a tag for backward-compat readers but no longer drives pipeline depth or hat selection. New decompositions may set `non_pp` uniformly.)*
       For each phase, assign `pp_proximity`:
       - `pp_core`: directly implements a CONFIRMED PP
       - `pp_adjacent`: implements PROVISIONAL PP or extends a pp_core phase

--- a/agents/mpl-interviewer.md
+++ b/agents/mpl-interviewer.md
@@ -45,7 +45,7 @@ disallowedTools: Write, Edit, Bash, Task
   <Constraints>
     - Use Read, Glob, Grep, WebFetch for Pre-Research. No Write, Edit, Bash, Task.
     - Use AskUserQuestion for all user-facing questions (not plain text questions).
-    - Respect interview_depth from Triage:
+    - Respect interview_depth from Triage *(v0.17 REMOVED — Triage and `interview_depth` no longer computed; behavior collapses to `full` always. Rows below preserved for back-reference; treat all invocations as `full` until this constraint is rewritten.)*:
       - "light": 1-2 rounds max; for density >= 8, extract PPs directly then run Uncertainty Scan
       - "full": up to 4 rounds, exit early when converged
     - Maximum 2 questions per round (avoid interview fatigue).
@@ -138,7 +138,7 @@ disallowedTools: Write, Edit, Bash, Task
     ```
   </Convergence_Exit>
 
-  ## Behavior by interview_depth
+  ## Behavior by interview_depth *(v0.17 REMOVED — Triage gone, `interview_depth` no longer set; runtime always picks `full`. Table preserved as historical reference only.)*
 
   | depth | PP Rounds | Uncertainty Scan | Output |
   |-------|-----------|-----------------|--------|

--- a/commands/mpl-run-execute-context.md
+++ b/commands/mpl-run-execute-context.md
@@ -21,7 +21,7 @@ context = {
   phase_definition: phases[current_index],
   phase_seed:       load_phase_seed(current_phase),   // D-01: JIT seed (null if not generated)
   impact_files:     load_impact_files(phase.impact),
-  pp_proximity:     state.pp_proximity,
+  pp_proximity:     state.pp_proximity,    // (v0.17 REMOVED — Triage gone; field is null/legacy. Consumers should treat as `non_pp` or absent.)
   prev_summary:       Read previous phase's state-summary.md (if available),
   prev_verification:  Read previous phase's verification.md (if available),    // v0.7.0: failure context
   prev_changes_diff:  load_prev_phase_diff(prev_phase),                        // v0.7.0: code diff (N-1 only)

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -2,7 +2,7 @@
 
 All fields for `.mpl/config.json`. Single source of truth for configuration.
 
-> **Version**: v0.16.0 (v0.17 cleanup pending — `session_cache` added; manifest/field_classification marked removed)
+> **Version**: v0.17.0 (Triage / interview_depth / pp_proximity / Hat model / F-22 routing recall removed; `session_cache` added; manifest/field_classification removed)
 > **Last updated**: 2026-04-26
 
 ---

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,4 +1,4 @@
-# MPL (Micro-Phase Loop) v0.16.0 Design Document
+# MPL (Micro-Phase Loop) v0.17.0 Design Document
 
 ## 1. Overview
 
@@ -481,6 +481,43 @@ The following options are supported in `.mpl/config.json`:
 ---
 
 ## 9. Version History
+
+### v0.17.0 — Simplification + P1/P2 Hardening Stream (2026-04-26)
+
+Bundles the v0.17 simplification (#55) with five issue-driven hardening PRs (#80/#82/#84/#87/#88) merged 2026-04-23 ~ 2026-04-26. Roadmap-level overview in `docs/roadmap/overview.md` "v0.17.0" section. The simplification removes legacy concepts that empirical runs (ygg-exp10/11) showed had zero downstream effect; the P1/P2 stream hardens MCP session handling, machine-enforces AP-CHAIN-01, unifies state.json into a single SSOT, and generalizes the cross-project session cache across MCP tools.
+
+| Change | Before | After | Type | Rationale |
+|--------|--------|-------|------|-----------|
+| Step -1 LSP Warm-up | Orchestrator-driven turn step | `hooks/mpl-lsp-warmup.mjs` (UserPromptSubmit hook) | Removal/move | Out-of-band hook is faster and saves orchestrator tokens (#55) |
+| Step 0.0.5 Artifact Freshness + Field Classification | Generated `.mpl/manifest.json` per phase | REMOVED — manifest no longer generated | Removal | Empirical: zero downstream consumer in v0.14/v0.15 runs (#55) |
+| Step 0 Triage | Computed `interview_depth` (skip/light/full) and `pp_proximity` | REMOVED entirely; pipeline always enters at full-depth equivalent | Removal | Triage choice rarely changed orchestrator behavior in measured runs; complexity > value (#55) |
+| Step 1-D PP Confirmation | Separate confirmation gate | Absorbed into Stage 1.9 (single confirmation inside the interview) | Consolidation | Reduce orchestrator turn count (#55) |
+| Step 1-E Interview Snapshot Save | Separate step | Renumbered to Stage 1.9 | Renumbering | Mirrors PP-Confirmation absorption (#55) |
+| Routing-pattern recall (F-22) | `routing-patterns.jsonl` consulted at Triage start | DROPPED — no recall, no recording | Removal | Triage gone; recall has no consumer (#55) |
+| Hat model PP-proximity tier branching | Pipeline depth routed on `pp_proximity` score | DROPPED — no hat selection | Removal | Same root cause as Triage removal (#55) |
+| MCP `state.ambiguity_history` growth | Unbounded array | `MAX_AMBIGUITY_HISTORY=10` ring buffer | Hardening | Prevent state.json bloat across long pipelines (#80, P1-3a) |
+| MCP session cache TTL | Global default | Per-project `session_cache.ttl_minutes` config override | Hardening | Long-running projects need longer TTL than default (#80, P1-3b) |
+| MCP session 404 handling | Stale session id retried until pipeline failure | Auto-invalidate on 404 + retry once | Hardening | Survives Anthropic-side session expiry mid-pipeline (#80, P1-3c) |
+| MCP session degraded state | Silent degradation | `degraded` flag escalated to user via systemMessage | Hardening | Surfaces persistent MCP failure instead of silent stall (#80, P1-3d) |
+| AP-CHAIN-01 enforcement | Prompt-only convention | `hooks/mpl-require-chain-assignment.mjs` PreToolUse hook (matcher: Task\|Agent, subagent_type=mpl-seed-generator). Denies dispatch when `chain_seed.enabled=true` ∧ `chain-assignment.yaml` absent | Hook (new) | Prompt-level enforcement was bypassed in measured runs (#82, P1-4d) |
+| `state.json` layout | Split across `.mpl/state.json` + `.mpl/mpl/state.json` | Single SSOT `.mpl/state.json` with `execution` subtree (`CURRENT_SCHEMA_VERSION=2`); auto v1→v2 migration on first read; `detectStateDrift()` warning on dual-write attempts | Schema | Two-file split was the source of resume-state drift (#84, P2-6) |
+| Legacy execution state | Lived at `.mpl/mpl/state.json` | Auto-archived to `.mpl/archive/{pipeline_id}-legacy-execution-state.json` on first read | Migration | Preserves debug evidence without leaving live drift surface (#84, P2-6) |
+| MCP cross-tool session cache | `cachedSessionId` module-level var per file (3 callers: scorer, classifier, diagnoser) | New `mcp-server/src/lib/agent-sdk-query.ts` with `runCachedQuery<T>` + `isSessionExpiredError`; all 3 callers reuse `~/.mpl/cache/sessions.json` via lazy `cacheDir()` resolve | Refactor | −187 net lines; absorbs the proposed-but-not-built P2-8 separate cache-manager abstraction (#87, P2-7) |
+| Manifest schema in config docs | Documented as live | Removed from `docs/config-schema.md`; v0.8.5 history entry gets REMOVED banner | Docs | Matches runtime removal (#88, drift audit) |
+| `session_cache.ttl_minutes` config | Undocumented | Added to `docs/config-schema.md` | Docs | Matches P1-3b feature (#88, drift audit) |
+
+**Affected files:**
+- Hooks: `hooks/mpl-require-chain-assignment.mjs` (new), `hooks/lib/mpl-state.mjs`, `hooks/hooks.json`
+- MCP: `mcp-server/src/lib/agent-sdk-query.ts` (new), `mcp-server/src/lib/session-cache.ts`, `mcp-server/src/lib/state-manager.ts`, `mcp-server/src/lib/llm-scorer.ts`, `mcp-server/src/lib/feature-classifier.ts`, `mcp-server/src/lib/e2e-diagnoser.ts`, `mcp-server/src/tools/feature-scope.ts`, `mcp-server/src/tools/e2e-diagnose.ts`
+- Prompts: `commands/mpl-run-phase0.md`, `commands/mpl-run-decompose.md`, `commands/mpl-run-execute.md`, `commands/mpl-run-finalize.md`, `commands/mpl-run-finalize-resume.md`, `commands/mpl-run.md`
+- Skills: `skills/mpl-resume/SKILL.md`, `skills/mpl-status/SKILL.md`, `skills/mpl/SKILL.md`
+- Docs: `docs/config-schema.md`, `docs/design.md` (this entry + §3.2 v0.17 markers + v0.8.5 REMOVED banner), `docs/roadmap/overview.md`, `docs/roadmap/pending-features.md`, `docs/roadmap/sprints.md`, `docs/roadmap/adaptive-router-plan.md`, `docs/roadmap/0.16-exp12-plan.md`, `docs/pm-design.md`, `agents/mpl-decomposer.md`, `agents/mpl-interviewer.md`, `commands/mpl-run-execute-context.md`, `skills/mpl-pivot/SKILL.md`
+
+**Tests:** Hooks 287 → 317 pass (+30 across P1-3a / P1-4d / P2-6). MCP 42 → 73 pass (+31 across P1-3a-d / P2-7).
+
+**Breaking changes:** Removal of observable state fields (`interview_depth`, `pp_proximity`, `pipeline_tier`, `routing_pattern_*`) and `.mpl/manifest.json` artifact. State schema bumped v1→v2 with auto-migration on read — projects do not need manual intervention. Any external consumer reading the removed fields must be re-baselined. Plugin minor bump signals this surface change.
+
+**Issues closed:** #55 (v0.17 simplification), #79 (P1-3), #81 (P1-4d), #83 (P2-6), #85 (P2-7).
 
 ### v0.16.0 — 3-Tier User Contract Architecture (2026-04-20)
 

--- a/docs/pm-design.md
+++ b/docs/pm-design.md
@@ -5,6 +5,8 @@
 > **Status**: Design complete — awaiting mpl-interviewer v2 extension implementation
 > **Related Roadmap**: F-26 (PM Capability, mpl-interviewer integrated)
 > **References**: AI_PM(kimsanguine/AI_PM), UAM uam-pm, mpl-interviewer.md, pm-skill-proposal, mpl-pm-skill-research
+>
+> **v0.17 status (2026-04-26)**: This document is **historically frozen**. Triage, `interview_depth`, `pp_proximity`, and routing-pattern recall (F-22) were all removed in v0.17 (#55). Every reference below to `interview_depth` (light/full branching), `pp_proximity` tier mapping, F-20 router, and F-22 routing-pattern learning describes the pre-v0.17 architecture. The PM subsystem itself was not implemented as designed; PP interview is now a single always-on `full`-equivalent flow inside `agents/mpl-interviewer.md`. Use this doc as design archaeology only — do not implement against it without re-baselining.
 
 ---
 

--- a/docs/roadmap/0.16-exp12-plan.md
+++ b/docs/roadmap/0.16-exp12-plan.md
@@ -9,6 +9,15 @@ Related:
 - Decision `~/project/decision/2026-04-19-mpl-0.16-implementation-plan.md`
 - Baseline: `~/project/harness_lab/analysis/mpl-exp11-opus47-evaluation.md`
 
+> **Currency note (2026-04-26)** — Plan validated against post-v0.17 state:
+> - State paths: `.mpl/state.json` is now the **single SSOT** (P2-6 schema v2 unified `.mpl/state.json` + `.mpl/mpl/state.json`). Existing `cp .mpl/state.json analysis/exp12/` step is correct. Legacy `.mpl/mpl/state.json` is auto-archived to `.mpl/archive/{pipeline_id}-legacy-execution-state.json` on first read — don't expect it in fresh runs.
+> - Triage / `interview_depth` / `pp_proximity` removed in v0.17 (#55) — none of the 5 primary metrics depend on them, so no rewrite needed.
+> - Session-cache infra: classifier + diagnoser now reuse `~/.mpl/cache/sessions.json` via `runCachedQuery<T>` (P2-7). Metric 4 prompt-version stability hash check still applies — frozen `PROMPT_VERSION` is asserted on cache hit, not bypassed.
+> - **NOT covered by this plan** (out of scope, requires separate measurement design):
+>   - F-25 4-Tier Memory: Tier-3/4 actual load frequency. Decision rule: <10% load → collapse to 2-tier. Source would be `.mpl/mpl/profile/phases.jsonl` + a memory-tier-load counter (not yet emitted).
+>   - F-28 `phase_domain`: routing effect beyond phase-runner model selection. Needs A/B comparison runs.
+>   - F-39 `phase_subdomain` / `task_type` / `lang` (4-Layer prompt composition): whether distinct prompt paths actually compose. Needs prompt-composition trace logging (not yet emitted).
+
 ## Experimental Design
 
 | Aspect | exp11 baseline | exp12 target |

--- a/docs/roadmap/adaptive-router-plan.md
+++ b/docs/roadmap/adaptive-router-plan.md
@@ -1,6 +1,8 @@
 # Adaptive Pipeline Router — Implementation Plan
 
 > **⚠ v2 이후 Deprecated**: Hat model(pp_proximity)로 대체됨. 역사적 참조용.
+>
+> **⚠ v0.17 (#55) REMOVED**: Hat model itself is now also dropped. F-20 Quick Scope Scan + `pipeline_score`/`pipeline_tier` classification, F-21 Dynamic Escalation, F-22 Routing Pattern Learning + `routing-patterns.jsonl` recall — every component documented below is no longer wired into the runtime. Step 0 Triage was deleted; the pipeline always enters at the equivalent of the previous Frontier/Full tier with no hat selection. Treat this entire document as archived design archaeology.
 
 > Implementation plan for F-20, F-21, F-22. Based on Ouroboros PAL Router analysis.
 > Written: 2026-03-07

--- a/docs/roadmap/overview.md
+++ b/docs/roadmap/overview.md
@@ -1,6 +1,8 @@
 # MPL Roadmap: Evolution and Remaining Plans
 
 > **Version notation (v0.9.4)**: This file uses legacy major-version notation (v1.0, v3.0, v4.0) from the original roadmap. Actual release versions follow the `v0.x.y` semver series. Mapping: v1.0 = initial design, v3.x ≈ v0.3.x, v4.x ≈ v0.4.x. See `design.md` for the canonical version reference.
+>
+> **Currency note (2026-04-26)**: Plugin version is `0.17.0` (released 2026-04-26 — bundles v0.17 simplification + P1/P2 hardening stream #80/#82/#84/#87/#88). The roadmap-level summary for v0.15.x → v0.16.0 → v0.17 is the first release section below. Per-version detail for v0.15.x and v0.16.0 lives in `docs/design.md` §9 to avoid duplication.
 
 ## Vision: "Phase 0 Enhanced + Phase 5 Minimized"
 
@@ -257,6 +259,61 @@ Structural protocol changes leveraging 1M context for richer cross-phase informa
 | `docs/design.md` | v0.7.0 version bump, all planned notes resolved |
 
 Full analysis: `analysis/mpl-1m-context-impact-analysis.md`
+
+---
+
+## v0.17.0 — Simplification + P1/P2 Hardening Stream (2026-04-21 ~ 2026-04-26)
+
+> Per-version detail lives in `docs/design.md` Section 9. This block is the roadmap-level summary for v0.15.x → v0.16.0 → v0.17 simplification + the merged P1/P2 follow-ups (#80, #82, #84, #87, #88). Released as plugin `0.17.0` on 2026-04-26.
+
+### v0.15.x → v0.16.0 — Documented in design.md
+
+| Release | Theme | design.md anchor |
+|---|---|---|
+| v0.15.0 (2026-04-19) | Measurement Integrity (AD-0006): gate-recorder + RUNBOOK self-report removal + launch smoke deterministic detection + Anti-rationalization guardrails | `### v0.15.0` |
+| v0.15.1 (2026-04-19) | Test-Agent Enforcement (AD-0007): `test_agent_required` field + `mpl-require-test-agent.mjs` hook | `### v0.15.1` |
+| v0.15.2 (2026-04-19) | E2E Scenario Enforcement (AD-0008): two-layer scenario design + `mpl-require-e2e.mjs` hook | `### v0.15.2` |
+| v0.15.3 (2026-04-19) | QMD Removal Actual Completion: 121 references / 14 files, 2 file deletions, .mcp.json qmd entry removed | `### v0.15.3` |
+| v0.16.0 (2026-04-20) | 3-Tier User Contract Architecture: Tier A' UC spec + `mpl_classify_feature_scope` MCP tool + Tier B `covers:[UC-NN]` decomposer field + `mpl-require-covers.mjs` hook + Tier C `@contract(UC-NN)` E2E annotation + `mpl-validate-pp-schema.mjs` hook + `mpl_diagnose_e2e_failure` MCP tool. Zero new agent files. | `### v0.16.0` |
+
+### v0.17 Simplification (#55, ~2026-04-21)
+
+> Pivot from instrumentation accretion back to mechanical minimalism. Removes legacy concepts that empirical runs (ygg-exp10/11) showed had zero downstream effect.
+
+| Concept removed | Replacement / fate |
+|---|---|
+| Step -1 LSP Warm-up (orchestrator-driven) | Moved to `hooks/mpl-lsp-warmup.mjs` (UserPromptSubmit hook) — out of orchestrator turn |
+| Step 0.0.5 Artifact Freshness + Field Classification | REMOVED entirely. `.mpl/manifest.json` no longer generated. |
+| Step 0 Triage | REMOVED. `interview_depth` and `pp_proximity` no longer computed. Stage 1 interview always runs to PP completion. |
+| Step 1-D PP Confirmation (separate step) | Absorbed into Stage 1.9 (single confirmation gate inside the interview) |
+| Step 1-E Interview Snapshot Save | Renumbered to Stage 1.9 (`.mpl/mpl/interview-snapshot.md`) |
+| Routing pattern recall (F-22) | DROPPED. `routing-patterns.jsonl` no longer consulted at start. |
+| Hat model PP-proximity tier branching | DROPPED. Pipeline depth no longer routes on PP-proximity score. |
+
+Cross-reference: `docs/design.md` §3.2 Flow table carries v0.17 markers row-by-row; `docs/design.md` §9 v0.8.5 entry has a REMOVED banner.
+
+### Post-v0.17 — P1/P2 Hardening Stream (#80, #82, #84, #87, #88) (2026-04-23 ~ 2026-04-26)
+
+5 PRs merged on top of the v0.16.0 baseline + v0.17 simplification. All issue-driven, scoped to specific defects/duplications discovered during v0.16/v0.17 settling.
+
+| PR | Issue | Theme | Impact |
+|---|---|---|---|
+| #80 | #79 | **P1-3 — MCP session robustness** | 4-in-1 hardening: `MAX_AMBIGUITY_HISTORY=10` ring buffer + per-project TTL override (`session_cache.ttl_minutes`) + 404 auto-invalidate on session expiry + `degraded` flag escalation to user. New tests: state-manager ring buffer (3), TTL override (6), scorer detector + recovery + degraded (11). |
+| #82 | #81 | **P1-4d — AP-CHAIN-01 machine enforcement** | New `hooks/mpl-require-chain-assignment.mjs` PreToolUse hook (matcher: Task\|Agent, subagent_type=mpl-seed-generator). Denies dispatch when `chain_seed.enabled=true` ∧ `chain-assignment.yaml` absent. Inline-mode escapes via "AP-SEED-01 exempt per #58" message. 17 tests (helper unit + spawnSync integration). |
+| #84 | #83 | **P2-6 — `state.json` schema v2 unification** | Single source: `.mpl/state.json` → `execution` subtree (was split with `.mpl/mpl/state.json`). `CURRENT_SCHEMA_VERSION=2` + auto v1→v2 migration on first read + `detectStateDrift()`. Legacy `.mpl/mpl/state.json` preserved at `.mpl/archive/{pipeline_id}-legacy-execution-state.json`. Ring buffer cap defense-in-depth in `writeState`. 13 tests (migration + drift). |
+| #87 | #85 | **P2-7 — Generic cross-project session cache** | New `mcp-server/src/lib/agent-sdk-query.ts` extracts `runCachedQuery<T>` + `isSessionExpiredError` helpers. `feature-classifier.ts` and `e2e-diagnoser.ts` reuse the same cache (`~/.mpl/cache/sessions.json`) — module-level `cachedSessionId` removed in 3 callers. Net code: −187 lines. 11 tests (helper + classifier/diagnoser integration). **Side effect**: P2-8 (separate cache-manager abstraction) is now naturally absorbed; no separate work needed. |
+| #88 | — | **docs drift audit** | Manifest.json schema removed from `docs/config-schema.md`. `session_cache.ttl_minutes` added. `docs/design.md` Section 3.2 carries v0.17 marker; v0.8.5 history entry gets REMOVED banner. |
+
+**Test totals at end of stream:**
+- Hooks: 287 → 317 pass (+30)
+- MCP server: 42 → 73 pass (+31)
+
+**Issues closed this stream:** 4 (#79, #81, #83, #85). #88 is chore-only.
+
+### Decision boundaries (open)
+
+- **Plugin version bump**: ✅ released as `0.17.0` (2026-04-26). 0.18.0 reserved for the next stream (post-exp12 F-25/F-28/F-39 reductions if measurement justifies them).
+- **F-25 / F-28 / F-39 future**: 4-Tier Memory + `phase_domain` + `phase_subdomain`/`task_type`/`lang` reduction decisions remain blocked on exp12 measurement (`docs/roadmap/0.16-exp12-plan.md`). Not in scope of this release.
 
 ---
 

--- a/docs/roadmap/pending-features.md
+++ b/docs/roadmap/pending-features.md
@@ -1,10 +1,35 @@
 # MPL Roadmap TEMP: Pending Feature Candidates
 
 > **⚠ v2 반영 완료 (v0.12.2)**: maturity_mode 제거, 5-Gate → 3H+1A Gate, pipeline_tier → pp_proximity 반영됨. 삭제된 에이전트(mpl-compound, mpl-scout, mpl-code-reviewer, mpl-verification-planner 등) 참조는 현행 담당자로 주석 처리됨.
+>
+> **⚠ v0.17 (#55) 반영**: Triage / `interview_depth` / `pp_proximity` / Hat model / F-22 routing-pattern recall 모두 삭제됨. 본 문서 내 위 개념을 가정한 설계(특히 `interview_depth` 분기를 활용하는 PM 설계, F-20→F-22 라우터 의존 항목)는 **재기준선화 필요**. 측정 대기 항목(F-25/F-28/F-39)은 `docs/roadmap/0.16-exp12-plan.md` exp12 데이터로 결정 보류 중.
 
 > **Status**: Pending implementation (for review)
-> **Last updated**: 2026-04-10
+> **Last updated**: 2026-04-26
 > **Purpose**: Consolidated list of all features not yet implemented. Completed items have been moved to `overview.md`.
+
+### Recently Completed (Post-v0.16 — 2026-04-21 ~ 2026-04-26)
+
+Moved out of "pending" because they were merged in the v0.17 + P1/P2 hardening stream. Detail in `docs/design.md` §9 + `docs/roadmap/overview.md` "Post-v0.16" section.
+
+| ID / PR | Item | Resolution |
+|---|---|---|
+| #55 | v0.17 Simplification | Triage + Step 0.0.5 (manifest.json) + `interview_depth` + `pp_proximity` + Hat model + F-22 routing recall — all REMOVED. Step -1 LSP Warm-up moved to `hooks/mpl-lsp-warmup.mjs`. |
+| #79 / PR #80 | P1-3 MCP session robustness | Ring buffer + per-project TTL override + 404 auto-invalidate + degraded escalation. |
+| #81 / PR #82 | P1-4d AP-CHAIN-01 enforcement | New `mpl-require-chain-assignment.mjs` PreToolUse hook. |
+| #83 / PR #84 | P2-6 state.json schema v2 | Single file + `execution` subtree + auto v1→v2 migration + `detectStateDrift()`. |
+| #85 / PR #87 | P2-7 generic session cache (also absorbs P2-8) | `runCachedQuery<T>` helper extracted; classifier + diagnoser reuse `~/.mpl/cache/sessions.json`. **P2-8 (separate cache-manager abstraction) no longer needed — naturally absorbed.** |
+| — / PR #88 | docs drift audit | manifest.json schema removed from config-schema; `session_cache.ttl_minutes` added; design.md §3.2 + v0.8.5 entry markers. |
+
+### Measurement-blocked items
+
+Decision pending exp12 measurement (`docs/roadmap/0.16-exp12-plan.md`). Do not promote/sunset until data exists.
+
+| ID | Item | Decision rule |
+|---|---|---|
+| F-25 | 4-Tier Adaptive Memory | If Tier-3/4 actual load frequency < 10% across exp12 runs → collapse to 2-tier. |
+| F-28 | `phase_domain` field | If field has no routing effect beyond phase-runner model selection → demote to plain tag and remove metadata wiring. |
+| F-39 | `phase_subdomain` / `task_type` / `lang` (4-Layer prompt composition) | Validate that distinct prompt paths actually compose; if always-same path → simplify. |
 
 ---
 

--- a/docs/roadmap/sprints.md
+++ b/docs/roadmap/sprints.md
@@ -2,6 +2,8 @@
 
 > Remaining 10 items organized into 4 Sprints, starting from Sprint 1 completion criteria.
 > Written: 2026-03-08
+>
+> **Currency note (2026-04-26)**: Sprints 1-7 below describe the v3.2 → v0.13.x work and are completed as recorded. Releases since then (v0.14 → v0.16.0 → v0.17 simplification + the P1/P2 hardening stream #80/#82/#84/#87/#88) are tracked release-by-release, not sprint-by-sprint, and live in `docs/design.md` §9 + `docs/roadmap/overview.md` "Post-v0.16" section. F-22 (Sprint 2) is **REMOVED in v0.17** — routing-pattern recall no longer runs at start. Acceptance criteria for F-22 are historical.
 
 ---
 
@@ -19,7 +21,7 @@ Single entry point + automatic tier classification + dynamic escalation + RUNBOO
 |----|------|---------|--------|-----------|
 | F-11 | Cross-Run Learning Accumulation | HIGH | F-10 (RUNBOOK) complete | `.mpl/memory/learnings.md`, orchestrator distillation logic *(was mpl-compound, removed v0.11.0)* |
 | F-12 | Intra-Session Context Persistence | HIGH | None | `<remember priority>` marking protocol, RUNBOOK dual safety net |
-| F-22 | Routing Pattern Learning | MED | F-20 (Router) complete | `.mpl/memory/routing-patterns.jsonl`, Jaccard matching |
+| F-22 | Routing Pattern Learning *(v0.17 REMOVED — recall + recording dropped)* | MED | F-20 (Router) complete | `.mpl/memory/routing-patterns.jsonl`, Jaccard matching |
 
 ### Dependency Graph
 

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mpl-mcp-server",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "MPL MCP Server — deterministic scoring + active state access",
   "type": "module",
   "main": "dist/index.js",

--- a/skills/mpl-pivot/SKILL.md
+++ b/skills/mpl-pivot/SKILL.md
@@ -14,7 +14,7 @@ This skill discovers and defines PPs through a structured interview.
 - When starting a new project or making a large directional change
 - When running `/mpl:mpl` and no PP exists, this skill runs automatically first
 
-## Triage Integration
+## Triage Integration *(v0.17 REMOVED — Triage step deleted; `interview_depth` is no longer set by the pipeline. Treat all invocations as `full`. Section preserved as historical reference until rewrite.)*
 
 When invoked from the MPL pipeline, the Triage step determines interview depth:
 


### PR DESCRIPTION
## Summary

- Bumps plugin to **0.17.0**, cutting a release that bundles the v0.17 simplification (#55) with the five issue-driven P1/P2 hardening PRs already merged on top of v0.16.0 (#80, #82, #84, #87, #88)
- Mandatory version refs updated: `plugin.json`, `marketplace.json` (top + plugin entry), `mcp-server/package.json`, `README.md`, `README_ko.md`, `docs/design.md` (title + new §9 v0.17.0 entry), `docs/config-schema.md`
- Roadmap docs aligned: `overview.md` retitled "Post-v0.16" section to "v0.17.0", `pending-features.md` Recently Completed + Measurement-blocked tables, `sprints.md` / `adaptive-router-plan.md` / `0.16-exp12-plan.md` / `pm-design.md` carry v0.17 REMOVED markers; agent + skill files get inline `(v0.17 REMOVED)` markers on `interview_depth` / `pp_proximity` / Triage references

## Breaking changes

Removal of observable state fields (`interview_depth`, `pp_proximity`, `pipeline_tier`, `routing_pattern_*`) and the `.mpl/manifest.json` artifact. State schema bumped v1→v2 with auto-migration on first read — projects do not need manual intervention. Any external consumer reading the removed fields must be re-baselined; the minor bump signals this surface change.

## Issues closed by the bundled stream

- #55 — v0.17 simplification
- #79 — P1-3 MCP session robustness
- #81 — P1-4d AP-CHAIN-01 enforcement
- #83 — P2-6 state.json schema v2
- #85 — P2-7 generic session cache

## Test plan

- [x] hooks: `node --test __tests__/*.test.mjs` → 317/317 pass
- [x] mcp-server: `npm test` → 73/73 pass
- [x] grep verifies no stale `0.16.0` reference remains in mandatory targets (`.claude-plugin/*`, `mcp-server/package.json`, README titles, design.md title, config-schema.md Version field)
- [x] design.md §9 v0.17.0 entry enumerates every change with Before/After/Type/Rationale columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)