### PR TITLE
docs(roadmap): record exp12 pre-flight gaps as deferred work

### DIFF
--- a/docs/roadmap/0.16-exp12-plan.md
+++ b/docs/roadmap/0.16-exp12-plan.md
@@ -9,6 +9,13 @@ Related:
 - Decision `~/project/decision/2026-04-19-mpl-0.16-implementation-plan.md`
 - Baseline: `~/project/harness_lab/analysis/mpl-exp11-opus47-evaluation.md`
 
+> **Pre-flight gaps (2026-05-02)** — exp12 본 실행 시작 전에 닫아야 할 항목, 본 실행 미시작 상태라 보류 중:
+>
+> 1. **Metric 4/5 emission missing**: this plan promises `.mpl/metrics/e2e-recovery.jsonl` per-iteration record (line 71) and `commands/references/e2e-recovery.md:154` repeats the promise, but no code in the repo writes to that path. `mpl_diagnose_e2e_failure` (mcp-server/src/tools/e2e-diagnose.ts) returns the diagnosis JSON to the orchestrator without any side-effect file write. Decision when exp12 is ready: either (a) MCP tool emits the jsonl as a side effect, or (b) `commands/references/e2e-recovery.md` step 3 explicitly appends after `mpl_state_write`. Schema must be co-designed with the labeler (item 2) since the labeler reconstructs the diagnoser's input from this line.
+> 2. **Q8 labeler script**: belongs in maintainer's harness_lab (analysis-time, single-operator). Not an MPL ship surface. Deferred until exp12 starts so the script can be written against real exp12 data. Plan section "Metric 5" is therefore a methodology spec, not a runtime contract.
+>
+> Both items unblock exp12 Stage 4 (promote / keep / sunset of `mpl_diagnose_e2e_failure`). exp12 itself depends on F-25/F-28/F-39 measurement opportunity — no current schedule.
+
 > **Currency note (2026-04-26)** — Plan validated against post-v0.17 state:
 > - State paths: `.mpl/state.json` is now the **single SSOT** (P2-6 schema v2 unified `.mpl/state.json` + `.mpl/mpl/state.json`). Existing `cp .mpl/state.json analysis/exp12/` step is correct. Legacy `.mpl/mpl/state.json` is auto-archived to `.mpl/archive/{pipeline_id}-legacy-execution-state.json` on first read — don't expect it in fresh runs.
 > - Triage / `interview_depth` / `pp_proximity` removed in v0.17 (#55) — none of the 5 primary metrics depend on them, so no rewrite needed.

--- a/docs/roadmap/0.16-exp12-plan.md
+++ b/docs/roadmap/0.16-exp12-plan.md
@@ -14,7 +14,7 @@ Related:
 > 1. **Metric 4/5 emission missing**: this plan promises `.mpl/metrics/e2e-recovery.jsonl` per-iteration record (line 71) and `commands/references/e2e-recovery.md:154` repeats the promise, but no code in the repo writes to that path. `mpl_diagnose_e2e_failure` (mcp-server/src/tools/e2e-diagnose.ts) returns the diagnosis JSON to the orchestrator without any side-effect file write. Decision when exp12 is ready: either (a) MCP tool emits the jsonl as a side effect, or (b) `commands/references/e2e-recovery.md` step 3 explicitly appends after `mpl_state_write`. Schema must be co-designed with the labeler (item 2) since the labeler reconstructs the diagnoser's input from this line.
 > 2. **Q8 labeler script**: belongs in maintainer's harness_lab (analysis-time, single-operator). Not an MPL ship surface. Deferred until exp12 starts so the script can be written against real exp12 data. Plan section "Metric 5" is therefore a methodology spec, not a runtime contract.
 >
-> Both items unblock exp12 Stage 4 (promote / keep / sunset of `mpl_diagnose_e2e_failure`). exp12 itself depends on F-25/F-28/F-39 measurement opportunity — no current schedule.
+> Both items unblock the **Stage 4 classifier decision** (which classifier drives Step 5.0.4). The auto-recovery loop itself stays regardless of Stage 4 outcome — see "Scope correction" under "Sunset / Promotion Decision" below. exp12 itself depends on F-25/F-28/F-39 measurement opportunity — no current schedule.
 
 > **Currency note (2026-04-26)** — Plan validated against post-v0.17 state:
 > - State paths: `.mpl/state.json` is now the **single SSOT** (P2-6 schema v2 unified `.mpl/state.json` + `.mpl/mpl/state.json`). Existing `cp .mpl/state.json analysis/exp12/` step is correct. Legacy `.mpl/mpl/state.json` is auto-archived to `.mpl/archive/{pipeline_id}-legacy-execution-state.json` on first read — don't expect it in fresh runs.
@@ -158,12 +158,14 @@ All of the following must hold on at least one clean run:
 
 ## Sunset / Promotion Decision (Stage 4)
 
+> **Scope correction (2026-05-02)**: Stage 4 decides the **classifier implementation**, not whether recovery exists. The auto-recovery loop itself (Finalize Step 5.0.4 — fail → diagnose → auto-fix per A/B/C/D → re-test → fall through to HITL only after circuit break) is treated as **structurally essential** once E2E is part of the pipeline; without it every E2E failure becomes a HITL touch and the value of the v0.16 Tier C investment evaporates. So no Stage 4 outcome removes Step 5.0.4. The question is *which classifier drives it*.
+
 After exp12 completes, open a follow-up debate using the 4-agent pattern
 (Architect / Contrarian / Simplifier / Evaluator) with the measurement summary
 as input. The debate decides:
 
 | Outcome | Action |
 |---|---|
-| Promote to agent | New `mpl-e2e-diagnostician` agent file; sunset MCP tool |
-| Keep MCP tool | No change; continue in Stage 4.1 maintenance |
-| Sunset MCP tool | Remove `mcp-server/src/tools/e2e-diagnose.ts` + Finalize Step 5.0.4; fall back to HITL |
+| Promote to agent | New `mpl-e2e-diagnostician` agent file replaces the MCP tool as the classifier behind Step 5.0.4. Recovery loop unchanged. |
+| Keep MCP tool | No change; classifier stays as `mpl_diagnose_e2e_failure` MCP tool. Continue in Stage 4.1 maintenance. |
+| Sunset LLM classifier | Remove `mcp-server/src/tools/e2e-diagnose.ts`. Step 5.0.4 retained but the classifier slot is filled by a deterministic fallback (heuristic on `e2e_results.exit_code` + `stderr_tail` keyword matching for A/B/C/D, plus default-to-D on uncertain) **OR** by a single AskUserQuestion that prompts the operator for the A/B/C/D label. Either keeps the auto-fix dispatch table (Step 5.0.4 step 4) intact. |


### PR DESCRIPTION
## Summary

Two changes to \`docs/roadmap/0.16-exp12-plan.md\`:

### 1. Pre-flight gaps recorded (commit 1)

- \`.mpl/metrics/e2e-recovery.jsonl\` is promised by the plan + the protocol but no code emits it
- Q8 labeler script does not exist (and arguably belongs in maintainer's harness_lab, not MPL)
- Both deferred until exp12 actually starts so they can be co-designed against real data

### 2. Stage 4 scope correction (commit 2)

The original plan defined \"Sunset MCP tool\" as removing both \`mcp-server/src/tools/e2e-diagnose.ts\` AND Finalize Step 5.0.4 (the recovery loop), with everything falling back to HITL. That collapses two independent decisions into one — a single classifier-quality outcome would erase the entire Tier C investment.

Reframe Stage 4 around **the classifier slot only**:

- Auto-recovery loop (Step 5.0.4) treated as structurally essential once E2E is in the pipeline; staying regardless of Stage 4 outcome
- Stage 4 outcomes now operate on which classifier drives the loop:
  - Promote → \`mpl-e2e-diagnostician\` agent file replaces the MCP tool
  - Keep → MCP tool remains
  - Sunset LLM → MCP tool removed, classifier slot filled by deterministic heuristic (exit_code + stderr_tail keyword match → A/B/C/D, default D) OR by a single AskUserQuestion. Dispatch table intact.

## Test plan

- [x] Pure docs change

🤖 Generated with [Claude Code](https://claude.com/claude-code)