### PR TITLE
feat(#108): G3 + H1 — state invariant checker + sprint/phase schema freeze

### DIFF
--- a/docs/schemas/state.md
+++ b/docs/schemas/state.md
@@ -14,7 +14,7 @@
 | Field path | Unit | Notes |
 |---|---|---|
 | `current_phase` | lifecycle marker (string enum) | Not a phase id. Values: `phase1-plan`, `phase1a-research`, `phase1b-plan`, `mpl-decompose`, `mpl-ambiguity-resolve`, `phase2-sprint`, `phase3-gate`, `phase4-fix`, `phase5-finalize`, `completed`, `cancelled`, or a concrete `phase-N` id while inside the sprint. |
-| `execution.phases.*` | per-phase | One entry per phase-runner invocation. `completed` count must match `.mpl/mpl/phases/phase-*` directory count (G3 invariant I4). |
+| `execution.phases.*` | per-phase | One entry per phase-runner invocation. `completed` count must match the number of `.mpl/mpl/phases/phase-*/` directories that carry a `state-summary.md` finalize artifact (G3 invariant I4). Empty pre-created directories from `mpl-run-decompose.md` Step 4 do NOT count. |
 | `execution.phase_details[]` | per-phase | Status/retries/pass_rate per phase id. |
 | `sprint_status.total_todos` | sprint-aggregated | Sum of TODO counts across all phases of the active sprint (typically all of phase2-sprint). |
 | `sprint_status.completed_todos` | sprint-aggregated | Number of TODOs marked complete. |

--- a/docs/schemas/state.md
+++ b/docs/schemas/state.md
@@ -37,7 +37,7 @@ strict mode elevates `warn → block`.
 | I1 | `session_status='paused_budget' AND finalize_done=true` is impossible | all | Mutual contradiction. |
 | I2 | `current_phase='completed' AND finalize_done=false` is impossible | all | Completion requires finalize. |
 | I3 | `paused_*` or `verification_hang` AND new Task/Agent dispatch | task-dispatch | Resume the pipeline (`/mpl:mpl-resume`) before dispatching. |
-| I4 | `execution.phases.completed != phase folder count` | all | Disk truth wins; declared count must match. |
+| I4 | `execution.phases.completed != count(phase-N/state-summary.md)` | all | Disk truth = number of phase directories carrying the `state-summary.md` finalize artifact. Declared count must match. Empty `phase-N/` directories pre-created by `mpl-run-decompose.md` Step 4 do NOT count. |
 | I5 | `fix_loop_count != sum(fix_loop_history)` | all | G5 (#114) writes history; counter must agree. |
 | I6 | phase3-gate state-write missing structured gate evidence | state-write | P0-1 (#102) requirement. |
 | I7 | `current_phase='phase-N' AND .mpl/mpl/phases/phase-N/` absent | all | Lifecycle marker vs disk drift. |

--- a/docs/schemas/state.md
+++ b/docs/schemas/state.md
@@ -1,0 +1,66 @@
+# `.mpl/state.json` Schema (H1, frozen v0.18.0)
+
+> **Status**: Frozen — H1 (#108) freezes the sprint-vs-phase split so the
+> G3 invariant checker (`hooks/lib/mpl-state-invariant.mjs`) has a stable
+> reference. Changes that break these invariants must bump
+> `schema_version` and add a migration in `hooks/lib/mpl-state.mjs`.
+>
+> **Source-of-truth**: runtime `DEFAULT_STATE` in `hooks/lib/mpl-state.mjs`.
+> This document mirrors that shape and adds the unit semantics that the
+> code itself can't carry inline.
+
+## Unit semantics (sprint vs phase)
+
+| Field path | Unit | Notes |
+|---|---|---|
+| `current_phase` | lifecycle marker (string enum) | Not a phase id. Values: `phase1-plan`, `phase1a-research`, `phase1b-plan`, `mpl-decompose`, `mpl-ambiguity-resolve`, `phase2-sprint`, `phase3-gate`, `phase4-fix`, `phase5-finalize`, `completed`, `cancelled`, or a concrete `phase-N` id while inside the sprint. |
+| `execution.phases.*` | per-phase | One entry per phase-runner invocation. `completed` count must match `.mpl/mpl/phases/phase-*` directory count (G3 invariant I4). |
+| `execution.phase_details[]` | per-phase | Status/retries/pass_rate per phase id. |
+| `sprint_status.total_todos` | sprint-aggregated | Sum of TODO counts across all phases of the active sprint (typically all of phase2-sprint). |
+| `sprint_status.completed_todos` | sprint-aggregated | Number of TODOs marked complete. |
+| `gate_results.hard{1,2,3}_{baseline,coverage,resilience}` | per-pipeline | Structured machine evidence. P0-1 (#102) requires `{command, exit_code, stdout_tail, timestamp}`. |
+| `fix_loop_count` | sprint-aggregated | Total fix-loop iterations across the active sprint. Must equal `sum(fix_loop_history[].count)` (G3 I5; G5 #114 introduces history). |
+| `fix_loop_history[]` | per-phase | `{phase: string, count: number}` entries. Optional in v0.18.0; mandatory once #114 lands. |
+| `session_status` | per-session | `null \| active \| paused_budget \| paused_checkpoint \| verification_hang \| cancelled`. Single-valued — pause / hang / cancel states are mutually exclusive (G3 I9). |
+| `last_tool_at` | per-session | ISO-8601 stamp from `mpl-tool-tracker.mjs`. Powers G4 (#109). |
+| `enforcement.*` | per-pipeline override | P0-2 (#110) per-rule policy. Top of the precedence chain. |
+
+## Invariants enforced (G3 / #108)
+
+The G3 hook (`mpl-state-invariant.mjs`) checks the table below at four
+trigger points. Action policy comes from
+`enforcement.state_invariant_violation` (P0-2) — `off | warn | block`,
+strict mode elevates `warn → block`.
+
+| ID | Description | Triggers | Notes |
+|---|---|---|---|
+| I1 | `session_status='paused_budget' AND finalize_done=true` is impossible | all | Mutual contradiction. |
+| I2 | `current_phase='completed' AND finalize_done=false` is impossible | all | Completion requires finalize. |
+| I3 | `paused_*` or `verification_hang` AND new Task/Agent dispatch | task-dispatch | Resume the pipeline (`/mpl:mpl-resume`) before dispatching. |
+| I4 | `execution.phases.completed != phase folder count` | all | Disk truth wins; declared count must match. |
+| I5 | `fix_loop_count != sum(fix_loop_history)` | all | G5 (#114) writes history; counter must agree. |
+| I6 | phase3-gate state-write missing structured gate evidence | state-write | P0-1 (#102) requirement. |
+| I7 | `current_phase='phase-N' AND .mpl/mpl/phases/phase-N/` absent | all | Lifecycle marker vs disk drift. |
+| I8 | `schema_version > CURRENT_SCHEMA_VERSION` | all | Hook is older than writer; upgrade plugin. |
+| I9 | `session_status` outside the allowed enum | all | Forward-compat with G4 / #109 future fields. |
+
+## Trigger registration
+
+| Hook event | Matcher | Trigger constant |
+|---|---|---|
+| PreToolUse | `Task\|Agent` | `task-dispatch` |
+| PreToolUse | `Edit\|Write\|MultiEdit` (with `.mpl/state.json` target filter) | `state-write` |
+| Stop | (none) | `stop` |
+| PreCompact | (none) | `pre-compact` (planned) |
+
+## Schema version
+
+- `CURRENT_SCHEMA_VERSION = 2` (P2-6 — unified state, `execution` subtree absorbs the legacy `.mpl/mpl/state.json`).
+- Migration v1 → v2 runs automatically on `readState`. Newer-than-supported writes raise I8.
+
+## See also
+
+- `hooks/lib/mpl-state.mjs` — runtime schema + migration.
+- `hooks/lib/mpl-state-invariant.mjs` — invariant checker (this document's mechanical mirror).
+- `commands/mpl-run.md` §"MPL State" — orchestrator protocol view.
+- `docs/config-schema.md` §Enforcement — `state_invariant_violation` policy.

--- a/hooks/__tests__/mpl-state-invariant.test.mjs
+++ b/hooks/__tests__/mpl-state-invariant.test.mjs
@@ -1,0 +1,362 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { tmpdir } from 'os';
+
+import {
+  checkInvariants,
+  formatViolations,
+  TRIGGERS,
+  VIOLATION_IDS,
+} from '../lib/mpl-state-invariant.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const HOOK_PATH = join(dirname(__filename), '..', 'mpl-state-invariant.mjs');
+
+let tmp;
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'mpl-inv-'));
+  mkdirSync(join(tmp, '.mpl'), { recursive: true });
+});
+afterEach(() => rmSync(tmp, { recursive: true, force: true }));
+
+function withState(s) {
+  writeFileSync(join(tmp, '.mpl', 'state.json'), JSON.stringify(s));
+}
+
+function makePhaseFolders(n) {
+  for (let i = 1; i <= n; i++) {
+    mkdirSync(join(tmp, '.mpl', 'mpl', 'phases', `phase-${i}`), { recursive: true });
+  }
+}
+
+/* ────────────────────────── lib unit ──────────────────────────────────── */
+
+describe('checkInvariants — basics', () => {
+  it('null/undefined state → ok=true', () => {
+    assert.deepStrictEqual(checkInvariants(null), { ok: true, violations: [] });
+    assert.deepStrictEqual(checkInvariants(undefined), { ok: true, violations: [] });
+  });
+
+  it('empty state → ok=true', () => {
+    assert.strictEqual(checkInvariants({}, { cwd: tmp }).ok, true);
+  });
+
+  it('clean realistic state → ok=true', () => {
+    makePhaseFolders(2);
+    const r = checkInvariants({
+      current_phase: 'phase2-sprint',
+      finalize_done: false,
+      session_status: 'active',
+      schema_version: 2,
+      execution: { phases: { completed: 2 } },
+      fix_loop_count: 3,
+      fix_loop_history: [{ phase: 'p1', count: 2 }, { phase: 'p2', count: 1 }],
+    }, { cwd: tmp });
+    assert.strictEqual(r.ok, true, JSON.stringify(r.violations, null, 2));
+  });
+});
+
+describe('I1 paused_budget AND finalize_done', () => {
+  it('flags the contradiction', () => {
+    const r = checkInvariants({ session_status: 'paused_budget', finalize_done: true }, { cwd: tmp });
+    assert.strictEqual(r.ok, false);
+    assert.strictEqual(r.violations[0].id, VIOLATION_IDS.PAUSED_BUT_FINALIZED);
+  });
+});
+
+describe('I2 completed AND !finalize_done', () => {
+  it('flags the contradiction', () => {
+    const r = checkInvariants({ current_phase: 'completed', finalize_done: false }, { cwd: tmp });
+    assert.ok(r.violations.some((v) => v.id === VIOLATION_IDS.COMPLETED_BUT_NOT_FINALIZED));
+  });
+  it('completed AND finalize_done=true is fine', () => {
+    const r = checkInvariants({ current_phase: 'completed', finalize_done: true }, { cwd: tmp });
+    assert.ok(!r.violations.some((v) => v.id === VIOLATION_IDS.COMPLETED_BUT_NOT_FINALIZED));
+  });
+});
+
+describe('I3 paused/hung blocks new dispatch', () => {
+  for (const status of ['paused_budget', 'paused_checkpoint', 'verification_hang']) {
+    it(`flags new Task/Agent dispatch under ${status}`, () => {
+      const r = checkInvariants(
+        { session_status: status },
+        { cwd: tmp, trigger: TRIGGERS.TASK_DISPATCH },
+      );
+      assert.ok(r.violations.some((v) => v.id === VIOLATION_IDS.PAUSED_NEW_DISPATCH));
+    });
+  }
+  it('does NOT flag dispatch under active', () => {
+    const r = checkInvariants(
+      { session_status: 'active' },
+      { cwd: tmp, trigger: TRIGGERS.TASK_DISPATCH },
+    );
+    assert.ok(!r.violations.some((v) => v.id === VIOLATION_IDS.PAUSED_NEW_DISPATCH));
+  });
+  it('paused under STOP trigger is not I3 (I1/I2 may apply but I3 does not)', () => {
+    const r = checkInvariants(
+      { session_status: 'paused_budget' },
+      { cwd: tmp, trigger: TRIGGERS.STOP },
+    );
+    assert.ok(!r.violations.some((v) => v.id === VIOLATION_IDS.PAUSED_NEW_DISPATCH));
+  });
+});
+
+describe('I4 phase folder count vs execution.phases.completed', () => {
+  it('flags mismatch', () => {
+    makePhaseFolders(3);
+    const r = checkInvariants({ execution: { phases: { completed: 1 } } }, { cwd: tmp });
+    assert.ok(r.violations.some((v) => v.id === VIOLATION_IDS.PHASE_FOLDER_MISMATCH));
+  });
+  it('match passes', () => {
+    makePhaseFolders(3);
+    const r = checkInvariants({ execution: { phases: { completed: 3 } } }, { cwd: tmp });
+    assert.ok(!r.violations.some((v) => v.id === VIOLATION_IDS.PHASE_FOLDER_MISMATCH));
+  });
+  it('no execution subtree → not measurable', () => {
+    makePhaseFolders(3);
+    const r = checkInvariants({}, { cwd: tmp });
+    assert.ok(!r.violations.some((v) => v.id === VIOLATION_IDS.PHASE_FOLDER_MISMATCH));
+  });
+});
+
+describe('I5 fix_loop_count vs fix_loop_history', () => {
+  it('flags desync', () => {
+    const r = checkInvariants({
+      fix_loop_count: 5,
+      fix_loop_history: [{ phase: 'p1', count: 2 }, { phase: 'p2', count: 1 }],
+    }, { cwd: tmp });
+    assert.ok(r.violations.some((v) => v.id === VIOLATION_IDS.FIX_LOOP_HISTORY_DESYNC));
+  });
+  it('matching count passes', () => {
+    const r = checkInvariants({
+      fix_loop_count: 3,
+      fix_loop_history: [{ phase: 'p1', count: 2 }, { phase: 'p2', count: 1 }],
+    }, { cwd: tmp });
+    assert.ok(!r.violations.some((v) => v.id === VIOLATION_IDS.FIX_LOOP_HISTORY_DESYNC));
+  });
+  it('no history → not measurable', () => {
+    const r = checkInvariants({ fix_loop_count: 5 }, { cwd: tmp });
+    assert.ok(!r.violations.some((v) => v.id === VIOLATION_IDS.FIX_LOOP_HISTORY_DESYNC));
+  });
+  it('numeric history entries also work', () => {
+    const r = checkInvariants({
+      fix_loop_count: 3,
+      fix_loop_history: [1, 2],
+    }, { cwd: tmp });
+    assert.ok(!r.violations.some((v) => v.id === VIOLATION_IDS.FIX_LOOP_HISTORY_DESYNC));
+  });
+});
+
+describe('I6 phase3-gate state-write missing structured evidence', () => {
+  const ent = (exit_code) => ({ command: 'npm test', exit_code, stdout_tail: '', timestamp: 'now' });
+
+  it('all three structured → no violation', () => {
+    const r = checkInvariants({
+      current_phase: 'phase3-gate',
+      gate_results: { hard1_baseline: ent(0), hard2_coverage: ent(0), hard3_resilience: ent(0) },
+    }, { cwd: tmp, trigger: TRIGGERS.STATE_WRITE });
+    assert.ok(!r.violations.some((v) => v.id === VIOLATION_IDS.GATE_EVIDENCE_MISSING));
+  });
+
+  it('partial structured → violation lists missing names', () => {
+    const r = checkInvariants({
+      current_phase: 'phase3-gate',
+      gate_results: { hard1_baseline: ent(0) },
+    }, { cwd: tmp, trigger: TRIGGERS.STATE_WRITE });
+    const v = r.violations.find((x) => x.id === VIOLATION_IDS.GATE_EVIDENCE_MISSING);
+    assert.ok(v);
+    assert.deepStrictEqual(v.missing.sort(), ['hard2_coverage', 'hard3_resilience']);
+  });
+
+  it('not phase3-gate → not checked', () => {
+    const r = checkInvariants({
+      current_phase: 'phase2-sprint',
+      gate_results: {},
+    }, { cwd: tmp, trigger: TRIGGERS.STATE_WRITE });
+    assert.ok(!r.violations.some((v) => v.id === VIOLATION_IDS.GATE_EVIDENCE_MISSING));
+  });
+
+  it('STOP trigger → not checked (mpl-phase-controller already gates)', () => {
+    const r = checkInvariants({
+      current_phase: 'phase3-gate',
+      gate_results: {},
+    }, { cwd: tmp, trigger: TRIGGERS.STOP });
+    assert.ok(!r.violations.some((v) => v.id === VIOLATION_IDS.GATE_EVIDENCE_MISSING));
+  });
+});
+
+describe('I7 current_phase folder lifecycle', () => {
+  it('flags missing folder for concrete phase id', () => {
+    const r = checkInvariants({ current_phase: 'phase-7' }, { cwd: tmp });
+    assert.ok(r.violations.some((v) => v.id === VIOLATION_IDS.PHASE_FOLDER_LIFECYCLE));
+  });
+  it('passes when folder exists', () => {
+    makePhaseFolders(3);
+    const r = checkInvariants({ current_phase: 'phase-2' }, { cwd: tmp });
+    assert.ok(!r.violations.some((v) => v.id === VIOLATION_IDS.PHASE_FOLDER_LIFECYCLE));
+  });
+  it('lifecycle markers (phase2-sprint) are exempt', () => {
+    const r = checkInvariants({ current_phase: 'phase2-sprint' }, { cwd: tmp });
+    assert.ok(!r.violations.some((v) => v.id === VIOLATION_IDS.PHASE_FOLDER_LIFECYCLE));
+  });
+});
+
+describe('I8 schema_version range', () => {
+  it('flags schema_version > CURRENT_SCHEMA_VERSION', () => {
+    const r = checkInvariants({ schema_version: 99 }, { cwd: tmp });
+    assert.ok(r.violations.some((v) => v.id === VIOLATION_IDS.SCHEMA_VERSION_UNSUPPORTED));
+  });
+  it('matches current → ok', () => {
+    const r = checkInvariants({ schema_version: 2 }, { cwd: tmp });
+    assert.ok(!r.violations.some((v) => v.id === VIOLATION_IDS.SCHEMA_VERSION_UNSUPPORTED));
+  });
+});
+
+describe('I9 session_status enum', () => {
+  it('flags unknown session_status', () => {
+    const r = checkInvariants({ session_status: 'mystery_state' }, { cwd: tmp });
+    assert.ok(r.violations.some((v) => v.id === VIOLATION_IDS.SESSION_STATUS_CONFLICT));
+  });
+  for (const valid of [null, 'active', 'paused_budget', 'paused_checkpoint', 'verification_hang', 'cancelled']) {
+    it(`accepts ${valid === null ? 'null' : valid}`, () => {
+      const r = checkInvariants({ session_status: valid }, { cwd: tmp });
+      assert.ok(!r.violations.some((v) => v.id === VIOLATION_IDS.SESSION_STATUS_CONFLICT));
+    });
+  }
+});
+
+describe('Multi-violation aggregation (exp15 4-way desync)', () => {
+  it('surfaces 4 simultaneous violations', () => {
+    // Realistic desync — I1 (paused+finalize), I4 (folder mismatch), I5
+    // (count vs history), I7 (current_phase names a folder that doesn't
+    // exist). I1 and I2 are mutually exclusive on the finalize_done field,
+    // so this fixture picks the I1 branch.
+    makePhaseFolders(2);
+    const r = checkInvariants({
+      schema_version: 2,
+      session_status: 'paused_budget',
+      finalize_done: true,                       // I1
+      current_phase: 'phase-7',                  // I7 (no phase-7 folder)
+      execution: { phases: { completed: 5 } },   // I4 (5 vs 2 on disk)
+      fix_loop_count: 10,
+      fix_loop_history: [{ phase: 'p1', count: 1 }], // I5 (10 vs 1)
+    }, { cwd: tmp });
+    const ids = r.violations.map((v) => v.id);
+    assert.ok(ids.includes(VIOLATION_IDS.PAUSED_BUT_FINALIZED));
+    assert.ok(ids.includes(VIOLATION_IDS.PHASE_FOLDER_MISMATCH));
+    assert.ok(ids.includes(VIOLATION_IDS.FIX_LOOP_HISTORY_DESYNC));
+    assert.ok(ids.includes(VIOLATION_IDS.PHASE_FOLDER_LIFECYCLE));
+    assert.ok(r.violations.length >= 4);
+  });
+});
+
+describe('formatViolations', () => {
+  it('returns empty string when ok', () => {
+    assert.strictEqual(formatViolations({ ok: true, violations: [] }), '');
+  });
+  it('lists ids in summary', () => {
+    const text = formatViolations({
+      ok: false,
+      violations: [
+        { id: 'I1', message: 'x' },
+        { id: 'I4', message: 'y' },
+      ],
+    });
+    assert.match(text, /\[MPL G3\]/);
+    assert.match(text, /I1, I4/);
+  });
+});
+
+/* ────────────────────────── hook integration ──────────────────────────── */
+
+describe('mpl-state-invariant hook integration', () => {
+  function runHook(eventName, toolName, toolInput = {}, extraState = null) {
+    if (extraState) withState(extraState);
+    const stdin = JSON.stringify({
+      cwd: tmp,
+      hook_event_name: eventName,
+      tool_name: toolName,
+      tool_input: toolInput,
+    });
+    const out = execFileSync('node', [HOOK_PATH], { input: stdin, encoding: 'utf-8' });
+    return JSON.parse(out);
+  }
+
+  it('clean state → silent', () => {
+    const r = runHook('Stop', null, {}, { current_phase: 'phase2-sprint', schema_version: 2 });
+    assert.strictEqual(r.continue, true);
+    assert.strictEqual(r.suppressOutput, true);
+  });
+
+  it('I1 violation under default policy (warn) → systemMessage', () => {
+    const r = runHook('Stop', null, {}, {
+      current_phase: 'phase2-sprint',
+      session_status: 'paused_budget',
+      finalize_done: true,
+    });
+    assert.strictEqual(r.continue, true);
+    assert.match(r.systemMessage, /\[MPL G3\]/);
+    assert.match(r.systemMessage, /I1/);
+  });
+
+  it('strict mode → block', () => {
+    const r = runHook('Stop', null, {}, {
+      current_phase: 'phase2-sprint',
+      session_status: 'paused_budget',
+      finalize_done: true,
+      enforcement: { strict: true },
+    });
+    assert.strictEqual(r.decision, 'block');
+    assert.match(r.reason, /I1/);
+  });
+
+  it('off opt-out → silent even with violations', () => {
+    writeFileSync(
+      join(tmp, '.mpl', 'config.json'),
+      JSON.stringify({ enforcement: { state_invariant_violation: 'off' } }),
+    );
+    const r = runHook('Stop', null, {}, {
+      current_phase: 'completed',
+      finalize_done: false,
+    });
+    assert.strictEqual(r.continue, true);
+    assert.strictEqual(r.suppressOutput, true);
+  });
+
+  it('PreToolUse Task with paused_budget → I3 surfaced', () => {
+    const r = runHook('PreToolUse', 'Task', {}, {
+      current_phase: 'phase2-sprint',
+      session_status: 'paused_budget',
+    });
+    assert.match(r.systemMessage || r.reason || '', /I3/);
+  });
+
+  it('PreToolUse Edit on unrelated file → silent (state.json filter)', () => {
+    const r = runHook('PreToolUse', 'Edit',
+      { file_path: '/tmp/foo.ts', old_string: 'x', new_string: 'y' },
+      { current_phase: 'phase3-gate', gate_results: {} },
+    );
+    assert.strictEqual(r.continue, true);
+    assert.strictEqual(r.suppressOutput, true);
+  });
+
+  it('PreToolUse Edit on .mpl/state.json with phase3-gate missing evidence → I6 surfaced', () => {
+    const stateJsonPath = join(tmp, '.mpl', 'state.json');
+    const r = runHook('PreToolUse', 'Edit',
+      { file_path: stateJsonPath, old_string: 'x', new_string: 'y' },
+      { current_phase: 'phase3-gate', gate_results: {} },
+    );
+    assert.match(r.systemMessage || r.reason || '', /I6/);
+  });
+
+  it('MPL not active → silent', () => {
+    rmSync(join(tmp, '.mpl'), { recursive: true });
+    const r = runHook('Stop', null, {});
+    assert.strictEqual(r.continue, true);
+    assert.strictEqual(r.suppressOutput, true);
+  });
+});

--- a/hooks/__tests__/mpl-state-invariant.test.mjs
+++ b/hooks/__tests__/mpl-state-invariant.test.mjs
@@ -47,6 +47,9 @@ describe('checkInvariants — basics', () => {
 
   it('clean realistic state → ok=true', () => {
     makePhaseFolders(2);
+    // Both phase folders carry state-summary.md → counted as completed.
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'phases', 'phase-1', 'state-summary.md'), '# done');
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'phases', 'phase-2', 'state-summary.md'), '# done');
     const r = checkInvariants({
       current_phase: 'phase2-sprint',
       finalize_done: false,
@@ -106,13 +109,25 @@ describe('I3 paused/hung blocks new dispatch', () => {
 });
 
 describe('I4 phase folder count vs execution.phases.completed', () => {
-  it('flags mismatch', () => {
+  function markCompleted(n) {
+    // Only phase-N directories carrying state-summary.md count as completed.
+    for (let i = 1; i <= n; i++) {
+      writeFileSync(
+        join(tmp, '.mpl', 'mpl', 'phases', `phase-${i}`, 'state-summary.md'),
+        '# done',
+      );
+    }
+  }
+
+  it('flags mismatch when 3 phases completed but state says 1', () => {
     makePhaseFolders(3);
+    markCompleted(3);
     const r = checkInvariants({ execution: { phases: { completed: 1 } } }, { cwd: tmp });
     assert.ok(r.violations.some((v) => v.id === VIOLATION_IDS.PHASE_FOLDER_MISMATCH));
   });
-  it('match passes', () => {
+  it('match passes when 3 completed and state agrees', () => {
     makePhaseFolders(3);
+    markCompleted(3);
     const r = checkInvariants({ execution: { phases: { completed: 3 } } }, { cwd: tmp });
     assert.ok(!r.violations.some((v) => v.id === VIOLATION_IDS.PHASE_FOLDER_MISMATCH));
   });
@@ -120,6 +135,22 @@ describe('I4 phase folder count vs execution.phases.completed', () => {
     makePhaseFolders(3);
     const r = checkInvariants({}, { cwd: tmp });
     assert.ok(!r.violations.some((v) => v.id === VIOLATION_IDS.PHASE_FOLDER_MISMATCH));
+  });
+
+  it('PR #128 review #1: decompose-pre-created phase-N dirs without state-summary do NOT count', () => {
+    // commands/mpl-run-decompose.md Step 4 pre-creates every phase-N/ directory
+    // before any phase runs; Step 5 initializes execution.phases.completed=0.
+    // I4 must read the disk-truth that matches phase-runner finalize artifacts
+    // (state-summary.md), not raw directory existence.
+    makePhaseFolders(3); // empty dirs only — no state-summary.md
+    const r = checkInvariants({
+      current_phase: 'phase2-sprint',
+      execution: { phases: { total: 3, completed: 0 } },
+    }, { cwd: tmp });
+    assert.ok(
+      !r.violations.some((v) => v.id === VIOLATION_IDS.PHASE_FOLDER_MISMATCH),
+      `expected no I4 false positive, got: ${JSON.stringify(r.violations, null, 2)}`,
+    );
   });
 });
 
@@ -351,6 +382,99 @@ describe('mpl-state-invariant hook integration', () => {
       { current_phase: 'phase3-gate', gate_results: {} },
     );
     assert.match(r.systemMessage || r.reason || '', /I6/);
+  });
+
+  it('PR #128 review #2: PreToolUse Write that strips structured evidence → I6 surfaced (proposed state simulation)', () => {
+    // Pre-write state HAS structured evidence; the Write replaces it with
+    // legacy-booleans only. The hook must validate the PROPOSED state, not
+    // the current on-disk state, otherwise the strip-down silently passes.
+    const stateJsonPath = join(tmp, '.mpl', 'state.json');
+    const ent = (e) => ({ command: 'npm test', exit_code: e, stdout_tail: '', timestamp: 'now' });
+    const cleanState = {
+      schema_version: 2,
+      current_phase: 'phase3-gate',
+      gate_results: {
+        hard1_baseline: ent(0),
+        hard2_coverage: ent(0),
+        hard3_resilience: ent(0),
+      },
+    };
+    writeFileSync(stateJsonPath, JSON.stringify(cleanState));
+    const proposedDirty = {
+      schema_version: 2,
+      current_phase: 'phase3-gate',
+      gate_results: { hard1_passed: true, hard2_passed: true, hard3_passed: true },
+    };
+    const stdin = JSON.stringify({
+      cwd: tmp,
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Write',
+      tool_input: { file_path: stateJsonPath, content: JSON.stringify(proposedDirty) },
+    });
+    const out = execFileSync('node', [HOOK_PATH], { input: stdin, encoding: 'utf-8' });
+    const r = JSON.parse(out);
+    assert.match(r.systemMessage || r.reason || '', /I6/);
+  });
+
+  it('PR #128 review #2: PreToolUse Edit that swaps structured for legacy → I6 surfaced', () => {
+    const stateJsonPath = join(tmp, '.mpl', 'state.json');
+    const ent = (e) => ({ command: 'npm test', exit_code: e, stdout_tail: '', timestamp: 'now' });
+    const cleanState = {
+      schema_version: 2,
+      current_phase: 'phase3-gate',
+      gate_results: {
+        hard1_baseline: ent(0),
+        hard2_coverage: ent(0),
+        hard3_resilience: ent(0),
+      },
+    };
+    const cleanText = JSON.stringify(cleanState);
+    writeFileSync(stateJsonPath, cleanText);
+    const dirtyText = JSON.stringify({
+      schema_version: 2,
+      current_phase: 'phase3-gate',
+      gate_results: { hard1_passed: true, hard2_passed: true, hard3_passed: true },
+    });
+    const stdin = JSON.stringify({
+      cwd: tmp,
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Edit',
+      tool_input: { file_path: stateJsonPath, old_string: cleanText, new_string: dirtyText },
+    });
+    const out = execFileSync('node', [HOOK_PATH], { input: stdin, encoding: 'utf-8' });
+    const r = JSON.parse(out);
+    assert.match(r.systemMessage || r.reason || '', /I6/);
+  });
+
+  it('Write that ADDS structured evidence (clean transition) → silent, no I6', () => {
+    // Inverse case: a Write that introduces structured evidence to a state
+    // that previously had none should NOT surface I6.
+    const stateJsonPath = join(tmp, '.mpl', 'state.json');
+    const ent = (e) => ({ command: 'npm test', exit_code: e, stdout_tail: '', timestamp: 'now' });
+    writeFileSync(stateJsonPath, JSON.stringify({
+      schema_version: 2,
+      current_phase: 'phase3-gate',
+      gate_results: {},
+    }));
+    const proposedClean = {
+      schema_version: 2,
+      current_phase: 'phase3-gate',
+      gate_results: {
+        hard1_baseline: ent(0),
+        hard2_coverage: ent(0),
+        hard3_resilience: ent(0),
+      },
+    };
+    const stdin = JSON.stringify({
+      cwd: tmp,
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Write',
+      tool_input: { file_path: stateJsonPath, content: JSON.stringify(proposedClean) },
+    });
+    const out = execFileSync('node', [HOOK_PATH], { input: stdin, encoding: 'utf-8' });
+    const r = JSON.parse(out);
+    assert.strictEqual(r.continue, true);
+    assert.strictEqual(r.suppressOutput, true);
   });
 
   it('MPL not active → silent', () => {

--- a/hooks/__tests__/mpl-state-invariant.test.mjs
+++ b/hooks/__tests__/mpl-state-invariant.test.mjs
@@ -106,6 +106,17 @@ describe('I3 paused/hung blocks new dispatch', () => {
     );
     assert.ok(!r.violations.some((v) => v.id === VIOLATION_IDS.PAUSED_NEW_DISPATCH));
   });
+
+  it("PR #128 nit #1: 'cancelled' session does NOT block dispatch (cleanup Tasks allowed)", () => {
+    // The DISPATCH_BLOCKED_STATUSES set intentionally excludes `cancelled` —
+    // a cancelled pipeline may still need to dispatch cleanup Tasks before
+    // the session truly exits. The exclusion is documented in lib code.
+    const r = checkInvariants(
+      { session_status: 'cancelled' },
+      { cwd: tmp, trigger: TRIGGERS.TASK_DISPATCH },
+    );
+    assert.ok(!r.violations.some((v) => v.id === VIOLATION_IDS.PAUSED_NEW_DISPATCH));
+  });
 });
 
 describe('I4 phase folder count vs execution.phases.completed', () => {
@@ -250,12 +261,12 @@ describe('I8 schema_version range', () => {
 describe('I9 session_status enum', () => {
   it('flags unknown session_status', () => {
     const r = checkInvariants({ session_status: 'mystery_state' }, { cwd: tmp });
-    assert.ok(r.violations.some((v) => v.id === VIOLATION_IDS.SESSION_STATUS_CONFLICT));
+    assert.ok(r.violations.some((v) => v.id === VIOLATION_IDS.SESSION_STATUS_INVALID));
   });
   for (const valid of [null, 'active', 'paused_budget', 'paused_checkpoint', 'verification_hang', 'cancelled']) {
     it(`accepts ${valid === null ? 'null' : valid}`, () => {
       const r = checkInvariants({ session_status: valid }, { cwd: tmp });
-      assert.ok(!r.violations.some((v) => v.id === VIOLATION_IDS.SESSION_STATUS_CONFLICT));
+      assert.ok(!r.violations.some((v) => v.id === VIOLATION_IDS.SESSION_STATUS_INVALID));
     });
   }
 });

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -42,6 +42,16 @@
         ]
       },
       {
+        "matcher": "Task|Agent|Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/mpl-state-invariant.mjs\"",
+            "timeout": 3
+          }
+        ]
+      },
+      {
         "matcher": "Edit|Write",
         "hooks": [
           {
@@ -239,6 +249,11 @@
           {
             "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/mpl-phase-controller.mjs\""
+          },
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/mpl-state-invariant.mjs\"",
+            "timeout": 3
           }
         ]
       }

--- a/hooks/lib/mpl-state-invariant.mjs
+++ b/hooks/lib/mpl-state-invariant.mjs
@@ -67,12 +67,21 @@ function v(id, message, details = {}) {
   return { id, message, ...details };
 }
 
+/**
+ * Count phase folders that have actually completed — i.e. carry a
+ * `state-summary.md` artifact written by phase-runner at finalize. Plain
+ * directory existence is NOT enough: `commands/mpl-run-decompose.md` Step 4
+ * pre-creates every `phase-N/` directory before any phase runs, so naïve
+ * folder count would report N completed phases the moment decomposition
+ * finishes even though `execution.phases.completed === 0`. (PR #128 review.)
+ */
 function countPhaseFolders(cwd) {
   const phasesDir = join(cwd, '.mpl', 'mpl', 'phases');
   if (!existsSync(phasesDir)) return null; // signal "not measurable"
   try {
     return readdirSync(phasesDir, { withFileTypes: true })
       .filter((e) => e.isDirectory() && /^phase-\d+/.test(e.name))
+      .filter((e) => existsSync(join(phasesDir, e.name, 'state-summary.md')))
       .length;
   } catch {
     return null;

--- a/hooks/lib/mpl-state-invariant.mjs
+++ b/hooks/lib/mpl-state-invariant.mjs
@@ -43,7 +43,11 @@ export const VIOLATION_IDS = Object.freeze({
   GATE_EVIDENCE_MISSING: 'I6',
   PHASE_FOLDER_LIFECYCLE: 'I7',
   SCHEMA_VERSION_UNSUPPORTED: 'I8',
-  SESSION_STATUS_CONFLICT: 'I9', // G4 forward-compat: paused_* ⊥ verification_hang
+  // G4 forward-compat — values must match the H1 enum allowlist. New
+  // session_status values added by future writers MUST be registered in
+  // checkI9 before this hook can vouch for them; otherwise unknown values
+  // surface here.
+  SESSION_STATUS_INVALID: 'I9',
 });
 
 const ACTIVE_PHASES = new Set([
@@ -60,6 +64,12 @@ const ACTIVE_PHASES = new Set([
 
 const PAUSE_STATUSES = new Set(['paused_budget', 'paused_checkpoint']);
 const HANG_STATUSES = new Set(['verification_hang']);
+// I3 dispatch-block set. `cancelled` is intentionally NOT included: a
+// cancelled pipeline may need to dispatch cleanup Tasks (e.g. archive
+// artifacts, post-mortem agent) before the session truly exits. If a future
+// writer needs to forbid Task dispatch during cancel, add it here AND extend
+// the resume protocol to cover the new resume direction.
+const DISPATCH_BLOCKED_STATUSES = new Set([...PAUSE_STATUSES, ...HANG_STATUSES]);
 
 /* ────────────────────────── helpers ──────────────────────────────────────── */
 
@@ -146,8 +156,9 @@ function checkI2(state) {
 
 function checkI3(state, trigger) {
   // No new phase dispatch (PreToolUse Task|Agent) while paused/hung.
+  // See DISPATCH_BLOCKED_STATUSES above for why `cancelled` is excluded.
   if (trigger !== TRIGGERS.TASK_DISPATCH) return null;
-  if (PAUSE_STATUSES.has(state.session_status) || HANG_STATUSES.has(state.session_status)) {
+  if (DISPATCH_BLOCKED_STATUSES.has(state.session_status)) {
     return v(VIOLATION_IDS.PAUSED_NEW_DISPATCH,
       `session_status='${state.session_status}' — new Task/Agent dispatches are blocked. Resume the pipeline first (/mpl:mpl-resume).`,
       { session_status: state.session_status });
@@ -237,16 +248,14 @@ function checkI8(state) {
 }
 
 function checkI9(state) {
-  // session_status mutual exclusivity (forward-compat with G4 #109): a
-  // pipeline cannot be intentionally paused AND mid-hang at the same time.
-  // Although session_status is a single field today, future writers might
-  // combine flags or mark transition states; this guards against schema
-  // expansion that breaks the assumption.
-  // Note: the field is a string, so direct combination isn't currently
-  // expressible. We instead validate the value is in the allowed enum.
+  // session_status enum validity (G4 #109 forward-compat). Today the field is
+  // a single-valued string so mutual exclusivity is structurally enforced;
+  // this check guards the value itself. Future writers introducing new
+  // statuses MUST add them to the H1 allowlist (`docs/schemas/state.md`)
+  // before they can be emitted — otherwise unknown values surface as I9.
   const allowed = new Set([null, 'active', 'paused_budget', 'paused_checkpoint', 'verification_hang', 'cancelled']);
   if (!allowed.has(state.session_status ?? null)) {
-    return v(VIOLATION_IDS.SESSION_STATUS_CONFLICT,
+    return v(VIOLATION_IDS.SESSION_STATUS_INVALID,
       `session_status='${state.session_status}' is not in the allowed enum (null|active|paused_budget|paused_checkpoint|verification_hang|cancelled).`,
       { session_status: state.session_status });
   }

--- a/hooks/lib/mpl-state-invariant.mjs
+++ b/hooks/lib/mpl-state-invariant.mjs
@@ -1,0 +1,295 @@
+/**
+ * MPL State Invariant Checker (G3 + H1, #108)
+ *
+ * exp15 surfaced 4 simultaneous state.json contradictions that no existing
+ * gate caught (R-STATE-DESYNC, Evidence grade A). G3 introduces a single
+ * structural validator; H1 freezes the sprint-vs-phase schema split so the
+ * checker has a stable reference.
+ *
+ * Pure functions. Returns a list of violations; the consuming hook decides
+ * `warn` / `block` / `off` via the P0-2 `state_invariant_violation` rule.
+ *
+ * Schema reference (H1 frozen — see docs/schemas/state.md):
+ *   - `execution.phases.*`  = phase units (per phase-runner invocation)
+ *   - `sprint_status.*`     = sprint units (multiple phases together)
+ *   - `current_phase`       = lifecycle marker, not a phase id
+ *   - `session_status`      = pause/hang reason; mutually exclusive with each other
+ */
+
+import { existsSync, readdirSync, statSync } from 'fs';
+import { join } from 'path';
+
+import { CURRENT_SCHEMA_VERSION } from './mpl-state.mjs';
+
+/**
+ * Trigger contexts. Different triggers care about different invariants — for
+ * example "no new phase dispatch while paused" only matters when the trigger
+ * is a Task/Agent PreToolUse, not a vanilla Stop.
+ */
+export const TRIGGERS = Object.freeze({
+  STOP: 'stop',
+  TASK_DISPATCH: 'task-dispatch', // PreToolUse Task|Agent
+  STATE_WRITE: 'state-write',     // Edit/Write of .mpl/state.json
+  PRE_COMPACT: 'pre-compact',
+});
+
+/** All known violation IDs — surfaced by hooks for log/reporting. */
+export const VIOLATION_IDS = Object.freeze({
+  PAUSED_BUT_FINALIZED: 'I1',
+  COMPLETED_BUT_NOT_FINALIZED: 'I2',
+  PAUSED_NEW_DISPATCH: 'I3',
+  PHASE_FOLDER_MISMATCH: 'I4',
+  FIX_LOOP_HISTORY_DESYNC: 'I5',
+  GATE_EVIDENCE_MISSING: 'I6',
+  PHASE_FOLDER_LIFECYCLE: 'I7',
+  SCHEMA_VERSION_UNSUPPORTED: 'I8',
+  SESSION_STATUS_CONFLICT: 'I9', // G4 forward-compat: paused_* ⊥ verification_hang
+});
+
+const ACTIVE_PHASES = new Set([
+  'phase1-plan',
+  'phase1a-research',
+  'phase1b-plan',
+  'mpl-decompose',
+  'mpl-ambiguity-resolve',
+  'phase2-sprint',
+  'phase3-gate',
+  'phase4-fix',
+  'phase5-finalize',
+]);
+
+const PAUSE_STATUSES = new Set(['paused_budget', 'paused_checkpoint']);
+const HANG_STATUSES = new Set(['verification_hang']);
+
+/* ────────────────────────── helpers ──────────────────────────────────────── */
+
+function v(id, message, details = {}) {
+  return { id, message, ...details };
+}
+
+function countPhaseFolders(cwd) {
+  const phasesDir = join(cwd, '.mpl', 'mpl', 'phases');
+  if (!existsSync(phasesDir)) return null; // signal "not measurable"
+  try {
+    return readdirSync(phasesDir, { withFileTypes: true })
+      .filter((e) => e.isDirectory() && /^phase-\d+/.test(e.name))
+      .length;
+  } catch {
+    return null;
+  }
+}
+
+function phaseFolderExists(cwd, phaseId) {
+  // current_phase is a lifecycle marker (phase2-sprint, mpl-decompose, ...);
+  // we only correlate with disk when it looks like a phase folder id.
+  if (!phaseId || !/^phase-\d+/.test(phaseId)) return null;
+  const dir = join(cwd, '.mpl', 'mpl', 'phases', phaseId);
+  return existsSync(dir) && safeIsDir(dir);
+}
+
+function safeIsDir(path) {
+  try { return statSync(path).isDirectory(); }
+  catch { return false; }
+}
+
+function sumFixLoopHistory(state) {
+  const history = state?.fix_loop_history;
+  if (!Array.isArray(history)) return null; // not measurable
+  let sum = 0;
+  for (const entry of history) {
+    // Each entry: { phase: string, count: number } or just a count.
+    const count = typeof entry === 'number'
+      ? entry
+      : (typeof entry?.count === 'number' ? entry.count : null);
+    if (count === null || !Number.isFinite(count)) return null;
+    sum += count;
+  }
+  return sum;
+}
+
+function isStructuredEntry(e) {
+  return e && typeof e === 'object'
+    && typeof e.exit_code === 'number'
+    && Number.isFinite(e.exit_code);
+}
+
+/* ────────────────────────── individual invariants ────────────────────────── */
+
+function checkI1(state) {
+  // Paused-budget AND finalize_done=true → contradiction
+  if (state.session_status === 'paused_budget' && state.finalize_done === true) {
+    return v(VIOLATION_IDS.PAUSED_BUT_FINALIZED,
+      "session_status='paused_budget' but finalize_done=true — pipeline can't be both paused and finalized.",
+      { session_status: state.session_status, finalize_done: state.finalize_done });
+  }
+  return null;
+}
+
+function checkI2(state) {
+  // current_phase='completed' AND finalize_done=false → contradiction
+  if (state.current_phase === 'completed' && state.finalize_done !== true) {
+    return v(VIOLATION_IDS.COMPLETED_BUT_NOT_FINALIZED,
+      "current_phase='completed' but finalize_done is not true — completion claims must be backed by finalize_done.",
+      { current_phase: state.current_phase, finalize_done: state.finalize_done });
+  }
+  return null;
+}
+
+function checkI3(state, trigger) {
+  // No new phase dispatch (PreToolUse Task|Agent) while paused/hung.
+  if (trigger !== TRIGGERS.TASK_DISPATCH) return null;
+  if (PAUSE_STATUSES.has(state.session_status) || HANG_STATUSES.has(state.session_status)) {
+    return v(VIOLATION_IDS.PAUSED_NEW_DISPATCH,
+      `session_status='${state.session_status}' — new Task/Agent dispatches are blocked. Resume the pipeline first (/mpl:mpl-resume).`,
+      { session_status: state.session_status });
+  }
+  return null;
+}
+
+function checkI4(state, cwd) {
+  // execution.phases.completed should match phase folder count on disk.
+  // Only meaningful when execution subtree exists and the phases directory exists.
+  const declared = state?.execution?.phases?.completed;
+  if (typeof declared !== 'number') return null;
+  const onDisk = countPhaseFolders(cwd);
+  if (onDisk === null) return null;
+  if (declared !== onDisk) {
+    return v(VIOLATION_IDS.PHASE_FOLDER_MISMATCH,
+      `execution.phases.completed=${declared} but ${onDisk} phase folders exist on disk. Drift between state and filesystem.`,
+      { declared, onDisk });
+  }
+  return null;
+}
+
+function checkI5(state) {
+  // fix_loop_count must equal sum(fix_loop_history) when both are present.
+  const count = state?.fix_loop_count;
+  if (typeof count !== 'number') return null;
+  const sum = sumFixLoopHistory(state);
+  if (sum === null) return null; // history absent → can't compare
+  if (count !== sum) {
+    return v(VIOLATION_IDS.FIX_LOOP_HISTORY_DESYNC,
+      `fix_loop_count=${count} disagrees with sum(fix_loop_history)=${sum}. G5 history and counter must agree.`,
+      { count, sum });
+  }
+  return null;
+}
+
+function checkI6(state, trigger) {
+  // Gate transition (state-write whose target leaves phase3-gate) must carry
+  // structured evidence. The hook surfaces this only on STATE_WRITE — at
+  // STOP, mpl-phase-controller already gates with checkGateResults.
+  if (trigger !== TRIGGERS.STATE_WRITE) return null;
+  if (state.current_phase !== 'phase3-gate') return null;
+  const gr = state?.gate_results;
+  if (!gr || typeof gr !== 'object') {
+    return v(VIOLATION_IDS.GATE_EVIDENCE_MISSING,
+      "phase3-gate state-write without gate_results. Run real verification commands so mpl-gate-recorder produces structured evidence.",
+      { gate_results: null });
+  }
+  const required = ['hard1_baseline', 'hard2_coverage', 'hard3_resilience'];
+  const missing = required.filter((k) => !isStructuredEntry(gr[k]));
+  if (missing.length > 0) {
+    return v(VIOLATION_IDS.GATE_EVIDENCE_MISSING,
+      `phase3-gate state-write missing structured gate evidence: ${missing.join(', ')}. P0-1 (#102) — legacy booleans alone do not satisfy G3.`,
+      { missing });
+  }
+  return null;
+}
+
+function checkI7(state, cwd) {
+  // current_phase that names a specific phase folder (phase-N) must have a
+  // matching directory. Lifecycle markers (phase2-sprint, mpl-decompose, ...)
+  // are exempt.
+  const phaseId = state.current_phase;
+  if (!phaseId) return null;
+  const exists = phaseFolderExists(cwd, phaseId);
+  if (exists === null) return null;
+  if (!exists) {
+    return v(VIOLATION_IDS.PHASE_FOLDER_LIFECYCLE,
+      `current_phase='${phaseId}' but no matching .mpl/mpl/phases/${phaseId}/ directory.`,
+      { phaseId });
+  }
+  return null;
+}
+
+function checkI8(state) {
+  // Refuse states with a schema_version newer than this hook supports.
+  // Migration handles older versions automatically — newer ones mean the
+  // hook is stale relative to the writer.
+  const sv = state?.schema_version;
+  if (typeof sv !== 'number') return null;
+  if (sv > CURRENT_SCHEMA_VERSION) {
+    return v(VIOLATION_IDS.SCHEMA_VERSION_UNSUPPORTED,
+      `state.schema_version=${sv} exceeds supported CURRENT_SCHEMA_VERSION=${CURRENT_SCHEMA_VERSION}. Hook may be out of date — upgrade mpl plugin.`,
+      { schema_version: sv, supported: CURRENT_SCHEMA_VERSION });
+  }
+  return null;
+}
+
+function checkI9(state) {
+  // session_status mutual exclusivity (forward-compat with G4 #109): a
+  // pipeline cannot be intentionally paused AND mid-hang at the same time.
+  // Although session_status is a single field today, future writers might
+  // combine flags or mark transition states; this guards against schema
+  // expansion that breaks the assumption.
+  // Note: the field is a string, so direct combination isn't currently
+  // expressible. We instead validate the value is in the allowed enum.
+  const allowed = new Set([null, 'active', 'paused_budget', 'paused_checkpoint', 'verification_hang', 'cancelled']);
+  if (!allowed.has(state.session_status ?? null)) {
+    return v(VIOLATION_IDS.SESSION_STATUS_CONFLICT,
+      `session_status='${state.session_status}' is not in the allowed enum (null|active|paused_budget|paused_checkpoint|verification_hang|cancelled).`,
+      { session_status: state.session_status });
+  }
+  return null;
+}
+
+/* ────────────────────────── aggregator ──────────────────────────────────── */
+
+/**
+ * Run the invariant suite. Some invariants only fire on specific triggers
+ * (see TRIGGERS).
+ *
+ * @param {object | null | undefined} state - state.json contents
+ * @param {{ cwd?: string, trigger?: string }} [opts]
+ * @returns {{ ok: boolean, violations: Array<{id, message, ...}> }}
+ */
+export function checkInvariants(state, opts = {}) {
+  if (!state || typeof state !== 'object') {
+    return { ok: true, violations: [] };
+  }
+  const cwd = opts.cwd ?? process.cwd();
+  const trigger = opts.trigger ?? TRIGGERS.STOP;
+
+  const checks = [
+    () => checkI1(state),
+    () => checkI2(state),
+    () => checkI3(state, trigger),
+    () => checkI4(state, cwd),
+    () => checkI5(state),
+    () => checkI6(state, trigger),
+    () => checkI7(state, cwd),
+    () => checkI8(state),
+    () => checkI9(state),
+  ];
+
+  const violations = [];
+  for (const fn of checks) {
+    const r = fn();
+    if (r) violations.push(r);
+  }
+  return { ok: violations.length === 0, violations };
+}
+
+/**
+ * Format a single concise summary line for systemMessage / stopReason output.
+ *
+ * @param {ReturnType<typeof checkInvariants>} result
+ * @returns {string}
+ */
+export function formatViolations(result) {
+  if (result.ok) return '';
+  const ids = result.violations.map((v) => v.id).join(', ');
+  const heads = result.violations.map((v) => `[${v.id}] ${v.message}`).join('\n');
+  return `[MPL G3] state invariant violations (${result.violations.length}: ${ids})\n${heads}`;
+}

--- a/hooks/lib/mpl-state-invariant.mjs
+++ b/hooks/lib/mpl-state-invariant.mjs
@@ -167,15 +167,17 @@ function checkI3(state, trigger) {
 }
 
 function checkI4(state, cwd) {
-  // execution.phases.completed should match phase folder count on disk.
-  // Only meaningful when execution subtree exists and the phases directory exists.
+  // execution.phases.completed should match the number of `phase-N/` directories
+  // that carry a `state-summary.md` finalize artifact (the disk truth phase-runner
+  // emits at completion). Empty pre-created directories from
+  // `commands/mpl-run-decompose.md` Step 4 are NOT counted — see countPhaseFolders.
   const declared = state?.execution?.phases?.completed;
   if (typeof declared !== 'number') return null;
   const onDisk = countPhaseFolders(cwd);
   if (onDisk === null) return null;
   if (declared !== onDisk) {
     return v(VIOLATION_IDS.PHASE_FOLDER_MISMATCH,
-      `execution.phases.completed=${declared} but ${onDisk} phase folders exist on disk. Drift between state and filesystem.`,
+      `execution.phases.completed=${declared} but ${onDisk} phase(s) carry state-summary.md on disk. Drift between state and finalize artifacts.`,
       { declared, onDisk });
   }
   return null;

--- a/hooks/mpl-state-invariant.mjs
+++ b/hooks/mpl-state-invariant.mjs
@@ -19,6 +19,7 @@
 
 import { dirname, join, resolve, sep } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
+import { existsSync, readFileSync } from 'fs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -72,6 +73,58 @@ function isStateWriteTarget(toolInput, cwd) {
       || abs.endsWith('.mpl/state.json');
 }
 
+/**
+ * Simulate the state.json contents AFTER the proposed Write/Edit/MultiEdit.
+ * The PreToolUse hook fires before the tool applies, so reading the current
+ * file would miss the very change about to land. (PR #128 review #2.)
+ *
+ * Returns the parsed proposed state object, or null when simulation isn't
+ * possible (parse failure, missing inputs, edit string not found). Callers
+ * fall back to the current state — conservative: hook may miss but never
+ * blocks a write on a hypothetical state we can't compute.
+ */
+function simulateWrittenState(toolName, toolInput, cwd) {
+  const t = (toolName || '').toLowerCase();
+  const fp = toolInput?.file_path || toolInput?.filePath;
+  const abs = fp ? resolve(cwd, fp) : null;
+
+  if (t === 'write') {
+    if (typeof toolInput.content !== 'string') return null;
+    try { return JSON.parse(toolInput.content); } catch { return null; }
+  }
+
+  if (t === 'edit' || t === 'multiedit') {
+    if (!abs || !existsSync(abs)) return null;
+    let content;
+    try { content = readFileSync(abs, 'utf-8'); } catch { return null; }
+
+    const apply = (oldStr, newStr, replaceAll) => {
+      if (typeof oldStr !== 'string' || typeof newStr !== 'string') return null;
+      if (replaceAll === true) return content.split(oldStr).join(newStr);
+      const idx = content.indexOf(oldStr);
+      if (idx === -1) return null;
+      return content.slice(0, idx) + newStr + content.slice(idx + oldStr.length);
+    };
+
+    if (t === 'edit') {
+      const next = apply(toolInput.old_string, toolInput.new_string, toolInput.replace_all);
+      if (next === null) return null;
+      content = next;
+    } else {
+      // MultiEdit: edits[] applied in order
+      if (!Array.isArray(toolInput.edits)) return null;
+      for (const e of toolInput.edits) {
+        const next = apply(e?.old_string, e?.new_string, e?.replace_all);
+        if (next === null) return null;
+        content = next;
+      }
+    }
+    try { return JSON.parse(content); } catch { return null; }
+  }
+
+  return null;
+}
+
 async function main() {
   const input = await readStdin();
   let data;
@@ -81,15 +134,26 @@ async function main() {
   if (!isMplActive(cwd)) return silent();
 
   const trigger = deriveTrigger(data);
+  const toolInput = data.tool_input || data.toolInput || {};
+  const toolName = data.tool_name || data.toolName || '';
 
   // Filter STATE_WRITE to actual state.json targets — otherwise unrelated
   // Edit/Write events would invoke the gate-evidence check.
   if (trigger === TRIGGERS.STATE_WRITE) {
-    const toolInput = data.tool_input || data.toolInput || {};
     if (!isStateWriteTarget(toolInput, cwd)) return silent();
   }
 
-  const state = readState(cwd);
+  // For state-writes, validate the PROPOSED state (post-write content), not
+  // the on-disk state — otherwise a Write that strips structured evidence
+  // would slip through because the current file still has it.
+  let state = readState(cwd);
+  if (trigger === TRIGGERS.STATE_WRITE) {
+    const proposed = simulateWrittenState(toolName, toolInput, cwd);
+    if (proposed && typeof proposed === 'object') state = proposed;
+    // If simulation failed (unparseable, missing string), fall back to
+    // current state. Conservative: we may miss a violation rather than
+    // block a write on a hypothetical we couldn't compute.
+  }
   if (!state) return silent();
 
   const result = checkInvariants(state, { cwd, trigger });

--- a/hooks/mpl-state-invariant.mjs
+++ b/hooks/mpl-state-invariant.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+/**
+ * MPL State Invariant Hook (G3 + H1, #108)
+ *
+ * Triggers (per hooks.json registration):
+ *   - PreToolUse Task|Agent     → trigger='task-dispatch'
+ *   - PreToolUse Edit|Write     → trigger='state-write' (only when target is .mpl/state.json)
+ *   - Stop                       → trigger='stop'
+ *
+ * Action policy is resolved through P0-2 (#110)
+ * `enforcement.state_invariant_violation`:
+ *   - off  → silent (audit-only)
+ *   - warn → continue + systemMessage
+ *   - block → block the triggering action with a structured reason
+ *
+ * Strict mode elevates 'warn' to 'block' at the resolver, per the standard
+ * P0-2 escalation rules.
+ */
+
+import { dirname, join, resolve, sep } from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const { isMplActive, readState } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-state.mjs')).href
+);
+const { readStdin } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'stdin.mjs')).href
+);
+const { checkInvariants, formatViolations, TRIGGERS } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-state-invariant.mjs')).href
+);
+const { resolveRuleAction } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-enforcement.mjs')).href
+);
+
+function silent() {
+  console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+}
+
+/**
+ * Decide which trigger context applies to this invocation. Hook spec passes
+ * `hook_event_name` (Stop / PreToolUse / etc) and `tool_name` (Bash / Edit / Task).
+ */
+function deriveTrigger(data) {
+  const event = (data.hook_event_name || data.hookEventName || '').toLowerCase();
+  const tool = (data.tool_name || data.toolName || '').toLowerCase();
+
+  if (event === 'precompact' || event === 'pre_compact') return TRIGGERS.PRE_COMPACT;
+  if (event === 'stop') return TRIGGERS.STOP;
+  if (event === 'pretooluse' || event === 'pre_tool_use') {
+    if (['task', 'agent'].includes(tool)) return TRIGGERS.TASK_DISPATCH;
+    if (['edit', 'write', 'multiedit'].includes(tool)) return TRIGGERS.STATE_WRITE;
+  }
+  // Unknown event: fall back to STOP semantics (safest — broadest checks).
+  return TRIGGERS.STOP;
+}
+
+/**
+ * Was the file path a state.json target? Filters STATE_WRITE so the hook
+ * only fires on the relevant write — Edit/Write of unrelated files don't
+ * trigger gate-evidence invariants.
+ */
+function isStateWriteTarget(toolInput, cwd) {
+  if (!toolInput) return false;
+  const fp = toolInput.file_path || toolInput.filePath;
+  if (!fp || typeof fp !== 'string') return false;
+  const abs = resolve(cwd, fp);
+  return abs.endsWith(`.mpl${sep}state.json`)
+      || abs.endsWith('.mpl/state.json');
+}
+
+async function main() {
+  const input = await readStdin();
+  let data;
+  try { data = JSON.parse(input); } catch { return silent(); }
+
+  const cwd = data.cwd || data.directory || process.cwd();
+  if (!isMplActive(cwd)) return silent();
+
+  const trigger = deriveTrigger(data);
+
+  // Filter STATE_WRITE to actual state.json targets — otherwise unrelated
+  // Edit/Write events would invoke the gate-evidence check.
+  if (trigger === TRIGGERS.STATE_WRITE) {
+    const toolInput = data.tool_input || data.toolInput || {};
+    if (!isStateWriteTarget(toolInput, cwd)) return silent();
+  }
+
+  const state = readState(cwd);
+  if (!state) return silent();
+
+  const result = checkInvariants(state, { cwd, trigger });
+  if (result.ok) return silent();
+
+  const action = resolveRuleAction(cwd, state, 'state_invariant_violation');
+  if (action === 'off') return silent();
+
+  const reason = formatViolations(result);
+  if (action === 'block') {
+    console.log(JSON.stringify({
+      decision: 'block',
+      reason,
+    }));
+    return;
+  }
+  // warn
+  console.log(JSON.stringify({
+    continue: true,
+    systemMessage: reason,
+  }));
+}
+
+await main().catch(() => silent());


### PR DESCRIPTION
## Summary

exp15 surfaced 4 simultaneous \`state.json\` contradictions that no existing gate caught (R-STATE-DESYNC, Evidence grade A). G3 introduces a single structural validator; H1 freezes the sprint-vs-phase split so the validator has a stable reference. Action policy comes from P0-2 (#110) \`enforcement.state_invariant_violation\`.

## 9 Invariants

| ID | Description | Trigger |
|---|---|---|
| I1 | \`paused_budget AND finalize_done=true\` | all |
| I2 | \`current_phase='completed' AND !finalize_done\` | all |
| I3 | paused/hung AND new Task/Agent dispatch | task-dispatch |
| I4 | \`execution.phases.completed != phase folder count\` | all |
| I5 | \`fix_loop_count != sum(fix_loop_history)\` | all |
| I6 | phase3-gate state-write missing structured evidence | state-write |
| I7 | \`current_phase='phase-N'\` but folder absent | all |
| I8 | \`schema_version > CURRENT_SCHEMA_VERSION\` | all |
| I9 | \`session_status\` outside allowed enum (G4 forward-compat) | all |

## Architecture

| Layer | File | Role |
|---|---|---|
| Pure lib | \`hooks/lib/mpl-state-invariant.mjs\` (new, ~280 lines) | \`checkInvariants(state, opts)\`, \`formatViolations\`, \`TRIGGERS\`, \`VIOLATION_IDS\` |
| Thin hook | \`hooks/mpl-state-invariant.mjs\` (new) | Trigger derivation, state.json target filter for state-write, \`resolveRuleAction\` integration |
| hooks.json | PreToolUse \`Task\|Agent\|Edit\|Write\|MultiEdit\` + Stop | Stacked after \`mpl-phase-controller.mjs\` in Stop |
| H1 schema doc | \`docs/schemas/state.md\` (new) | Frozen sprint-vs-phase semantics, invariant table, schema_version migration policy |

## Action policy (P0-2)

\`\`\`
enforcement.state_invariant_violation: 'warn' | 'block' | 'off'
  default: warn (transitional per #110 §정책)
  strict mode → warn elevates to block
  off → silent (audit-only)
\`\`\`

## Tests (45 cases)

- **basics** (3) — null / empty / clean realistic state
- **I1–I9** individually (24) — positive + negative per invariant; I9 covers all 5 valid enum values
- **multi-violation** (1) — exp15-shape 4-way desync, asserts simultaneous I1+I4+I5+I7
- **formatViolations** (2)
- **hook integration** (8) — clean / I1 warn / strict block / off opt-out / I3 Task / Edit on unrelated file (state.json filter) / Edit on \`.mpl/state.json\` triggering I6 / MPL inactive

Full hook regression: 474 → **519/519** (+45 G3).

## H1 schema freeze (\`docs/schemas/state.md\`)

- \`current_phase\` = lifecycle marker, NOT a phase id
- \`execution.phases.*\` = per-phase (matches disk folder count via I4)
- \`sprint_status.*\` = sprint-aggregated
- \`fix_loop_count\` sprint-aggregated; G5 (#114) populates \`fix_loop_history\` for I5 reconciliation
- \`session_status\` single-valued enum (I9)
- \`schema_version=2\` current; older auto-migrates, newer raises I8

## Forward integration

- **G5+G6 (#114)** — \`fix_loop_history\` writer; I5 enforces once mandatory.
- **P0-K (#115)** — artifact schema validator can lift checks into G3 invariants for state-related artifacts.
- **exp16 strict rollout** — workspace \`enforcement.state_invariant_violation: 'block'\` elevates every I1–I9 to hard block without code change here.

## Files

\`\`\`
docs/schemas/state.md                          |  88 ++++++++
hooks/__tests__/mpl-state-invariant.test.mjs   | 297 +++++++++++++++++++++++++++
hooks/hooks.json                               |  17 +++
hooks/lib/mpl-state-invariant.mjs              | 277 ++++++++++++++++++++++++
hooks/mpl-state-invariant.mjs                  | 117 ++++++++++
5 files changed, 854 insertions(+)
\`\`\`

## Related

- Closes #108
- Part of #101 (v0.18.0 critical 8/10 → **9/10** on merge)
- Builds on P0-1 (#102), P0-2 (#110), G4 (#109) — invariants reference all three

🤖 Generated with [Claude Code](https://claude.com/claude-code)