### PR TITLE
feat(#103): P0-A redesign — orchestrator-driven adversarial reviewer

### DIFF
--- a/agents/mpl-adversarial-reviewer.md
+++ b/agents/mpl-adversarial-reviewer.md
@@ -1,0 +1,138 @@
+---
+name: mpl-adversarial-reviewer
+description: Adversarial reviewer for MPL phase artifacts. Compares phase-runner's stated intent against the actual implementation and verification record, scores quality, surfaces hidden gaps. Dispatched by the orchestrator (commands/mpl-run-execute.md Step 4.3.8) after every phase-runner finishes; the score is consumed by hooks/mpl-quality-gate.mjs.
+model: sonnet
+disallowedTools: []
+---
+
+<Agent_Prompt>
+  <Role>
+    Adversarial Quality Reviewer for MPL (P0-A redesign, #103).
+
+    Phase-runner just finished a phase and self-reported success (`status: complete`, criteria_passed=N/M).
+    Your job is to **disagree productively**: locate gaps between the phase's
+    declared intent and what actually shipped. The score you produce gates
+    pipeline progress — a generous score lets fake-gate / scope-leak / hidden
+    regression patterns slip through; a stingy score wastes the user's loop
+    budget. Aim for *calibration*.
+
+    You do NOT modify code. You read artifacts, weigh evidence, and write a
+    structured score record. The orchestrator decides whether to retry the
+    phase or surface the failure to the user — that retry policy lives in
+    `hooks/lib/mpl-quality-gate.mjs#decideAction` and the orchestrator's
+    Step 4.3.8.
+  </Role>
+
+  <Constraints>
+    - **No source edits**. You may use Read, Grep, Glob, Bash (read-only — no `rm`, `mv`, `git push`, etc.).
+    - **One score per dispatch**. Always write `.mpl/signals/quality-score.json` exactly once before returning.
+    - **Score in [0, 1]**. Verdict in {`PASS`, `FAIL`}. The two must agree with the
+      threshold the workspace configures (`adversarial.threshold`, default 0.7) — if
+      score < threshold and verdict='PASS', you must explain why in `issues[]`.
+    - **Audit, not author**. Do not propose new code. Surface gaps; the orchestrator routes the fix.
+    - **Be specific**. Generic "could be better" issues are worthless. Cite line numbers, file paths, missing test cases, contract clauses.
+  </Constraints>
+
+  <Inputs>
+    Provided in your dispatch prompt by the orchestrator:
+    - `phase_id` — e.g. `phase-3` (matches `.mpl/mpl/phases/phase-3/`)
+    - `phase_definition` — scope, impact files, success_criteria, interface_contract
+    - `state_summary_path` — `.mpl/mpl/phases/phase-N/state-summary.md`
+    - `verification_path` — `.mpl/mpl/phases/phase-N/verification.md`
+    - `changes_diff_path` — `.mpl/mpl/phases/phase-N/changes.diff` (optional; may be absent on first phase)
+    - `prior_history` — `state.quality_score_history` so you can see whether this is a retry round and what the prior reviewer flagged
+
+    Read these. Trust the criteria the user/decomposer wrote, not phase-runner's self-summary.
+  </Inputs>
+
+  <Audit_Procedure>
+    ### Step 1 — Read the artifacts
+
+    1. `state_summary_path` — phase-runner's claim. Note "What was implemented" vs the declared scope.
+    2. `verification_path` — pass_rate, criteria_passed, micro_cycle_fixes. Cross-check against `success_criteria` from `phase_definition`.
+    3. `changes_diff_path` — actual file deltas. Compare against declared `impact` files; flag scope leak.
+    4. `prior_history[-1]` (if exists) — what the previous reviewer flagged. Check whether this round addresses those issues or papers over them.
+
+    ### Step 2 — Evidence cross-check
+
+    Run mechanical checks (do NOT trust prose claims alone):
+
+    - **Anti-pattern self-scan** — `Bash("rg -n 'expect\\(true\\)\\.toBe\\(true\\)|test\\.todo|@ts-ignore' {impact_files} | head -20")`. Tautological assertions or skipped tests in the diff are F2/F3 violations the in-process hook may have missed during edits made via tools the live grep didn't see.
+    - **Stub leakage** — `Bash("rg -n 'TODO|FIXME|throw new Error.*not.implemented|unimplemented!' {impact_files}")`. Phase-runner's anti-stub guard runs only for THE phase's TODOs; cross-impact files can still carry stubs.
+    - **Verification reality** — does `verification.md` quote actual exit codes, or just "✅ all tests pass"? Real evidence has `exit_code=0` shaped fields.
+    - **Scope leak** — files in `changes.diff` outside `phase_definition.impact`. Score penalty proportional to leak count.
+    - **Contract honour** — `interface_contract.requires` / `provides` met? grep the diff for the named functions/types.
+
+    ### Step 3 — Score composition
+
+    Compose a score in [0, 1] by deducting from 1.0:
+
+    | Finding | Deduction |
+    |---|---|
+    | Tautological assertion in impact files | −0.20 each (cap −0.40) |
+    | Stub / TODO / `throw not implemented` in impact files | −0.15 each (cap −0.30) |
+    | Verification claims success but no machine-evidence exit codes | −0.25 |
+    | Scope leak (file outside declared `impact`) | −0.10 each (cap −0.30) |
+    | Interface contract function not present in diff | −0.15 each (cap −0.30) |
+    | success_criteria item with no corresponding test | −0.10 each (cap −0.20) |
+    | Prior reviewer's issues not addressed AND no rationale | −0.20 |
+
+    Verdict rule:
+    - score >= threshold (default 0.7) AND no severity-block findings → `PASS`
+    - else → `FAIL`
+
+    On retry rounds: if the prior reviewer's `issues[]` entries are **literally still present**, FAIL automatically (no score smoothing).
+
+    ### Step 4 — Write the score
+
+    Write to `.mpl/signals/quality-score.json`:
+
+    ```json
+    {
+      "phase": "phase-3",
+      "score": 0.82,
+      "verdict": "PASS",
+      "issues": [
+        "scope leak: src/utils.ts modified but not in phase_definition.impact",
+        "success_criteria 'auth boundary documented' has no test"
+      ],
+      "timestamp": "2026-05-04T17:30:00Z"
+    }
+    ```
+
+    Then return a one-paragraph summary in your text response so the user can
+    skim. The orchestrator does not read your text — it reads the JSON via
+    `mpl-quality-gate.mjs`.
+  </Audit_Procedure>
+
+  <Output_Schema>
+    Required side effect: `.mpl/signals/quality-score.json` written exactly once.
+
+    Schema (all fields required):
+    ```typescript
+    {
+      phase: string,           // matches phase_definition phase id
+      score: number,           // [0, 1]
+      verdict: 'PASS' | 'FAIL',
+      issues: string[],        // empty when PASS with no findings
+      timestamp: string        // ISO-8601, set with `new Date().toISOString()`
+    }
+    ```
+
+    Returned text response (free-form, ≤200 words): summary of the audit. Cite
+    the score and the top three issues. Do not propose fixes — that's the
+    orchestrator's job on retry.
+  </Output_Schema>
+
+  <Failure_Modes_To_Avoid>
+    - **Self-pass under pressure**: do not raise the score because the phase
+      "looks fine". The reviewer's job is to disagree where evidence permits.
+    - **Generic feedback**: "tests could be more thorough" is unfalsifiable
+      and counts as a non-finding.
+    - **Code authoring**: do not propose specific replacement code. List the
+      gap; the orchestrator routes the fix.
+    - **Skipping the JSON write**: the hook only fires on the artifact. A
+      response without the JSON is treated as "no decision" and silently
+      drops the round — wasting the dispatch.
+  </Failure_Modes_To_Avoid>
+</Agent_Prompt>

--- a/agents/mpl-adversarial-reviewer.md
+++ b/agents/mpl-adversarial-reviewer.md
@@ -2,7 +2,7 @@
 name: mpl-adversarial-reviewer
 description: Adversarial reviewer for MPL phase artifacts. Compares phase-runner's stated intent against the actual implementation and verification record, scores quality, surfaces hidden gaps. Dispatched by the orchestrator (commands/mpl-run-execute.md Step 4.3.8) after every phase-runner finishes; the score is consumed by hooks/mpl-quality-gate.mjs.
 model: sonnet
-disallowedTools: []
+disallowedTools: [Edit, MultiEdit, NotebookEdit]
 ---
 
 <Agent_Prompt>

--- a/commands/mpl-run-execute.md
+++ b/commands/mpl-run-execute.md
@@ -618,9 +618,42 @@ Skip/conditional rules prevent unnecessary invocations, keeping actual additions
       announce: "[MPL] Regression suite: {regression_suite.total_assertions} assertions accumulated across {regression_suite.accumulated_tests.length} phases"
     ```
 
-12. More phases → continue in `phase2-sprint`, return to 4.1
+12. **Adversarial Review (P0-A redesign, #103)** — dispatch the reviewer
+    BEFORE advancing to the next phase:
+    ```
+    Task({
+      subagent_type: "mpl-adversarial-reviewer",
+      prompt: `Audit phase ${phase.id}.
+        - phase_definition: ${JSON.stringify(phase_definition)}
+        - state_summary_path: .mpl/mpl/phases/${phase.id}/state-summary.md
+        - verification_path: .mpl/mpl/phases/${phase.id}/verification.md
+        - changes_diff_path: .mpl/mpl/phases/${phase.id}/changes.diff (optional)
+        - prior_history: ${JSON.stringify(state.quality_score_history)}
+
+        Write the score JSON to .mpl/signals/quality-score.json per
+        agents/mpl-adversarial-reviewer.md spec. Return a one-paragraph summary.`
+    })
+    ```
+
+    `hooks/mpl-quality-gate.mjs` (PostToolUse Task) reads the JSON, mutates
+    `state.adversarial_retry_count` + `state.quality_score_history[]`, and
+    surfaces a `systemMessage` describing the action:
+
+    - **PASS** (score ≥ threshold AND verdict=PASS) → reset retry, proceed to step 13.
+    - **RETRY** (score < threshold OR verdict=FAIL, retry < 3) → re-dispatch
+      `mpl-phase-runner` for ${phase.id} with the issues list as fix prompt.
+      Phase artifacts are overwritten on the retry; re-enter step 4.3.7.
+    - **ESCALATE** (retry ≥ 3) → halt the sprint, surface to the user via
+      AskUserQuestion: {force-pass, manual-fix, cancel}. On force-pass record
+      the override in `state.adversarial_overrides[]` and proceed.
+
+    Workspace tunables (`.mpl/config.json:adversarial`):
+    - `threshold` (default 0.7)
+    - `max_retries` (default 3)
+
+13. More phases → continue in `phase2-sprint`, return to 4.1
     → **Budget Check (F-33)**: See Step 4.3 extension — check session budget before starting next Phase.
-13. All done → **MANDATORY Gate System entry (Floor guarantee)**:
+14. All done → **MANDATORY Gate System entry (Floor guarantee)**:
     ```
     // This is NOT optional. ALL phases, regardless of PP-proximity, MUST pass
     // Hard 1 + Hard 2 + Hard 3 (Floor Definition, mpl-run-execute-gates.md:16).

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -188,6 +188,23 @@ the immutable post-Phase-0 snapshot consumed by delta calculation and rollback.
 |-------|------|---------|-------------|--------|
 | `e2e_timeout` | number | `60000` | Timeout per E2E scenario in milliseconds | `mpl-run-finalize.md` Step 5.0 |
 
+## Adversarial Reviewer (P0-A, #103)
+
+Orchestrator-driven quality gate. After every phase-runner finishes, the
+orchestrator (`commands/mpl-run-execute.md` Step 4.3.7 step 12) dispatches
+`mpl-adversarial-reviewer`. The agent writes
+`.mpl/signals/quality-score.json`; `hooks/mpl-quality-gate.mjs` consumes it
+and decides pass / retry / escalate.
+
+| Field | Type | Default | Description | Source |
+|-------|------|---------|-------------|--------|
+| `adversarial.threshold` | number (0..1) | `0.7` | Minimum score required for `PASS` (combined with reviewer's verdict). Below this, the gate emits `retry` until `max_retries`. | `mpl-quality-gate.mjs` |
+| `adversarial.max_retries` | integer ≥0 | `3` | Retry budget before escalation to the user via AskUserQuestion. The retry counter resets to 0 on the next PASS. | `mpl-quality-gate.mjs` |
+
+State fields (per pipeline):
+- `adversarial_retry_count` — current consecutive retry; resets on PASS, freezes at max on escalate.
+- `quality_score_history[]` — `{phase, score, verdict, issues[], timestamp, action, retry_count}` per reviewer dispatch.
+
 ## Dogfood Mode (P0-3, #111)
 
 When developing the MPL plugin against itself (i.e. when the workspace IS the

--- a/hooks/__tests__/mpl-quality-gate.test.mjs
+++ b/hooks/__tests__/mpl-quality-gate.test.mjs
@@ -1,0 +1,264 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { tmpdir } from 'os';
+
+import {
+  parseScore,
+  decideAction,
+  composeHistoryEntry,
+  DEFAULT_QUALITY_THRESHOLD,
+  DEFAULT_MAX_ADVERSARIAL_RETRIES,
+} from '../lib/mpl-quality-gate.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const HOOK_PATH = join(dirname(__filename), '..', 'mpl-quality-gate.mjs');
+
+const VALID_PASS = {
+  phase: 'phase-3',
+  score: 0.85,
+  verdict: 'PASS',
+  issues: [],
+  timestamp: '2026-05-04T17:30:00Z',
+};
+
+const VALID_FAIL = {
+  phase: 'phase-3',
+  score: 0.45,
+  verdict: 'FAIL',
+  issues: ['scope leak: src/utils.ts'],
+  timestamp: '2026-05-04T17:30:00Z',
+};
+
+/* parseScore --------------------------------------------------------------- */
+
+describe('parseScore', () => {
+  it('parses a valid object', () => {
+    const r = parseScore(VALID_PASS);
+    assert.deepStrictEqual(r, VALID_PASS);
+  });
+
+  it('parses a valid JSON string', () => {
+    const r = parseScore(JSON.stringify(VALID_FAIL));
+    assert.deepStrictEqual(r, VALID_FAIL);
+  });
+
+  it('rejects null/non-object', () => {
+    assert.strictEqual(parseScore(null), null);
+    assert.strictEqual(parseScore(42), null);
+    assert.strictEqual(parseScore('not-json'), null);
+  });
+
+  it('rejects when required field missing', () => {
+    assert.strictEqual(parseScore({ ...VALID_PASS, phase: undefined }), null);
+    assert.strictEqual(parseScore({ ...VALID_PASS, score: 'high' }), null);
+    assert.strictEqual(parseScore({ ...VALID_PASS, verdict: 'maybe' }), null);
+    assert.strictEqual(parseScore({ ...VALID_PASS, timestamp: undefined }), null);
+  });
+
+  it('rejects non-finite score (NaN, Infinity)', () => {
+    assert.strictEqual(parseScore({ ...VALID_PASS, score: NaN }), null);
+    assert.strictEqual(parseScore({ ...VALID_PASS, score: Infinity }), null);
+  });
+
+  it('coerces issues[] safely (filters non-strings)', () => {
+    const r = parseScore({ ...VALID_PASS, issues: ['ok', 42, null, 'also-ok'] });
+    assert.deepStrictEqual(r.issues, ['ok', 'also-ok']);
+  });
+
+  it('treats missing issues[] as []', () => {
+    const r = parseScore({ ...VALID_PASS, issues: undefined });
+    assert.deepStrictEqual(r.issues, []);
+  });
+});
+
+/* decideAction ------------------------------------------------------------- */
+
+describe('decideAction', () => {
+  it('PASS verdict + score >= threshold → pass', () => {
+    const r = decideAction({ score: 0.85, verdict: 'PASS' });
+    assert.strictEqual(r.action, 'pass');
+    assert.strictEqual(r.threshold, DEFAULT_QUALITY_THRESHOLD);
+    assert.match(r.reason, /Adversarial review PASS/);
+  });
+
+  it('FAIL verdict (even with high score) → retry', () => {
+    const r = decideAction({ score: 0.95, verdict: 'FAIL' });
+    assert.strictEqual(r.action, 'retry');
+  });
+
+  it('PASS verdict but score < threshold → retry', () => {
+    const r = decideAction({ score: 0.5, verdict: 'PASS' });
+    assert.strictEqual(r.action, 'retry');
+  });
+
+  it('escalates after max retries', () => {
+    const r = decideAction({ score: 0.4, verdict: 'FAIL' }, { retryCount: 3 });
+    assert.strictEqual(r.action, 'escalate');
+    assert.match(r.reason, /after 3 retries/);
+  });
+
+  it('retries up to max', () => {
+    const r1 = decideAction({ score: 0.4, verdict: 'FAIL' }, { retryCount: 0 });
+    assert.strictEqual(r1.action, 'retry');
+    assert.match(r1.reason, /Retry 1\/3/);
+    const r2 = decideAction({ score: 0.4, verdict: 'FAIL' }, { retryCount: 2 });
+    assert.strictEqual(r2.action, 'retry');
+    assert.match(r2.reason, /Retry 3\/3/);
+  });
+
+  it('honours custom threshold', () => {
+    // 0.75 < 0.9 → retry under stricter threshold
+    const r = decideAction({ score: 0.75, verdict: 'PASS' }, { threshold: 0.9 });
+    assert.strictEqual(r.action, 'retry');
+  });
+
+  it('honours custom maxRetries', () => {
+    const r = decideAction({ score: 0.4, verdict: 'FAIL' }, { retryCount: 1, maxRetries: 1 });
+    assert.strictEqual(r.action, 'escalate');
+  });
+
+  it('singular wording for retryCount=1 in escalate reason', () => {
+    const r = decideAction({ score: 0.3, verdict: 'FAIL' }, { retryCount: 1, maxRetries: 1 });
+    assert.match(r.reason, /after 1 retry\b/);
+  });
+});
+
+/* composeHistoryEntry ------------------------------------------------------ */
+
+describe('composeHistoryEntry', () => {
+  it('produces a flat record for state.quality_score_history', () => {
+    const decision = decideAction(VALID_PASS, { retryCount: 0 });
+    const entry = composeHistoryEntry(VALID_PASS, decision);
+    assert.strictEqual(entry.phase, VALID_PASS.phase);
+    assert.strictEqual(entry.score, VALID_PASS.score);
+    assert.strictEqual(entry.verdict, 'PASS');
+    assert.strictEqual(entry.action, 'pass');
+    assert.strictEqual(entry.retry_count, 0);
+    assert.deepStrictEqual(entry.issues, []);
+    assert.strictEqual(entry.timestamp, VALID_PASS.timestamp);
+  });
+
+  it('captures retry count for retry action', () => {
+    const decision = decideAction(VALID_FAIL, { retryCount: 2 });
+    const entry = composeHistoryEntry(VALID_FAIL, decision);
+    assert.strictEqual(entry.action, 'retry');
+    assert.strictEqual(entry.retry_count, 2);
+  });
+});
+
+/* hook integration --------------------------------------------------------- */
+
+describe('mpl-quality-gate hook integration', () => {
+  let tmp;
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'mpl-qg-'));
+    mkdirSync(join(tmp, '.mpl', 'signals'), { recursive: true });
+    writeFileSync(join(tmp, '.mpl', 'state.json'), JSON.stringify({ current_phase: 'phase2-sprint' }));
+  });
+  afterEach(() => rmSync(tmp, { recursive: true, force: true }));
+
+  function writeScore(obj) {
+    writeFileSync(join(tmp, '.mpl', 'signals', 'quality-score.json'), JSON.stringify(obj));
+  }
+
+  function readState() {
+    return JSON.parse(readFileSync(join(tmp, '.mpl', 'state.json'), 'utf-8'));
+  }
+
+  function runHook(toolName, toolInput, extraState) {
+    if (extraState) {
+      const cur = JSON.parse(readFileSync(join(tmp, '.mpl', 'state.json'), 'utf-8'));
+      writeFileSync(join(tmp, '.mpl', 'state.json'), JSON.stringify({ ...cur, ...extraState }));
+    }
+    const stdin = JSON.stringify({
+      cwd: tmp,
+      tool_name: toolName,
+      tool_input: toolInput,
+    });
+    const out = execFileSync('node', [HOOK_PATH], { input: stdin, encoding: 'utf-8' });
+    return JSON.parse(out);
+  }
+
+  it('non-Task tool → silent', () => {
+    const r = runHook('Bash', { command: 'ls' });
+    assert.strictEqual(r.continue, true);
+    assert.strictEqual(r.suppressOutput, true);
+  });
+
+  it('Task with non-adversarial subagent → silent', () => {
+    const r = runHook('Task', { subagent_type: 'mpl-test-agent', prompt: 'x' });
+    assert.strictEqual(r.continue, true);
+    assert.strictEqual(r.suppressOutput, true);
+  });
+
+  it('adversarial Task with no score file → silent (reviewer wrote nothing)', () => {
+    const r = runHook('Task', { subagent_type: 'mpl-adversarial-reviewer', prompt: 'audit' });
+    assert.strictEqual(r.continue, true);
+    assert.strictEqual(r.suppressOutput, true);
+  });
+
+  it('adversarial Task with malformed score → systemMessage, no state mutation', () => {
+    writeFileSync(join(tmp, '.mpl', 'signals', 'quality-score.json'), 'not-json');
+    const r = runHook('Task', { subagent_type: 'mpl-adversarial-reviewer', prompt: 'audit' });
+    assert.match(r.systemMessage, /malformed/);
+    assert.strictEqual(readState().adversarial_retry_count, undefined);
+  });
+
+  it('PASS verdict → systemMessage, retry counter reset, history appended', () => {
+    writeScore(VALID_PASS);
+    const r = runHook('Task', { subagent_type: 'mpl-adversarial-reviewer', prompt: 'audit' },
+      { adversarial_retry_count: 2 });
+    assert.match(r.systemMessage, /Adversarial review PASS/);
+    const s = readState();
+    assert.strictEqual(s.adversarial_retry_count, 0);
+    assert.strictEqual(s.quality_score_history.length, 1);
+    assert.strictEqual(s.quality_score_history[0].action, 'pass');
+  });
+
+  it('FAIL retry → counter increments, history captures retry', () => {
+    writeScore(VALID_FAIL);
+    const r = runHook('Task', { subagent_type: 'mpl-adversarial-reviewer', prompt: 'audit' });
+    assert.match(r.systemMessage, /Retry 1\/3/);
+    const s = readState();
+    assert.strictEqual(s.adversarial_retry_count, 1);
+    assert.strictEqual(s.quality_score_history[0].action, 'retry');
+  });
+
+  it('FAIL at retry budget exhaustion → escalate, counter freezes', () => {
+    writeScore(VALID_FAIL);
+    const r = runHook('Task', { subagent_type: 'mpl-adversarial-reviewer', prompt: 'audit' },
+      { adversarial_retry_count: 3 });
+    assert.match(r.systemMessage, /after 3 retries/);
+    assert.match(r.systemMessage, /Surface to the user/);
+    const s = readState();
+    assert.strictEqual(s.adversarial_retry_count, 3); // frozen
+    assert.strictEqual(s.quality_score_history[0].action, 'escalate');
+  });
+
+  it('workspace config tunes threshold and max_retries', () => {
+    writeFileSync(
+      join(tmp, '.mpl', 'config.json'),
+      JSON.stringify({ adversarial: { threshold: 0.95, max_retries: 1 } }),
+    );
+    // score 0.85 PASS would normally pass the default 0.7 threshold; here it
+    // must fall short of 0.95.
+    writeScore({ ...VALID_PASS, score: 0.85 });
+    const r = runHook('Task', { subagent_type: 'mpl-adversarial-reviewer', prompt: 'x' });
+    assert.match(r.systemMessage, /Retry 1\/1/);
+    // After one retry, max_retries=1 means escalate on next failure.
+    writeScore({ ...VALID_FAIL });
+    const r2 = runHook('Task', { subagent_type: 'mpl-adversarial-reviewer', prompt: 'x' });
+    assert.match(r2.systemMessage, /after 1 retry/);
+  });
+
+  it('MPL inactive → silent', () => {
+    rmSync(join(tmp, '.mpl'), { recursive: true });
+    const r = runHook('Task', { subagent_type: 'mpl-adversarial-reviewer', prompt: 'x' });
+    assert.strictEqual(r.continue, true);
+    assert.strictEqual(r.suppressOutput, true);
+  });
+});

--- a/hooks/__tests__/mpl-quality-gate.test.mjs
+++ b/hooks/__tests__/mpl-quality-gate.test.mjs
@@ -1,7 +1,7 @@
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync } from 'fs';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { tmpdir } from 'os';
@@ -62,6 +62,15 @@ describe('parseScore', () => {
   it('rejects non-finite score (NaN, Infinity)', () => {
     assert.strictEqual(parseScore({ ...VALID_PASS, score: NaN }), null);
     assert.strictEqual(parseScore({ ...VALID_PASS, score: Infinity }), null);
+  });
+
+  it('PR #130 review nit: rejects score outside [0, 1] bounds', () => {
+    assert.strictEqual(parseScore({ ...VALID_PASS, score: 1.5 }), null);
+    assert.strictEqual(parseScore({ ...VALID_PASS, score: -0.1 }), null);
+    assert.strictEqual(parseScore({ ...VALID_PASS, score: 2 }), null);
+    // boundary values are valid
+    assert.ok(parseScore({ ...VALID_PASS, score: 0 }));
+    assert.ok(parseScore({ ...VALID_PASS, score: 1 }));
   });
 
   it('coerces issues[] safely (filters non-strings)', () => {
@@ -148,6 +157,13 @@ describe('composeHistoryEntry', () => {
     assert.strictEqual(entry.action, 'retry');
     assert.strictEqual(entry.retry_count, 2);
   });
+
+  it('PR #130 review nit: history entry includes the decision reason', () => {
+    const decision = decideAction(VALID_FAIL, { retryCount: 0 });
+    const entry = composeHistoryEntry(VALID_FAIL, decision);
+    assert.strictEqual(entry.reason, decision.reason);
+    assert.match(entry.reason, /Retry 1\/3/);
+  });
 });
 
 /* hook integration --------------------------------------------------------- */
@@ -195,10 +211,13 @@ describe('mpl-quality-gate hook integration', () => {
     assert.strictEqual(r.suppressOutput, true);
   });
 
-  it('adversarial Task with no score file → silent (reviewer wrote nothing)', () => {
+  it('PR #130 review High #1: missing score file → systemMessage (fail-closed surface)', () => {
     const r = runHook('Task', { subagent_type: 'mpl-adversarial-reviewer', prompt: 'audit' });
     assert.strictEqual(r.continue, true);
-    assert.strictEqual(r.suppressOutput, true);
+    assert.match(r.systemMessage, /quality-score\.json is missing/);
+    assert.match(r.systemMessage, /gate-NOT-passed/);
+    // history must NOT mutate when the artifact is missing
+    assert.strictEqual(readState().quality_score_history, undefined);
   });
 
   it('adversarial Task with malformed score → systemMessage, no state mutation', () => {
@@ -253,6 +272,25 @@ describe('mpl-quality-gate hook integration', () => {
     writeScore({ ...VALID_FAIL });
     const r2 = runHook('Task', { subagent_type: 'mpl-adversarial-reviewer', prompt: 'x' });
     assert.match(r2.systemMessage, /after 1 retry/);
+  });
+
+  it('PR #130 review High #2: score file is consumed (deleted) after processing → next dispatch without write fails closed', () => {
+    // Round 1: reviewer writes → hook consumes → file gone
+    writeScore(VALID_PASS);
+    runHook('Task', { subagent_type: 'mpl-adversarial-reviewer', prompt: 'audit' });
+    assert.strictEqual(
+      existsSync(join(tmp, '.mpl', 'signals', 'quality-score.json')),
+      false,
+      'score file must be deleted after consume',
+    );
+
+    // Round 2: next reviewer dispatch fails to write — must NOT re-process round 1
+    const r2 = runHook('Task', { subagent_type: 'mpl-adversarial-reviewer', prompt: 'audit phase 2' });
+    assert.match(r2.systemMessage, /quality-score\.json is missing/);
+    // History should still have only the round-1 entry; no double-append
+    const s = readState();
+    assert.strictEqual(s.quality_score_history.length, 1);
+    assert.strictEqual(s.quality_score_history[0].phase, VALID_PASS.phase);
   });
 
   it('MPL inactive → silent', () => {

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -158,6 +158,16 @@
         "hooks": [
           {
             "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/mpl-quality-gate.mjs\"",
+            "timeout": 3
+          }
+        ]
+      },
+      {
+        "matcher": "Task|Agent",
+        "hooks": [
+          {
+            "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/mpl-validate-output.mjs\"",
             "timeout": 3
           }

--- a/hooks/lib/mpl-quality-gate.mjs
+++ b/hooks/lib/mpl-quality-gate.mjs
@@ -54,8 +54,14 @@ export function parseScore(input) {
   }
   if (!obj || typeof obj !== 'object') return null;
   const phase = typeof obj.phase === 'string' ? obj.phase : null;
-  const score = typeof obj.score === 'number' && Number.isFinite(obj.score)
-    ? obj.score : null;
+  // PR #130 review nit: enforce the [0, 1] bound the prompt promises so a
+  // miscalibrated reviewer (score=2 or score=-0.5) cannot bypass the gate.
+  const score = (
+    typeof obj.score === 'number'
+    && Number.isFinite(obj.score)
+    && obj.score >= 0
+    && obj.score <= 1
+  ) ? obj.score : null;
   const verdict = obj.verdict === 'PASS' || obj.verdict === 'FAIL' ? obj.verdict : null;
   const issues = Array.isArray(obj.issues) ? obj.issues.filter((s) => typeof s === 'string') : [];
   const timestamp = typeof obj.timestamp === 'string' ? obj.timestamp : null;
@@ -143,5 +149,6 @@ export function composeHistoryEntry(parsed, decision) {
     timestamp: parsed.timestamp,
     action: decision.action,
     retry_count: decision.retryCount,
+    reason: decision.reason,
   };
 }

--- a/hooks/lib/mpl-quality-gate.mjs
+++ b/hooks/lib/mpl-quality-gate.mjs
@@ -1,0 +1,147 @@
+/**
+ * MPL Quality Gate (P0-A redesign, #103)
+ *
+ * Original P0-A had `mpl-phase-runner` itself dispatch an adversarial reviewer
+ * via Step 4.5. Claude Code does NOT support nested Agent dispatch ("Agent
+ * tool is not available in this environment"), so the redesign moves the
+ * reviewer to the orchestrator (`commands/mpl-run-execute.md`) which calls
+ * `Task(subagent_type='mpl-adversarial-reviewer')` after each phase finishes.
+ * The reviewer writes a score JSON; this lib + hook decide pass / retry /
+ * escalate.
+ *
+ * Pure functions. No I/O.
+ */
+
+/**
+ * Default acceptance threshold. Workspace can override via
+ * `.mpl/config.json:adversarial.threshold`.
+ */
+export const DEFAULT_QUALITY_THRESHOLD = 0.7;
+
+/**
+ * Default retry budget before escalation to the user. Workspace can override
+ * via `.mpl/config.json:adversarial.max_retries`.
+ */
+export const DEFAULT_MAX_ADVERSARIAL_RETRIES = 3;
+
+/**
+ * Parse the JSON written by the adversarial-reviewer agent. Returns null when
+ * the input isn't a valid object with the required fields. Conservative:
+ * malformed score is treated as "no decision" rather than auto-pass/fail.
+ *
+ * Expected shape:
+ *   {
+ *     phase: string,
+ *     score: number (0..1),
+ *     verdict: 'PASS' | 'FAIL',
+ *     issues: string[],
+ *     timestamp: ISO-8601 string
+ *   }
+ *
+ * @param {unknown} input
+ * @returns {{
+ *   phase: string,
+ *   score: number,
+ *   verdict: 'PASS' | 'FAIL',
+ *   issues: string[],
+ *   timestamp: string,
+ * } | null}
+ */
+export function parseScore(input) {
+  let obj = input;
+  if (typeof obj === 'string') {
+    try { obj = JSON.parse(obj); } catch { return null; }
+  }
+  if (!obj || typeof obj !== 'object') return null;
+  const phase = typeof obj.phase === 'string' ? obj.phase : null;
+  const score = typeof obj.score === 'number' && Number.isFinite(obj.score)
+    ? obj.score : null;
+  const verdict = obj.verdict === 'PASS' || obj.verdict === 'FAIL' ? obj.verdict : null;
+  const issues = Array.isArray(obj.issues) ? obj.issues.filter((s) => typeof s === 'string') : [];
+  const timestamp = typeof obj.timestamp === 'string' ? obj.timestamp : null;
+  if (phase === null || score === null || verdict === null || timestamp === null) return null;
+  return { phase, score, verdict, issues, timestamp };
+}
+
+/**
+ * Decide the gate action from a parsed score + retry history.
+ *
+ * @param {{ score: number, verdict: 'PASS' | 'FAIL' }} parsed
+ * @param {{ retryCount?: number, threshold?: number, maxRetries?: number }} [opts]
+ * @returns {{
+ *   action: 'pass' | 'retry' | 'escalate',
+ *   reason: string,
+ *   retryCount: number,
+ *   threshold: number,
+ *   maxRetries: number,
+ * }}
+ */
+export function decideAction(parsed, opts = {}) {
+  const threshold = typeof opts.threshold === 'number' ? opts.threshold : DEFAULT_QUALITY_THRESHOLD;
+  const maxRetries = typeof opts.maxRetries === 'number' ? opts.maxRetries : DEFAULT_MAX_ADVERSARIAL_RETRIES;
+  const retryCount = typeof opts.retryCount === 'number' ? opts.retryCount : 0;
+
+  // Verdict from the reviewer is authoritative; score is the secondary signal.
+  // Both must agree for PASS — score >= threshold AND verdict='PASS'. A high
+  // score with verdict='FAIL' surfaces (the reviewer found something the score
+  // didn't capture); a low score with verdict='PASS' also surfaces (we trust
+  // the explicit threshold).
+  const passes = parsed.score >= threshold && parsed.verdict === 'PASS';
+
+  if (passes) {
+    return {
+      action: 'pass',
+      reason: `[MPL P0-A] Adversarial review PASS (score=${parsed.score.toFixed(3)} >= ${threshold}, verdict=${parsed.verdict}).`,
+      retryCount,
+      threshold,
+      maxRetries,
+    };
+  }
+
+  if (retryCount >= maxRetries) {
+    return {
+      action: 'escalate',
+      reason: `[MPL P0-A] Adversarial review FAIL after ${retryCount} retr${retryCount === 1 ? 'y' : 'ies'} (max ${maxRetries}). Score=${parsed.score.toFixed(3)} threshold=${threshold} verdict=${parsed.verdict}. Surface to the user — phase-runner cannot self-correct further.`,
+      retryCount,
+      threshold,
+      maxRetries,
+    };
+  }
+
+  return {
+    action: 'retry',
+    reason: `[MPL P0-A] Adversarial review FAIL (score=${parsed.score.toFixed(3)} < ${threshold} OR verdict=${parsed.verdict}). Retry ${retryCount + 1}/${maxRetries} — re-dispatch phase-runner with reviewer feedback.`,
+    retryCount,
+    threshold,
+    maxRetries,
+  };
+}
+
+/**
+ * Compose a fresh history entry for `state.quality_score_history[]`. Tracks
+ * one record per reviewer dispatch so resume + finalize can replay the
+ * accept/reject sequence.
+ *
+ * @param {ReturnType<typeof parseScore>} parsed
+ * @param {ReturnType<typeof decideAction>} decision
+ * @returns {{
+ *   phase: string,
+ *   score: number,
+ *   verdict: 'PASS' | 'FAIL',
+ *   issues: string[],
+ *   timestamp: string,
+ *   action: 'pass' | 'retry' | 'escalate',
+ *   retry_count: number,
+ * }}
+ */
+export function composeHistoryEntry(parsed, decision) {
+  return {
+    phase: parsed.phase,
+    score: parsed.score,
+    verdict: parsed.verdict,
+    issues: parsed.issues,
+    timestamp: parsed.timestamp,
+    action: decision.action,
+    retry_count: decision.retryCount,
+  };
+}

--- a/hooks/lib/mpl-state.mjs
+++ b/hooks/lib/mpl-state.mjs
@@ -183,6 +183,11 @@ const DEFAULT_STATE = {
   // mpl-tool-tracker.mjs. Stop hook compares to wall clock; > threshold (default
   // 15min) without an active "paused_*" flag → verification_hang marking.
   last_tool_at: null,            // ISO-8601 timestamp | null
+  // #103 P0-A redesign: orchestrator-driven adversarial reviewer.
+  // hooks/mpl-quality-gate.mjs increments retry on FAIL, resets to 0 on PASS,
+  // freezes at max on escalate. Default budget = 3 retries before user surface.
+  adversarial_retry_count: 0,    // current consecutive retry count
+  quality_score_history: [],     // [{ phase, score, verdict, issues, timestamp, action, retry_count }]
   // P2-6: execution-scope state (formerly .mpl/mpl/state.json). Schema mirrors
   // the shape documented in commands/mpl-run.md §"MPL State". Orchestrator
   // prompts (mpl-run-decompose.md, mpl-run-execute.md) update this subtree via

--- a/hooks/mpl-quality-gate.mjs
+++ b/hooks/mpl-quality-gate.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+/**
+ * MPL Quality Gate Hook (PostToolUse Task|Agent, P0-A redesign #103)
+ *
+ * Fires after the orchestrator dispatches `Task(subagent_type='mpl-adversarial-reviewer')`
+ * and the agent has written `.mpl/signals/quality-score.json`. Reads the
+ * score, decides pass / retry / escalate, mutates state (retry counter +
+ * history), and surfaces the next action to the orchestrator.
+ *
+ * Triggers ONLY on Task/Agent invocations whose subagent_type names the
+ * adversarial reviewer — other Task dispatches (test agents, codebase
+ * analyzer, etc.) are silent passthrough.
+ */
+
+import { dirname, join } from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+import { existsSync, readFileSync } from 'fs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const { isMplActive, readState, writeState } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-state.mjs')).href
+);
+const { readStdin } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'stdin.mjs')).href
+);
+const { loadConfig } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-config.mjs')).href
+);
+const {
+  parseScore,
+  decideAction,
+  composeHistoryEntry,
+  DEFAULT_QUALITY_THRESHOLD,
+  DEFAULT_MAX_ADVERSARIAL_RETRIES,
+} = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-quality-gate.mjs')).href
+);
+
+const SCORE_PATH = '.mpl/signals/quality-score.json';
+const ADVERSARIAL_AGENT = 'mpl-adversarial-reviewer';
+
+function silent() {
+  console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+}
+
+function isAdversarialDispatch(toolName, toolInput) {
+  if (!['Task', 'Agent', 'task', 'agent'].includes(toolName)) return false;
+  const sub = toolInput?.subagent_type || toolInput?.subagentType;
+  return sub === ADVERSARIAL_AGENT;
+}
+
+async function main() {
+  const input = await readStdin();
+  let data;
+  try { data = JSON.parse(input); } catch { return silent(); }
+
+  const cwd = data.cwd || data.directory || process.cwd();
+  if (!isMplActive(cwd)) return silent();
+
+  const toolName = data.tool_name || data.toolName || '';
+  const toolInput = data.tool_input || data.toolInput || {};
+
+  if (!isAdversarialDispatch(toolName, toolInput)) return silent();
+
+  const scoreFile = join(cwd, SCORE_PATH);
+  if (!existsSync(scoreFile)) {
+    // Reviewer ran but did not write the score artifact — treat as missing
+    // signal. Silent so the orchestrator can decide; the quality_score_history
+    // will simply not gain an entry this round.
+    return silent();
+  }
+
+  let raw;
+  try { raw = readFileSync(scoreFile, 'utf-8'); } catch { return silent(); }
+
+  const parsed = parseScore(raw);
+  if (!parsed) {
+    console.log(JSON.stringify({
+      continue: true,
+      systemMessage: `[MPL P0-A] quality-score.json is malformed — expected {phase, score, verdict, issues[], timestamp}. Reviewer must rewrite the file.`,
+    }));
+    return;
+  }
+
+  const state = readState(cwd) || {};
+  const config = loadConfig(cwd);
+  const adv = (config && typeof config.adversarial === 'object') ? config.adversarial : {};
+  const threshold = typeof adv.threshold === 'number' ? adv.threshold : DEFAULT_QUALITY_THRESHOLD;
+  const maxRetries = typeof adv.max_retries === 'number' ? adv.max_retries : DEFAULT_MAX_ADVERSARIAL_RETRIES;
+  const retryCount = typeof state.adversarial_retry_count === 'number' ? state.adversarial_retry_count : 0;
+
+  const decision = decideAction(parsed, { retryCount, threshold, maxRetries });
+  const entry = composeHistoryEntry(parsed, decision);
+
+  // Persist history regardless of action. Retry counter advances on retry,
+  // resets on pass, freezes (== maxRetries) on escalate so resume can see
+  // the wall hit.
+  const history = Array.isArray(state.quality_score_history) ? state.quality_score_history : [];
+  let nextRetry;
+  if (decision.action === 'pass') nextRetry = 0;
+  else if (decision.action === 'retry') nextRetry = retryCount + 1;
+  else nextRetry = retryCount; // escalate — preserve last value
+  try {
+    writeState(cwd, {
+      adversarial_retry_count: nextRetry,
+      quality_score_history: [...history, entry],
+    });
+  } catch {
+    // Best-effort — never block the surfacing decision on disk.
+  }
+
+  if (decision.action === 'pass') {
+    console.log(JSON.stringify({
+      continue: true,
+      systemMessage: decision.reason,
+    }));
+    return;
+  }
+
+  // retry or escalate — both surface the reason via systemMessage so the
+  // orchestrator (commands/mpl-run-execute.md Step 4.3.8) can branch:
+  // retry → re-dispatch phase-runner with reviewer feedback;
+  // escalate → halt and ask the user.
+  console.log(JSON.stringify({
+    continue: true,
+    systemMessage: decision.reason,
+  }));
+}
+
+await main().catch(() => silent());

--- a/hooks/mpl-quality-gate.mjs
+++ b/hooks/mpl-quality-gate.mjs
@@ -14,7 +14,7 @@
 
 import { dirname, join } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
-import { existsSync, readFileSync } from 'fs';
+import { existsSync, readFileSync, rmSync } from 'fs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -66,10 +66,15 @@ async function main() {
 
   const scoreFile = join(cwd, SCORE_PATH);
   if (!existsSync(scoreFile)) {
-    // Reviewer ran but did not write the score artifact — treat as missing
-    // signal. Silent so the orchestrator can decide; the quality_score_history
-    // will simply not gain an entry this round.
-    return silent();
+    // PR #130 review High #1: fail-closed surface so the orchestrator knows
+    // the reviewer dispatch finished without producing an audit artifact.
+    // Silent return would let the gate skip — reviewer prompt-compliance is
+    // not enough to guarantee the file exists.
+    console.log(JSON.stringify({
+      continue: true,
+      systemMessage: `[MPL P0-A] adversarial-reviewer dispatch finished but ${SCORE_PATH} is missing. Treat as gate-NOT-passed: re-dispatch the reviewer or surface to the user. Quality history was NOT mutated this round.`,
+    }));
+    return;
   }
 
   let raw;
@@ -79,7 +84,7 @@ async function main() {
   if (!parsed) {
     console.log(JSON.stringify({
       continue: true,
-      systemMessage: `[MPL P0-A] quality-score.json is malformed — expected {phase, score, verdict, issues[], timestamp}. Reviewer must rewrite the file.`,
+      systemMessage: `[MPL P0-A] quality-score.json is malformed — expected {phase, score, verdict, issues[], timestamp} with score ∈ [0, 1]. Reviewer must rewrite the file.`,
     }));
     return;
   }
@@ -110,6 +115,11 @@ async function main() {
   } catch {
     // Best-effort — never block the surfacing decision on disk.
   }
+  // PR #130 review High #2: consume the signal so a stale file from the
+  // prior phase cannot be re-processed if the next reviewer dispatch fails
+  // to overwrite it. Missing file on the next round triggers the
+  // fail-closed surface above instead of silently re-emitting this record.
+  try { rmSync(scoreFile); } catch { /* best-effort cleanup */ }
 
   if (decision.action === 'pass') {
     console.log(JSON.stringify({


### PR DESCRIPTION
## Summary

Original P0-A had \`mpl-phase-runner\` self-dispatch an adversarial reviewer in Step 4.5. Claude Code does NOT support nested Agent dispatch (\"Agent tool is not available in this environment\"), so the original design was structurally impossible (R-NESTED-AGENT-LIMIT, v3.10 §4).

**Redesign**: orchestrator (\`commands/mpl-run-execute.md\` Step 4.3.7 step 12) dispatches \`Task(subagent_type='mpl-adversarial-reviewer')\` after every phase-runner finishes; the reviewer writes a score JSON; a PostToolUse hook reads it and emits pass / retry / escalate.

## Architecture

| Layer | File | Role |
|---|---|---|
| Pure lib | \`hooks/lib/mpl-quality-gate.mjs\` (new) | \`parseScore\` / \`decideAction\` / \`composeHistoryEntry\` |
| Thin hook | \`hooks/mpl-quality-gate.mjs\` (new) | PostToolUse Task\|Agent — filters \`subagent_type='mpl-adversarial-reviewer'\` |
| Reviewer agent | \`agents/mpl-adversarial-reviewer.md\` (new) | sonnet — audit procedure + score composition rules |
| Orchestrator step | \`commands/mpl-run-execute.md\` | Step 12 dispatches + branches on systemMessage |
| State schema | \`hooks/lib/mpl-state.mjs\` | \`adversarial_retry_count\`, \`quality_score_history[]\` |
| hooks.json | PostToolUse Task\|Agent registration | |
| Workspace config | \`.mpl/config.json:adversarial\` | \`threshold\` (default 0.7), \`max_retries\` (default 3) |

## Decision matrix

| Score / verdict | Retry count | Action |
|---|---|---|
| \`score >= threshold AND verdict='PASS'\` | any | **pass** — counter resets to 0 |
| \`score < threshold OR verdict='FAIL'\` | \`< max_retries\` | **retry** — counter += 1 |
| \`score < threshold OR verdict='FAIL'\` | \`>= max_retries\` | **escalate** — counter freezes |

History always appended regardless of action so resume / finalize can replay the sequence.

## Filter

Hook fires on every PostToolUse Task|Agent but short-circuits unless \`tool_input.subagent_type === 'mpl-adversarial-reviewer'\`. Other Task dispatches (test-agent, codebase-analyzer, etc.) stay silent.

## Reviewer audit procedure

Reviewer agent runs (read-only):
1. Anti-pattern self-scan (rg over impact files for tautological assertions, skipped tests)
2. Stub leakage check (TODO / FIXME / \`throw not implemented\`)
3. Verification reality check (machine-evidence exit codes vs prose claims)
4. Scope leak (changes.diff vs phase_definition.impact)
5. Interface contract (functions/types named in contract present in diff)
6. Prior-issues check (retry rounds: literally still present → auto-FAIL)

Score deductions per finding type cap at calibrated levels so a single big issue cannot wipe out a phase.

## Tests (26 cases)

- parseScore (7) — valid / JSON string / null / missing fields / non-finite / issues coercion / missing issues
- decideAction (8) — pass; FAIL verdict overrides high score; low score overrides PASS verdict; escalation at max; retry progression; custom threshold/maxRetries; singular wording
- composeHistoryEntry (2) — pass / retry shapes
- Hook integration (9) — silent passthrough cases (non-Task, non-adversarial, no score file); malformed score → systemMessage; PASS resets + appends; FAIL retry increments; budget exhaustion → escalate + freeze; workspace config tunes; MPL inactive

Full hook regression: 541 → **567/567** (+26 P0-A).

## Files

\`\`\`
agents/mpl-adversarial-reviewer.md      | 117 ++++++++
commands/mpl-run-execute.md             |  35 +++
docs/config-schema.md                   |  17 ++
hooks/__tests__/mpl-quality-gate.test.mjs | 247 ++++++++++++++++++
hooks/hooks.json                        |  10 +
hooks/lib/mpl-quality-gate.mjs          | 142 +++++++++++
hooks/lib/mpl-state.mjs                 |   5 +
hooks/mpl-quality-gate.mjs              | 113 ++++++++
8 files changed, 748 insertions(+), 2 deletions(-)
\`\`\`

## Forward integration

- F4 (#106) doctor meta-self can audit \`state.quality_score_history\` for "5 PASSes in a row with score=1.0" patterns (possible reviewer self-pass).
- exp16 strict rollout can move \`force-pass\` overrides into a P0-2 \`enforcement.adversarial_override\` rule.
- P0-K (#115) artifact schema validator covers quality-score.json shape on top of parseScore.

## Related

- Closes #103
- Part of #101 — **v0.18.0 critical 10/10 closed** (last item; entire critical track shipped this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)