### PR TITLE
feat(#109): G4 — hang detection (last_tool_at + verification_hang)

### DIFF
--- a/hooks/__tests__/mpl-hang-detector.test.mjs
+++ b/hooks/__tests__/mpl-hang-detector.test.mjs
@@ -1,0 +1,111 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  detectHang,
+  formatHangMessage,
+  DEFAULT_HANG_THRESHOLD_MS,
+} from '../lib/mpl-hang-detector.mjs';
+
+const MIN = 60_000;
+
+describe('detectHang', () => {
+  it('returns not-hung when state is null/undefined/non-object', () => {
+    assert.strictEqual(detectHang(null, Date.now()).hung, false);
+    assert.strictEqual(detectHang(undefined, Date.now()).hung, false);
+    assert.strictEqual(detectHang('not-an-object', Date.now()).hung, false);
+    assert.strictEqual(detectHang(42, Date.now()).hung, false);
+  });
+
+  it('returns not-hung when last_tool_at is missing or wrong type', () => {
+    assert.strictEqual(detectHang({}, Date.now()).hung, false);
+    assert.strictEqual(detectHang({ last_tool_at: null }, Date.now()).hung, false);
+    assert.strictEqual(detectHang({ last_tool_at: 12345 }, Date.now()).hung, false);
+    assert.strictEqual(detectHang({ last_tool_at: 'not-a-timestamp' }, Date.now()).hung, false);
+  });
+
+  it('returns not-hung when elapsed time is within threshold', () => {
+    const t = Date.now();
+    const last = new Date(t - 5 * MIN).toISOString();
+    const r = detectHang({ last_tool_at: last }, t);
+    assert.strictEqual(r.hung, false);
+    assert.strictEqual(r.elapsedMs, 5 * MIN);
+    assert.strictEqual(r.thresholdMs, DEFAULT_HANG_THRESHOLD_MS);
+  });
+
+  it('flags hang exactly past threshold (default 15min)', () => {
+    const t = Date.now();
+    const last = new Date(t - 16 * MIN).toISOString();
+    const r = detectHang({ last_tool_at: last }, t);
+    assert.strictEqual(r.hung, true);
+    assert.match(r.reason, /\[MPL G4\] ⚠ Verification appears hung/);
+    assert.match(r.reason, /16min ago/);
+    assert.match(r.reason, /threshold 15min/);
+  });
+
+  it('flag is NOT raised exactly AT threshold (boundary inclusive lower side)', () => {
+    const t = Date.now();
+    const last = new Date(t - DEFAULT_HANG_THRESHOLD_MS).toISOString();
+    const r = detectHang({ last_tool_at: last }, t);
+    assert.strictEqual(r.hung, false);
+  });
+
+  it('honours custom threshold via opts.thresholdMs', () => {
+    const t = Date.now();
+    const last = new Date(t - 6 * MIN).toISOString();
+    // 6min elapsed > 5min threshold
+    assert.strictEqual(detectHang({ last_tool_at: last }, t, { thresholdMs: 5 * MIN }).hung, true);
+    // 6min elapsed < 30min threshold
+    assert.strictEqual(detectHang({ last_tool_at: last }, t, { thresholdMs: 30 * MIN }).hung, false);
+  });
+
+  it('exempt: paused_budget never flags', () => {
+    const t = Date.now();
+    const last = new Date(t - 60 * MIN).toISOString();
+    const r = detectHang({ last_tool_at: last, session_status: 'paused_budget' }, t);
+    assert.strictEqual(r.hung, false);
+    assert.match(r.reason, /exempt status: paused_budget/);
+  });
+
+  it('exempt: paused_checkpoint never flags', () => {
+    const t = Date.now();
+    const last = new Date(t - 60 * MIN).toISOString();
+    const r = detectHang({ last_tool_at: last, session_status: 'paused_checkpoint' }, t);
+    assert.strictEqual(r.hung, false);
+  });
+
+  it('exempt: verification_hang preserves marker (no re-detection)', () => {
+    const t = Date.now();
+    const last = new Date(t - 5 * 60 * MIN).toISOString();
+    // Even 5h elapsed: already-marked sessions should not be re-marked.
+    const r = detectHang({ last_tool_at: last, session_status: 'verification_hang' }, t);
+    assert.strictEqual(r.hung, false);
+    assert.match(r.reason, /exempt status: verification_hang/);
+  });
+
+  it('accepts now as Date object', () => {
+    const now = new Date();
+    const last = new Date(now.getTime() - 30 * MIN).toISOString();
+    const r = detectHang({ last_tool_at: last }, now);
+    assert.strictEqual(r.hung, true);
+  });
+
+  it('does not flag when last_tool_at is in the future (clock skew)', () => {
+    const t = Date.now();
+    const last = new Date(t + 60 * MIN).toISOString();
+    const r = detectHang({ last_tool_at: last }, t);
+    assert.strictEqual(r.hung, false);
+    assert.ok(r.elapsedMs < 0);
+  });
+});
+
+describe('formatHangMessage', () => {
+  it('returns empty string when not hung', () => {
+    assert.strictEqual(formatHangMessage({ hung: false, reason: 'within threshold' }), '');
+  });
+
+  it('returns reason text when hung', () => {
+    const text = '[MPL G4] ⚠ Verification appears hung. ...';
+    assert.strictEqual(formatHangMessage({ hung: true, reason: text }), text);
+  });
+});

--- a/hooks/__tests__/mpl-hang-detector.test.mjs
+++ b/hooks/__tests__/mpl-hang-detector.test.mjs
@@ -41,6 +41,11 @@ describe('detectHang', () => {
     assert.match(r.reason, /\[MPL G4\] ⚠ Verification appears hung/);
     assert.match(r.reason, /16min ago/);
     assert.match(r.reason, /threshold 15min/);
+    // PR #126 review nit: tense — banner should describe past-tense marking
+    // ("Session marked as verification_hang") rather than future "Resume marks ...".
+    assert.match(r.reason, /Session marked as verification_hang/);
+    assert.match(r.reason, /\/mpl:mpl-resume to triage/);
+    assert.doesNotMatch(r.reason, /Resume marks session_status/);
   });
 
   it('flag is NOT raised exactly AT threshold (boundary inclusive lower side)', () => {

--- a/hooks/__tests__/mpl-phase-controller.test.mjs
+++ b/hooks/__tests__/mpl-phase-controller.test.mjs
@@ -475,16 +475,47 @@ describe('G4 hang detection (#109) Stop hook integration', () => {
     assert.strictEqual(readState().session_status, 'paused_budget');
   });
 
-  it('verification_hang pre-mark → not re-marked, banner suppressed (idempotent)', () => {
-    // Already-marked sessions should pass through to phase routing so the
-    // user sees the normal phase message; the marker persists for resume.
+  it('verification_hang pre-mark → not re-marked, alarm banner suppressed', () => {
+    // Already-marked sessions: alarm banner is replaced with a softer triage
+    // pointer (so the user is told to resume rather than re-shown the alarm
+    // every Stop tick). Marker itself persists.
     const stale = new Date(Date.now() - 5 * 60 * 60_000).toISOString();
     const out = runStopHook(tmpDir, {
       current_phase: 'phase2-sprint',
       last_tool_at: stale,
       session_status: 'verification_hang',
     });
-    assert.doesNotMatch(out.stopReason || '', /Verification appears hung/);
+    assert.doesNotMatch(out.stopReason || '', /⚠ Verification appears hung/);
+    assert.match(out.stopReason, /Session is currently marked verification_hang/);
+    assert.match(out.stopReason, /\/mpl:mpl-resume/);
     assert.strictEqual(readState().session_status, 'verification_hang');
+  });
+
+  it('verification_hang pre-mark on phase3-gate PASS → blocks Phase 5 transition (PR #126 review)', () => {
+    // Reproduction of the high-severity finding: previously the exempt branch
+    // fell through to phase switch, allowing checkGateResults → Phase 5
+    // writeState even though the user had not triaged the hang. Marker must
+    // gate every transition.
+    const ent = (exit_code) => ({
+      command: 'npm test', exit_code, stdout_tail: '', timestamp: '2026-05-04T00:00:00Z',
+    });
+    const stale = new Date(Date.now() - 30 * 60_000).toISOString();
+    const out = runStopHook(tmpDir, {
+      current_phase: 'phase3-gate',
+      last_tool_at: stale,
+      session_status: 'verification_hang',
+      gate_results: {
+        hard1_baseline: ent(0),
+        hard2_coverage: ent(0),
+        hard3_resilience: ent(0),
+      },
+    });
+    assert.match(out.stopReason, /Session is currently marked verification_hang/);
+    // Phase routing must NOT have advanced.
+    assert.doesNotMatch(out.stopReason, /Transitioning to Phase 5/);
+    assert.doesNotMatch(out.stopReason, /All Quality Gates passed/);
+    const state = readState();
+    assert.strictEqual(state.current_phase, 'phase3-gate', 'phase must NOT transition');
+    assert.strictEqual(state.session_status, 'verification_hang');
   });
 });

--- a/hooks/__tests__/mpl-phase-controller.test.mjs
+++ b/hooks/__tests__/mpl-phase-controller.test.mjs
@@ -1,7 +1,7 @@
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'fs';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { tmpdir } from 'os';
@@ -424,5 +424,67 @@ describe('phase3-gate Stop hook integration (PR #119 review #5 follow-up)', () =
     assert.match(out.stopReason, /Phase 3: Quality Gate in progress\. Run all 3 gates before proceeding/);
     // source=='none' here, so the legacy fallback warn does NOT prepend (warn is for source=='legacy')
     assert.doesNotMatch(out.stopReason, /⚠ Using legacy gate boolean fallback/);
+  });
+});
+
+describe('G4 hang detection (#109) Stop hook integration', () => {
+  let tmpDir;
+  beforeEach(() => { tmpDir = mkdtempSync(join(tmpdir(), 'mpl-g4-')); });
+  afterEach(() => { rmSync(tmpDir, { recursive: true, force: true }); });
+
+  function readState() {
+    return JSON.parse(readFileSync(join(tmpDir, '.mpl', 'state.json'), 'utf-8'));
+  }
+
+  it('no last_tool_at → falls through to phase routing (no hang marking)', () => {
+    const out = runStopHook(tmpDir, { current_phase: 'phase2-sprint' });
+    // Whatever phase2-sprint emits is fine; we just want NOT to see the hang banner.
+    assert.doesNotMatch(out.stopReason || '', /\[MPL G4\] ⚠ Verification appears hung/);
+    assert.notStrictEqual(readState().session_status, 'verification_hang');
+  });
+
+  it('last_tool_at within 15min → falls through (no hang marking)', () => {
+    const recent = new Date(Date.now() - 5 * 60_000).toISOString();
+    const out = runStopHook(tmpDir, {
+      current_phase: 'phase2-sprint',
+      last_tool_at: recent,
+    });
+    assert.doesNotMatch(out.stopReason || '', /Verification appears hung/);
+    assert.notStrictEqual(readState().session_status, 'verification_hang');
+  });
+
+  it('last_tool_at older than 15min → marks verification_hang and surfaces banner', () => {
+    const stale = new Date(Date.now() - 30 * 60_000).toISOString();
+    const out = runStopHook(tmpDir, {
+      current_phase: 'phase2-sprint',
+      last_tool_at: stale,
+    });
+    assert.match(out.stopReason, /\[MPL G4\] ⚠ Verification appears hung/);
+    assert.match(out.stopReason, /threshold 15min/);
+    assert.strictEqual(readState().session_status, 'verification_hang');
+  });
+
+  it('paused_budget pre-mark → never flagged as hang (intentional pause)', () => {
+    const stale = new Date(Date.now() - 60 * 60_000).toISOString();
+    const out = runStopHook(tmpDir, {
+      current_phase: 'phase2-sprint',
+      last_tool_at: stale,
+      session_status: 'paused_budget',
+    });
+    assert.doesNotMatch(out.stopReason || '', /Verification appears hung/);
+    assert.strictEqual(readState().session_status, 'paused_budget');
+  });
+
+  it('verification_hang pre-mark → not re-marked, banner suppressed (idempotent)', () => {
+    // Already-marked sessions should pass through to phase routing so the
+    // user sees the normal phase message; the marker persists for resume.
+    const stale = new Date(Date.now() - 5 * 60 * 60_000).toISOString();
+    const out = runStopHook(tmpDir, {
+      current_phase: 'phase2-sprint',
+      last_tool_at: stale,
+      session_status: 'verification_hang',
+    });
+    assert.doesNotMatch(out.stopReason || '', /Verification appears hung/);
+    assert.strictEqual(readState().session_status, 'verification_hang');
   });
 });

--- a/hooks/__tests__/mpl-tool-tracker.test.mjs
+++ b/hooks/__tests__/mpl-tool-tracker.test.mjs
@@ -1,0 +1,104 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { tmpdir } from 'os';
+
+const __filename = fileURLToPath(import.meta.url);
+const HOOK_PATH = join(dirname(__filename), '..', 'mpl-tool-tracker.mjs');
+
+describe('mpl-tool-tracker hook', () => {
+  let tmpDir;
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'mpl-tracker-'));
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    writeFileSync(
+      join(tmpDir, '.mpl', 'state.json'),
+      JSON.stringify({ current_phase: 'phase2-sprint' }),
+    );
+  });
+  afterEach(() => rmSync(tmpDir, { recursive: true, force: true }));
+
+  function runHook(toolName, toolInput = {}) {
+    const stdin = JSON.stringify({
+      cwd: tmpDir,
+      tool_name: toolName,
+      tool_input: toolInput,
+    });
+    const out = execFileSync('node', [HOOK_PATH], { input: stdin, encoding: 'utf-8' });
+    return JSON.parse(out);
+  }
+
+  function readState() {
+    return JSON.parse(readFileSync(join(tmpDir, '.mpl', 'state.json'), 'utf-8'));
+  }
+
+  it('writes last_tool_at on Bash invocation', () => {
+    const before = Date.now();
+    const r = runHook('Bash', { command: 'ls' });
+    assert.strictEqual(r.continue, true);
+    assert.strictEqual(r.suppressOutput, true);
+    const state = readState();
+    assert.ok(state.last_tool_at, 'last_tool_at should be set');
+    const ts = Date.parse(state.last_tool_at);
+    assert.ok(!Number.isNaN(ts), 'last_tool_at should be valid ISO-8601');
+    assert.ok(ts >= before, 'last_tool_at should be >= before');
+    assert.ok(ts <= Date.now() + 1000, 'last_tool_at should be <= now');
+  });
+
+  it('writes last_tool_at on Edit invocation', () => {
+    runHook('Edit', { file_path: '/tmp/x', old_string: 'a', new_string: 'b' });
+    assert.ok(readState().last_tool_at);
+  });
+
+  it('writes last_tool_at on Read / Glob / TodoWrite (broad coverage)', () => {
+    runHook('Read', { file_path: '/tmp/x' });
+    const ts1 = readState().last_tool_at;
+    assert.ok(ts1);
+
+    // Tiny delay to ensure timestamp difference if hook writes again
+    runHook('Glob', { pattern: '*.ts' });
+    const ts2 = readState().last_tool_at;
+    assert.ok(ts2);
+    assert.ok(Date.parse(ts2) >= Date.parse(ts1));
+
+    runHook('TodoWrite', { todos: [] });
+    assert.ok(readState().last_tool_at);
+  });
+
+  it('preserves other state fields (shallow merge)', () => {
+    writeFileSync(
+      join(tmpDir, '.mpl', 'state.json'),
+      JSON.stringify({
+        current_phase: 'phase3-gate',
+        fix_loop_count: 2,
+        gate_results: { hard1_passed: true },
+      }),
+    );
+    runHook('Bash', { command: 'ls' });
+    const state = readState();
+    assert.strictEqual(state.current_phase, 'phase3-gate');
+    assert.strictEqual(state.fix_loop_count, 2);
+    assert.deepStrictEqual(state.gate_results, { hard1_passed: true });
+    assert.ok(state.last_tool_at);
+  });
+
+  it('MPL not active → silent, state untouched', () => {
+    rmSync(join(tmpDir, '.mpl'), { recursive: true });
+    const r = runHook('Bash', { command: 'ls' });
+    assert.strictEqual(r.continue, true);
+    assert.strictEqual(r.suppressOutput, true);
+    assert.strictEqual(existsSync(join(tmpDir, '.mpl')), false);
+  });
+
+  it('malformed stdin → silent (no crash)', () => {
+    const out = execFileSync('node', [HOOK_PATH], {
+      input: '{ this is not json',
+      encoding: 'utf-8',
+    });
+    const r = JSON.parse(out);
+    assert.strictEqual(r.continue, true);
+  });
+});

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -104,7 +104,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Bash|Edit|Write|MultiEdit|Task|Agent|Read|Grep|Glob|TodoWrite|NotebookEdit|WebFetch|WebSearch|SlashCommand|BashOutput|KillShell|ExitPlanMode",
+        "matcher": "Bash|Edit|Write|MultiEdit|Task|Agent|Read|Grep|Glob|TodoWrite|NotebookEdit|WebFetch|WebSearch|SlashCommand|BashOutput|KillShell|ExitPlanMode|mcp__.*",
         "hooks": [
           {
             "type": "command",

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -104,6 +104,16 @@
     ],
     "PostToolUse": [
       {
+        "matcher": "Bash|Edit|Write|MultiEdit|Task|Agent|Read|Grep|Glob|TodoWrite|NotebookEdit|WebFetch|WebSearch|SlashCommand|BashOutput|KillShell|ExitPlanMode",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/mpl-tool-tracker.mjs\"",
+            "timeout": 2
+          }
+        ]
+      },
+      {
         "matcher": "Bash|Task|Agent",
         "hooks": [
           {

--- a/hooks/lib/mpl-hang-detector.mjs
+++ b/hooks/lib/mpl-hang-detector.mjs
@@ -89,7 +89,7 @@ export function detectHang(state, now, opts = {}) {
     true,
     elapsedMs,
     lastToolAt,
-    `[MPL G4] ⚠ Verification appears hung. Last tool execution: ${lastToolAt} (${minutes}min ago, threshold ${Math.floor(thresholdMs / 60_000)}min). Check verification command or kill stuck process. Resume marks session_status=verification_hang.`,
+    `[MPL G4] ⚠ Verification appears hung. Last tool execution: ${lastToolAt} (${minutes}min ago, threshold ${Math.floor(thresholdMs / 60_000)}min). Check the verification command or kill the stuck process. Session marked as verification_hang — run /mpl:mpl-resume to triage (resume / rollback / cancel).`,
   );
 }
 

--- a/hooks/lib/mpl-hang-detector.mjs
+++ b/hooks/lib/mpl-hang-detector.mjs
@@ -1,0 +1,106 @@
+/**
+ * MPL Hang Detection (G4, #109)
+ *
+ * G1 (#107) bounds individual Bash verification runs. G4 catches the
+ * orthogonal failure mode: orchestrator silently stalled — no tool call has
+ * fired in N minutes. exp15 phase-10 produced a 5h 18m hang because nothing
+ * marked the session, so the user had to externally notice and kill it.
+ *
+ * Mechanism:
+ *   1. PostToolUse `mpl-tool-tracker.mjs` writes `state.last_tool_at` on every
+ *      tool invocation.
+ *   2. Stop hook (`mpl-phase-controller.mjs`) calls `detectHang(state, now)`
+ *      before phase routing. If `now - last_tool_at > threshold` AND the
+ *      session is not already paused for a known reason, mark
+ *      `session_status = 'verification_hang'`.
+ *   3. Resume / user intervention surfaces the marking.
+ *
+ * Pure functions. No I/O.
+ */
+
+/**
+ * Hang threshold in ms — 15 minutes per issue #109.
+ * Configurable via `.mpl/config.json:hang_detection.threshold_ms` (future).
+ */
+export const DEFAULT_HANG_THRESHOLD_MS = 15 * 60 * 1000;
+
+/**
+ * Status values for which hang detection should NOT fire.
+ * `paused_budget` / `paused_checkpoint` are intentional, user-acknowledged pauses.
+ * `verification_hang` itself: don't re-mark; preserve the original detection time.
+ */
+const HANG_EXEMPT_STATUSES = new Set([
+  'paused_budget',
+  'paused_checkpoint',
+  'verification_hang',
+]);
+
+/**
+ * Detect a verification hang from state + current wall clock.
+ *
+ * @param {object | null | undefined} state - state.json contents
+ * @param {Date | number} now - reference time (Date or epoch-ms)
+ * @param {{ thresholdMs?: number }} [opts]
+ * @returns {{
+ *   hung: boolean,
+ *   elapsedMs: number | null,
+ *   thresholdMs: number,
+ *   lastToolAt: string | null,
+ *   reason: string,
+ * }}
+ */
+export function detectHang(state, now, opts = {}) {
+  const thresholdMs = opts.thresholdMs ?? DEFAULT_HANG_THRESHOLD_MS;
+  const result = (hung, elapsedMs, lastToolAt, reason) => ({
+    hung,
+    elapsedMs,
+    thresholdMs,
+    lastToolAt: lastToolAt ?? null,
+    reason,
+  });
+
+  if (!state || typeof state !== 'object') {
+    return result(false, null, null, 'no state');
+  }
+  if (HANG_EXEMPT_STATUSES.has(state.session_status)) {
+    return result(false, null, state.last_tool_at ?? null, `exempt status: ${state.session_status}`);
+  }
+
+  const lastToolAt = state.last_tool_at;
+  if (!lastToolAt || typeof lastToolAt !== 'string') {
+    // No PostToolUse has fired yet — can't detect a hang.
+    return result(false, null, null, 'no last_tool_at recorded');
+  }
+
+  const lastMs = Date.parse(lastToolAt);
+  if (Number.isNaN(lastMs)) {
+    return result(false, null, lastToolAt, 'unparseable last_tool_at');
+  }
+
+  const nowMs = typeof now === 'number' ? now : now.getTime();
+  const elapsedMs = nowMs - lastMs;
+
+  if (elapsedMs <= thresholdMs) {
+    return result(false, elapsedMs, lastToolAt, 'within threshold');
+  }
+
+  const minutes = Math.floor(elapsedMs / 60_000);
+  return result(
+    true,
+    elapsedMs,
+    lastToolAt,
+    `[MPL G4] ⚠ Verification appears hung. Last tool execution: ${lastToolAt} (${minutes}min ago, threshold ${Math.floor(thresholdMs / 60_000)}min). Check verification command or kill stuck process. Resume marks session_status=verification_hang.`,
+  );
+}
+
+/**
+ * Format the user-facing message for a detected hang. Returned as
+ * `stopReason` text in the Stop hook output so the user can intervene.
+ *
+ * @param {ReturnType<typeof detectHang>} det
+ * @returns {string}
+ */
+export function formatHangMessage(det) {
+  if (!det.hung) return '';
+  return det.reason;
+}

--- a/hooks/lib/mpl-state.mjs
+++ b/hooks/lib/mpl-state.mjs
@@ -172,11 +172,17 @@ const DEFAULT_STATE = {
   ambiguity_history: [],
   // F-33: Session budget prediction
   // #35 (v0.14.1): "paused_checkpoint" added for orchestrator verbal pause (self-pause on checkpoint report)
-  session_status: null,          // null | "active" | "paused_budget" | "paused_checkpoint"
+  // #109 G4 (v0.18.0): "verification_hang" added — Stop hook detects when last_tool_at is older
+  // than the hang threshold (default 15min) and marks the session for resume / user intervention.
+  session_status: null,          // null | "active" | "paused_budget" | "paused_checkpoint" | "verification_hang"
   pause_reason: null,            // human-readable pause reason
   resume_from_phase: null,       // phase ID to resume from
   pause_timestamp: null,         // ISO timestamp of pause
   budget_at_pause: null,         // { context_pct, estimated_needed_pct }
+  // #109 G4: ISO-8601 timestamp of the most recent PostToolUse event from
+  // mpl-tool-tracker.mjs. Stop hook compares to wall clock; > threshold (default
+  // 15min) without an active "paused_*" flag → verification_hang marking.
+  last_tool_at: null,            // ISO-8601 timestamp | null
   // P2-6: execution-scope state (formerly .mpl/mpl/state.json). Schema mirrors
   // the shape documented in commands/mpl-run.md §"MPL State". Orchestrator
   // prompts (mpl-run-decompose.md, mpl-run-execute.md) update this subtree via

--- a/hooks/mpl-phase-controller.mjs
+++ b/hooks/mpl-phase-controller.mjs
@@ -224,9 +224,18 @@ async function main() {
 
   // G4 (#109) — hang detection. Run before phase routing so a stalled
   // session is marked even when the phase branch would otherwise return
-  // a generic "in progress" message. Skipped when state already carries
-  // an intentional pause (paused_budget / paused_checkpoint) or the hang
-  // marker (preserve original detection time).
+  // a generic "in progress" message.
+  //
+  // Three branches:
+  //   (a) Newly detected hang (state.last_tool_at is stale, no exempt status):
+  //       mark `session_status='verification_hang'` and emit the alarm banner.
+  //   (b) Already-marked verification_hang: short-circuit phase routing so
+  //       phase transitions (e.g. phase3-gate → phase5-finalize) cannot
+  //       advance silently while the session is awaiting user triage. The
+  //       resume skill clears the marker only after the user picks resume /
+  //       rollback / cancel — until then every Stop tick re-surfaces the
+  //       triage guidance. (PR #126 review #1 — was previously a fall-through.)
+  //   (c) paused_budget / paused_checkpoint: intentional pauses, untouched.
   const hangDet = detectHang(state, Date.now());
   if (hangDet.hung) {
     try {
@@ -235,6 +244,13 @@ async function main() {
     console.log(JSON.stringify({
       continue: true,
       stopReason: hangDet.reason,
+    }));
+    return;
+  }
+  if (state.session_status === 'verification_hang') {
+    console.log(JSON.stringify({
+      continue: true,
+      stopReason: '[MPL G4] Session is currently marked verification_hang. Phase routing is paused until user triage. Run /mpl:mpl-resume to choose: resume current phase, roll back, or cancel.',
     }));
     return;
   }

--- a/hooks/mpl-phase-controller.mjs
+++ b/hooks/mpl-phase-controller.mjs
@@ -36,6 +36,11 @@ const { resolveRuleAction } = await import(
   pathToFileURL(join(__dirname, 'lib', 'mpl-enforcement.mjs')).href
 );
 
+// G4 hang detection (#109)
+const { detectHang } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-hang-detector.mjs')).href
+);
+
 /**
  * Check PLAN.md checkbox completion status
  */
@@ -214,6 +219,23 @@ async function main() {
   const state = readState(cwd);
   if (!state) {
     console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+    return;
+  }
+
+  // G4 (#109) — hang detection. Run before phase routing so a stalled
+  // session is marked even when the phase branch would otherwise return
+  // a generic "in progress" message. Skipped when state already carries
+  // an intentional pause (paused_budget / paused_checkpoint) or the hang
+  // marker (preserve original detection time).
+  const hangDet = detectHang(state, Date.now());
+  if (hangDet.hung) {
+    try {
+      writeState(cwd, { session_status: 'verification_hang' });
+    } catch { /* best-effort marking — never fail Stop hook on disk error */ }
+    console.log(JSON.stringify({
+      continue: true,
+      stopReason: hangDet.reason,
+    }));
     return;
   }
 

--- a/hooks/mpl-tool-tracker.mjs
+++ b/hooks/mpl-tool-tracker.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+/**
+ * MPL Tool Tracker Hook (PostToolUse, all tools)
+ *
+ * G4 (#109). Updates `state.last_tool_at = ISO-8601` on every tool invocation
+ * so the Stop hook (`mpl-phase-controller.mjs`) can detect verification hangs
+ * (no tool fired in > threshold minutes → mark `session_status=verification_hang`).
+ *
+ * Thin: read state, write last_tool_at, return silent. No decisions made here.
+ * Always exits success — never blocks a tool result.
+ */
+
+import { dirname, join } from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const { isMplActive, readState, writeState } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-state.mjs')).href
+);
+const { readStdin } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'stdin.mjs')).href
+);
+
+function silent() {
+  console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+}
+
+async function main() {
+  const input = await readStdin();
+  let data;
+  try { data = JSON.parse(input); } catch { return silent(); }
+
+  const cwd = data.cwd || data.directory || process.cwd();
+  if (!isMplActive(cwd)) return silent();
+
+  const state = readState(cwd);
+  if (!state) return silent();
+
+  // Write only the timestamp; do not perturb any other state field.
+  // mpl-state.mjs writeState performs a shallow merge.
+  try {
+    writeState(cwd, { last_tool_at: new Date().toISOString() });
+  } catch {
+    // Never propagate — tracker is best-effort.
+  }
+  return silent();
+}
+
+await main().catch(() => silent());

--- a/hooks/mpl-tool-tracker.mjs
+++ b/hooks/mpl-tool-tracker.mjs
@@ -39,7 +39,8 @@ async function main() {
   if (!state) return silent();
 
   // Write only the timestamp; do not perturb any other state field.
-  // mpl-state.mjs writeState performs a shallow merge.
+  // writeState performs a deep merge — patching the flat `last_tool_at`
+  // key leaves nested fields (`execution`, `gate_results`, etc.) untouched.
   try {
     writeState(cwd, { last_tool_at: new Date().toISOString() });
   } catch {

--- a/skills/mpl-resume/SKILL.md
+++ b/skills/mpl-resume/SKILL.md
@@ -19,9 +19,24 @@ Expected resumable states:
 - `current_phase = "cancelled"` with `resume_point` (manual cancel)
 - `session_status = "paused_budget"` (F-33 context rotation)
 - `session_status = "paused_checkpoint"` (orchestrator self-pause, v0.14.1 #35)
+- `session_status = "verification_hang"` (G4 hang detection, #109) — Stop hook detected no tool fired in > 15min
 - **Drift**: `current_phase` active but disk artifacts show completed phases beyond `sprint_status.completed_todos`
 
 For `paused_budget` / `paused_checkpoint`: the pipeline was paused, not cancelled. Resume from `resume_from_phase` (or `current_phase` if unset) and clear `session_status`, `pause_reason`, `pause_timestamp`, `budget_at_pause`.
+
+For `verification_hang` (G4, #109): the previous session went silent (typical cause: a verification command without `tool_input.timeout` ran past Claude Code's default kill point, or the orchestrator stalled waiting for a response). Surface the hang to the user before continuing:
+```
+AskUserQuestion({
+  question: "Previous session was marked verification_hang at {state.last_tool_at} (no tool fired for >15min). Resume current_phase={phase} and re-run verification?",
+  header: "G4 hang resume",
+  options: [
+    { label: "Resume from current phase", description: "Re-enter {phase}; rerun the gate/sprint command. Add an explicit timeout if it was missing." },
+    { label: "Roll back to phase2-sprint", description: "Drop the in-progress fix loop and re-plan." },
+    { label: "Cancel pipeline",            description: "/mpl:mpl-cancel — investigate manually before retrying." },
+  ]
+})
+```
+Clear `session_status` and `last_tool_at` only after the user confirms the resume direction (so a subsequent crash can still see the hang record). Carry `fix_loop_count` and `pass_rate_history` through unchanged — convergence trend analysis depends on it.
 
 ## Step 2: Drift Detection (v0.14.1 #35, extended by P2-6)
 


### PR DESCRIPTION
## Summary

G1 (#107) bounds individual Bash verification runs. G4 catches the orthogonal failure mode: orchestrator silently stalled — no tool call fires in N minutes. exp15 phase-10 produced a 5h 18m silent hang because nothing marked the session. G4 stamps `state.last_tool_at` on every PostToolUse and the Stop hook flips `session_status='verification_hang'` past the 15-minute threshold so resume / user intervention surfaces it.

## Architecture

| Layer | File | Role |
|---|---|---|
| PostToolUse tracker | `hooks/mpl-tool-tracker.mjs` (new) | Stamps `last_tool_at` ISO-8601 on every tool. Thin, ~50 lines, timeout 2s |
| Pure detector | `hooks/lib/mpl-hang-detector.mjs` (new) | `detectHang(state, now, opts)` — null-safe, exempt-status-aware |
| Stop hook | `hooks/mpl-phase-controller.mjs` | Runs `detectHang` BEFORE phase routing — hung → mark + banner + return |
| Schema | `hooks/lib/mpl-state.mjs` | `session_status` enum += `verification_hang`; `last_tool_at` field |
| Resume | `skills/mpl-resume/SKILL.md` | New `verification_hang` resumable state with AskUserQuestion gating |

### Detection rules

- `state == null` / non-object → not-hung
- `last_tool_at` missing / unparseable → not-hung (no PostToolUse fired yet)
- `session_status ∈ {paused_budget, paused_checkpoint}` → exempt (intentional pauses)
- `session_status === 'verification_hang'` → exempt (idempotent — preserve original detection time)
- `now - last_tool_at > threshold (default 15min)` → hung

### PostToolUse matcher

Broad union covers all Claude Code tools that could be the last activity before a hang:
```
Bash|Edit|Write|MultiEdit|Task|Agent|Read|Grep|Glob|TodoWrite|NotebookEdit|WebFetch|WebSearch|SlashCommand|BashOutput|KillShell|ExitPlanMode
```

`writeState` performs a shallow merge so other state fields (current_phase, fix_loop_count, gate_results) are untouched.

## Tests

- `mpl-hang-detector.test.mjs` (12 cases) — null state, missing/unparseable last_tool_at, within-threshold, exactly-past-threshold (banner regex), at-threshold boundary, custom thresholdMs, 3× exempt status paths, Date arg support, future-timestamp clock-skew safety.
- `mpl-tool-tracker.test.mjs` (7 cases) — Bash/Edit/Read+Glob+TodoWrite writes, ISO validity, monotonic ordering, shallow-merge preservation, MPL-inactive silent, malformed stdin tolerance.
- `mpl-phase-controller.test.mjs` G4 integration (5 cases) — fall-through (no/recent timestamp), stale → mark + banner, paused_budget exempt, verification_hang idempotent.

**Full hook regression: 447/447** (was 423, +24 G4).

## Files

| File | Lines | Role |
|---|---|---|
| `hooks/mpl-tool-tracker.mjs` | +52 | Thin PostToolUse stamper |
| `hooks/lib/mpl-hang-detector.mjs` | +103 | Pure detection lib |
| `hooks/mpl-phase-controller.mjs` | +22 | Stop hook integration |
| `hooks/lib/mpl-state.mjs` | +6 / -2 | Schema |
| `hooks/hooks.json` | +10 | PostToolUse registration |
| `skills/mpl-resume/SKILL.md` | +14 / -1 | Resume protocol |
| `hooks/__tests__/mpl-hang-detector.test.mjs` | +110 (new) | 12 cases |
| `hooks/__tests__/mpl-tool-tracker.test.mjs` | +97 (new) | 7 cases |
| `hooks/__tests__/mpl-phase-controller.test.mjs` | +63 / -2 | 5 G4 cases |

## Decisions / deferred

- **15min hard-coded threshold** — issue #109 spec. Config override path (`enforcement.json: hang_detection.threshold_ms` or similar) deferred to a follow-up; v0.18.0 ships fixed.
- **G3+H1 (#108) invariant** — will validate that `verification_hang` is mutually exclusive with `paused_budget|paused_checkpoint`. Forward-compatible: hang detector already short-circuits when those are set.
- **Auto-mode (#114 G5+G6)** — `verification_hang → resume` will count as a `user_intervention` sample once that ships.
- **Tracker `*` matcher** — opted for an explicit union over a wildcard. Safer against future Claude Code tool additions that should NOT count as activity (none currently, but the union is auditable).

## Related

- Closes #109
- Part of #101 (v0.18.0 critical 6/10 → **7/10** on merge)
- Builds on G1 (#107) — pair forms verification budget enforcement (per-call cap + idle-time floor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)