### PR TITLE
feat(#107): G1 — Bash verification timeout 강제 (mpl-bash-timeout.mjs)

### DIFF
--- a/agents/mpl-phase-runner.md
+++ b/agents/mpl-phase-runner.md
@@ -21,9 +21,9 @@ disallowedTools: []
     - Edit/Write are allowed: Phase Runner uses them for working.md, state updates, and direct code implementation.
     - **Bash timeout (G1, #107)** — verification commands MUST set `tool_input.timeout` (ms) within the category bounds enforced by `mpl-bash-timeout.mjs`:
       - vitest / jest / npm test: 60_000–300_000 ms (recommend 300_000)
-      - playwright / pw test: 60_000–600_000 ms (recommend 600_000)
-      - tsc / vite build / cargo build: 30_000–180_000 ms
-      - tsc --noEmit / eslint / ruff / pyright / mypy: 10_000–120_000 ms
+      - playwright / npx playwright test: 60_000–600_000 ms (recommend 600_000)
+      - tsc / vite build / cargo build / gradle / mvn: 30_000–180_000 ms
+      - tsc --noEmit / eslint / biome / ruff / flake8 / pyright / mypy / py_compile / cargo check / npm run typecheck|lint: 10_000–120_000 ms
       Strict mode (`state.enforcement.strict === true`) hard-blocks under-spec'd or over-spec'd timeouts; non-strict warns. Untimed verification accumulates 5h fix-loop walls (exp15 phase-10).
   </Constraints>
 

--- a/agents/mpl-phase-runner.md
+++ b/agents/mpl-phase-runner.md
@@ -19,6 +19,12 @@ disallowedTools: []
     - **No state.json modification** — orchestrator manages pipeline state.
     - **PD Override**: never silently change a prior phase's decision. Create an explicit override request.
     - Edit/Write are allowed: Phase Runner uses them for working.md, state updates, and direct code implementation.
+    - **Bash timeout (G1, #107)** — verification commands MUST set `tool_input.timeout` (ms) within the category bounds enforced by `mpl-bash-timeout.mjs`:
+      - vitest / jest / npm test: 60_000–300_000 ms (recommend 300_000)
+      - playwright / pw test: 60_000–600_000 ms (recommend 600_000)
+      - tsc / vite build / cargo build: 30_000–180_000 ms
+      - tsc --noEmit / eslint / ruff / pyright / mypy: 10_000–120_000 ms
+      Strict mode (`state.enforcement.strict === true`) hard-blocks under-spec'd or over-spec'd timeouts; non-strict warns. Untimed verification accumulates 5h fix-loop walls (exp15 phase-10).
   </Constraints>
 
   <Execution_Flow>

--- a/hooks/__tests__/mpl-bash-timeout.test.mjs
+++ b/hooks/__tests__/mpl-bash-timeout.test.mjs
@@ -1,0 +1,205 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { tmpdir } from 'os';
+
+import {
+  CATEGORIES,
+  classifyCommand,
+  decideTimeout,
+} from '../lib/bash-timeout-categories.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const HOOK_PATH = join(dirname(__filename), '..', 'mpl-bash-timeout.mjs');
+
+describe('classifyCommand', () => {
+  it('classifies vitest / jest / npm test', () => {
+    assert.strictEqual(classifyCommand('vitest run').name, 'vitest-jest');
+    assert.strictEqual(classifyCommand('npx jest --watch=false').name, 'vitest-jest');
+    assert.strictEqual(classifyCommand('npm test').name, 'vitest-jest');
+    assert.strictEqual(classifyCommand('pnpm run test').name, 'vitest-jest');
+  });
+
+  it('classifies playwright', () => {
+    assert.strictEqual(classifyCommand('npx playwright test').name, 'playwright');
+    assert.strictEqual(classifyCommand('playwright test').name, 'playwright');
+    assert.strictEqual(classifyCommand('pw test').name, 'playwright');
+  });
+
+  it('classifies build commands', () => {
+    assert.strictEqual(classifyCommand('tsc').name, 'build');
+    assert.strictEqual(classifyCommand('vite build').name, 'build');
+    assert.strictEqual(classifyCommand('cargo build --release').name, 'build');
+    assert.strictEqual(classifyCommand('npm run build').name, 'build');
+  });
+
+  it('classifies typecheck/lint (tsc --noEmit / eslint / ruff)', () => {
+    assert.strictEqual(classifyCommand('tsc --noEmit').name, 'typecheck-lint');
+    assert.strictEqual(classifyCommand('npx eslint src/').name, 'typecheck-lint');
+    assert.strictEqual(classifyCommand('ruff check .').name, 'typecheck-lint');
+  });
+
+  it('returns null for non-verification commands', () => {
+    assert.strictEqual(classifyCommand('ls -la'), null);
+    assert.strictEqual(classifyCommand('git status'), null);
+    assert.strictEqual(classifyCommand('echo hello'), null);
+    assert.strictEqual(classifyCommand(''), null);
+    assert.strictEqual(classifyCommand(null), null);
+  });
+
+  it('disambiguates tsc (build) vs tsc --noEmit (typecheck)', () => {
+    // tsc with no flags → build category (emits files, longer timeout)
+    assert.strictEqual(classifyCommand('tsc').name, 'build');
+    assert.strictEqual(classifyCommand('tsc -p tsconfig.json').name, 'build');
+    // tsc --noEmit → typecheck (faster, lower ceiling)
+    assert.strictEqual(classifyCommand('tsc --noEmit').name, 'typecheck-lint');
+  });
+
+  it('first-match wins (playwright before vitest-jest)', () => {
+    // A theoretical command that matches both: playwright should win because it's narrower
+    // (Real example: "npx playwright test" matches playwright pattern, not the npm-test one)
+    const c = classifyCommand('npx playwright test');
+    assert.strictEqual(c.name, 'playwright');
+  });
+});
+
+describe('decideTimeout', () => {
+  it('non-verification command → silent', () => {
+    const r = decideTimeout('ls -la', undefined);
+    assert.strictEqual(r.action, 'silent');
+    assert.strictEqual(r.category, null);
+  });
+
+  it('vitest + no timeout (non-strict) → warn with recommended', () => {
+    const r = decideTimeout('vitest run', undefined, { strict: false });
+    assert.strictEqual(r.action, 'warn');
+    assert.strictEqual(r.category, 'vitest-jest');
+    assert.strictEqual(r.recommendedMs, 300_000);
+    assert.match(r.reason, /needs an explicit timeout/);
+  });
+
+  it('vitest + no timeout (strict) → block', () => {
+    const r = decideTimeout('vitest run', undefined, { strict: true });
+    assert.strictEqual(r.action, 'block');
+    assert.strictEqual(r.recommendedMs, 300_000);
+  });
+
+  it('vitest + timeout in range → silent', () => {
+    const r = decideTimeout('vitest run', 240_000);
+    assert.strictEqual(r.action, 'silent');
+  });
+
+  it('vitest + timeout below sanity floor → warn (typo guard)', () => {
+    // 200 ms is almost certainly a typo for 200000 ms
+    const r = decideTimeout('vitest run', 200);
+    assert.strictEqual(r.action, 'warn');
+    assert.match(r.reason, /below the sanity floor/);
+  });
+
+  it('vitest + timeout above ceiling (non-strict) → warn', () => {
+    const r = decideTimeout('vitest run', 1_200_000);  // 20 min
+    assert.strictEqual(r.action, 'warn');
+    assert.match(r.reason, /exceeds the per-call ceiling/);
+  });
+
+  it('vitest + timeout above ceiling (strict) → block', () => {
+    const r = decideTimeout('vitest run', 1_200_000, { strict: true });
+    assert.strictEqual(r.action, 'block');
+  });
+
+  it('playwright timeout up to 600000ms accepted', () => {
+    assert.strictEqual(decideTimeout('npx playwright test', 600_000).action, 'silent');
+    assert.strictEqual(decideTimeout('npx playwright test', 599_999).action, 'silent');
+    assert.strictEqual(decideTimeout('npx playwright test', 600_001, { strict: true }).action, 'block');
+  });
+
+  it('build (tsc) within 30s-180s window', () => {
+    assert.strictEqual(decideTimeout('tsc', 60_000).action, 'silent');
+    assert.strictEqual(decideTimeout('tsc', 200_000, { strict: true }).action, 'block');
+    assert.strictEqual(decideTimeout('tsc', 5_000).action, 'warn');  // below floor
+  });
+
+  it('typecheck-lint within 10s-120s window', () => {
+    assert.strictEqual(decideTimeout('tsc --noEmit', 60_000).action, 'silent');
+    assert.strictEqual(decideTimeout('eslint src/', 30_000).action, 'silent');
+    assert.strictEqual(decideTimeout('eslint src/', 200_000, { strict: true }).action, 'block');
+  });
+
+  it('rejects bogus timeout values (negative, NaN, 0)', () => {
+    // These all act as "missing" → warn with recommended
+    assert.strictEqual(decideTimeout('vitest run', 0).action, 'warn');
+    assert.strictEqual(decideTimeout('vitest run', -100).action, 'warn');
+    assert.strictEqual(decideTimeout('vitest run', NaN).action, 'warn');
+  });
+});
+
+describe('mpl-bash-timeout hook integration', () => {
+  let tmpDir;
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'mpl-bashtimeout-'));
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    writeFileSync(join(tmpDir, '.mpl', 'state.json'), JSON.stringify({ current_phase: 'phase2-sprint' }));
+  });
+  afterEach(() => rmSync(tmpDir, { recursive: true, force: true }));
+
+  function runHook(toolName, toolInput, extraState) {
+    if (extraState) {
+      const state = JSON.parse(readFileSync(join(tmpDir, '.mpl', 'state.json'), 'utf-8'));
+      writeFileSync(join(tmpDir, '.mpl', 'state.json'), JSON.stringify({ ...state, ...extraState }));
+    }
+    const stdin = JSON.stringify({
+      cwd: tmpDir,
+      tool_name: toolName,
+      tool_input: toolInput,
+    });
+    const out = execFileSync('node', [HOOK_PATH], { input: stdin, encoding: 'utf-8' });
+    return JSON.parse(out);
+  }
+
+  it('non-Bash tool → silent', () => {
+    const r = runHook('Edit', { file_path: '/tmp/foo.ts', new_string: 'x', old_string: 'y' });
+    assert.strictEqual(r.continue, true);
+    assert.strictEqual(r.suppressOutput, true);
+  });
+
+  it('non-verification command (ls) → silent', () => {
+    const r = runHook('Bash', { command: 'ls -la' });
+    assert.strictEqual(r.continue, true);
+    assert.strictEqual(r.suppressOutput, true);
+  });
+
+  it('vitest without timeout (non-strict) → warn (not block)', () => {
+    const r = runHook('Bash', { command: 'vitest run' });
+    assert.strictEqual(r.continue, true);
+    assert.match(r.systemMessage, /vitest-jest command needs an explicit timeout/);
+    assert.notStrictEqual(r.decision, 'block');
+  });
+
+  it('vitest without timeout + strict → block', () => {
+    const r = runHook('Bash', { command: 'vitest run' }, { enforcement: { strict: true } });
+    assert.strictEqual(r.decision, 'block');
+    assert.match(r.reason, /vitest-jest command needs an explicit timeout/);
+  });
+
+  it('vitest with sane timeout → silent', () => {
+    const r = runHook('Bash', { command: 'vitest run --silent', timeout: 300_000 });
+    assert.strictEqual(r.continue, true);
+    assert.strictEqual(r.suppressOutput, true);
+  });
+
+  it('playwright without timeout + strict → block', () => {
+    const r = runHook('Bash', { command: 'npx playwright test' }, { enforcement: { strict: true } });
+    assert.strictEqual(r.decision, 'block');
+    assert.match(r.reason, /playwright/);
+  });
+
+  it('MPL not active → silent (no enforcement outside MPL)', () => {
+    rmSync(join(tmpDir, '.mpl'), { recursive: true });
+    const r = runHook('Bash', { command: 'vitest run' });
+    assert.strictEqual(r.continue, true);
+    assert.strictEqual(r.suppressOutput, true);
+  });
+});

--- a/hooks/__tests__/mpl-bash-timeout.test.mjs
+++ b/hooks/__tests__/mpl-bash-timeout.test.mjs
@@ -26,7 +26,13 @@ describe('classifyCommand', () => {
   it('classifies playwright', () => {
     assert.strictEqual(classifyCommand('npx playwright test').name, 'playwright');
     assert.strictEqual(classifyCommand('playwright test').name, 'playwright');
-    assert.strictEqual(classifyCommand('pw test').name, 'playwright');
+    assert.strictEqual(classifyCommand('playwright install').name, 'playwright');
+  });
+
+  it('does NOT match `pw test` (non-standard alias, removed for collision safety)', () => {
+    // `pw` is not the canonical playwright binary; it collides with `pwgen` and other
+    // user aliases. Use `playwright` or `npx playwright` instead.
+    assert.strictEqual(classifyCommand('pw test'), null);
   });
 
   it('classifies build commands', () => {
@@ -34,12 +40,31 @@ describe('classifyCommand', () => {
     assert.strictEqual(classifyCommand('vite build').name, 'build');
     assert.strictEqual(classifyCommand('cargo build --release').name, 'build');
     assert.strictEqual(classifyCommand('npm run build').name, 'build');
+    assert.strictEqual(classifyCommand('./gradlew compileJava').name, 'build');
+    assert.strictEqual(classifyCommand('./gradlew build').name, 'build');
+    assert.strictEqual(classifyCommand('mvn compile -q').name, 'build');
+    assert.strictEqual(classifyCommand('mvn package').name, 'build');
   });
 
   it('classifies typecheck/lint (tsc --noEmit / eslint / ruff)', () => {
     assert.strictEqual(classifyCommand('tsc --noEmit').name, 'typecheck-lint');
     assert.strictEqual(classifyCommand('npx eslint src/').name, 'typecheck-lint');
     assert.strictEqual(classifyCommand('ruff check .').name, 'typecheck-lint');
+  });
+
+  it('classifies MPL gate-generated typecheck-lint commands (#107 review fix)', () => {
+    // commands/mpl-run-execute-gates.md emits these — they MUST be enforced.
+    assert.strictEqual(classifyCommand('npm run typecheck').name, 'typecheck-lint');
+    assert.strictEqual(classifyCommand('pnpm run typecheck').name, 'typecheck-lint');
+    assert.strictEqual(classifyCommand('yarn typecheck').name, 'typecheck-lint');
+    assert.strictEqual(classifyCommand('npm run lint').name, 'typecheck-lint');
+    assert.strictEqual(classifyCommand('cd src-tauri && cargo check').name, 'typecheck-lint');
+    assert.strictEqual(
+      classifyCommand("python -m py_compile $(find . -name '*.py')").name,
+      'typecheck-lint',
+    );
+    assert.strictEqual(classifyCommand('flake8 .').name, 'typecheck-lint');
+    assert.strictEqual(classifyCommand('npx biome check .').name, 'typecheck-lint');
   });
 
   it('returns null for non-verification commands', () => {
@@ -56,6 +81,16 @@ describe('classifyCommand', () => {
     assert.strictEqual(classifyCommand('tsc -p tsconfig.json').name, 'build');
     // tsc --noEmit → typecheck (faster, lower ceiling)
     assert.strictEqual(classifyCommand('tsc --noEmit').name, 'typecheck-lint');
+  });
+
+  it('tsc with intermediate flags + --noEmit anywhere → typecheck-lint (#107 review fix)', () => {
+    // Prior implementation used a negative lookahead that only checked the first token
+    // after `tsc`, so `tsc -p tsconfig.json --noEmit` was misclassified as build.
+    assert.strictEqual(classifyCommand('tsc -p tsconfig.json --noEmit').name, 'typecheck-lint');
+    assert.strictEqual(classifyCommand('tsc --project ./packages/foo --noEmit').name, 'typecheck-lint');
+    assert.strictEqual(classifyCommand('npx tsc -p tsconfig.json --noEmit').name, 'typecheck-lint');
+    // Reverse — `tsc -p ...` without --noEmit is still build
+    assert.strictEqual(classifyCommand('tsc -p tsconfig.json').name, 'build');
   });
 
   it('first-match wins (playwright before vitest-jest)', () => {

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -32,6 +32,16 @@
         ]
       },
       {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/mpl-bash-timeout.mjs\"",
+            "timeout": 3
+          }
+        ]
+      },
+      {
         "matcher": "Edit|Write",
         "hooks": [
           {

--- a/hooks/lib/bash-timeout-categories.mjs
+++ b/hooks/lib/bash-timeout-categories.mjs
@@ -1,0 +1,124 @@
+/**
+ * Bash command category classifier + timeout policy (G1 / #107).
+ *
+ * Maps verification-shaped Bash commands to category bounds. Used by
+ * `mpl-bash-timeout.mjs` PreToolUse hook to enforce sensible timeout windows
+ * (Claude Code default 2 min is fine for short utilities but kills longer
+ * verification — vitest, playwright — prematurely; conversely commands without
+ * any timeout cap can let infinite loops accumulate fix-loop wall time, the
+ * exp15 phase-10 5h shape from v3.10 §6.6 G1).
+ *
+ * Pure functions: easily testable in isolation. Hook is a thin wrapper.
+ */
+
+/**
+ * Category catalog. Commands matching `pattern` get the bounds.
+ * - `minMs`: sanity floor — typo / accidentally low timeout is rejected.
+ * - `maxMs`: ceiling — single-invocation budget. Strict-mode block when exceeded.
+ * - `recommendedMs`: injected as the suggested value when the orchestrator omits timeout.
+ *
+ * Order matters — first match wins. Place narrower patterns first.
+ */
+export const CATEGORIES = [
+  {
+    name: 'playwright',
+    // playwright / pw test / npx playwright test
+    pattern: /\b(?:npx\s+)?(?:playwright|pw)\s+test\b|\bplaywright\s+(?:install|test|debug)\b/,
+    minMs: 60_000,
+    maxMs: 600_000,
+    recommendedMs: 600_000,
+  },
+  {
+    name: 'vitest-jest',
+    // vitest / jest / npm test / pnpm test / yarn test (the latter typically wraps vitest|jest)
+    pattern: /\bvitest\b|\bjest\b|\b(?:npm|pnpm|yarn)\s+(?:run\s+)?test\b/,
+    minMs: 60_000,
+    maxMs: 300_000,
+    recommendedMs: 300_000,
+  },
+  {
+    name: 'build',
+    // tsc (without --noEmit), vite build, cargo build, npm run build, go build
+    pattern: /\btsc\s*$|\btsc\s+(?!--noEmit)|\bvite\s+build\b|\bcargo\s+build\b|\b(?:npm|pnpm|yarn)\s+(?:run\s+)?build\b|\bgo\s+build\b/,
+    minMs: 30_000,
+    maxMs: 180_000,
+    recommendedMs: 180_000,
+  },
+  {
+    name: 'typecheck-lint',
+    // tsc --noEmit, eslint, ruff, pyright, mypy
+    pattern: /\btsc\s+--noEmit\b|\beslint\b|\bruff\b|\bpyright\b|\bmypy\b/,
+    minMs: 10_000,
+    maxMs: 120_000,
+    recommendedMs: 120_000,
+  },
+];
+
+/**
+ * Classify a command into a category. Returns null when no category matches —
+ * such commands get no timeout enforcement (orchestrator decides freely).
+ *
+ * @param {string} command
+ * @returns {(typeof CATEGORIES)[number] | null}
+ */
+export function classifyCommand(command) {
+  if (!command || typeof command !== 'string') return null;
+  for (const c of CATEGORIES) {
+    if (c.pattern.test(command)) return c;
+  }
+  return null;
+}
+
+/**
+ * Decide whether a command + timeout combination is acceptable.
+ *
+ * @param {string} command
+ * @param {number | undefined | null} timeoutMs - tool_input.timeout in milliseconds
+ * @param {{ strict?: boolean }} [opts]
+ * @returns {{
+ *   action: 'silent' | 'warn' | 'block',
+ *   category: string | null,
+ *   reason: string,
+ *   recommendedMs: number | null,
+ * }}
+ */
+export function decideTimeout(command, timeoutMs, opts = {}) {
+  const strict = opts.strict === true;
+  const cat = classifyCommand(command);
+  if (!cat) return { action: 'silent', category: null, reason: '', recommendedMs: null };
+
+  const present = typeof timeoutMs === 'number' && Number.isFinite(timeoutMs) && timeoutMs > 0;
+
+  // Case 1: missing timeout for a verification-shaped command.
+  if (!present) {
+    return {
+      action: strict ? 'block' : 'warn',
+      category: cat.name,
+      reason: `[MPL G1] ${cat.name} command needs an explicit timeout. Add tool_input.timeout=${cat.recommendedMs} (≥${cat.minMs}, ≤${cat.maxMs} ms). exp15 §6.6 G1: untimed verification accumulates 5h fix-loop walls.`,
+      recommendedMs: cat.recommendedMs,
+    };
+  }
+
+  // Case 2: timeout below the sanity floor (likely typo, e.g. 200 instead of 200000).
+  if (timeoutMs < cat.minMs) {
+    return {
+      action: strict ? 'block' : 'warn',
+      category: cat.name,
+      reason: `[MPL G1] ${cat.name} timeout=${timeoutMs}ms is below the sanity floor (${cat.minMs}ms). Likely a typo — bump to ${cat.recommendedMs}ms.`,
+      recommendedMs: cat.recommendedMs,
+    };
+  }
+
+  // Case 3: timeout above the ceiling — clamp request.
+  if (timeoutMs > cat.maxMs) {
+    return {
+      action: strict ? 'block' : 'warn',
+      category: cat.name,
+      reason: `[MPL G1] ${cat.name} timeout=${timeoutMs}ms exceeds the per-call ceiling (${cat.maxMs}ms). Reduce or split the run; persistent over-budget points to fix-loop wall accumulation.`,
+      recommendedMs: cat.maxMs,
+    };
+  }
+
+  // Case 4: in range.
+  return { action: 'silent', category: cat.name, reason: '', recommendedMs: null };
+}

--- a/hooks/lib/bash-timeout-categories.mjs
+++ b/hooks/lib/bash-timeout-categories.mjs
@@ -22,15 +22,19 @@
 export const CATEGORIES = [
   {
     name: 'playwright',
-    // playwright / pw test / npx playwright test
-    pattern: /\b(?:npx\s+)?(?:playwright|pw)\s+test\b|\bplaywright\s+(?:install|test|debug)\b/,
+    // playwright test / npx playwright test / playwright {install,debug}
+    // (`pw` alias intentionally omitted — non-standard, collides with `pwgen` etc.)
+    pattern: /\b(?:npx\s+)?playwright\s+(?:install|test|debug)\b/,
     minMs: 60_000,
     maxMs: 600_000,
     recommendedMs: 600_000,
   },
   {
     name: 'vitest-jest',
-    // vitest / jest / npm test / pnpm test / yarn test (the latter typically wraps vitest|jest)
+    // vitest / jest / npm test / pnpm test / yarn test (the latter typically wraps vitest|jest).
+    // Note: bare `vitest` (no args) defaults to watch mode in dev — keeping it in the
+    // pattern is intentional. Watch hangs are precisely the 5h fix-loop wall G1 guards
+    // against; if phase-runner forgets `run`, classifier still catches it.
     pattern: /\bvitest\b|\bjest\b|\b(?:npm|pnpm|yarn)\s+(?:run\s+)?test\b/,
     minMs: 60_000,
     maxMs: 300_000,
@@ -38,16 +42,18 @@ export const CATEGORIES = [
   },
   {
     name: 'build',
-    // tsc (without --noEmit), vite build, cargo build, npm run build, go build
-    pattern: /\btsc\s*$|\btsc\s+(?!--noEmit)|\bvite\s+build\b|\bcargo\s+build\b|\b(?:npm|pnpm|yarn)\s+(?:run\s+)?build\b|\bgo\s+build\b/,
+    // vite build, cargo build, npm run build, go build, gradle compile/build, maven compile/verify/package.
+    // (tsc is handled in classifyCommand to disambiguate --noEmit anywhere in the command.)
+    pattern: /\bvite\s+build\b|\bcargo\s+build\b|\b(?:npm|pnpm|yarn)\s+(?:run\s+)?build\b|\bgo\s+build\b|\.\/gradlew\s+(?:compile\w*|build|assemble\w*)\b|\bmvn\s+(?:compile|verify|package|install)\b/,
     minMs: 30_000,
     maxMs: 180_000,
     recommendedMs: 180_000,
   },
   {
     name: 'typecheck-lint',
-    // tsc --noEmit, eslint, ruff, pyright, mypy
-    pattern: /\btsc\s+--noEmit\b|\beslint\b|\bruff\b|\bpyright\b|\bmypy\b/,
+    // tsc --noEmit, eslint, biome, ruff, flake8, pyright, mypy, py_compile, cargo check,
+    // npm/pnpm/yarn run {typecheck,lint,check}.
+    pattern: /\beslint\b|\bbiome\s+check\b|\bruff\b|\bflake8\b|\bpyright\b|\bmypy\b|\bpython\s+-m\s+py_compile\b|\bcargo\s+check\b|\b(?:npm|pnpm|yarn)\s+(?:run\s+)?(?:typecheck|lint|check)\b/,
     minMs: 10_000,
     maxMs: 120_000,
     recommendedMs: 120_000,
@@ -63,6 +69,13 @@ export const CATEGORIES = [
  */
 export function classifyCommand(command) {
   if (!command || typeof command !== 'string') return null;
+  // tsc special case: `--noEmit` may appear after `-p tsconfig.json`, `--project`, etc.
+  // Single-pass lookahead (the prior approach) only inspected the token immediately
+  // after `tsc`, misclassifying `tsc -p tsconfig.json --noEmit` as build.
+  if (/\btsc\b/.test(command)) {
+    const name = /--noEmit\b/.test(command) ? 'typecheck-lint' : 'build';
+    return CATEGORIES.find((c) => c.name === name);
+  }
   for (const c of CATEGORIES) {
     if (c.pattern.test(command)) return c;
   }

--- a/hooks/mpl-bash-timeout.mjs
+++ b/hooks/mpl-bash-timeout.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+/**
+ * MPL Bash Timeout Hook (PreToolUse on Bash)
+ *
+ * G1 (#107). Verification-shape Bash commands (vitest, playwright, build, lint)
+ * get category-aware timeout bounds. Without enforcement the orchestrator either
+ * (a) omits timeout and Claude Code's 2-minute default kills legitimate longer
+ * runs, or (b) sets an overly-large timeout that lets infinite loops accumulate
+ * fix-loop wall time (exp15 phase-10 5h shape, v3.10 §6.6 G1).
+ *
+ * Decision matrix (see `lib/bash-timeout-categories.mjs#decideTimeout`):
+ *   - non-verification command → silent allow
+ *   - verification + missing timeout → strict block / non-strict warn (with recommended)
+ *   - verification + timeout < sanity floor → block/warn (typo guard)
+ *   - verification + timeout > ceiling → block/warn (per-call budget)
+ *   - verification + in range → silent allow
+ *
+ * Strict mode = `state.enforcement.strict === true` (#110 P0-2).
+ */
+
+import { dirname, join } from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const { isMplActive, readState } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-state.mjs')).href
+);
+const { readStdin } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'stdin.mjs')).href
+);
+const { decideTimeout } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'bash-timeout-categories.mjs')).href
+);
+
+function silent() {
+  console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+}
+
+async function main() {
+  const input = await readStdin();
+
+  let data;
+  try { data = JSON.parse(input); } catch { return silent(); }
+
+  const toolName = data.tool_name || data.toolName || '';
+  if (!['Bash', 'bash'].includes(toolName)) return silent();
+
+  const cwd = data.cwd || data.directory || process.cwd();
+  if (!isMplActive(cwd)) return silent();
+
+  const toolInput = data.tool_input || data.toolInput || {};
+  const command = toolInput.command || '';
+  const timeoutMs = toolInput.timeout;
+
+  const state = readState(cwd) || {};
+  const strict = state.enforcement && state.enforcement.strict === true;
+
+  const decision = decideTimeout(command, timeoutMs, { strict });
+
+  if (decision.action === 'silent') return silent();
+
+  if (decision.action === 'block') {
+    console.log(JSON.stringify({
+      decision: 'block',
+      reason: decision.reason,
+    }));
+    return;
+  }
+
+  // warn: continue with a system-reminder
+  console.log(JSON.stringify({
+    continue: true,
+    systemMessage: decision.reason,
+  }));
+}
+
+await main().catch(() => silent());


### PR DESCRIPTION
## Summary

신규 PreToolUse Bash hook + 카테고리별 classifier library. verification-shape 명령 (vitest, playwright, build, lint) 의 timeout 을 카테고리별 sanity floor + ceiling 으로 강제. exp15 §6.6 G1 — 미지정/under-spec/over-spec timeout 으로 인한 5h fix-loop wall 누적 직접 방지.

## 카테고리

| Category | Pattern | minMs | maxMs | recommended |
|---|---|---|---|---|
| playwright | \`playwright test\`, \`pw test\`, \`npx playwright test\` | 60_000 | 600_000 | 600_000 |
| vitest-jest | \`vitest\`, \`jest\`, \`npm/pnpm/yarn test\` | 60_000 | 300_000 | 300_000 |
| build | \`tsc\` (no --noEmit), \`vite build\`, \`cargo build\`, \`npm run build\`, \`go build\` | 30_000 | 180_000 | 180_000 |
| typecheck-lint | \`tsc --noEmit\`, \`eslint\`, \`ruff\`, \`pyright\`, \`mypy\` | 10_000 | 120_000 | 120_000 |

비-verification 명령 (\`ls\`, \`git\`, \`echo\` 등) → null 분류 → silent allow.

## Decision matrix

| Case | Default | Strict |
|---|---|---|
| Non-verification command | silent | silent |
| Verification + missing timeout | warn (recommended 명시) | **block** |
| Verification + timeout < minMs (typo guard) | warn | **block** |
| Verification + timeout > maxMs (over-spec) | warn | **block** |
| Verification + timeout in range | silent | silent |

Strict mode = \`state.enforcement.strict === true\` (#110 P0-2 schema).

## Architecture

**Library 분리** (pure-function, testable):
- \`hooks/lib/bash-timeout-categories.mjs\` — \`CATEGORIES\`, \`classifyCommand\`, \`decideTimeout\`

**Hook thin wrapper**:
- \`hooks/mpl-bash-timeout.mjs\` — PreToolUse Bash, state read, decideTimeout, output

**Phase-runner constraint** — \`agents/mpl-phase-runner.md\` Constraints 섹션에 카테고리별 bounds 명시 (prompt-side 도 일치 → orchestrator 가 사전 인지).

## Test plan

**Classifier unit (7)**:
- vitest/jest/npm test/pnpm test 분류
- playwright/pw/npx playwright test 분류
- build (tsc, vite build, cargo build, npm run build) 분류
- typecheck-lint (tsc --noEmit, eslint, ruff) 분류
- non-verification (ls, git, echo) → null
- **tsc vs tsc --noEmit 분리** (build vs typecheck-lint, 모호성 검증)
- first-match 우선 (playwright > npm test 같은 경우)

**Decision unit (11)**:
- non-verification → silent
- vitest no-timeout: warn (non-strict) / block (strict) + recommended 포함
- vitest in-range → silent
- vitest below floor (200ms typo) → warn
- vitest over ceiling (1.2M ms) → warn (non-strict) / block (strict)
- playwright 600_000 boundary, build 30s-180s, typecheck-lint 10s-120s
- bogus values (NaN, negative, 0) → warn

**Hook integration (7, real \`execFileSync\`)**:
- non-Bash tool → silent
- \`ls\` non-verification → silent
- \`vitest run\` no timeout (non-strict) → warn
- \`vitest run\` no timeout + strict → block
- \`vitest run\` with sane timeout → silent
- \`playwright test\` no timeout + strict → block
- MPL inactive → silent

총 25 G1 tests + 전체 hook regression **390/390 pass**.

## Files

- \`hooks/lib/bash-timeout-categories.mjs\` — 신규 110 lines (classifier + decideTimeout)
- \`hooks/mpl-bash-timeout.mjs\` — 신규 80 lines (thin hook)
- \`hooks/__tests__/mpl-bash-timeout.test.mjs\` — 신규 200 lines (25 tests)
- \`hooks/hooks.json\` — PreToolUse Bash 매처 등록 (mpl-write-guard 다음)
- \`agents/mpl-phase-runner.md\` — Constraints 에 카테고리별 timeout bounds 명시

## Related

- Closes part of #101 (v0.18.0 critical enforcement)
- Closes #107
- Companion: #109 G4 (hang detection — \`session_status: verification_hang\`) consumes 본 hook 의 enforcement 결과
- Forward-compatible: #110 P0-2 가 \`state.enforcement.strict\` 토글 도입 시 자동 활성

🤖 Generated with [Claude Code](https://claude.com/claude-code)