### PR TITLE
feat(#105): F3 — mpl-fallback-grep.mjs Tier 1 anti-pattern observer

### DIFF
--- a/hooks/__tests__/mpl-fallback-grep.test.mjs
+++ b/hooks/__tests__/mpl-fallback-grep.test.mjs
@@ -1,0 +1,324 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync } from 'fs';
+import { join, dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+import { tmpdir } from 'os';
+
+import {
+  parseRegistry,
+  compileRegistry,
+  isInScope,
+  scanContent,
+  decideAction,
+  loadRegistry,
+} from '../lib/anti-pattern-registry.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const PLUGIN_ROOT = resolve(__dirname, '..', '..');
+const REGISTRY_PATH = join(PLUGIN_ROOT, 'commands', 'references', 'anti-patterns.md');
+const HOOK_PATH = join(__dirname, '..', 'mpl-fallback-grep.mjs');
+
+describe('parseRegistry', () => {
+  it('parses scope blocks (allowed + excluded)', () => {
+    const md = `
+\`\`\`scope
+.mjs .ts .py
+.rs
+\`\`\`
+
+\`\`\`scope-excluded
+.md .json
+*.test.{ts,tsx}
+\`\`\`
+`;
+    const { scope } = parseRegistry(md);
+    assert.ok(scope.allowed.has('.mjs'));
+    assert.ok(scope.allowed.has('.ts'));
+    assert.ok(scope.allowed.has('.py'));
+    assert.ok(scope.allowed.has('.rs'));
+    assert.ok(scope.excluded.has('.md'));
+    assert.ok(scope.excluded.has('.json'));
+    assert.ok(scope.excluded.has('*.test.{ts,tsx}'));
+  });
+
+  it('parses pattern heading + frontmatter + regex + permitted-when', () => {
+    const md = `
+### TC1 · Tautological assertion
+
+- **id**: \`TC1\`
+- **category**: \`test-fake\`
+- **severity**: \`block\`
+- **escalation**: tier_3_block_in: production
+- **rationale**: SUT-independent
+- **ground-truth count**: 5
+
+\`\`\`regex
+expect\\s*\\(\\s*true\\s*\\)
+assert\\s*\\(\\s*true\\s*\\)
+\`\`\`
+
+\`\`\`permitted-when
+- inside an environment precondition test
+\`\`\`
+`;
+    const { patterns } = parseRegistry(md);
+    assert.strictEqual(patterns.length, 1);
+    const p = patterns[0];
+    assert.strictEqual(p.id, 'TC1');
+    assert.strictEqual(p.title, 'Tautological assertion');
+    assert.strictEqual(p.category, 'test-fake');
+    assert.strictEqual(p.severity, 'block');
+    assert.deepStrictEqual(p.escalation, ['tier_3_block_in:production']);
+    assert.strictEqual(p.regexLines.length, 2);
+    assert.match(p.permittedWhen, /environment precondition/);
+  });
+
+  it('parses real registry into 10 patterns', () => {
+    const md = readFileSync(REGISTRY_PATH, 'utf-8');
+    const { patterns, scope } = parseRegistry(md);
+    assert.strictEqual(patterns.length, 10);
+    const ids = patterns.map(p => p.id).sort();
+    assert.deepStrictEqual(ids, ['C2', 'C3', 'CSP', 'D1.a', 'D1.b', 'D2', 'M1', 'TC1', 'TC2', 'TC3']);
+    assert.ok(scope.allowed.has('.mjs'));
+    assert.ok(scope.allowed.has('.ts'));
+    assert.ok(scope.excluded.has('.md'));
+  });
+});
+
+describe('compileRegistry', () => {
+  it('compiles real registry without dropping any regexes', () => {
+    const reg = loadRegistry(REGISTRY_PATH);
+    assert.strictEqual(reg.dropped, 0);
+    for (const p of reg.patterns) {
+      assert.ok(p.compiled.length > 0, `${p.id} has at least one regex`);
+      for (const re of p.compiled) assert.ok(re instanceof RegExp);
+    }
+  });
+});
+
+describe('isInScope', () => {
+  const scope = { allowed: new Set(['.mjs', '.ts', '.py']), excluded: new Set(['.md', '*.test.{ts,tsx}']) };
+
+  it('accepts allowed extensions', () => {
+    assert.strictEqual(isInScope('/repo/src/foo.ts', scope), true);
+    assert.strictEqual(isInScope('/repo/lib/bar.mjs', scope), true);
+  });
+
+  it('rejects extensions not in allowlist', () => {
+    assert.strictEqual(isInScope('/repo/README.md', scope), false);
+    assert.strictEqual(isInScope('/repo/config.json', scope), false);
+  });
+
+  it('rejects excluded glob patterns (*.test.ts)', () => {
+    assert.strictEqual(isInScope('/repo/src/foo.test.ts', scope), false);
+    assert.strictEqual(isInScope('/repo/src/foo.test.tsx', scope), false);
+  });
+
+  it('rejects registry doc itself (self-application contract)', () => {
+    assert.strictEqual(isInScope('/repo/commands/references/anti-patterns.md', scope), false);
+  });
+
+  it('rejects agent prompts (registry self-doc surface)', () => {
+    // .md is already excluded by extension, but explicit guard is still tested
+    const broadScope = { allowed: new Set(['.md', '.mjs']), excluded: new Set() };
+    assert.strictEqual(isInScope('/repo/agents/mpl-phase-runner.md', broadScope), false);
+  });
+
+  it('handles missing file path', () => {
+    assert.strictEqual(isInScope('', scope), false);
+    assert.strictEqual(isInScope(null, scope), false);
+  });
+});
+
+describe('scanContent', () => {
+  const registry = loadRegistry(REGISTRY_PATH);
+
+  it('TC1 fixture (positive) → match', () => {
+    const src = `
+import { test, expect } from 'vitest';
+test('foo', () => {
+  expect(true).toBe(true);
+});
+`;
+    const hits = scanContent(src, registry.patterns);
+    const tc1 = hits.filter(h => h.id === 'TC1');
+    assert.ok(tc1.length >= 1);
+  });
+
+  it('TC1 fixture (negative — real assertion) → no match', () => {
+    const src = `
+import { test, expect } from 'vitest';
+test('foo', () => {
+  expect(add(2, 2)).toBe(4);
+});
+`;
+    const hits = scanContent(src, registry.patterns);
+    assert.strictEqual(hits.filter(h => h.id === 'TC1').length, 0);
+  });
+
+  it('M1 fixture → match', () => {
+    const src = `const x = obj as unknown as MyType;`;
+    const hits = scanContent(src, registry.patterns);
+    assert.ok(hits.filter(h => h.id === 'M1').length >= 1);
+  });
+
+  it('D2 fixture (swallowed reject) → match', () => {
+    const src = `await fetch(url).catch(() => false);`;
+    const hits = scanContent(src, registry.patterns);
+    assert.ok(hits.filter(h => h.id === 'D2').length >= 1);
+  });
+
+  it('D1.b synthetic-id literal → match', () => {
+    const src = `const id = \`no-git-\${Date.now()}\`;`;
+    const hits = scanContent(src, registry.patterns);
+    assert.ok(hits.filter(h => h.id === 'D1.b').length >= 1);
+  });
+
+  it('clean source → no hits in block-severity patterns', () => {
+    const src = `
+function add(a, b) { return a + b; }
+export { add };
+`;
+    const hits = scanContent(src, registry.patterns);
+    const blockIds = ['TC1', 'TC2', 'TC3', 'C3', 'D1.b', 'D2'];
+    const blockHits = hits.filter(h => blockIds.includes(h.id));
+    assert.strictEqual(blockHits.length, 0);
+  });
+
+  it('reports line numbers + snippets', () => {
+    const src = `// header line\n// another\nexpect(true).toBe(true);`;
+    const hits = scanContent(src, registry.patterns).filter(h => h.id === 'TC1');
+    assert.ok(hits[0]);
+    assert.strictEqual(hits[0].line, 3);
+    assert.match(hits[0].snippet, /expect\(true\)\.toBe\(true\)/);
+  });
+});
+
+describe('decideAction', () => {
+  it('no hits → silent', () => {
+    const r = decideAction([], { strict: false });
+    assert.strictEqual(r.action, 'silent');
+  });
+
+  it('hits + non-strict → warn', () => {
+    const r = decideAction([{ id: 'TC1', severity: 'block', escalation: [] }], { strict: false });
+    assert.strictEqual(r.action, 'warn');
+    assert.match(r.summary, /TC1/);
+  });
+
+  it('block-severity hit + strict → block', () => {
+    const r = decideAction([{ id: 'TC1', severity: 'block', escalation: [] }], { strict: true });
+    assert.strictEqual(r.action, 'block');
+    assert.strictEqual(r.blocking.length, 1);
+  });
+
+  it('warn-severity hit + strict → still warn (Tier 1 cannot semantically validate)', () => {
+    const r = decideAction([{ id: 'M1', severity: 'warn', escalation: ['tier_3_block_in:production'] }], { strict: true });
+    assert.strictEqual(r.action, 'warn');
+  });
+
+  it('block-severity + tier_3_only escalation + strict → warn (defer to Tier 3)', () => {
+    const r = decideAction([{ id: 'C3', severity: 'block', escalation: ['tier_3_only'] }], { strict: true });
+    assert.strictEqual(r.action, 'warn');
+  });
+});
+
+describe('mpl-fallback-grep hook integration', () => {
+  let tmpDir;
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'mpl-fbgrep-'));
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    writeFileSync(join(tmpDir, '.mpl', 'state.json'), JSON.stringify({ current_phase: 'phase2-sprint' }));
+  });
+  afterEach(() => rmSync(tmpDir, { recursive: true, force: true }));
+
+  function runHook(toolName, toolInput, extraState) {
+    if (extraState) {
+      const cur = JSON.parse(readFileSync(join(tmpDir, '.mpl', 'state.json'), 'utf-8'));
+      writeFileSync(join(tmpDir, '.mpl', 'state.json'), JSON.stringify({ ...cur, ...extraState }));
+    }
+    const stdin = JSON.stringify({
+      cwd: tmpDir,
+      tool_name: toolName,
+      tool_input: toolInput,
+    });
+    const out = execFileSync('node', [HOOK_PATH], { input: stdin, encoding: 'utf-8' });
+    return JSON.parse(out);
+  }
+
+  it('non-Edit/Write tool → silent', () => {
+    const r = runHook('Bash', { command: 'ls' });
+    assert.strictEqual(r.continue, true);
+    assert.strictEqual(r.suppressOutput, true);
+  });
+
+  it('Edit on .md file (registry self-doc) → silent (path-extension excluded)', () => {
+    const md = join(tmpDir, 'doc.md');
+    writeFileSync(md, 'expect(true).toBe(true)');
+    const r = runHook('Edit', { file_path: md, old_string: 'a', new_string: 'b' });
+    assert.strictEqual(r.continue, true);
+    assert.strictEqual(r.suppressOutput, true);
+  });
+
+  it('Edit on .ts with TC1 violation → warn (non-strict default)', () => {
+    const ts = join(tmpDir, 'foo.ts');
+    writeFileSync(ts, 'test("x", () => { expect(true).toBe(true); });\n');
+    const r = runHook('Edit', { file_path: ts, old_string: 'a', new_string: 'b' });
+    assert.strictEqual(r.continue, true);
+    assert.match(r.systemMessage, /Tier 1 anti-pattern advisory/);
+    assert.match(r.systemMessage, /TC1/);
+  });
+
+  it('Edit on .ts with TC1 violation + strict mode → block', () => {
+    const ts = join(tmpDir, 'foo.ts');
+    writeFileSync(ts, 'test("x", () => { expect(true).toBe(true); });\n');
+    const r = runHook('Edit', { file_path: ts, old_string: 'a', new_string: 'b' }, { enforcement: { strict: true } });
+    assert.strictEqual(r.decision, 'block');
+    assert.match(r.reason, /strict mode anti-pattern block/);
+    assert.match(r.reason, /TC1/);
+  });
+
+  it('Edit on clean .ts file → silent', () => {
+    const ts = join(tmpDir, 'foo.ts');
+    writeFileSync(ts, 'export function add(a, b) { return a + b; }\n');
+    const r = runHook('Edit', { file_path: ts, old_string: 'a', new_string: 'b' });
+    assert.strictEqual(r.continue, true);
+    assert.strictEqual(r.suppressOutput, true);
+  });
+
+  it('Edit on .ts with M1 (warn-severity) + strict → still warn (Tier 1 limitation)', () => {
+    const ts = join(tmpDir, 'foo.ts');
+    writeFileSync(ts, 'const x = obj as unknown as MyType;\n');
+    const r = runHook('Edit', { file_path: ts, old_string: 'a', new_string: 'b' }, { enforcement: { strict: true } });
+    assert.strictEqual(r.continue, true);
+    assert.match(r.systemMessage, /M1/);
+    assert.notStrictEqual(r.decision, 'block');
+  });
+
+  it('writes hits to .mpl/signals/anti-pattern-hits.jsonl', () => {
+    const ts = join(tmpDir, 'foo.ts');
+    writeFileSync(ts, 'test("x", () => { expect(true).toBe(true); });\n');
+    runHook('Edit', { file_path: ts, old_string: 'a', new_string: 'b' });
+    const sig = join(tmpDir, '.mpl', 'signals', 'anti-pattern-hits.jsonl');
+    assert.ok(existsSync(sig));
+    const lines = readFileSync(sig, 'utf-8').trim().split('\n').filter(Boolean);
+    assert.ok(lines.length >= 1);
+    const rec = JSON.parse(lines[0]);
+    assert.strictEqual(rec.id, 'TC1');
+    assert.strictEqual(rec.action, 'warn');
+    assert.ok(rec.line);
+    assert.match(rec.file, /foo\.ts$/);
+  });
+
+  it('MPL not active → silent', () => {
+    rmSync(join(tmpDir, '.mpl'), { recursive: true });
+    const ts = join(tmpDir, 'foo.ts');
+    writeFileSync(ts, 'expect(true).toBe(true);\n');
+    const r = runHook('Edit', { file_path: ts, old_string: 'a', new_string: 'b' });
+    assert.strictEqual(r.continue, true);
+    assert.strictEqual(r.suppressOutput, true);
+  });
+});

--- a/hooks/__tests__/mpl-fallback-grep.test.mjs
+++ b/hooks/__tests__/mpl-fallback-grep.test.mjs
@@ -86,6 +86,69 @@ assert\\s*\\(\\s*true\\s*\\)
     assert.ok(scope.allowed.has('.ts'));
     assert.ok(scope.excluded.has('.md'));
   });
+
+  it('parses bullet value when trailing prose follows backticked token (PR #122 review)', () => {
+    // Pre-fix bug: regex required `\s*$` after the optional closing backtick, dropping
+    // any line that had explanatory prose after the backticked value. Real registry
+    // entries (C2/C3/M1/CSP/D1.a/TC1) all carry such prose. With the bug, escalation
+    // was [] for those patterns and strict-mode F3 erroneously blocked C3 (severity=block,
+    // tier_3_only) instead of deferring to Tier 3.
+    const md = `
+### XX · Test pattern
+
+- **id**: \`XX\`
+- **category**: \`test-fake\`
+- **severity**: \`block\`
+- **escalation**: \`tier_3_only\` (Tier 1 emits warn only — explanatory prose after backtick)
+- **rationale**: arbitrary prose with no backticks
+- **ground-truth count**: 5 (exp15)
+
+\`\`\`regex
+foo
+\`\`\`
+`;
+    const { patterns } = parseRegistry(md);
+    assert.strictEqual(patterns.length, 1);
+    const p = patterns[0];
+    assert.strictEqual(p.id, 'XX');
+    assert.strictEqual(p.category, 'test-fake');
+    assert.strictEqual(p.severity, 'block');
+    assert.deepStrictEqual(p.escalation, ['tier_3_only']);
+    assert.match(p.rationale, /arbitrary prose/);
+    assert.match(p.groundTruthCount, /5 \(exp15\)/);
+  });
+
+  it('real registry: every escalation-bearing pattern parses non-empty escalation', () => {
+    const reg = loadRegistry(REGISTRY_PATH);
+    // From the registry source-of-truth, these patterns explicitly declare escalation:
+    const expected = {
+      'TC1': ['tier_3_block_in:production'],
+      'TC2': ['strict_block'],
+      'C2':  ['tier_3_block_in:production'],
+      'C3':  ['tier_3_only'],
+      'M1':  ['tier_3_block_in:production'],
+      'CSP': ['tier_3_only'],
+      'D1.a': ['tier_3_block_in:verification-result-LHS'],
+    };
+    for (const [id, exp] of Object.entries(expected)) {
+      const p = reg.patterns.find(x => x.id === id);
+      assert.ok(p, `${id} pattern present`);
+      assert.deepStrictEqual(p.escalation, exp, `${id} escalation should be ${JSON.stringify(exp)}`);
+    }
+    // And patterns that intentionally omit escalation:
+    for (const id of ['TC3', 'D1.b', 'D2']) {
+      const p = reg.patterns.find(x => x.id === id);
+      assert.deepStrictEqual(p.escalation, [], `${id} has no escalation field`);
+    }
+  });
+
+  it('real registry: every severity is the bare enum (no compound text)', () => {
+    const reg = loadRegistry(REGISTRY_PATH);
+    for (const p of reg.patterns) {
+      assert.ok(['block', 'warn'].includes(p.severity),
+        `${p.id} severity must be 'block' or 'warn', got '${p.severity}'`);
+    }
+  });
 });
 
 describe('compileRegistry', () => {
@@ -223,6 +286,21 @@ describe('decideAction', () => {
   it('block-severity + tier_3_only escalation + strict → warn (defer to Tier 3)', () => {
     const r = decideAction([{ id: 'C3', severity: 'block', escalation: ['tier_3_only'] }], { strict: true });
     assert.strictEqual(r.action, 'warn');
+  });
+
+  it('PR #122 review repro — real-registry C3 hit + strict → warn (not block)', () => {
+    // Reviewer's exact repro:
+    //   const c3 = r.patterns.find(p => p.id === 'C3');
+    //   const hits = scanContent('console.log("INV-123 PASS");', [c3]);
+    //   decideAction(hits, {strict: true}).action  // should be 'warn', was 'block'
+    // Root cause: parser dropped the `tier_3_only` escalation due to trailing prose.
+    const reg = loadRegistry(REGISTRY_PATH);
+    const c3 = reg.patterns.find(p => p.id === 'C3');
+    const hits = scanContent('console.log("INV-123 PASS");', [c3]);
+    assert.ok(hits.length > 0, 'C3 must match the silent INV PASS pattern');
+    const decision = decideAction(hits, { strict: true });
+    assert.strictEqual(decision.action, 'warn');
+    assert.deepStrictEqual(decision.blocking, []);
   });
 });
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -104,6 +104,16 @@
         ]
       },
       {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/mpl-fallback-grep.mjs\"",
+            "timeout": 5
+          }
+        ]
+      },
+      {
         "matcher": "Task|Agent",
         "hooks": [
           {

--- a/hooks/lib/anti-pattern-registry.mjs
+++ b/hooks/lib/anti-pattern-registry.mjs
@@ -1,0 +1,264 @@
+/**
+ * Anti-pattern registry parser + scanner (F2/F3 single-source consumer).
+ *
+ * Parses commands/references/anti-patterns.md per the BNF grammar declared in
+ * §"F3 / F4 parsing contract" of that file:
+ *
+ *   pattern    := heading frontmatter regex_block permitted_block
+ *   heading    := "### " ID " · " Title
+ *   frontmatter:= bullet list of: id | category | severity | escalation? | rationale | ground_truth_count
+ *   regex_block:= ```regex ... ```
+ *   permitted  := ```permitted-when ... ```
+ *
+ * Plus parses §"## Scope" path-extension allowlist so consumers can apply the
+ * filter BEFORE regex compilation (self-application contract: markdown / config
+ * files are never scanned, eliminating registry-self-fail).
+ */
+
+import { readFileSync } from 'fs';
+import { extname } from 'path';
+
+/**
+ * Parse the registry markdown into a structured shape.
+ *
+ * @param {string} md - markdown content
+ * @returns {{
+ *   scope: { allowed: Set<string>, excluded: Set<string> },
+ *   patterns: Array<{
+ *     id: string, title: string, category: string,
+ *     severity: 'block' | 'warn',
+ *     escalation: string[],
+ *     rationale: string,
+ *     groundTruthCount: string,
+ *     regexLines: string[],
+ *     permittedWhen: string,
+ *   }>
+ * }}
+ */
+export function parseRegistry(md) {
+  const lines = md.split('\n');
+
+  // 1. Scope blocks: fenced ```scope and ```scope-excluded
+  const scope = { allowed: new Set(), excluded: new Set() };
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i].trim();
+    if (line === '```scope' || line === '```scope-excluded') {
+      const target = line === '```scope' ? scope.allowed : scope.excluded;
+      i++;
+      while (i < lines.length && !lines[i].trim().startsWith('```')) {
+        const tokens = lines[i].split(/\s+/).filter(Boolean);
+        for (const t of tokens) {
+          // Skip comments
+          if (t.startsWith('#')) break;
+          // Take leading dot-extension or wildcard pattern
+          if (t.startsWith('.')) target.add(t);
+          else if (t.includes('*')) target.add(t);
+        }
+        i++;
+      }
+    }
+    i++;
+  }
+
+  // 2. Patterns: walk ### headings
+  const patterns = [];
+  i = 0;
+  while (i < lines.length) {
+    const m = lines[i].match(/^### ([A-Za-z0-9.]+) · (.+)$/);
+    if (!m) { i++; continue; }
+    const pat = {
+      id: m[1],
+      title: m[2].trim(),
+      category: '',
+      severity: 'warn',
+      escalation: [],
+      rationale: '',
+      groundTruthCount: '',
+      regexLines: [],
+      permittedWhen: '',
+    };
+    i++;
+    // Front matter bullets until first fenced block or next heading
+    while (i < lines.length) {
+      const l = lines[i];
+      if (l.startsWith('### ') || l.startsWith('```regex') || l.startsWith('```permitted-when')) break;
+      const bm = l.match(/^- \*\*([\w\s-]+)\*\*:?\s*[`]?([^`\n]*?)[`]?\s*$/);
+      if (bm) {
+        const key = bm[1].trim().toLowerCase().replace(/\s+/g, '_');
+        const val = bm[2].trim();
+        if (key === 'id') pat.id = val || pat.id;
+        else if (key === 'category') pat.category = val;
+        else if (key === 'severity') pat.severity = val.replace(/[`]/g, '').trim();
+        else if (key === 'escalation') pat.escalation = parseEscalation(val);
+        else if (key === 'rationale') pat.rationale = val;
+        else if (key === 'ground-truth_count' || key === 'ground_truth_count' || key === 'ground-truth_source' || key === 'ground_truth_source') pat.groundTruthCount = val;
+      }
+      i++;
+    }
+    // regex block
+    if (i < lines.length && lines[i].startsWith('```regex')) {
+      i++;
+      while (i < lines.length && !lines[i].startsWith('```')) {
+        const rl = lines[i].trim();
+        if (rl) pat.regexLines.push(rl);
+        i++;
+      }
+      i++; // closing ```
+    }
+    // permitted-when block (may be after regex, may not exist)
+    while (i < lines.length && !lines[i].startsWith('```permitted-when') && !lines[i].startsWith('### ')) i++;
+    if (i < lines.length && lines[i].startsWith('```permitted-when')) {
+      i++;
+      const buf = [];
+      while (i < lines.length && !lines[i].startsWith('```')) {
+        buf.push(lines[i]);
+        i++;
+      }
+      pat.permittedWhen = buf.join('\n').trim();
+      i++; // closing ```
+    }
+    patterns.push(pat);
+  }
+
+  return { scope, patterns };
+}
+
+function parseEscalation(val) {
+  // Escalation prose may reference: tier_3_only, strict_block, tier_3_block_in: <selector>
+  const tokens = [];
+  if (/tier_3_only/i.test(val)) tokens.push('tier_3_only');
+  if (/strict_block/i.test(val)) tokens.push('strict_block');
+  const m = val.match(/tier_3_block_in:\s*([\w-]+)/i);
+  if (m) tokens.push(`tier_3_block_in:${m[1]}`);
+  return tokens;
+}
+
+/**
+ * Compile the parsed pattern set into a runtime-ready shape with RegExp objects.
+ * Invalid regexes are dropped silently with a count returned for diagnostics.
+ *
+ * @param {ReturnType<typeof parseRegistry>} parsed
+ * @returns {{ patterns: Array<{...parsed.patterns[number], compiled: RegExp[]}>, scope: typeof parsed.scope, dropped: number }}
+ */
+export function compileRegistry(parsed) {
+  let dropped = 0;
+  const patterns = parsed.patterns.map(p => {
+    const compiled = [];
+    for (const rl of p.regexLines) {
+      try { compiled.push(new RegExp(rl, 'gm')); }
+      catch { dropped++; }
+    }
+    return { ...p, compiled };
+  });
+  return { patterns, scope: parsed.scope, dropped };
+}
+
+/**
+ * Determine whether a file path is in scope for registry enforcement.
+ * Path extension allowlist + explicit excluded-pattern check.
+ *
+ * @param {string} filePath - absolute or workspace-relative path
+ * @param {{ allowed: Set<string>, excluded: Set<string> }} scope
+ * @returns {boolean}
+ */
+export function isInScope(filePath, scope) {
+  if (!filePath) return false;
+  const ext = extname(filePath).toLowerCase();
+  if (!scope.allowed.has(ext)) return false;
+  // Excluded glob-like patterns: *.test.{ts,tsx,js,jsx,mjs}
+  for (const exc of scope.excluded) {
+    if (matchesGlob(filePath, exc)) return false;
+  }
+  // Explicitly exclude self-application surfaces (registry doc + agent prompts)
+  if (/commands\/references\/anti-patterns\.md$/.test(filePath)) return false;
+  if (/agents\/[^/]+\.md$/.test(filePath)) return false;
+  return true;
+}
+
+function matchesGlob(filePath, pattern) {
+  if (!pattern.includes('*') && !pattern.includes('{')) return false;
+  // Translate { , } alternation into regex group, * into [^/]+
+  let re = pattern
+    .replace(/\./g, '\\.')
+    .replace(/\{([^}]+)\}/g, (_, alts) => '(' + alts.split(',').map(s => s.trim()).join('|') + ')')
+    .replace(/\*/g, '[^/]+');
+  return new RegExp(re + '$').test(filePath);
+}
+
+/**
+ * Scan file content against compiled patterns. Returns hits keyed by pattern id.
+ *
+ * @param {string} content - file content
+ * @param {ReturnType<typeof compileRegistry>['patterns']} patterns
+ * @returns {Array<{ id: string, severity: string, escalation: string[], line: number, snippet: string, regex: string }>}
+ */
+export function scanContent(content, patterns) {
+  const hits = [];
+  for (const p of patterns) {
+    for (let i = 0; i < p.compiled.length; i++) {
+      const re = new RegExp(p.compiled[i].source, p.compiled[i].flags);
+      let m;
+      let safety = 0;
+      while ((m = re.exec(content)) && safety++ < 200) {
+        const before = content.slice(0, m.index);
+        const line = (before.match(/\n/g) || []).length + 1;
+        hits.push({
+          id: p.id,
+          severity: p.severity,
+          escalation: p.escalation,
+          line,
+          snippet: m[0].slice(0, 200).replace(/\n/g, ' '),
+          regex: p.regexLines[i],
+        });
+        if (m.index === re.lastIndex) re.lastIndex++; // zero-length match safety
+      }
+    }
+  }
+  return hits;
+}
+
+/**
+ * Decide hook outcome from hits + strict mode.
+ *
+ * Tier 1 (this hook) is observational — it can't evaluate semantic permitted-when
+ * exceptions. Default behavior is `warn` for any match. In strict mode, severity:block
+ * patterns NOT marked tier_3_only escalate to actual `block`. Tier 3 (#112) is the
+ * authoritative consumer for nuanced permitted-when handling.
+ *
+ * @param {ReturnType<typeof scanContent>} hits
+ * @param {{ strict: boolean }} opts
+ * @returns {{ action: 'silent' | 'warn' | 'block', summary: string, blocking: typeof hits }}
+ */
+export function decideAction(hits, opts = {}) {
+  if (hits.length === 0) return { action: 'silent', summary: '', blocking: [] };
+  const strict = opts.strict === true;
+  const blocking = strict
+    ? hits.filter(h => h.severity === 'block' && !h.escalation.includes('tier_3_only'))
+    : [];
+  if (blocking.length > 0) {
+    const ids = [...new Set(blocking.map(h => h.id))].join(', ');
+    return {
+      action: 'block',
+      summary: `Anti-pattern violation (strict mode): ${ids}. ${blocking.length} match(es). See commands/references/anti-patterns.md for permitted-when exceptions.`,
+      blocking,
+    };
+  }
+  const ids = [...new Set(hits.map(h => h.id))].join(', ');
+  return {
+    action: 'warn',
+    summary: `[MPL anti-pattern] ${hits.length} match(es): ${ids}. Tier 1 advisory — review against commands/references/anti-patterns.md permitted-when before declaring TODO complete.`,
+    blocking: [],
+  };
+}
+
+/**
+ * Convenience: load + parse + compile from a registry file path.
+ *
+ * @param {string} registryPath
+ * @returns {ReturnType<typeof compileRegistry>}
+ */
+export function loadRegistry(registryPath) {
+  const md = readFileSync(registryPath, 'utf-8');
+  return compileRegistry(parseRegistry(md));
+}

--- a/hooks/lib/anti-pattern-registry.mjs
+++ b/hooks/lib/anti-pattern-registry.mjs
@@ -79,17 +79,27 @@ export function parseRegistry(md) {
       permittedWhen: '',
     };
     i++;
-    // Front matter bullets until first fenced block or next heading
+    // Front matter bullets until first fenced block or next heading.
+    // PR #122 review fix: previous regex required `\s*$` after the optional closing
+    // backtick, dropping any line with trailing prose (e.g. `- **escalation**:
+    // \`tier_3_only\` (Tier 1 emits warn only ...)`). The registry intentionally
+    // mixes backticked canonical values with explanatory prose, so the parser must
+    // accept both forms.
     while (i < lines.length) {
       const l = lines[i];
       if (l.startsWith('### ') || l.startsWith('```regex') || l.startsWith('```permitted-when')) break;
-      const bm = l.match(/^- \*\*([\w\s-]+)\*\*:?\s*[`]?([^`\n]*?)[`]?\s*$/);
+      const bm = l.match(/^- \*\*([\w\s-]+)\*\*:?\s*(.*)$/);
       if (bm) {
         const key = bm[1].trim().toLowerCase().replace(/\s+/g, '_');
-        const val = bm[2].trim();
+        const rest = bm[2].trim();
+        // Extract first backticked code-span as canonical value when present.
+        // Backticked = id/category/severity/escalation. Plain prose = rationale,
+        // ground-truth count (which may begin with a number then prose).
+        const tickMatch = rest.match(/^`([^`]+)`/);
+        const val = tickMatch ? tickMatch[1].trim() : rest;
         if (key === 'id') pat.id = val || pat.id;
         else if (key === 'category') pat.category = val;
-        else if (key === 'severity') pat.severity = val.replace(/[`]/g, '').trim();
+        else if (key === 'severity') pat.severity = val;
         else if (key === 'escalation') pat.escalation = parseEscalation(val);
         else if (key === 'rationale') pat.rationale = val;
         else if (key === 'ground-truth_count' || key === 'ground_truth_count' || key === 'ground-truth_source' || key === 'ground_truth_source') pat.groundTruthCount = val;

--- a/hooks/mpl-fallback-grep.mjs
+++ b/hooks/mpl-fallback-grep.mjs
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+/**
+ * MPL Fallback Grep Hook (PostToolUse on Edit|Write|MultiEdit)
+ *
+ * F3 (#105). Tier 1 anti-pattern observer per commands/references/anti-patterns.md.
+ * Path-extension scope filter applied BEFORE regex compile. Hits are appended to
+ * `.mpl/signals/anti-pattern-hits.jsonl` for Tier 3 (#112 F5) and adversarial
+ * reviewer (#103 P0-A) to consume. Strict mode (#110 P0-2:
+ * `state.enforcement.strict`) escalates `severity: block` matches to actual block;
+ * default emits a `system-reminder` warn.
+ *
+ * Self-application contract (PR #120 review): markdown / config files are filtered
+ * by extension allowlist before any regex compiles. The registry doc and agent
+ * prompts are explicitly excluded so F3/F4 cannot self-fail on the registry's own
+ * literal example occurrences.
+ */
+
+import { dirname, join, resolve, relative } from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+import { existsSync, readFileSync, mkdirSync, appendFileSync } from 'fs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const { isMplActive, readState } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-state.mjs')).href
+);
+const { readStdin } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'stdin.mjs')).href
+);
+const { loadRegistry, isInScope, scanContent, decideAction } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'anti-pattern-registry.mjs')).href
+);
+
+const REGISTRY_RELATIVE = 'commands/references/anti-patterns.md';
+const SIGNALS_RELATIVE = '.mpl/signals/anti-pattern-hits.jsonl';
+
+function silent() {
+  console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+}
+
+function workspaceRel(cwd, abs) {
+  const cwdAbs = resolve(cwd);
+  const path = resolve(abs);
+  return path.startsWith(cwdAbs + '/') ? path.slice(cwdAbs.length + 1) : abs;
+}
+
+function logHits(cwd, file, hits, action) {
+  if (hits.length === 0) return;
+  const sigDir = join(cwd, '.mpl', 'signals');
+  try { mkdirSync(sigDir, { recursive: true }); } catch {}
+  const ts = new Date().toISOString();
+  const lines = hits.map(h => JSON.stringify({
+    ts,
+    file,
+    id: h.id,
+    severity: h.severity,
+    escalation: h.escalation,
+    line: h.line,
+    snippet: h.snippet,
+    regex: h.regex,
+    action,
+  })).join('\n') + '\n';
+  try { appendFileSync(join(cwd, SIGNALS_RELATIVE), lines); } catch {}
+}
+
+async function main() {
+  const input = await readStdin();
+
+  let data;
+  try { data = JSON.parse(input); } catch { return silent(); }
+
+  const toolName = data.tool_name || data.toolName || '';
+  if (!['Edit', 'edit', 'Write', 'write', 'MultiEdit', 'multiEdit'].includes(toolName)) {
+    return silent();
+  }
+
+  const cwd = data.cwd || data.directory || process.cwd();
+  if (!isMplActive(cwd)) return silent();
+
+  const toolInput = data.tool_input || data.toolInput || {};
+  // Collect file paths — Edit/Write give one, MultiEdit gives multiple via edits[]
+  const filePaths = [];
+  if (toolInput.file_path) filePaths.push(toolInput.file_path);
+  else if (toolInput.filePath) filePaths.push(toolInput.filePath);
+  if (Array.isArray(toolInput.edits)) {
+    for (const e of toolInput.edits) {
+      if (e?.file_path) filePaths.push(e.file_path);
+      else if (e?.filePath) filePaths.push(e.filePath);
+    }
+  }
+  if (filePaths.length === 0) return silent();
+
+  // Locate registry — relative to plugin root (this file lives at hooks/, registry at commands/references/)
+  const pluginRoot = resolve(__dirname, '..');
+  const registryPath = join(pluginRoot, REGISTRY_RELATIVE);
+  if (!existsSync(registryPath)) return silent();
+
+  let registry;
+  try { registry = loadRegistry(registryPath); }
+  catch { return silent(); }
+
+  const state = readState(cwd) || {};
+  const strict = state.enforcement && state.enforcement.strict === true;
+
+  const allHits = [];
+  const blockingDetails = [];
+  for (const fp of filePaths) {
+    const abs = resolve(cwd, fp);
+    if (!isInScope(abs, registry.scope)) continue;
+    if (!existsSync(abs)) continue;
+    let content;
+    try { content = readFileSync(abs, 'utf-8'); } catch { continue; }
+    const hits = scanContent(content, registry.patterns);
+    const decision = decideAction(hits, { strict });
+    const rel = workspaceRel(cwd, abs);
+    logHits(cwd, rel, hits, decision.action);
+    if (hits.length > 0) {
+      allHits.push({ file: rel, hits, decision });
+      if (decision.action === 'block') blockingDetails.push({ file: rel, decision });
+    }
+  }
+
+  if (allHits.length === 0) return silent();
+
+  if (blockingDetails.length > 0) {
+    const reasons = blockingDetails.map(b => `${b.file}: ${b.decision.summary}`).join('\n');
+    console.log(JSON.stringify({
+      decision: 'block',
+      reason: `[MPL F3] strict mode anti-pattern block:\n${reasons}`,
+    }));
+    return;
+  }
+
+  const summary = allHits.map(h => `${h.file}: ${h.decision.summary}`).join('\n');
+  console.log(JSON.stringify({
+    continue: true,
+    systemMessage: `[MPL F3] Tier 1 anti-pattern advisory:\n${summary}`,
+  }));
+}
+
+await main().catch(() => silent());


### PR DESCRIPTION
## Summary

F2 (#104) registry 의 첫 consumer. PostToolUse Edit|Write|MultiEdit 에서 변경된 파일을 grep, hits 를 \`.mpl/signals/anti-pattern-hits.jsonl\` 에 기록 + system-reminder warn (default) / block (strict). Tier 3 (#112 F5) 와 adversarial-reviewer (#103 P0-A) 가 JSONL 을 consume 하여 authoritative block 결정.

## Architecture

**Library 분리** — \`hooks/lib/anti-pattern-registry.mjs\`:
- pure functions, testable in isolation
- \`parseRegistry\`, \`compileRegistry\`, \`isInScope\`, \`scanContent\`, \`decideAction\`, \`loadRegistry\`
- BNF grammar (registry §"F3 / F4 parsing contract") 따라 markdown 파싱

**Hook thin wrapper** — \`hooks/mpl-fallback-grep.mjs\`:
- PostToolUse Edit|Write|MultiEdit (5s timeout)
- Edit/Write \`tool_input.file_path\` + MultiEdit \`tool_input.edits[].file_path\` 모두 처리
- path-extension scope filter **regex compile 전에** 적용 (self-application contract)
- 결과는 JSONL append + 즉시 응답

## Decision matrix (Tier 1)

| Hits | Severity / Escalation | strict | Action |
|------|----------------------|--------|--------|
| 0 | — | — | silent |
| ≥1 | severity=block, 일반 | true | **block** (decision='block', reason 포함) |
| ≥1 | severity=block, tier_3_only | true | warn (Tier 3 #112 가 authoritative) |
| ≥1 | severity=warn, 일반 | true | warn (Tier 1 의 prose permitted-when 평가 불가, 보수적) |
| ≥1 | 모두 | false | warn (continue + systemMessage) |

Tier 1 은 보수적 — prose \`permitted-when\` 평가 불가하므로 strict 에서도 severity=warn 패턴은 warn 유지. authoritative block 결정은 Tier 3 (#112 F5) 가 file-scope-aware 로 처리.

## Self-application contract (PR #120 review)

3 layers:
1. **Path-extension allowlist** (\`isInScope\`): \`.mjs/.cjs/.ts/.tsx/.py/.rs/...\` 만 enforcement 대상
2. **Excluded glob**: \`*.test.{ts,tsx,js,jsx,mjs}\` 자동 제외 (테스트 fixture 의 literal anti-pattern 예시)
3. **명시적 self-doc 차단**: \`commands/references/anti-patterns.md\` (registry) + \`agents/*.md\` (prompts)

→ regex compile 전에 filter 적용 → registry/agent prompt 가 자기 자신을 신고하지 않음. \`/tmp/registry-self-check.mjs\` smoke 도 동일 결과 확인 (test path hits 는 isInScope 에서 차단).

## JSONL signal format

\`.mpl/signals/anti-pattern-hits.jsonl\` 한 줄당:
\`\`\`json
{"ts": "ISO-8601", "file": "src/foo.ts", "id": "TC1", "severity": "block", "escalation": ["tier_3_block_in:production"], "line": 42, "snippet": "expect(true).toBe(true)", "regex": "expect\\\\s*\\\\(\\\\s*true...", "action": "warn"}
\`\`\`

Tier 3 (#112) 와 adversarial-reviewer (#103) 가 본 JSONL 을 입력으로 사용.

## Tests (30 신규, 361/361 hook regression pass)

**Library unit tests**:
- [x] parseRegistry: scope blocks, pattern frontmatter+regex+permitted, 실제 registry → **10 패턴 정확 파싱**, dropped=0 으로 컴파일
- [x] isInScope: allowlist accept (.mjs/.ts), blocklist reject (.md/.json), \`*.test.{ts,tsx}\` glob, registry doc 자기-제외
- [x] scanContent: TC1 positive/negative, M1 (\`as unknown as\`) match, D2 (\`.catch(() => false)\`) match, D1.b synthetic-id match, clean source 0 hits, line/snippet 정확
- [x] decideAction: silent/warn/block 5 cases (strict toggle, tier_3_only escalation, severity 분기)

**Hook integration tests** (\`execFileSync\` real Edit/Write):
- [x] Bash 같은 비-Edit 툴 → silent
- [x] Edit on .md (registry self-doc) → silent (path-extension excluded)
- [x] Edit on .ts with TC1 violation → warn (non-strict)
- [x] Edit on .ts with TC1 violation + strict → block (decision='block')
- [x] Edit on clean .ts → silent
- [x] Edit on .ts with M1 + strict → 여전히 warn (Tier 1 한계 검증)
- [x] JSONL 기록 확인
- [x] MPL 비활성 → silent

## Files

- \`hooks/lib/anti-pattern-registry.mjs\` — 신규 250 lines (pure-function library)
- \`hooks/mpl-fallback-grep.mjs\` — 신규 130 lines (thin hook)
- \`hooks/__tests__/mpl-fallback-grep.test.mjs\` — 신규 270 lines (30 tests)
- \`hooks/hooks.json\` — PostToolUse Edit|Write|MultiEdit 매처 추가

## Related

- Closes part of #101 (v0.18.0 critical enforcement)
- Closes #105
- Source consumer: F2 (#104) registry
- Downstream consumers (planned PRs): #112 F5 (Tier 3 property-check), #117 F6 (Tier 4 codex auditor) 모두 본 JSONL signal 을 입력으로 사용

🤖 Generated with [Claude Code](https://claude.com/claude-code)