### PR TITLE
feat(metrics): emit .mpl/metrics/e2e-recovery.jsonl per diagnose call

### DIFF
--- a/commands/references/e2e-recovery.md
+++ b/commands/references/e2e-recovery.md
@@ -149,10 +149,14 @@ AskUserQuestion(
 directly from state.json and inlines the summary into the orchestrator
 prompt. No MCP round-trip.
 
-**Exp12 measurement**: every diagnostician call increments
-`state.e2e_recovery.iter` by `iter_hint`; the pipeline summary writes
-`{classification, confidence, iter}` into `.mpl/metrics/e2e-recovery.jsonl`
-for Stage 4 data-driven promotion analysis.
+**Recovery audit trail**: the `mpl_diagnose_e2e_failure` MCP tool itself
+appends one line per call to `.mpl/metrics/e2e-recovery.jsonl` —
+`{ts, classification, confidence, iter, prompt_version}`. Emission is a
+side effect of the tool handler (`mcp-server/src/tools/e2e-diagnose.ts`),
+so any pipeline that runs E2E recovery accumulates a per-call record
+without orchestrator-side bookkeeping. The file is the substrate for
+exp12 Metric 4 (diagnostician behavior) and Metric 5 (Q8 agreement
+rate); routine projects can also read it for post-hoc inspection.
 
 ### 5.0.5: AD Final Verification
 

--- a/docs/roadmap/0.16-exp12-plan.md
+++ b/docs/roadmap/0.16-exp12-plan.md
@@ -9,12 +9,12 @@ Related:
 - Decision `~/project/decision/2026-04-19-mpl-0.16-implementation-plan.md`
 - Baseline: `~/project/harness_lab/analysis/mpl-exp11-opus47-evaluation.md`
 
-> **Pre-flight gaps (2026-05-02)** — exp12 본 실행 시작 전에 닫아야 할 항목, 본 실행 미시작 상태라 보류 중:
+> **Pre-flight status (2026-05-02)**:
 >
-> 1. **Metric 4/5 emission missing**: this plan promises `.mpl/metrics/e2e-recovery.jsonl` per-iteration record (line 71) and `commands/references/e2e-recovery.md:154` repeats the promise, but no code in the repo writes to that path. `mpl_diagnose_e2e_failure` (mcp-server/src/tools/e2e-diagnose.ts) returns the diagnosis JSON to the orchestrator without any side-effect file write. Decision when exp12 is ready: either (a) MCP tool emits the jsonl as a side effect, or (b) `commands/references/e2e-recovery.md` step 3 explicitly appends after `mpl_state_write`. Schema must be co-designed with the labeler (item 2) since the labeler reconstructs the diagnoser's input from this line.
-> 2. **Q8 labeler script**: belongs in maintainer's harness_lab (analysis-time, single-operator). Not an MPL ship surface. Deferred until exp12 starts so the script can be written against real exp12 data. Plan section "Metric 5" is therefore a methodology spec, not a runtime contract.
+> 1. ✅ **Metric 4 emission CLOSED**: `mpl_diagnose_e2e_failure` MCP tool handler now appends one line per call to `.mpl/metrics/e2e-recovery.jsonl` via `appendRecoveryMetric()` in `mcp-server/src/lib/e2e-diagnoser.ts`. Every pipeline running E2E recovery accumulates the per-call audit trail automatically (no orchestrator action required). Schema: `{ts, classification, confidence, iter, prompt_version}` — frozen here.
+> 2. ⏸ **Q8 labeler script**: belongs in maintainer's harness_lab (analysis-time, single-operator). Not an MPL ship surface. Deferred until exp12 starts so the script can be written against real exp12 data. Plan section "Metric 5" is therefore a methodology spec, not a runtime contract.
 >
-> Both items unblock the **Stage 4 classifier decision** (which classifier drives Step 5.0.4). The auto-recovery loop itself stays regardless of Stage 4 outcome — see "Scope correction" under "Sunset / Promotion Decision" below. exp12 itself depends on F-25/F-28/F-39 measurement opportunity — no current schedule.
+> Item 2 unblocks the **Stage 4 classifier decision** (which classifier drives Step 5.0.4). The auto-recovery loop itself stays regardless of Stage 4 outcome — see "Scope correction" under "Sunset / Promotion Decision" below. exp12 itself depends on F-25/F-28/F-39 measurement opportunity — no current schedule.
 
 > **Currency note (2026-04-26)** — Plan validated against post-v0.17 state:
 > - State paths: `.mpl/state.json` is now the **single SSOT** (P2-6 schema v2 unified `.mpl/state.json` + `.mpl/mpl/state.json`). Existing `cp .mpl/state.json analysis/exp12/` step is correct. Legacy `.mpl/mpl/state.json` is auto-archived to `.mpl/archive/{pipeline_id}-legacy-execution-state.json` on first read — don't expect it in fresh runs.

--- a/mcp-server/__tests__/e2e-diagnoser.test.mjs
+++ b/mcp-server/__tests__/e2e-diagnoser.test.mjs
@@ -1,9 +1,14 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, existsSync, rmSync, chmodSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import {
   PROMPT_VERSION,
   parseDiagnosis,
   neutralDiagnosis,
+  appendRecoveryMetric,
+  RECOVERY_METRICS_PATH,
 } from '../dist/lib/e2e-diagnoser.js';
 
 describe('PROMPT_VERSION', () => {
@@ -96,6 +101,84 @@ describe('parseDiagnosis', () => {
   it('returns null for malformed JSON', () => {
     assert.equal(parseDiagnosis('{unclosed'), null);
     assert.equal(parseDiagnosis(''), null);
+  });
+});
+
+describe('appendRecoveryMetric', () => {
+  function makeFixture() {
+    return mkdtempSync(join(tmpdir(), 'mpl-e2e-recovery-metric-'));
+  }
+
+  it('exports the canonical relative path', () => {
+    assert.equal(RECOVERY_METRICS_PATH, '.mpl/metrics/e2e-recovery.jsonl');
+  });
+
+  it('creates .mpl/metrics directory and writes one jsonl line', () => {
+    const cwd = makeFixture();
+    try {
+      const ok = appendRecoveryMetric(cwd, {
+        ts: '2026-05-02T00:00:00.000Z',
+        classification: 'A',
+        confidence: 0.87,
+        iter: 1,
+        prompt_version: PROMPT_VERSION,
+      });
+      assert.equal(ok, true);
+      const path = join(cwd, RECOVERY_METRICS_PATH);
+      assert.ok(existsSync(path));
+      const raw = readFileSync(path, 'utf-8');
+      assert.equal(raw.endsWith('\n'), true);
+      const parsed = JSON.parse(raw.trim());
+      assert.equal(parsed.classification, 'A');
+      assert.equal(parsed.confidence, 0.87);
+      assert.equal(parsed.iter, 1);
+      assert.equal(parsed.prompt_version, PROMPT_VERSION);
+      assert.equal(parsed.ts, '2026-05-02T00:00:00.000Z');
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('appends multiple records as separate lines', () => {
+    const cwd = makeFixture();
+    try {
+      for (let i = 0; i < 3; i += 1) {
+        appendRecoveryMetric(cwd, {
+          ts: `2026-05-02T00:00:0${i}.000Z`,
+          classification: 'D',
+          confidence: 0.5,
+          iter: i,
+          prompt_version: PROMPT_VERSION,
+        });
+      }
+      const lines = readFileSync(join(cwd, RECOVERY_METRICS_PATH), 'utf-8').trim().split('\n');
+      assert.equal(lines.length, 3);
+      assert.equal(JSON.parse(lines[0]).iter, 0);
+      assert.equal(JSON.parse(lines[2]).iter, 2);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('returns false on unwritable target without throwing', () => {
+    // Pointing at a non-existent root that cannot be created (permission denied)
+    // is hard to fake portably; instead simulate by chmod-ing the parent so
+    // the metrics dir creation fails.
+    const cwd = makeFixture();
+    try {
+      chmodSync(cwd, 0o400); // read-only
+      const ok = appendRecoveryMetric(cwd, {
+        ts: '2026-05-02T00:00:00.000Z',
+        classification: 'B',
+        confidence: 1,
+        iter: 0,
+        prompt_version: PROMPT_VERSION,
+      });
+      assert.equal(ok, false);
+    } finally {
+      chmodSync(cwd, 0o700);
+      rmSync(cwd, { recursive: true, force: true });
+    }
   });
 });
 

--- a/mcp-server/src/lib/e2e-diagnoser.ts
+++ b/mcp-server/src/lib/e2e-diagnoser.ts
@@ -20,8 +20,43 @@ export const PROMPT_VERSION = 'v1-2026-04-19';
 
 const SESSION_KIND = 'e2e_diagnose';
 
+import { existsSync, mkdirSync, appendFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { runCachedQuery } from './agent-sdk-query.js';
 import { readState } from './state-manager.js';
+
+export const RECOVERY_METRICS_PATH = '.mpl/metrics/e2e-recovery.jsonl';
+
+export interface RecoveryMetricRecord {
+  ts: string;
+  classification: 'A' | 'B' | 'C' | 'D';
+  confidence: number;
+  iter: number;
+  prompt_version: string;
+}
+
+/**
+ * Append one structured record to `.mpl/metrics/e2e-recovery.jsonl`.
+ *
+ * Called by the `mpl_diagnose_e2e_failure` MCP tool handler after every
+ * diagnose call so that any pipeline running E2E recovery emits a per-call
+ * audit trail without requiring orchestrator-side bookkeeping. Schema is
+ * stable per `docs/roadmap/0.16-exp12-plan.md` Metric 4.
+ *
+ * Returns true on successful append, false on any I/O failure (caller
+ * should not surface metrics emission errors — diagnosis return is the
+ * primary contract).
+ */
+export function appendRecoveryMetric(cwd: string, record: RecoveryMetricRecord): boolean {
+  try {
+    const metricsDir = join(cwd, '.mpl', 'metrics');
+    if (!existsSync(metricsDir)) mkdirSync(metricsDir, { recursive: true });
+    appendFileSync(join(cwd, RECOVERY_METRICS_PATH), JSON.stringify(record) + '\n', { mode: 0o600 });
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 export type Classification = 'A' | 'B' | 'C' | 'D';
 

--- a/mcp-server/src/tools/e2e-diagnose.ts
+++ b/mcp-server/src/tools/e2e-diagnose.ts
@@ -12,6 +12,7 @@
  */
 
 import {
+  appendRecoveryMetric,
   diagnoseE2EFailure,
   PROMPT_VERSION,
 } from '../lib/e2e-diagnoser.js';
@@ -97,6 +98,14 @@ export async function handleDiagnoseE2EFailure(args: {
     append_phases: result.append_phases,
     confidence: result.confidence,
   };
+
+  appendRecoveryMetric(args.cwd, {
+    ts: new Date().toISOString(),
+    classification: result.classification,
+    confidence: result.confidence,
+    iter: prev_iter + result.iter_hint,
+    prompt_version: PROMPT_VERSION,
+  });
 
   return {
     content: [{ type: 'text' as const, text: JSON.stringify(ordered, null, 2) }],


### PR DESCRIPTION
## Summary

Closes a real MPL-side gap surfaced during the 2026-05-02 exp12 measurement-infra audit: the 0.16 plan + \`commands/references/e2e-recovery.md\` both promised a per-iteration audit trail at \`.mpl/metrics/e2e-recovery.jsonl\`, but no code was emitting that path — \`mpl_diagnose_e2e_failure\` returned the diagnosis JSON to the orchestrator and stopped.

## What changed

- New \`appendRecoveryMetric(cwd, record)\` helper in \`mcp-server/src/lib/e2e-diagnoser.ts\`. Creates \`.mpl/metrics/\` on demand, appends one jsonl line, swallows I/O failures so metrics-write problems never poison the diagnosis return contract.
- Wired into \`mcp-server/src/tools/e2e-diagnose.ts\` handler so emission is a side effect of every diagnose call — orchestrator does not need to know about it.
- Schema (frozen per plan): \`{ts, classification, confidence, iter, prompt_version}\` with \`iter = prev_iter + iter_hint\`.
- \`commands/references/e2e-recovery.md\`: \"Exp12 measurement\" paragraph rewritten as \"Recovery audit trail\" — emission is universal, not exp12-specific.
- \`docs/roadmap/0.16-exp12-plan.md\` pre-flight gap note: Gap 1 flipped to ✅ closed; Gap 2 (Q8 labeler) remains deferred until exp12 starts.

## Why this is a routine MPL feature, not exp12-only

Discussion with maintainer (2026-05-02) clarified that the auto-recovery loop itself (Finalize Step 5.0.4) is structurally essential once E2E is part of the pipeline. Per-call observability ships with the loop — any project running E2E recovery accumulates a useful audit trail without opting in. Exp12 is one consumer of the file; routine post-hoc analysis is another.

## Test plan

- [x] mcp-server suite: 73 → 77 pass (+4 new tests for \`appendRecoveryMetric\`: directory creation, single append, multi-line append, graceful unwritable-cwd failure)
- [x] hooks suite: 317/317 unchanged
- [x] No new dependencies added (uses node:fs / node:path / node:os)

🤖 Generated with [Claude Code](https://claude.com/claude-code)