### PR TITLE
feat(#116): H8 — schema migration policy + registry + readState fail-closed

### DIFF
--- a/agents/mpl-doctor.md
+++ b/agents/mpl-doctor.md
@@ -73,6 +73,30 @@ disallowedTools: Write, Edit, Task
     - WARN if missing (setup will create)
     - Check `.mpl/mpl/` subdirectories if pipeline has been run before
 
+    **Schema version sub-check (H8 / #116)**:
+    Doctor surfaces `state.schema_version` against the plugin's
+    `CURRENT_SCHEMA_VERSION` so a stale-plugin / fresh-state mismatch is
+    caught before any other hook trips on it.
+
+    Procedure: read `.mpl/state.json` (skip with `NOT APPLICABLE` if the
+    file is absent) and `MPL/hooks/lib/mpl-state.mjs` to extract the
+    declared constant (line `export const CURRENT_SCHEMA_VERSION = ...`).
+    Compare:
+
+    - PASS — `state.schema_version === CURRENT_SCHEMA_VERSION`.
+    - WARN — `state.schema_version` absent (legacy v1; will auto-migrate
+      on next `readState`) OR `state.schema_version < CURRENT` (older
+      version, migration registry will run).
+    - FAIL — `state.schema_version > CURRENT` (state was written by a
+      newer plugin; `readState` will fail-closed and the pipeline will
+      not progress until the plugin is upgraded). Reference:
+      `docs/schemas/migration-policy.md`.
+
+    Surface the values in the Category 6 output:
+    ```
+    schema_version: state=N plugin=M  → PASS|WARN|FAIL
+    ```
+
     ### Category 7: Tool Availability (Standalone Check)
     - **Scope**: runtime probe (no file scope)
     Detect which tool tiers are available:

--- a/docs/schemas/migration-policy.md
+++ b/docs/schemas/migration-policy.md
@@ -1,0 +1,133 @@
+# `.mpl/state.json` Migration Policy (H8, v0.18.1)
+
+> **Status**: Active — H8 (#116) defines how `state.schema_version`
+> changes propagate through the codebase. Companion to
+> `docs/schemas/state.md` (the frozen schema) and `hooks/lib/migrations/`
+> (the executable registry).
+>
+> **Source-of-truth constant**: `CURRENT_SCHEMA_VERSION` in
+> `hooks/lib/mpl-state.mjs`.
+
+## Why this exists
+
+`state.json.schema_version` was added in P2-6 (#84) to unify the previously
+split state files. Before H8 it was effectively a marker only: `readState`
+ran the v1→v2 merge as a hard-coded branch and silently passed through any
+future version. G3 invariant I8 (#108) flagged newer-than-supported writes
+as warn — but a stale plugin reading a state from a fresher writer would
+still proceed and could misinterpret renamed or removed fields.
+
+H8 makes the version contract enforceable end-to-end: writers commit to a
+bump policy, the read path runs migrations from a registry, and
+out-of-range versions fail closed.
+
+## Bump policy (semantic)
+
+The schema version is a single integer. Bumps are classified by the kind
+of change to the state shape:
+
+| Change | Kind | Action | Example |
+|---|---|---|---|
+| Add a new optional field with a safe default | **Additive** | Bump `CURRENT_SCHEMA_VERSION`. Migration script is a one-line backfill (or a no-op if the default is `null`/`[]`). | Adding `state.fix_loop_history: []` (G5 #114). |
+| Add a new top-level subtree | **Additive** | Bump + initialize the subtree shape. | Adding `state.research` (v0.14). |
+| Rename an existing field | **Breaking** | Bump + migration must read the old name and write the new one. Drop the old name only after one stable release. | `current_phase` rename across exp16. |
+| Change the meaning of an existing field (units, enum) | **Breaking** | Bump + migration translates each prior value to the new domain. Hand-write the mapping — no implicit identity. | `session_status` enum widening (#109 G4 added `verification_hang`). |
+| Remove a field | **Breaking** | Bump + migration drops the key cleanly. Document the removal in this file. | (none yet). |
+
+### What this means in practice
+
+- **Additive** bump = patch number on the plugin (e.g. `0.18.1 → 0.18.2`).
+  Old hooks reading a fresh state see the new field as `undefined`; treat
+  it as the default. New hooks reading an old state run the migration on
+  first read and the field is backfilled.
+- **Breaking** bump = minor number on the plugin (e.g. `0.18.x → 0.19.0`).
+  A migration script is **mandatory** — no in-place rename, no field
+  removal without a translation. Without a registered migration, a writer
+  bumping `CURRENT_SCHEMA_VERSION` will trip its own G3 I8 on the next
+  read.
+
+## Migration registry
+
+`hooks/lib/migrations/index.mjs` exports an ordered list of migration
+entries:
+
+```js
+{
+  from: 1,                      // schema_version BEFORE migration
+  to: 2,                        // schema_version AFTER migration
+  description: 'Unify split state files (P2-6 / #84)',
+  migrate(state, cwd) {         // pure function (cwd for legacy I/O)
+    // ... return new state object with state.schema_version = to
+  }
+}
+```
+
+`readState(cwd)` resolves the migration chain:
+
+1. Parse `.mpl/state.json`. If `schema_version` is absent, treat as `1`
+   (the pre-P2-6 default).
+2. If `schema_version > CURRENT_SCHEMA_VERSION` → return `null` and log
+   `[MPL state] schema_version=N exceeds supported MAX=M; upgrade plugin`.
+   This is **fail-closed**: a stale plugin will not act on data shapes
+   it can't reason about. Operationally, this surfaces as the same
+   "state file unreadable" path that already exists for corrupt JSON, so
+   downstream hooks naturally degrade rather than misinterpret.
+3. If `schema_version < CURRENT_SCHEMA_VERSION` → walk the registry,
+   apply each migration whose `from` matches the current version, and
+   persist the result atomically.
+
+Migrations are run **at most once per stale read**: each migration writes
+back to disk with the new `schema_version`, so subsequent reads
+short-circuit. The chain runner is idempotent — calling it on
+already-current state is a no-op.
+
+## File naming
+
+Each migration lives in `hooks/lib/migrations/v{from}-to-v{to}.mjs` and
+exports a default object matching the registry shape above.
+`index.mjs` imports them in order.
+
+Files with `.example.` in the name (e.g.
+`v2-to-v3.example.mjs`) are **not** registered — they are templates for
+future authors and the registry deliberately ignores them so a stale
+example can never run against real state.
+
+## Authoring a new migration
+
+1. Copy `v2-to-v3.example.mjs` to `v{N}-to-v{N+1}.mjs` and fill in the
+   `migrate` body. Keep it pure: same input → same output, no clock or
+   network reads.
+2. Bump `CURRENT_SCHEMA_VERSION` in `hooks/lib/mpl-state.mjs` to `N+1`.
+3. Register the migration in `hooks/lib/migrations/index.mjs`.
+4. Add a unit test in `hooks/__tests__/mpl-migrations.test.mjs` that
+   feeds a `from`-shaped state object through `readState` and asserts the
+   `to` shape.
+5. Update the matrix at the top of this file with the change kind.
+6. If the bump is breaking, also update `docs/schemas/state.md` and any
+   consumer hooks; the G3 I8 invariant will fail in CI until both sides
+   agree.
+
+## Rollback
+
+State files are atomic — `writeState` writes to a temp path and renames.
+A failed migration leaves the original file in place because the
+migration chain only persists on success. A user who discovers a bad
+migration can:
+
+1. Pin the plugin to the prior version.
+2. Restore from `.mpl/archive/{pipeline_id}-legacy-execution-state.json`
+   if a legacy file was archived during a v1→v2 migration.
+3. Manually reset by deleting `.mpl/state.json` (loses pipeline progress;
+   only valid if the pipeline can be re-run from scratch).
+
+There is no automatic downgrade path. A bumped `schema_version` is a
+one-way commitment.
+
+## See also
+
+- `hooks/lib/mpl-state.mjs` — `readState` + `CURRENT_SCHEMA_VERSION`.
+- `hooks/lib/migrations/` — registry + per-version scripts.
+- `hooks/lib/mpl-state-invariant.mjs#checkI8` — G3 invariant that fires
+  when `schema_version` exceeds what the running hook supports
+  (defense-in-depth alongside `readState`'s fail-closed return).
+- `docs/schemas/state.md` — frozen field schema.

--- a/docs/schemas/state.md
+++ b/docs/schemas/state.md
@@ -56,11 +56,14 @@ strict mode elevates `warn → block`.
 ## Schema version
 
 - `CURRENT_SCHEMA_VERSION = 2` (P2-6 — unified state, `execution` subtree absorbs the legacy `.mpl/mpl/state.json`).
-- Migration v1 → v2 runs automatically on `readState`. Newer-than-supported writes raise I8.
+- The migration registry (`hooks/lib/migrations/`) walks any older state up to current on `readState`. Newer-than-supported writes are **fail-closed** by `readState` (returns `null` + diagnostic stderr) and additionally surfaced by G3 I8.
+- Bump policy and authoring workflow: `docs/schemas/migration-policy.md`.
 
 ## See also
 
-- `hooks/lib/mpl-state.mjs` — runtime schema + migration.
+- `hooks/lib/mpl-state.mjs` — runtime schema + `readState` fail-closed guard.
+- `hooks/lib/migrations/` — versioned migration registry (H8 / #116).
+- `docs/schemas/migration-policy.md` — bump policy + authoring workflow.
 - `hooks/lib/mpl-state-invariant.mjs` — invariant checker (this document's mechanical mirror).
 - `commands/mpl-run.md` §"MPL State" — orchestrator protocol view.
 - `docs/config-schema.md` §Enforcement — `state_invariant_violation` policy.

--- a/hooks/__tests__/mpl-migrations.test.mjs
+++ b/hooks/__tests__/mpl-migrations.test.mjs
@@ -1,0 +1,174 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync, readdirSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+import {
+  readState,
+  writeState,
+  CURRENT_SCHEMA_VERSION,
+} from '../lib/mpl-state.mjs';
+import { MIGRATIONS, runMigrations } from '../lib/migrations/index.mjs';
+
+/* ──────────────────────────── registry shape ──────────────────────────── */
+
+describe('H8 migration registry', () => {
+  it('every entry has the required fields and well-formed (from, to)', () => {
+    for (const m of MIGRATIONS) {
+      assert.equal(typeof m.from, 'number', 'from must be a number');
+      assert.equal(typeof m.to, 'number', 'to must be a number');
+      assert.equal(typeof m.description, 'string', 'description must be a string');
+      assert.equal(typeof m.migrate, 'function', 'migrate must be a function');
+      assert.ok(m.to > m.from, `${m.from} → ${m.to}: to must be greater than from`);
+    }
+  });
+
+  it('registry is contiguous from v1 up to CURRENT_SCHEMA_VERSION', () => {
+    let v = 1;
+    for (const m of MIGRATIONS) {
+      assert.equal(m.from, v, `chain breaks at ${m.from}; expected ${v}`);
+      v = m.to;
+    }
+    assert.equal(v, CURRENT_SCHEMA_VERSION, 'registry must terminate at CURRENT_SCHEMA_VERSION');
+  });
+
+  it('does not register .example. templates', () => {
+    // A new author dropping `v3-to-v4.example.mjs` into the directory must not
+    // suddenly be the active v3→v4 migration. The registry is hand-maintained
+    // in index.mjs precisely so example files cannot back-door their way in.
+    for (const m of MIGRATIONS) {
+      const desc = (m.description ?? '').toLowerCase();
+      assert.ok(!desc.startsWith('example'),
+        `MIGRATIONS includes an example template: "${m.description}". Move it to a .example. file or remove from registry.`);
+    }
+  });
+});
+
+/* ──────────────────────────── chain runner ────────────────────────────── */
+
+describe('runMigrations', () => {
+  let tmpDir;
+  beforeEach(() => { tmpDir = mkdtempSync(join(tmpdir(), 'mpl-mig-')); });
+  afterEach(() => { rmSync(tmpDir, { recursive: true, force: true }); });
+
+  it('returns input unchanged when state is already at target', () => {
+    const state = { current_phase: 'phase2-sprint', schema_version: CURRENT_SCHEMA_VERSION };
+    const out = runMigrations(state, tmpDir, CURRENT_SCHEMA_VERSION);
+    assert.equal(out.schema_version, CURRENT_SCHEMA_VERSION);
+  });
+
+  it('walks v1 → v2 when given an unversioned input', () => {
+    const state = { current_phase: 'phase1-plan' }; // schema_version absent → v1
+    const out = runMigrations(state, tmpDir, CURRENT_SCHEMA_VERSION);
+    assert.equal(out.schema_version, CURRENT_SCHEMA_VERSION);
+    assert.ok(out.execution, 'execution subtree must be created by v1→v2');
+  });
+
+  it('does not throw on null/undefined state', () => {
+    assert.equal(runMigrations(null, tmpDir, CURRENT_SCHEMA_VERSION), null);
+    assert.equal(runMigrations(undefined, tmpDir, CURRENT_SCHEMA_VERSION), undefined);
+  });
+
+  it('caps iterations defensively even if a migration mis-bumps schema_version', () => {
+    // Synthesize a corrupt registry entry semantics: pass a state whose
+    // current schema_version exceeds CURRENT — runMigrations should refuse
+    // to advance further and return as-is.
+    const state = { current_phase: 'phase1-plan', schema_version: 999 };
+    const out = runMigrations(state, tmpDir, CURRENT_SCHEMA_VERSION);
+    assert.equal(out.schema_version, 999, 'state with version above target is returned untouched');
+  });
+});
+
+/* ────────────────────────── readState fail-closed ─────────────────────── */
+
+describe('readState fail-closed on unsupported schema_version (H8)', () => {
+  let tmpDir;
+  let originalStderrWrite;
+  let stderrCaptured;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'mpl-h8-'));
+    stderrCaptured = '';
+    originalStderrWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = (chunk) => {
+      stderrCaptured += chunk;
+      return true;
+    };
+  });
+
+  afterEach(() => {
+    process.stderr.write = originalStderrWrite;
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeRawState(body) {
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    writeFileSync(join(tmpDir, '.mpl', 'state.json'), JSON.stringify(body));
+  }
+
+  it('returns null when schema_version exceeds CURRENT_SCHEMA_VERSION', () => {
+    writeRawState({
+      current_phase: 'phase2-sprint',
+      schema_version: CURRENT_SCHEMA_VERSION + 1,
+    });
+    const state = readState(tmpDir);
+    assert.equal(state, null);
+  });
+
+  it('writes a diagnostic stderr line referencing the migration policy doc', () => {
+    writeRawState({
+      current_phase: 'phase2-sprint',
+      schema_version: CURRENT_SCHEMA_VERSION + 5,
+    });
+    readState(tmpDir);
+    assert.match(stderrCaptured, new RegExp(`schema_version=${CURRENT_SCHEMA_VERSION + 5}`));
+    assert.match(stderrCaptured, new RegExp(`MAX=${CURRENT_SCHEMA_VERSION}`));
+    assert.match(stderrCaptured, /migration-policy\.md/);
+  });
+
+  it('does NOT mutate the on-disk file when refusing a newer version', () => {
+    writeRawState({
+      current_phase: 'phase2-sprint',
+      schema_version: CURRENT_SCHEMA_VERSION + 1,
+      sentinel: 'do-not-touch',
+    });
+    readState(tmpDir);
+    const raw = JSON.parse(readFileSync(join(tmpDir, '.mpl', 'state.json'), 'utf-8'));
+    assert.equal(raw.schema_version, CURRENT_SCHEMA_VERSION + 1);
+    assert.equal(raw.sentinel, 'do-not-touch');
+  });
+
+  it('still accepts equal schema_version (no fail-closed at parity)', () => {
+    writeRawState({
+      current_phase: 'phase2-sprint',
+      schema_version: CURRENT_SCHEMA_VERSION,
+    });
+    const state = readState(tmpDir);
+    assert.equal(state.schema_version, CURRENT_SCHEMA_VERSION);
+  });
+
+  it('legacy v1 state still migrates (regression — H8 must not regress P2-6)', () => {
+    writeRawState({
+      pipeline_id: 'mpl-h8-legacy',
+      current_phase: 'phase2-sprint',
+      // schema_version absent → treated as v1
+    });
+    const state = readState(tmpDir);
+    assert.equal(state.schema_version, CURRENT_SCHEMA_VERSION);
+    assert.ok(state.execution);
+  });
+});
+
+/* ──────────────────── consistency with G3 invariant I8 ────────────────── */
+
+describe('CURRENT_SCHEMA_VERSION is the single source of truth', () => {
+  it('migration chain terminates at the same constant readState enforces', async () => {
+    const { CURRENT_SCHEMA_VERSION: invariantSV } = await import('../lib/mpl-state-invariant.mjs').then(async (m) => {
+      // mpl-state-invariant re-imports the same constant — confirm both sides agree.
+      const stateMod = await import('../lib/mpl-state.mjs');
+      return { CURRENT_SCHEMA_VERSION: stateMod.CURRENT_SCHEMA_VERSION };
+    });
+    assert.equal(invariantSV, CURRENT_SCHEMA_VERSION);
+  });
+});

--- a/hooks/__tests__/mpl-migrations.test.mjs
+++ b/hooks/__tests__/mpl-migrations.test.mjs
@@ -8,6 +8,8 @@ import {
   readState,
   writeState,
   CURRENT_SCHEMA_VERSION,
+  UnsupportedSchemaVersionError,
+  LEGACY_EXECUTION_STATE_PATH,
 } from '../lib/mpl-state.mjs';
 import { MIGRATIONS, runMigrations } from '../lib/migrations/index.mjs';
 
@@ -70,10 +72,11 @@ describe('runMigrations', () => {
     assert.equal(runMigrations(undefined, tmpDir, CURRENT_SCHEMA_VERSION), undefined);
   });
 
-  it('caps iterations defensively even if a migration mis-bumps schema_version', () => {
-    // Synthesize a corrupt registry entry semantics: pass a state whose
-    // current schema_version exceeds CURRENT — runMigrations should refuse
-    // to advance further and return as-is.
+  it('refuses to advance state already past target (early-return, no migration applied)', () => {
+    // Names exactly what is being checked. The fromVersion >= target
+    // early-return at the top of runMigrations — distinct from the
+    // safety cap (`MIGRATIONS.length + 1`) which is harder to exercise
+    // without a stub registry and stays as in-code defense.
     const state = { current_phase: 'phase1-plan', schema_version: 999 };
     const out = runMigrations(state, tmpDir, CURRENT_SCHEMA_VERSION);
     assert.equal(out.schema_version, 999, 'state with version above target is returned untouched');
@@ -163,12 +166,153 @@ describe('readState fail-closed on unsupported schema_version (H8)', () => {
 /* ──────────────────── consistency with G3 invariant I8 ────────────────── */
 
 describe('CURRENT_SCHEMA_VERSION is the single source of truth', () => {
-  it('migration chain terminates at the same constant readState enforces', async () => {
-    const { CURRENT_SCHEMA_VERSION: invariantSV } = await import('../lib/mpl-state-invariant.mjs').then(async (m) => {
-      // mpl-state-invariant re-imports the same constant — confirm both sides agree.
-      const stateMod = await import('../lib/mpl-state.mjs');
-      return { CURRENT_SCHEMA_VERSION: stateMod.CURRENT_SCHEMA_VERSION };
+  it('mpl-state-invariant re-exports the same constant readState enforces', async () => {
+    // Re-export added in PR #132 review fix so the assertion actually
+    // crosses module boundaries instead of comparing the constant to
+    // itself.
+    const invariantMod = await import('../lib/mpl-state-invariant.mjs');
+    assert.equal(invariantMod.CURRENT_SCHEMA_VERSION, CURRENT_SCHEMA_VERSION);
+  });
+});
+
+/* ─────────────── PR #132 review #1: writeState fail-closed ────────────── */
+
+describe('writeState refuses to overwrite a future-schema state (PR #132)', () => {
+  let tmpDir;
+  let originalStderrWrite;
+  let stderrCaptured;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'mpl-write-h8-'));
+    stderrCaptured = '';
+    originalStderrWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = (chunk) => {
+      stderrCaptured += chunk;
+      return true;
+    };
+  });
+
+  afterEach(() => {
+    process.stderr.write = originalStderrWrite;
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeRawState(body) {
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    writeFileSync(join(tmpDir, '.mpl', 'state.json'), JSON.stringify(body));
+  }
+
+  it('throws UnsupportedSchemaVersionError when on-disk schema_version > CURRENT', () => {
+    writeRawState({
+      current_phase: 'phase2-sprint',
+      schema_version: CURRENT_SCHEMA_VERSION + 1,
+      sentinel: 'fresh-writer',
     });
-    assert.equal(invariantSV, CURRENT_SCHEMA_VERSION);
+    assert.throws(
+      () => writeState(tmpDir, { session_status: 'active' }),
+      (err) => err instanceof UnsupportedSchemaVersionError
+        && err.version === CURRENT_SCHEMA_VERSION + 1
+        && err.supported === CURRENT_SCHEMA_VERSION,
+    );
+  });
+
+  it('does NOT mutate the on-disk file when refusing the write', () => {
+    writeRawState({
+      current_phase: 'phase2-sprint',
+      schema_version: CURRENT_SCHEMA_VERSION + 2,
+      sentinel: 'fresh-writer',
+      futureField: { nested: 'data' },
+    });
+    try {
+      writeState(tmpDir, { session_status: 'active' });
+    } catch {
+      // expected
+    }
+    const raw = JSON.parse(readFileSync(join(tmpDir, '.mpl', 'state.json'), 'utf-8'));
+    assert.equal(raw.schema_version, CURRENT_SCHEMA_VERSION + 2, 'schema_version preserved');
+    assert.equal(raw.sentinel, 'fresh-writer', 'sentinel field preserved');
+    assert.deepEqual(raw.futureField, { nested: 'data' }, 'unknown future field preserved');
+    assert.equal(raw.session_status, undefined, 'patch did NOT land');
+  });
+
+  it('emits a stderr diagnostic referencing the migration policy doc', () => {
+    writeRawState({
+      current_phase: 'phase2-sprint',
+      schema_version: CURRENT_SCHEMA_VERSION + 1,
+    });
+    try { writeState(tmpDir, { session_status: 'active' }); } catch { /* expected */ }
+    assert.match(stderrCaptured, /writeState refused/);
+    assert.match(stderrCaptured, /migration-policy\.md/);
+  });
+
+  it('still writes normally when on-disk schema_version is at parity', () => {
+    writeRawState({
+      current_phase: 'phase2-sprint',
+      schema_version: CURRENT_SCHEMA_VERSION,
+      execution: { task: 'baseline', phases: { total: 0, completed: 0, current: null, failed: 0, circuit_breaks: 0 } },
+    });
+    const merged = writeState(tmpDir, { session_status: 'active' });
+    assert.equal(merged.session_status, 'active');
+    assert.equal(merged.schema_version, CURRENT_SCHEMA_VERSION);
+  });
+
+  it('still writes normally when state file does not exist (fresh init path)', () => {
+    const merged = writeState(tmpDir, { current_phase: 'phase1-plan' });
+    assert.equal(merged.current_phase, 'phase1-plan');
+    assert.equal(merged.schema_version, CURRENT_SCHEMA_VERSION);
+  });
+});
+
+/* ─────── PR #132 review nit #2: corrupt legacy file raw archival ──────── */
+
+describe('v1→v2 migration archives raw bytes when legacy file is corrupt (PR #132 nit #2)', () => {
+  let tmpDir;
+  beforeEach(() => { tmpDir = mkdtempSync(join(tmpdir(), 'mpl-corrupt-')); });
+  afterEach(() => { rmSync(tmpDir, { recursive: true, force: true }); });
+
+  it('preserves the original bytes in legacy_content_raw when JSON.parse fails', () => {
+    // Unversioned state (v1) with a corrupt legacy execution file.
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    writeFileSync(join(tmpDir, '.mpl', 'state.json'), JSON.stringify({
+      pipeline_id: 'mpl-corrupt-test',
+      current_phase: 'phase2-sprint',
+    }));
+    mkdirSync(join(tmpDir, '.mpl', 'mpl'), { recursive: true });
+    const corruptBytes = '{"task": "broken", "phases":';
+    writeFileSync(join(tmpDir, '.mpl', 'mpl', 'state.json'), corruptBytes);
+
+    readState(tmpDir);
+
+    // Source legacy file removed
+    assert.equal(existsSync(join(tmpDir, LEGACY_EXECUTION_STATE_PATH)), false);
+
+    // Archive carries the raw bytes verbatim plus a corrupt flag — no
+    // longer just `null` legacy_content.
+    const archiveDir = join(tmpDir, '.mpl', 'archive');
+    const archiveFile = readdirSync(archiveDir).find((f) => f.endsWith('legacy-execution-state.json'));
+    assert.ok(archiveFile, 'archive file expected');
+    const archive = JSON.parse(readFileSync(join(archiveDir, archiveFile), 'utf-8'));
+    assert.equal(archive.legacy_content, null);
+    assert.equal(archive.legacy_content_raw, corruptBytes, 'raw bytes preserved verbatim');
+    assert.equal(archive.legacy_content_corrupt, true);
+  });
+
+  it('does NOT add raw fields when the legacy file is well-formed', () => {
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    writeFileSync(join(tmpDir, '.mpl', 'state.json'), JSON.stringify({
+      pipeline_id: 'mpl-good-legacy',
+      current_phase: 'phase2-sprint',
+    }));
+    mkdirSync(join(tmpDir, '.mpl', 'mpl'), { recursive: true });
+    writeFileSync(join(tmpDir, '.mpl', 'mpl', 'state.json'), JSON.stringify({ task: 'ok' }));
+
+    readState(tmpDir);
+
+    const archiveDir = join(tmpDir, '.mpl', 'archive');
+    const archiveFile = readdirSync(archiveDir).find((f) => f.endsWith('legacy-execution-state.json'));
+    const archive = JSON.parse(readFileSync(join(archiveDir, archiveFile), 'utf-8'));
+    assert.equal(archive.legacy_content.task, 'ok');
+    assert.equal(archive.legacy_content_raw, undefined);
+    assert.equal(archive.legacy_content_corrupt, undefined);
   });
 });

--- a/hooks/lib/migrations/index.mjs
+++ b/hooks/lib/migrations/index.mjs
@@ -1,0 +1,74 @@
+/**
+ * Migration registry for `state.json` schema versions (H8 / #116).
+ *
+ * Each entry implements the contract:
+ *   { from: int, to: int, description: string,
+ *     migrate(state, cwd) -> state }
+ *
+ * `runMigrations(state, cwd, target)` walks the registry from the state's
+ * current `schema_version` (defaults to 1 when absent — the pre-P2-6 era)
+ * up to `target`, applying each matching entry exactly once. The walk is
+ * idempotent: if `state.schema_version >= target` the function returns the
+ * input unchanged.
+ *
+ * **File naming**: `v{from}-to-v{to}.mjs` is registered. Anything with
+ * `.example.` in the name is intentionally excluded so future authors can
+ * keep templates here without risking accidental load. See
+ * `docs/schemas/migration-policy.md` for the authoring workflow.
+ */
+
+import v1ToV2 from './v1-to-v2.mjs';
+
+/**
+ * Ordered registry. Add new entries here when bumping
+ * `CURRENT_SCHEMA_VERSION` in `hooks/lib/mpl-state.mjs`.
+ */
+export const MIGRATIONS = Object.freeze([
+  v1ToV2,
+]);
+
+/**
+ * Apply every registered migration whose `from` matches the current
+ * `schema_version`, in order, until no further migration applies or the
+ * target version is reached.
+ *
+ * Pure with respect to its inputs — does NOT persist to disk. The caller
+ * (`readState` in `mpl-state.mjs`) decides when to write the migrated
+ * state back.
+ *
+ * @param {object} state - parsed state.json (must be a plain object)
+ * @param {string} cwd - working directory (for migrations that read
+ *                       sibling files like `.mpl/mpl/state.json`)
+ * @param {number} target - desired terminal schema_version
+ * @returns {object} migrated state, or the input if already at target
+ */
+export function runMigrations(state, cwd, target) {
+  if (!state || typeof state !== 'object') return state;
+
+  let current = state;
+  // Cap iterations defensively — even if a migration mis-bumped its `to`
+  // field, we never loop more than the registry length.
+  const safety = MIGRATIONS.length + 1;
+  for (let i = 0; i < safety; i++) {
+    const fromVersion = current.schema_version ?? 1;
+    if (fromVersion >= target) return current;
+    const next = MIGRATIONS.find((m) => m.from === fromVersion);
+    if (!next) {
+      // No migration can advance us further — leave as-is. The caller's
+      // read path (and G3 I8) decides whether this is an error.
+      return current;
+    }
+    if (next.to > target) {
+      // Wouldn't normally happen — registry is monotonic — but if a
+      // future entry leaps past target we still stop at target by
+      // declining to apply it.
+      return current;
+    }
+    current = next.migrate(current, cwd);
+    if (typeof current?.schema_version !== 'number' || current.schema_version <= fromVersion) {
+      // Migration bug: did not advance schema_version. Refuse to loop.
+      return current;
+    }
+  }
+  return current;
+}

--- a/hooks/lib/migrations/v1-to-v2.mjs
+++ b/hooks/lib/migrations/v1-to-v2.mjs
@@ -38,33 +38,53 @@ const BASELINE_EXECUTION = Object.freeze({
   failure_phase: null,
 });
 
+/**
+ * Read the legacy execution-state file, returning both the parsed JSON
+ * (when valid) and the raw text. The raw form lets `archiveLegacyFile`
+ * preserve the original bytes when the file is corrupt — without that,
+ * the archive's `legacy_content` would be `null` while the source file
+ * is removed, defeating the forensic purpose of archiving (PR #132
+ * review nit #2).
+ */
 function readLegacyExecutionFile(legacyPath) {
-  if (!existsSync(legacyPath)) return null;
+  if (!existsSync(legacyPath)) {
+    return { parsed: null, raw: null, exists: false, corrupt: false };
+  }
+  let raw = null;
   try {
-    return JSON.parse(readFileSync(legacyPath, 'utf-8'));
+    raw = readFileSync(legacyPath, 'utf-8');
   } catch {
-    // Corrupt legacy file — return null so the migration falls back to
-    // baseline defaults; the corrupt file is still archived verbatim
-    // below for forensic value.
-    return null;
+    return { parsed: null, raw: null, exists: true, corrupt: true };
+  }
+  try {
+    return { parsed: JSON.parse(raw), raw, exists: true, corrupt: false };
+  } catch {
+    return { parsed: null, raw, exists: true, corrupt: true };
   }
 }
 
-function archiveLegacyFile(cwd, currentState, legacyParsed, legacyPath) {
-  if (legacyParsed === null && !existsSync(legacyPath)) return;
+function archiveLegacyFile(cwd, currentState, legacy, legacyPath) {
+  if (!legacy.exists && legacy.parsed === null) return;
   const archiveRoot = join(cwd, '.mpl', 'archive');
   try {
     mkdirSync(archiveRoot, { recursive: true });
     const archiveName = currentState?.pipeline_id
       ? `${currentState.pipeline_id}-legacy-execution-state.json`
       : 'legacy-execution-state.json';
+    const archiveBody = {
+      migrated_at: new Date().toISOString(),
+      pipeline_id: currentState?.pipeline_id ?? null,
+      legacy_content: legacy.parsed,
+    };
+    if (legacy.corrupt && legacy.raw !== null) {
+      // Preserve the original bytes verbatim so an operator can hand-fix
+      // and replay if the corruption matters.
+      archiveBody.legacy_content_raw = legacy.raw;
+      archiveBody.legacy_content_corrupt = true;
+    }
     writeFileSync(
       join(archiveRoot, archiveName),
-      JSON.stringify({
-        migrated_at: new Date().toISOString(),
-        pipeline_id: currentState?.pipeline_id ?? null,
-        legacy_content: legacyParsed,
-      }, null, 2),
+      JSON.stringify(archiveBody, null, 2),
       { mode: 0o600 },
     );
     if (existsSync(legacyPath)) rmSync(legacyPath, { force: true });
@@ -79,7 +99,7 @@ export default {
   description: 'Unify split state files (P2-6 / #84) — execution subtree absorbs .mpl/mpl/state.json',
   migrate(state, cwd) {
     const legacyPath = join(cwd, LEGACY_EXECUTION_STATE_PATH);
-    const legacyParsed = readLegacyExecutionFile(legacyPath);
+    const legacy = readLegacyExecutionFile(legacyPath);
 
     const merged = { ...state };
     const existingExecution = (state && typeof state.execution === 'object' && state.execution !== null)
@@ -87,12 +107,12 @@ export default {
       : {};
 
     merged.execution = deepMerge(
-      deepMerge(BASELINE_EXECUTION, legacyParsed && typeof legacyParsed === 'object' ? legacyParsed : {}),
+      deepMerge(BASELINE_EXECUTION, legacy.parsed && typeof legacy.parsed === 'object' ? legacy.parsed : {}),
       existingExecution,
     );
     merged.schema_version = 2;
 
-    archiveLegacyFile(cwd, state, legacyParsed, legacyPath);
+    archiveLegacyFile(cwd, state, legacy, legacyPath);
 
     return merged;
   },

--- a/hooks/lib/migrations/v1-to-v2.mjs
+++ b/hooks/lib/migrations/v1-to-v2.mjs
@@ -1,0 +1,99 @@
+/**
+ * v1 → v2 (P2-6 / #84): unify the split state files.
+ *
+ * Pre-P2-6 the pipeline-scope fields lived in `.mpl/state.json` and the
+ * execution-scope fields (task, phases, phase_details, totals,
+ * cumulative_pass_rate, failure_phase) lived in a separate
+ * `.mpl/mpl/state.json`. v2 absorbs the latter into `state.execution`.
+ *
+ * The migration:
+ *   1. Reads `.mpl/mpl/state.json` if present (legacy data).
+ *   2. Merges the legacy fields into `state.execution`, with already-unified
+ *      values winning over legacy values when both exist.
+ *   3. Archives the legacy file to
+ *      `.mpl/archive/{pipeline_id}-legacy-execution-state.json` (or
+ *      `legacy-execution-state.json` when no pipeline_id is known).
+ *   4. Removes the legacy file once archived.
+ *   5. Bumps schema_version to 2.
+ *
+ * I/O failure during archive is non-fatal — it's better to leave the
+ * legacy file in place than to wedge the pipeline.
+ */
+
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+
+import { deepMerge } from '../mpl-state-merge.mjs';
+
+export const LEGACY_EXECUTION_STATE_PATH = '.mpl/mpl/state.json';
+
+const BASELINE_EXECUTION = Object.freeze({
+  task: null,
+  status: null,
+  started_at: null,
+  phases: { total: 0, completed: 0, current: null, failed: 0, circuit_breaks: 0 },
+  phase_details: [],
+  totals: { total_retries: 0, total_micro_fixes: 0, total_discoveries: 0, elapsed_ms: 0 },
+  cumulative_pass_rate: null,
+  failure_phase: null,
+});
+
+function readLegacyExecutionFile(legacyPath) {
+  if (!existsSync(legacyPath)) return null;
+  try {
+    return JSON.parse(readFileSync(legacyPath, 'utf-8'));
+  } catch {
+    // Corrupt legacy file — return null so the migration falls back to
+    // baseline defaults; the corrupt file is still archived verbatim
+    // below for forensic value.
+    return null;
+  }
+}
+
+function archiveLegacyFile(cwd, currentState, legacyParsed, legacyPath) {
+  if (legacyParsed === null && !existsSync(legacyPath)) return;
+  const archiveRoot = join(cwd, '.mpl', 'archive');
+  try {
+    mkdirSync(archiveRoot, { recursive: true });
+    const archiveName = currentState?.pipeline_id
+      ? `${currentState.pipeline_id}-legacy-execution-state.json`
+      : 'legacy-execution-state.json';
+    writeFileSync(
+      join(archiveRoot, archiveName),
+      JSON.stringify({
+        migrated_at: new Date().toISOString(),
+        pipeline_id: currentState?.pipeline_id ?? null,
+        legacy_content: legacyParsed,
+      }, null, 2),
+      { mode: 0o600 },
+    );
+    if (existsSync(legacyPath)) rmSync(legacyPath, { force: true });
+  } catch {
+    // Non-fatal: better to keep the legacy file than wedge the pipeline.
+  }
+}
+
+export default {
+  from: 1,
+  to: 2,
+  description: 'Unify split state files (P2-6 / #84) — execution subtree absorbs .mpl/mpl/state.json',
+  migrate(state, cwd) {
+    const legacyPath = join(cwd, LEGACY_EXECUTION_STATE_PATH);
+    const legacyParsed = readLegacyExecutionFile(legacyPath);
+
+    const merged = { ...state };
+    const existingExecution = (state && typeof state.execution === 'object' && state.execution !== null)
+      ? state.execution
+      : {};
+
+    merged.execution = deepMerge(
+      deepMerge(BASELINE_EXECUTION, legacyParsed && typeof legacyParsed === 'object' ? legacyParsed : {}),
+      existingExecution,
+    );
+    merged.schema_version = 2;
+
+    archiveLegacyFile(cwd, state, legacyParsed, legacyPath);
+
+    return merged;
+  },
+};

--- a/hooks/lib/migrations/v2-to-v3.example.mjs
+++ b/hooks/lib/migrations/v2-to-v3.example.mjs
@@ -1,0 +1,42 @@
+/**
+ * EXAMPLE migration template — v2 → v3.
+ *
+ * **NOT REGISTERED**: the `.example.` suffix means
+ * `hooks/lib/migrations/index.mjs` will not pick this file up. It exists
+ * so future authors can copy the shape without inventing it from scratch.
+ *
+ * To author a real v2 → v3 migration:
+ *   1. Copy this file to `v2-to-v3.mjs` (drop `.example.`).
+ *   2. Bump `CURRENT_SCHEMA_VERSION` in `hooks/lib/mpl-state.mjs` to 3.
+ *   3. Register the new module in `hooks/lib/migrations/index.mjs`.
+ *   4. Add a unit test that feeds a v2 state through `readState` and
+ *      asserts the v3 shape.
+ *   5. If the change is breaking (rename / remove / semantic shift), also
+ *      update `docs/schemas/state.md` and any consumer hooks.
+ *
+ * Reference: `docs/schemas/migration-policy.md`.
+ *
+ * The body below illustrates an additive backfill — the most common
+ * shape: a new optional field gets seeded with its default whenever the
+ * incoming state lacks it. Replace with the actual change when used.
+ */
+
+export default {
+  from: 2,
+  to: 3,
+  description: 'EXAMPLE — additive backfill (replace with real change)',
+  migrate(state, _cwd) {
+    const merged = { ...state };
+
+    // Example: backfill `fix_loop_history` (G5 #114).
+    // Real authors should either replace this body or delete it entirely
+    // and add their own fields — the registry will not run this stub
+    // because the file is not imported by index.mjs.
+    if (!Array.isArray(merged.fix_loop_history)) {
+      merged.fix_loop_history = [];
+    }
+
+    merged.schema_version = 3;
+    return merged;
+  },
+};

--- a/hooks/lib/mpl-state-invariant.mjs
+++ b/hooks/lib/mpl-state-invariant.mjs
@@ -21,6 +21,12 @@ import { join } from 'path';
 
 import { CURRENT_SCHEMA_VERSION } from './mpl-state.mjs';
 
+// Re-export so consumers (and the H8 single-source-of-truth test) can
+// confirm both modules agree on the version constant via a single
+// import. Without this re-export the SSOT test had to reach back into
+// mpl-state.mjs and ended up comparing the constant to itself.
+export { CURRENT_SCHEMA_VERSION };
+
 /**
  * Trigger contexts. Different triggers care about different invariants — for
  * example "no new phase dispatch while paused" only matters when the trigger
@@ -239,6 +245,12 @@ function checkI8(state) {
   // Refuse states with a schema_version newer than this hook supports.
   // Migration handles older versions automatically — newer ones mean the
   // hook is stale relative to the writer.
+  //
+  // Note (H8 / #116): in production, `readState` fail-closes on the same
+  // condition before any caller can build a state object to pass here.
+  // I8 therefore mainly catches synthetic state objects that bypass
+  // readState (test fixtures, future programmatic writers) — defense in
+  // depth for the read path, not the writer-side guard.
   const sv = state?.schema_version;
   if (typeof sv !== 'number') return null;
   if (sv > CURRENT_SCHEMA_VERSION) {

--- a/hooks/lib/mpl-state-merge.mjs
+++ b/hooks/lib/mpl-state-merge.mjs
@@ -1,0 +1,38 @@
+/**
+ * Pure deep-merge helper for `state.json` patches.
+ *
+ * Lives in its own module so migration scripts under `hooks/lib/migrations/`
+ * can import it without forming a cycle with `mpl-state.mjs` (which itself
+ * imports the migration registry). `mpl-state.mjs` re-exports `deepMerge`
+ * so existing consumers keep working.
+ *
+ * Behavior contract:
+ *   - Plain objects → recursive merge.
+ *   - Arrays → replaced wholesale (not concatenated).
+ *   - `__proto__` / `constructor` / `prototype` keys → ignored
+ *     (prototype-pollution guard).
+ *   - Inputs are not mutated.
+ */
+
+const DANGEROUS_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+export function deepMerge(target, source) {
+  const result = { ...target };
+  for (const key of Object.keys(source)) {
+    if (DANGEROUS_KEYS.has(key)) continue;
+
+    if (
+      source[key] &&
+      typeof source[key] === 'object' &&
+      !Array.isArray(source[key]) &&
+      target[key] &&
+      typeof target[key] === 'object' &&
+      !Array.isArray(target[key])
+    ) {
+      result[key] = deepMerge(target[key], source[key]);
+    } else {
+      result[key] = source[key];
+    }
+  }
+  return result;
+}

--- a/hooks/lib/mpl-state.mjs
+++ b/hooks/lib/mpl-state.mjs
@@ -346,12 +346,73 @@ export function detectStateDrift(cwd) {
 }
 
 /**
- * Write/merge MPL state to .mpl/state.json (atomic via temp + rename)
+ * Thrown by `writeState` when `.mpl/state.json` already carries a
+ * `schema_version` that exceeds what this plugin supports. Without this
+ * the on-disk state would silently be overwritten with the v2 default
+ * shape + patch (PR #132 review #1) — a fresh-writer state from a newer
+ * plugin would be downgraded and any field outside v2's vocabulary lost.
+ */
+export class UnsupportedSchemaVersionError extends Error {
+  constructor(version, supported) {
+    super(
+      `state.schema_version=${version} exceeds supported MAX=${supported}. ` +
+      `Refusing to overwrite a fresher state with an older shape. ` +
+      `Upgrade the mpl plugin or restore .mpl/state.json from a compatible run. ` +
+      `See docs/schemas/migration-policy.md.`
+    );
+    this.name = 'UnsupportedSchemaVersionError';
+    this.version = version;
+    this.supported = supported;
+  }
+}
+
+/**
+ * Probe the on-disk state.json for a schema_version that this plugin can
+ * not safely round-trip. Returns the offending version if the file
+ * exists, parses, and exceeds CURRENT_SCHEMA_VERSION; null otherwise
+ * (missing, corrupt, parity, or older). Pure read — no mutation.
+ */
+function readPersistedSchemaVersion(cwd) {
+  const statePath = join(cwd, STATE_DIR, STATE_FILE);
+  if (!existsSync(statePath)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(statePath, 'utf-8'));
+    if (typeof parsed?.schema_version === 'number' && parsed.schema_version > CURRENT_SCHEMA_VERSION) {
+      return parsed.schema_version;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Write/merge MPL state to .mpl/state.json (atomic via temp + rename).
+ *
+ * H8 (#116, PR #132 review #1): if the on-disk file declares a
+ * `schema_version` newer than `CURRENT_SCHEMA_VERSION`, throw
+ * `UnsupportedSchemaVersionError` instead of overwriting it. `readState`
+ * already returns `null` for that case (fail-closed read), but
+ * `writeState` previously treated `null` the same as "no file" and
+ * wrote `DEFAULT_STATE` + patch — silently downgrading the fresher
+ * state and dropping any field outside the v2 vocabulary.
+ *
  * @param {string} cwd - Working directory
  * @param {object} patch - Fields to merge into state
  * @returns {object} Merged state
+ * @throws {UnsupportedSchemaVersionError} when on-disk schema_version > CURRENT
  */
 export function writeState(cwd, patch) {
+  const futureVersion = readPersistedSchemaVersion(cwd);
+  if (futureVersion !== null) {
+    process.stderr.write(
+      `[MPL state] writeState refused — on-disk schema_version=${futureVersion} ` +
+      `exceeds supported MAX=${CURRENT_SCHEMA_VERSION}. State left untouched. ` +
+      `See docs/schemas/migration-policy.md.\n`
+    );
+    throw new UnsupportedSchemaVersionError(futureVersion, CURRENT_SCHEMA_VERSION);
+  }
+
   const stateDir = join(cwd, STATE_DIR);
   if (!existsSync(stateDir)) {
     mkdirSync(stateDir, { recursive: true });

--- a/hooks/lib/mpl-state.mjs
+++ b/hooks/lib/mpl-state.mjs
@@ -9,6 +9,11 @@ import { readFileSync, writeFileSync, mkdirSync, existsSync, renameSync, rmSync,
 import { join } from 'path';
 import { randomBytes } from 'crypto';
 import { loadConfig } from './mpl-config.mjs';
+import { deepMerge } from './mpl-state-merge.mjs';
+import { runMigrations } from './migrations/index.mjs';
+import { LEGACY_EXECUTION_STATE_PATH as V1_TO_V2_LEGACY_PATH } from './migrations/v1-to-v2.mjs';
+
+export { deepMerge };
 
 const STATE_DIR = '.mpl';
 const STATE_FILE = 'state.json';
@@ -32,19 +37,20 @@ export const MAX_AMBIGUITY_HISTORY = 10;
  * - `2` = unified shape: everything in `.mpl/state.json`, execution-scope
  *   fields under the top-level `execution` subtree.
  *
- * readState() transparently migrates v1 → v2 on first access by merging any
- * surviving `.mpl/mpl/state.json` into `state.execution` and archiving the
- * legacy file.
+ * H8 (#116) routes per-version logic through `hooks/lib/migrations/`. To
+ * bump this constant, register a new migration entry; see
+ * `docs/schemas/migration-policy.md`.
  */
 export const CURRENT_SCHEMA_VERSION = 2;
 
 /**
  * Legacy execution state file. Pre-P2-6 orchestrator prompts wrote to this
  * via Write/Edit; v2 stores the same shape under `state.execution` in
- * `.mpl/state.json`. The constant is retained so the migration path can
- * locate and archive the legacy file.
+ * `.mpl/state.json`. The constant is re-exported from the v1-to-v2
+ * migration so existing consumers (resume skill, archive helpers) keep
+ * the import path stable.
  */
-export const LEGACY_EXECUTION_STATE_PATH = '.mpl/mpl/state.json';
+export const LEGACY_EXECUTION_STATE_PATH = V1_TO_V2_LEGACY_PATH;
 
 /**
  * Valid pipeline phase names (v0.13.1).
@@ -217,19 +223,22 @@ const DEFAULT_STATE = {
   },
 };
 
-// Prototype pollution guard keys
-const DANGEROUS_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
-
 /**
  * Read MPL state from .mpl/state.json.
  *
- * P2-6: if the parsed state lacks `schema_version` (legacy v1) AND a legacy
- * `.mpl/mpl/state.json` exists, run the migration before returning. The
- * migration is idempotent — subsequent reads see `schema_version: 2` and
- * skip the check.
+ * Schema-version handling (H8 / #116):
+ *   - `schema_version > CURRENT_SCHEMA_VERSION` → **fail-closed**. The
+ *     plugin is older than the writer; we cannot reason about field
+ *     shapes that may have been renamed or removed. Returns `null` so
+ *     downstream hooks degrade rather than misinterpret. A diagnostic
+ *     line is written to stderr; G3 I8 (defense-in-depth) also catches
+ *     the same condition when invoked.
+ *   - `schema_version < CURRENT_SCHEMA_VERSION` (or absent → treated as
+ *     1) → run the migration registry up to current. Migrations persist
+ *     atomically inside this function so subsequent reads short-circuit.
  *
  * @param {string} cwd - Working directory
- * @returns {object|null} State object or null if not found/invalid
+ * @returns {object|null} State object or null if not found/invalid/unsupported
  */
 export function readState(cwd) {
   try {
@@ -240,11 +249,18 @@ export function readState(cwd) {
     if (typeof parsed !== 'object' || parsed === null) return null;
     if (!parsed.current_phase) return null;
 
-    // P2-6: transparent v1 → v2 migration. Delegates to the pure helper so
-    // writers that bypass readState (direct JSON munging in tests) can
-    // still run the same logic on demand.
+    // H8 fail-closed guard — refuse to act on a state from a newer writer.
+    if (typeof parsed.schema_version === 'number' && parsed.schema_version > CURRENT_SCHEMA_VERSION) {
+      process.stderr.write(
+        `[MPL state] schema_version=${parsed.schema_version} exceeds supported MAX=${CURRENT_SCHEMA_VERSION}. ` +
+        `Upgrade the mpl plugin or restore .mpl/state.json from a compatible run. ` +
+        `See docs/schemas/migration-policy.md.\n`
+      );
+      return null;
+    }
+
     if ((parsed.schema_version ?? 1) < CURRENT_SCHEMA_VERSION) {
-      const migrated = migrateLegacyExecutionState(cwd, parsed);
+      const migrated = applyMigrationChain(cwd, parsed);
       if (migrated) return migrated;
     }
     return parsed;
@@ -254,99 +270,37 @@ export function readState(cwd) {
 }
 
 /**
- * P2-6: one-shot migration from the dual-file v1 layout to the unified v2
- * layout. Reads .mpl/mpl/state.json (if present), merges its fields into
- * `state.execution`, archives the legacy file to
- * `.mpl/archive/legacy-execution-state.json`, and bumps schema_version.
- *
- * Idempotent: callers may invoke freely — if there's nothing to migrate
- * (legacy file absent, already-migrated, or `state.execution` already
- * populated from a newer write) the function still bumps schema_version and
- * persists.
- *
- * Returns the migrated state object, or null on I/O failure (caller keeps
- * the unmigrated state so the pipeline doesn't wedge).
+ * Run the migration registry against `state` and persist the result
+ * atomically. Returns the migrated state, or `null` on I/O failure
+ * (caller falls back to the unmigrated state).
  */
-export function migrateLegacyExecutionState(cwd, currentState) {
+function applyMigrationChain(cwd, state) {
   try {
-    const legacyPath = join(cwd, LEGACY_EXECUTION_STATE_PATH);
+    const migrated = runMigrations(state, cwd, CURRENT_SCHEMA_VERSION);
+    if (!migrated || migrated === state) return migrated || state;
+
     const stateDir = join(cwd, STATE_DIR);
-    const merged = { ...currentState };
-
-    // Treat the DEFAULT_STATE.execution shape as the baseline so the legacy
-    // file only needs to contribute the fields it actually knows about.
-    const baseExecution = {
-      task: null,
-      status: null,
-      started_at: null,
-      phases: { total: 0, completed: 0, current: null, failed: 0, circuit_breaks: 0 },
-      phase_details: [],
-      totals: { total_retries: 0, total_micro_fixes: 0, total_discoveries: 0, elapsed_ms: 0 },
-      cumulative_pass_rate: null,
-      failure_phase: null,
-    };
-
-    let legacyParsed = null;
-    if (existsSync(legacyPath)) {
-      try {
-        legacyParsed = JSON.parse(readFileSync(legacyPath, 'utf-8'));
-      } catch {
-        // Corrupt legacy file — archive verbatim below, proceed with defaults.
-        legacyParsed = null;
-      }
-    }
-
-    // Later writes (v2) may have already populated state.execution. Preserve
-    // them: incoming merge order is base < legacy < already-unified, so a
-    // partial v2 write followed by a v1 read still keeps the newer data.
-    const existingExecution = (currentState && typeof currentState.execution === 'object' && currentState.execution !== null)
-      ? currentState.execution
-      : {};
-
-    merged.execution = deepMerge(
-      deepMerge(baseExecution, legacyParsed && typeof legacyParsed === 'object' ? legacyParsed : {}),
-      existingExecution,
-    );
-    merged.schema_version = CURRENT_SCHEMA_VERSION;
-
-    // Persist the migrated state back to disk so subsequent reads short-circuit.
     if (!existsSync(stateDir)) mkdirSync(stateDir, { recursive: true });
     const stateTmp = join(stateDir, `.state-${randomBytes(4).toString('hex')}.tmp`);
-    writeFileSync(stateTmp, JSON.stringify(merged, null, 2), { mode: 0o600 });
+    writeFileSync(stateTmp, JSON.stringify(migrated, null, 2), { mode: 0o600 });
     renameSync(stateTmp, join(stateDir, STATE_FILE));
-
-    // Archive the legacy file (once per migration). Using the pipeline_id
-    // when available keeps the archive co-located with other pipeline
-    // artifacts; otherwise a single legacy-execution-state.json at the
-    // archive root is sufficient.
-    if (legacyParsed !== null || existsSync(legacyPath)) {
-      const archiveRoot = join(cwd, '.mpl', 'archive');
-      try {
-        mkdirSync(archiveRoot, { recursive: true });
-        const archiveName = currentState?.pipeline_id
-          ? `${currentState.pipeline_id}-legacy-execution-state.json`
-          : 'legacy-execution-state.json';
-        const archivePath = join(archiveRoot, archiveName);
-        writeFileSync(
-          archivePath,
-          JSON.stringify({
-            migrated_at: new Date().toISOString(),
-            pipeline_id: currentState?.pipeline_id ?? null,
-            legacy_content: legacyParsed,
-          }, null, 2),
-          { mode: 0o600 },
-        );
-        if (existsSync(legacyPath)) rmSync(legacyPath, { force: true });
-      } catch {
-        // Archive failure is non-fatal — better to leave the legacy file in
-        // place than to wedge the pipeline.
-      }
-    }
-
-    return merged;
+    return migrated;
   } catch {
     return null;
   }
+}
+
+/**
+ * Public migration entry point. Retained from P2-6 so external consumers
+ * (e.g. `skills/mpl-resume/SKILL.md`) keep working — the body now
+ * delegates to the H8 migration registry, which handles archive +
+ * persistence in `applyMigrationChain`. The returned object is the
+ * migrated state, or `null` on I/O failure (caller keeps the unmigrated
+ * state so the pipeline doesn't wedge).
+ */
+export function migrateLegacyExecutionState(cwd, currentState) {
+  if (!currentState || typeof currentState !== 'object') return null;
+  return applyMigrationChain(cwd, currentState);
 }
 
 /**
@@ -673,27 +627,3 @@ export function checkConvergence(state) {
   return { status: 'improving', delta: improvement };
 }
 
-/**
- * Deep merge two objects (shallow for arrays, with prototype pollution guard)
- */
-export function deepMerge(target, source) {
-  const result = { ...target };
-  for (const key of Object.keys(source)) {
-    // Prototype pollution guard
-    if (DANGEROUS_KEYS.has(key)) continue;
-
-    if (
-      source[key] &&
-      typeof source[key] === 'object' &&
-      !Array.isArray(source[key]) &&
-      target[key] &&
-      typeof target[key] === 'object' &&
-      !Array.isArray(target[key])
-    ) {
-      result[key] = deepMerge(target[key], source[key]);
-    } else {
-      result[key] = source[key];
-    }
-  }
-  return result;
-}


### PR DESCRIPTION
## Summary

H8 (#116) makes `state.schema_version` an enforceable contract end-to-end.

Pre-H8: `readState` ran a hard-coded v1→v2 branch and silently passed through any future version. G3 invariant I8 caught newer-than-supported writes as warn — but a stale plugin reading a state from a fresher writer would still proceed and could misinterpret renamed/removed fields.

Post-H8:
- **Migration policy doc** — additive vs breaking taxonomy, patch vs minor bump, registry contract, authoring workflow.
- **Migration registry** (`hooks/lib/migrations/`) — `runMigrations` chain runner + `v1-to-v2.mjs` extracted from the prior monolith + `v2-to-v3.example.mjs` template (deliberately not registered).
- **`readState` fail-closed** on `schema_version > CURRENT` (returns `null` + diagnostic stderr; on-disk file untouched). Migration chain still runs for older versions; result persists atomically.
- **Doctor Category 6 schema_version sub-check** — surfaces `state=N plugin=M` and reports PASS/WARN/FAIL.
- **`deepMerge` extracted** to `mpl-state-merge.mjs` to break the cycle between `mpl-state.mjs` (imports registry) and `migrations/v1-to-v2.mjs` (needs deepMerge); re-exported from `mpl-state.mjs` so existing imports keep working.
- **`migrateLegacyExecutionState` retained** as a thin wrapper over the registry — `skills/mpl-resume/SKILL.md` keeps its current call signature.

## Spec matrix

| Issue requirement | Where landed |
|---|---|
| `state.json.schema_version` validated at every read site | `readState` fail-closed guard |
| Unsupported version → block + migration guidance | stderr diagnostic + `null` return + policy doc reference |
| Migration policy: additive vs breaking | `docs/schemas/migration-policy.md` matrix |
| `hooks/lib/migrations/v2-to-v3.mjs` (예시) | `v2-to-v3.example.mjs` (template, not registered) |
| `mpl-doctor` surfaces schema_version mismatch | Category 6 sub-check |
| Avoid duplicate with G3 I8 | I8 retained as defense-in-depth; readState is the first line |

## Test plan

- 13 new tests in `hooks/__tests__/mpl-migrations.test.mjs`:
  - Registry shape + contiguous chain v1 → CURRENT_SCHEMA_VERSION
  - `.example.` files NOT registered
  - `runMigrations` idempotency, null-safe, defensive iteration cap
  - `readState` fail-closed (null return, diagnostic stderr referencing policy doc, on-disk file untouched, parity accepted, legacy v1 still migrates)
  - Single-source-of-truth check (registry terminus == readState's enforced constant)
- Full regression: 595 → 608/608 (+13 H8)
- Doctor meta-self self-run: 0 hits
- Property-check self-run: unchanged (`enforcement.missing_artifact_schema` allow-list still the only forward-compat key)

## Forward integration

- G5/G6 (#114) ships `fix_loop_history` — additive bump per policy. Authors copy `v2-to-v3.example.mjs`, fill the backfill, register in `index.mjs`, bump `CURRENT_SCHEMA_VERSION`. The example body already shows the exact shape #114 needs.
- G3 I5 (`fix_loop_count vs sum(fix_loop_history)`) activates once the backfill lands.
- P0-K (#115) artifact schema validator can reuse the same registry pattern for per-file schema_version fields.

Closes #116.

🤖 Generated with [Claude Code](https://claude.com/claude-code)