### PR TITLE
feat(#111): P0-3 — write-guard hard block + dogfood mode

### DIFF
--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -188,6 +188,17 @@ the immutable post-Phase-0 snapshot consumed by delta calculation and rollback.
 |-------|------|---------|-------------|--------|
 | `e2e_timeout` | number | `60000` | Timeout per E2E scenario in milliseconds | `mpl-run-finalize.md` Step 5.0 |
 
+## Dogfood Mode (P0-3, #111)
+
+When developing the MPL plugin against itself (i.e. when the workspace IS the
+plugin), `/MPL/` paths should be subject to the same write-guard rules as
+ordinary application source — orchestrator must delegate edits through
+`mpl-phase-runner` rather than touching plugin files directly.
+
+| Field | Type | Default | Description | Source |
+|-------|------|---------|-------------|--------|
+| `dogfood` | boolean | `false` | When `true`, removes `/MPL/` from `mpl-write-guard.mjs` allowlist so plugin edits are governed by `enforcement.direct_source_edit`. Equivalent env: `MPL_DOGFOOD=1`. | `mpl-write-guard.mjs` |
+
 ## Enforcement (P0-2, #110)
 
 Strict-mode toggle and per-rule policy. Source-of-truth:

--- a/hooks/__tests__/mpl-write-guard.test.mjs
+++ b/hooks/__tests__/mpl-write-guard.test.mjs
@@ -249,6 +249,41 @@ describe('mpl-write-guard hook integration (P0-3, #111)', () => {
     assert.match(r.hookSpecificOutput?.additionalContext || '', /MPL SAFETY WARNING/);
   });
 
+  it('PR #129 review #1: MultiEdit on source file is intercepted (strict → block)', () => {
+    // Reviewer flagged that the previous matcher (Edit|Write|Bash) and the
+    // hook's tool allowlist both excluded MultiEdit, letting orchestrator
+    // bypass strict mode by switching tools.
+    const r = runHook('MultiEdit', {
+      file_path: join(tmp, 'src', 'app.ts'),
+      edits: [
+        { old_string: 'a', new_string: 'b' },
+        { old_string: 'c', new_string: 'd' },
+      ],
+    }, { enforcement: { strict: true } });
+    assert.strictEqual(r.decision, 'block');
+    assert.match(r.reason, /MPL DELEGATION NOTICE/);
+    assert.match(r.reason, /MultiEdit/);
+  });
+
+  it('MultiEdit on source file (default warn) → continue + delegation notice', () => {
+    const r = runHook('MultiEdit', {
+      file_path: join(tmp, 'src', 'app.ts'),
+      edits: [{ old_string: 'a', new_string: 'b' }],
+    });
+    assert.strictEqual(r.continue, true);
+    assert.match(r.hookSpecificOutput?.additionalContext || '', /MPL DELEGATION NOTICE/);
+    assert.match(r.hookSpecificOutput?.additionalContext || '', /MultiEdit/);
+  });
+
+  it('MultiEdit on allowed .mpl/ path → silent regardless of policy', () => {
+    const r = runHook('MultiEdit', {
+      file_path: join(tmp, '.mpl', 'memory', 'working.md'),
+      edits: [{ old_string: 'a', new_string: 'b' }],
+    }, { enforcement: { strict: true, direct_source_edit: 'block' } });
+    assert.strictEqual(r.continue, true);
+    assert.strictEqual(r.suppressOutput, true);
+  });
+
   it('MPL inactive → silent regardless of policy', () => {
     rmSync(join(tmp, '.mpl'), { recursive: true });
     const r = runHook('Edit', {

--- a/hooks/__tests__/mpl-write-guard.test.mjs
+++ b/hooks/__tests__/mpl-write-guard.test.mjs
@@ -1,7 +1,15 @@
-import { describe, it } from 'node:test';
+import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { tmpdir } from 'os';
 
 import { isAllowedPath, isSourceFile } from '../mpl-write-guard.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const HOOK_PATH = join(dirname(__filename), '..', 'mpl-write-guard.mjs');
 
 describe('isAllowedPath', () => {
   it('should allow .mpl/ paths', () => {
@@ -98,5 +106,157 @@ describe('isSourceFile', () => {
   it('should return false for null/empty path', () => {
     assert.strictEqual(isSourceFile(null), false);
     assert.strictEqual(isSourceFile(''), false);
+  });
+});
+
+/* ────────────────────────── P0-3 (#111) ──────────────────────────────── */
+
+describe('isAllowedPath dogfood mode (P0-3, #111)', () => {
+  it('default mode keeps /MPL/ allowed', () => {
+    assert.strictEqual(isAllowedPath('/proj/MPL/hooks/x.mjs', { dogfood: false }), true);
+    // backwards-compat without opts
+    assert.strictEqual(isAllowedPath('/proj/MPL/hooks/x.mjs'), true);
+  });
+  it('dogfood mode strips /MPL/ from allowlist', () => {
+    assert.strictEqual(isAllowedPath('/proj/MPL/hooks/x.mjs', { dogfood: true }), false);
+  });
+  it('dogfood mode does not affect .mpl/ / .claude/', () => {
+    assert.strictEqual(isAllowedPath('/proj/.mpl/state.json', { dogfood: true }), true);
+    assert.strictEqual(isAllowedPath('/proj/.claude/settings.json', { dogfood: true }), true);
+  });
+});
+
+describe('mpl-write-guard hook integration (P0-3, #111)', () => {
+  let tmp;
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'mpl-wg-'));
+    mkdirSync(join(tmp, '.mpl'), { recursive: true });
+    writeFileSync(join(tmp, '.mpl', 'state.json'), JSON.stringify({ current_phase: 'phase2-sprint' }));
+  });
+  afterEach(() => rmSync(tmp, { recursive: true, force: true }));
+
+  function runHook(toolName, toolInput, extraConfig, env) {
+    if (extraConfig) {
+      writeFileSync(join(tmp, '.mpl', 'config.json'), JSON.stringify(extraConfig));
+    }
+    const stdin = JSON.stringify({
+      cwd: tmp,
+      tool_name: toolName,
+      tool_input: toolInput,
+    });
+    const out = execFileSync('node', [HOOK_PATH], {
+      input: stdin,
+      encoding: 'utf-8',
+      env: { ...process.env, ...(env || {}) },
+    });
+    return JSON.parse(out);
+  }
+
+  it('default (warn) on source file outside allowlist → continue + delegation notice', () => {
+    const r = runHook('Edit', {
+      file_path: join(tmp, 'src', 'app.ts'),
+      old_string: 'a',
+      new_string: 'b',
+    });
+    assert.strictEqual(r.continue, true);
+    assert.match(r.hookSpecificOutput?.additionalContext || '', /MPL DELEGATION NOTICE/);
+  });
+
+  it('strict mode (P0-2) elevates direct_source_edit warn → block', () => {
+    const r = runHook('Edit', {
+      file_path: join(tmp, 'src', 'app.ts'),
+      old_string: 'a',
+      new_string: 'b',
+    }, { enforcement: { strict: true } });
+    assert.strictEqual(r.decision, 'block');
+    assert.match(r.reason, /MPL DELEGATION NOTICE/);
+  });
+
+  it('direct_source_edit: "block" + strict false → block', () => {
+    const r = runHook('Edit', {
+      file_path: join(tmp, 'src', 'app.ts'),
+      old_string: 'a',
+      new_string: 'b',
+    }, { enforcement: { direct_source_edit: 'block' } });
+    assert.strictEqual(r.decision, 'block');
+  });
+
+  it('direct_source_edit: "off" + strict true → silent (explicit opt-out)', () => {
+    const r = runHook('Edit', {
+      file_path: join(tmp, 'src', 'app.ts'),
+      old_string: 'a',
+      new_string: 'b',
+    }, { enforcement: { strict: true, direct_source_edit: 'off' } });
+    assert.strictEqual(r.continue, true);
+    assert.strictEqual(r.suppressOutput, true);
+  });
+
+  it('dogfood mode (config) + edit on /MPL/ source → delegation notice, not silent', () => {
+    const r = runHook('Edit', {
+      file_path: '/proj/MPL/hooks/test.mjs',
+      old_string: 'a',
+      new_string: 'b',
+    }, { dogfood: true });
+    assert.strictEqual(r.continue, true);
+    assert.match(r.hookSpecificOutput?.additionalContext || '', /MPL DELEGATION NOTICE/);
+    assert.match(r.hookSpecificOutput?.additionalContext || '', /dogfood mode/);
+  });
+
+  it('dogfood mode (env MPL_DOGFOOD=1) toggles equally', () => {
+    const r = runHook('Edit', {
+      file_path: '/proj/MPL/hooks/test.mjs',
+      old_string: 'a',
+      new_string: 'b',
+    }, null, { MPL_DOGFOOD: '1' });
+    assert.match(r.hookSpecificOutput?.additionalContext || '', /MPL DELEGATION NOTICE/);
+  });
+
+  it('non-dogfood + /MPL/ source still allowed (backwards-compat)', () => {
+    const r = runHook('Edit', {
+      file_path: '/proj/MPL/hooks/test.mjs',
+      old_string: 'a',
+      new_string: 'b',
+    });
+    assert.strictEqual(r.continue, true);
+    assert.strictEqual(r.suppressOutput, true);
+  });
+
+  it('allowed path .mpl/ → silent regardless of policy', () => {
+    const r = runHook('Edit', {
+      file_path: join(tmp, '.mpl', 'memory', 'working.md'),
+      old_string: 'a',
+      new_string: 'b',
+    }, { enforcement: { strict: true, direct_source_edit: 'block' } });
+    assert.strictEqual(r.continue, true);
+    assert.strictEqual(r.suppressOutput, true);
+  });
+
+  it('non-source file outside allowed (e.g. .md outside docs/learnings) → silent (no source rule)', () => {
+    // .md is not in SOURCE_EXTENSIONS, so direct_source_edit doesn't fire.
+    // Phase scope check only triggers when decomposition.yaml declares scope; here it doesn't.
+    const r = runHook('Edit', {
+      file_path: join(tmp, 'README.md'),
+      old_string: 'a',
+      new_string: 'b',
+    });
+    assert.strictEqual(r.continue, true);
+    assert.strictEqual(r.suppressOutput, true);
+  });
+
+  it('Bash dangerous command still warns (existing behaviour preserved)', () => {
+    const r = runHook('Bash', { command: 'rm -rf /tmp/foo' });
+    assert.strictEqual(r.continue, true);
+    assert.match(r.hookSpecificOutput?.additionalContext || '', /MPL SAFETY WARNING/);
+  });
+
+  it('MPL inactive → silent regardless of policy', () => {
+    rmSync(join(tmp, '.mpl'), { recursive: true });
+    const r = runHook('Edit', {
+      file_path: join(tmp, 'src', 'app.ts'),
+      old_string: 'a',
+      new_string: 'b',
+    });
+    assert.strictEqual(r.continue, true);
+    assert.strictEqual(r.suppressOutput, true);
   });
 });

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -22,7 +22,7 @@
         ]
       },
       {
-        "matcher": "Edit|Write|Bash",
+        "matcher": "Edit|Write|MultiEdit|Bash",
         "hooks": [
           {
             "type": "command",

--- a/hooks/mpl-write-guard.mjs
+++ b/hooks/mpl-write-guard.mjs
@@ -146,8 +146,8 @@ async function main() {
 
   const toolName = data.tool_name || data.toolName || '';
 
-  // Only intercept Edit, Write, and Bash tools
-  if (!['Edit', 'Write', 'edit', 'write', 'Bash', 'bash'].includes(toolName)) {
+  // Only intercept Edit, Write, MultiEdit, and Bash tools
+  if (!['Edit', 'Write', 'MultiEdit', 'edit', 'write', 'multiEdit', 'multiedit', 'Bash', 'bash'].includes(toolName)) {
     console.log(JSON.stringify({ continue: true, suppressOutput: true }));
     return;
   }

--- a/hooks/mpl-write-guard.mjs
+++ b/hooks/mpl-write-guard.mjs
@@ -34,16 +34,42 @@ const { getPhaseScope } = await import(
   pathToFileURL(join(__dirname, 'lib', 'mpl-decomposition-parser.mjs')).href
 );
 
-// Allowed path patterns (orchestrator CAN write to these)
+// P0-2 / #110 — per-rule policy resolver. P0-3 (#111) consumes
+// `direct_source_edit` and `phase_scope_violation`.
+const { resolveRuleAction } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-enforcement.mjs')).href
+);
+const { loadConfig } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-config.mjs')).href
+);
+
+// Dogfood mode (P0-3, #111): when developing the MPL plugin against itself,
+// `/MPL/` paths must be treated like ordinary source — orchestrator should
+// route those edits through phase-runner the same as application code.
+// Toggle via .mpl/config.json `dogfood: true` or env `MPL_DOGFOOD=1`.
+const DOGFOOD_SUPPRESSED = /\/MPL\//;
+
+// Allowed path patterns (orchestrator CAN write to these). DOGFOOD_SUPPRESSED
+// is included by reference so isAllowedPath() can drop it when dogfood is on.
 const ALLOWED_PATTERNS = [
   /\.mpl\//,           // .mpl/ state directory
   /\.omc\//,           // .omc/ OMC state
   /\.claude\//,        // .claude/ config
   /\/\.claude\//,      // absolute .claude/ paths
-  /\/MPL\//,           // MPL/ plugin directory
+  DOGFOOD_SUPPRESSED,  // /MPL/ plugin directory (suppressed in dogfood mode)
   /PLAN\.md$/,         // PLAN.md (orchestrator manages checkboxes)
   /docs\/learnings\//, // learnings directory
 ];
+
+function isDogfoodMode(cwd) {
+  if (process.env.MPL_DOGFOOD === '1') return true;
+  try {
+    const cfg = loadConfig(cwd);
+    return cfg?.dogfood === true;
+  } catch {
+    return false;
+  }
+}
 
 // Source file extensions (orchestrator must NOT write to these)
 const SOURCE_EXTENSIONS = new Set([
@@ -92,9 +118,13 @@ function isDangerousBashCommand(command) {
   return DANGEROUS_BASH_PATTERNS.some(p => p.test(command));
 }
 
-function isAllowedPath(filePath) {
+function isAllowedPath(filePath, opts = {}) {
   if (!filePath) return true;
-  return ALLOWED_PATTERNS.some(pattern => pattern.test(filePath));
+  const { dogfood = false } = opts;
+  return ALLOWED_PATTERNS.some((pattern) => {
+    if (dogfood && pattern === DOGFOOD_SUPPRESSED) return false;
+    return pattern.test(filePath);
+  });
 }
 
 function isSourceFile(filePath) {
@@ -156,7 +186,7 @@ ensure you have the correct target path. The command will proceed, but please ve
     return;
   }
 
-  // --- Edit/Write source file guard (existing behavior) ---
+  // --- Edit/Write source file guard (P0-3, #111) ---
   // Extract file path
   const filePath = toolInput.file_path || toolInput.filePath || '';
 
@@ -165,55 +195,81 @@ ensure you have the correct target path. The command will proceed, but please ve
     return;
   }
 
-  // Check if path is allowed for orchestrator
-  if (isAllowedPath(filePath)) {
+  const state = readState(cwd) || {};
+  const dogfood = isDogfoodMode(cwd);
+
+  // Check if path is allowed for orchestrator (honours dogfood mode).
+  if (isAllowedPath(filePath, { dogfood })) {
     console.log(JSON.stringify({ continue: true, suppressOutput: true }));
     return;
   }
 
-  // Check if it's a source file
+  // Check if it's a source file → resolve direct_source_edit policy.
   if (isSourceFile(filePath)) {
-    // SOFT BLOCK: warn and recommend delegation (OMC-style)
-    const message = `[MPL DELEGATION NOTICE] Direct ${toolName} on source file: ${filePath}
+    const action = resolveRuleAction(cwd, state, 'direct_source_edit');
+    if (action === 'off') {
+      console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+      return;
+    }
+    const dogfoodTag = dogfood ? ' [dogfood mode: MPL/ also enforced]' : '';
+    const message = `[MPL DELEGATION NOTICE] Direct ${toolName} on source file: ${filePath}${dogfoodTag}
 
 Source files should be edited by mpl-phase-runner agents, not the orchestrator.
-Delegate via: Agent(subagent_type="mpl-phase-runner", prompt="Edit ${filePath} to ...")
+Delegate via: Agent(subagent_type="mpl-phase-runner", prompt="Edit ${filePath} to ...")`;
 
-Next time, delegate to mpl-phase-runner instead of editing directly.`;
-
+    if (action === 'block') {
+      console.log(JSON.stringify({
+        decision: 'block',
+        reason: message,
+      }));
+      return;
+    }
+    // warn (transitional default)
     console.log(JSON.stringify({
       continue: true,
       hookSpecificOutput: {
         hookEventName: 'PreToolUse',
-        additionalContext: message
-      }
+        additionalContext: message,
+      },
     }));
     return;
   }
 
-  // --- Phase-Scoped File Lock (T-01 Phase 2, v3.9) ---
-  // Check if the file is within the current phase's declared scope
+  // --- Phase-Scoped File Lock (T-01 Phase 2, v3.9; P0-3 wiring) ---
+  // Check if the file is within the current phase's declared scope.
   try {
-    const state = readState(cwd);
     const currentPhase = state?.current_phase;
     if (currentPhase && filePath) {
       const scope = getPhaseScope(cwd, currentPhase);
       if (scope && scope.allowed.length > 0) {
-        const inScope = scope.allowed.some(f =>
-          filePath.endsWith(f) || filePath.includes(f)
+        const inScope = scope.allowed.some((f) =>
+          filePath.endsWith(f) || filePath.includes(f),
         );
         if (!inScope) {
+          const action = resolveRuleAction(cwd, state, 'phase_scope_violation');
+          if (action === 'off') {
+            console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+            return;
+          }
           const message = `[MPL SCOPE WARNING] File "${filePath}" is outside phase "${currentPhase}" scope.
 Declared scope files: ${scope.allowed.slice(0, 5).join(', ')}${scope.allowed.length > 5 ? ` (+${scope.allowed.length - 5} more)` : ''}
 
 This may cause cross-phase side effects. Verify this modification belongs in the current phase.`;
 
+          if (action === 'block') {
+            console.log(JSON.stringify({
+              decision: 'block',
+              reason: message,
+            }));
+            return;
+          }
+          // warn
           console.log(JSON.stringify({
             continue: true,
             hookSpecificOutput: {
               hookEventName: 'PreToolUse',
-              additionalContext: message
-            }
+              additionalContext: message,
+            },
           }));
           return;
         }
@@ -232,4 +288,4 @@ main().catch(() => {
   console.log(JSON.stringify({ continue: true, suppressOutput: true }));
 });
 
-export { isAllowedPath, isSourceFile, isDangerousBashCommand };
+export { isAllowedPath, isSourceFile, isDangerousBashCommand, isDogfoodMode };


### PR DESCRIPTION
## Summary

R-WRITE-GUARD-WARN-ONLY (Evidence grade A): \`mpl-write-guard.mjs\` returned \`continue: true\` on every path — \`decision: 'block'\` count was **zero**. Orchestrator-worker separation depended entirely on prompt compliance. P0-3 wires the guard into the P0-2 (#110) per-rule policy and introduces a dogfood mode so the plugin's own development workflow can self-enforce.

## Wiring

| Rule | Off | Warn (default) | Block |
|---|---|---|---|
| \`direct_source_edit\` | silent | continue + delegation notice (existing) | \`decision: 'block'\` with same notice as reason |
| \`phase_scope_violation\` | silent | continue + scope warning | \`decision: 'block'\` |

Both flow through \`resolveRuleAction(cwd, state, ...)\` — same precedence chain as F3/G1/G3. Strict mode elevates \`warn → block\` for both.

## Dogfood mode

\`.mpl/config.json: { "dogfood": true }\` (or env \`MPL_DOGFOOD=1\`) removes \`/MPL/\` from \`isAllowedPath\`. Editing plugin source then routes through \`direct_source_edit\` like application code. The delegation notice surfaces \"[dogfood mode: MPL/ also enforced]\" so the operator knows why a normally-allowed path is being challenged.

\`isAllowedPath\` now accepts \`{ dogfood: boolean }\` opts; no-arg callers default to \`dogfood: false\` — backwards-compat.

## Tests (+14 cases)

- isAllowedPath dogfood unit (3) — default / dogfood strips MPL/ / dogfood preserves .mpl/.claude/
- Hook integration (11):
    - default warn on source → continue + delegation notice
    - strict elevates warn → \`decision: 'block'\`
    - \`direct_source_edit: 'block'\` alone → block
    - \`direct_source_edit: 'off'\` under strict → silent
    - dogfood (config) on /MPL/ source → notice
    - dogfood (env MPL_DOGFOOD=1) → same
    - non-dogfood + /MPL/ source still allowed (backwards-compat)
    - .mpl/ allowed regardless of policy
    - non-source .md silent
    - Bash dangerous warning preserved
    - MPL inactive → silent

Full hook regression: 524 → **538/538** (+14 P0-3).

## Docs

\`docs/config-schema.md\` — new "Dogfood Mode (P0-3, #111)" section with field table and env equivalent.

## Forward integration

- exp16 \`enforcement.strict: true\` rollout makes every orchestrator source edit a hard block — closes the prompt-compliance-only gap.
- F4 (#106) doctor meta-self can flag workspaces that ship \`dogfood: true\` but still set \`direct_source_edit: 'off'\` (audit hole).

## Files

\`\`\`
docs/config-schema.md                    |  10 +++
hooks/__tests__/mpl-write-guard.test.mjs | 145 +++++++++++++++++++++
hooks/mpl-write-guard.mjs                | 113 ++++++++++++++++--
3 files changed, 251 insertions(+), 24 deletions(-)
\`\`\`

## Related

- Closes #111
- Closes the v3.10 P0 enforcement umbrella critical track: #101 v0.18.0 critical **9/10 → 10/10** on merge.
- Builds on #110 P0-2 (resolveRuleAction), #102 P0-1 (gate evidence), #105 F3 / #106 F4 (anti-pattern + doctor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)