### PR TITLE
chore(gitignore): add .resume/ for local session handoff notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ mcp-server/dist/
 .mpl/
 node_modules/
 .omc/
+.resume/


### PR DESCRIPTION
## Summary

Add \`.resume/\` to \`.gitignore\` for local-only cross-session handoff notes.

## Why

긴 작업 (v3.10 P0 enforcement 같은 17 이슈 stream) 진행 중 세션 단절 시 다음 세션이 자기완결적으로 이어가려면:
- 현재 main HEAD / 열린 PR / 회귀 수치
- 이미 land 한 architecture 결정 + 따라야 할 schema contract
- 남은 작업 의존성 + 추천 순서
- 사용자 review protocol

같은 컨텍스트가 한 곳에 정리돼 있어야 함. \`.resume/\` 는 이 용도 전용 로컬 디렉토리.

기존 leading-dot ignored pattern (\`.mpl/\`, \`.claude/\`, \`.omc/\`) 와 동일 컨벤션. 본 PR 후 \`.resume/v3.10-handoff-2026-05-05.md\` 같은 파일이 들어가지만 gitignored 라 commit 되지 않음.

## Files

- \`.gitignore\` — 한 줄 추가 (\`.resume/\`)

## Test plan

- [x] \`git status\` 가 \`.resume/\` 내용을 untracked 로 surface 안함

🤖 Generated with [Claude Code](https://claude.com/claude-code)