### PR TITLE
feat(#114): G5+G6 — fix_loop_history per phase + auto-mode user_intervention_count

### DIFF
--- a/docs/schemas/state.md
+++ b/docs/schemas/state.md
@@ -19,8 +19,9 @@
 | `sprint_status.total_todos` | sprint-aggregated | Sum of TODO counts across all phases of the active sprint (typically all of phase2-sprint). |
 | `sprint_status.completed_todos` | sprint-aggregated | Number of TODOs marked complete. |
 | `gate_results.hard{1,2,3}_{baseline,coverage,resilience}` | per-pipeline | Structured machine evidence. P0-1 (#102) requires `{command, exit_code, stdout_tail, timestamp}`. |
-| `fix_loop_count` | sprint-aggregated | Total fix-loop iterations across the active sprint. Must equal `sum(fix_loop_history[].count)` (G3 I5; G5 #114 introduces history). |
-| `fix_loop_history[]` | per-phase | `{phase: string, count: number}` entries. Optional in v0.18.0; mandatory once #114 lands. |
+| `fix_loop_count` | sprint-aggregated | Total fix-loop iterations across the active sprint. Equal to `sum(fix_loop_history[].count)` (G3 I5; writers populate via `writeState` mirror in `mpl-state.mjs#recordFixLoopHistory`). |
+| `fix_loop_history[]` | per-phase | `{phase, count, started_at, ended_at?, root_cause_summary?}` entries. Populated by `writeState` whenever `fix_loop_count` increases (G5 / #114). |
+| `user_intervention_count` | per-pipeline | Honest auto-mode telemetry. `mpl-keyword-detector` (UserPromptSubmit) increments by 1 on every prompt while pipeline is active and `run_mode === 'auto'` (G6 / #114). Surfaces in `/mpl-status` once G2 / #113 lands. |
 | `session_status` | per-session | `null \| active \| paused_budget \| paused_checkpoint \| verification_hang \| cancelled`. Single-valued — pause / hang / cancel states are mutually exclusive (G3 I9). |
 | `last_tool_at` | per-session | ISO-8601 stamp from `mpl-tool-tracker.mjs`. Powers G4 (#109). |
 | `enforcement.*` | per-pipeline override | P0-2 (#110) per-rule policy. Top of the precedence chain. |
@@ -55,8 +56,11 @@ strict mode elevates `warn → block`.
 
 ## Schema version
 
-- `CURRENT_SCHEMA_VERSION = 2` (P2-6 — unified state, `execution` subtree absorbs the legacy `.mpl/mpl/state.json`).
+- `CURRENT_SCHEMA_VERSION = 3` (G5+G6 / #114 — additive backfill: `fix_loop_history`, `user_intervention_count`).
+  - v2 (P2-6 / #84) — unified state, `execution` subtree absorbs the legacy `.mpl/mpl/state.json`.
+  - v3 (G5+G6 / #114) — telemetry hygiene fields.
 - The migration registry (`hooks/lib/migrations/`) walks any older state up to current on `readState`. Newer-than-supported writes are **fail-closed** by `readState` (returns `null` + diagnostic stderr) and additionally surfaced by G3 I8.
+- `writeState` also fail-closes (throws `UnsupportedSchemaVersionError`) when on-disk `schema_version > CURRENT` so a stale plugin can't downgrade a fresher state.
 - Bump policy and authoring workflow: `docs/schemas/migration-policy.md`.
 
 ## See also

--- a/hooks/__tests__/mpl-fix-loop-history.test.mjs
+++ b/hooks/__tests__/mpl-fix-loop-history.test.mjs
@@ -1,0 +1,153 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+import {
+  readState,
+  writeState,
+  CURRENT_SCHEMA_VERSION,
+} from '../lib/mpl-state.mjs';
+
+let tmpDir;
+beforeEach(() => { tmpDir = mkdtempSync(join(tmpdir(), 'mpl-fix-loop-')); });
+afterEach(() => rmSync(tmpDir, { recursive: true, force: true }));
+
+function seed(state) {
+  mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+  writeFileSync(join(tmpDir, '.mpl', 'state.json'), JSON.stringify({
+    schema_version: CURRENT_SCHEMA_VERSION,
+    current_phase: 'phase4-fix',
+    fix_loop_count: 0,
+    fix_loop_history: [],
+    user_intervention_count: 0,
+    ...state,
+  }));
+}
+
+/* ──────────────────────── G5: fix_loop_history ───────────────────────── */
+
+describe('G5 (#114) fix_loop_history mirror', () => {
+  it('preserve write (same fix_loop_count) does NOT append', () => {
+    seed({ fix_loop_count: 2, fix_loop_history: [{ phase: 'phase4-fix', count: 2, started_at: 't0' }] });
+    const merged = writeState(tmpDir, { fix_loop_count: 2 });
+    assert.equal(merged.fix_loop_history.length, 1);
+    assert.equal(merged.fix_loop_history[0].count, 2);
+  });
+
+  it('first increment under a new phase appends a fresh entry', () => {
+    seed({});
+    const merged = writeState(tmpDir, { fix_loop_count: 1 });
+    assert.equal(merged.fix_loop_history.length, 1);
+    assert.equal(merged.fix_loop_history[0].phase, 'phase4-fix');
+    assert.equal(merged.fix_loop_history[0].count, 1);
+    assert.ok(typeof merged.fix_loop_history[0].started_at === 'string');
+  });
+
+  it('subsequent increment under the same phase bumps the existing entry by the delta', () => {
+    seed({});
+    writeState(tmpDir, { fix_loop_count: 1 });
+    writeState(tmpDir, { fix_loop_count: 3 });
+    const state = readState(tmpDir);
+    assert.equal(state.fix_loop_history.length, 1, 'still one open entry');
+    assert.equal(state.fix_loop_history[0].count, 3, 'cumulative count');
+  });
+
+  it('phase change opens a new history entry', () => {
+    seed({});
+    writeState(tmpDir, { fix_loop_count: 2 });
+    const after = writeState(tmpDir, {
+      current_phase: 'small-sprint',
+      fix_loop_count: 5,
+    });
+    assert.equal(after.fix_loop_history.length, 2);
+    assert.equal(after.fix_loop_history[0].phase, 'phase4-fix');
+    assert.equal(after.fix_loop_history[0].count, 2);
+    assert.equal(after.fix_loop_history[1].phase, 'small-sprint');
+    assert.equal(after.fix_loop_history[1].count, 3, 'delta only, not cumulative');
+  });
+
+  it('execution.phases.current (concrete phase id) wins over current_phase lifecycle marker', () => {
+    seed({});
+    writeState(tmpDir, {
+      current_phase: 'phase4-fix',
+      execution: { phases: { current: 'phase-3', total: 0, completed: 0, failed: 0, circuit_breaks: 0 } },
+      fix_loop_count: 1,
+    });
+    const state = readState(tmpDir);
+    assert.equal(state.fix_loop_history[0].phase, 'phase-3', 'concrete id beats lifecycle marker');
+  });
+
+  it('decrement / reset does not corrupt history', () => {
+    seed({});
+    writeState(tmpDir, { fix_loop_count: 3 });
+    const after = writeState(tmpDir, { fix_loop_count: 0 });
+    assert.equal(after.fix_loop_history.length, 1, 'history retained for forensic value');
+    assert.equal(after.fix_loop_history[0].count, 3);
+  });
+
+  it('non-numeric or absent fix_loop_count → no history change', () => {
+    seed({ fix_loop_count: 2, fix_loop_history: [{ phase: 'phase4-fix', count: 2, started_at: 't' }] });
+    const merged = writeState(tmpDir, { current_phase: 'phase5-finalize' });
+    assert.equal(merged.fix_loop_history.length, 1);
+    assert.equal(merged.fix_loop_history[0].count, 2);
+  });
+
+  it('G3 invariant I5 equality holds across a sequence of writes', () => {
+    seed({});
+    writeState(tmpDir, { fix_loop_count: 1 });
+    writeState(tmpDir, { fix_loop_count: 2 });
+    writeState(tmpDir, { current_phase: 'small-sprint', fix_loop_count: 3 });
+    const state = readState(tmpDir);
+    const sum = state.fix_loop_history.reduce((acc, e) => acc + (e.count || 0), 0);
+    assert.equal(sum, state.fix_loop_count,
+      'fix_loop_count must equal sum(fix_loop_history[].count) — G3 I5');
+  });
+});
+
+/* ──────────────────────── v2 → v3 migration ──────────────────────────── */
+
+describe('v2 → v3 migration (#114): additive backfill', () => {
+  it('adds fix_loop_history: [] and user_intervention_count: 0 on first read', () => {
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    writeFileSync(join(tmpDir, '.mpl', 'state.json'), JSON.stringify({
+      schema_version: 2,
+      current_phase: 'phase2-sprint',
+      fix_loop_count: 0,
+    }));
+    const state = readState(tmpDir);
+    assert.equal(state.schema_version, CURRENT_SCHEMA_VERSION);
+    assert.deepEqual(state.fix_loop_history, []);
+    assert.equal(state.user_intervention_count, 0);
+  });
+
+  it('preserves an existing fix_loop_history that the v2 state already carried', () => {
+    // Forward-compat case: a v2 writer already populated the array (the
+    // schema doc allowed it as optional in v0.18.0). Migration must not
+    // reset to [].
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    writeFileSync(join(tmpDir, '.mpl', 'state.json'), JSON.stringify({
+      schema_version: 2,
+      current_phase: 'phase2-sprint',
+      fix_loop_count: 4,
+      fix_loop_history: [{ phase: 'phase-1', count: 4 }],
+    }));
+    const state = readState(tmpDir);
+    assert.equal(state.schema_version, CURRENT_SCHEMA_VERSION);
+    assert.deepEqual(state.fix_loop_history, [{ phase: 'phase-1', count: 4 }]);
+  });
+
+  it('persists v3 fields to disk so subsequent reads short-circuit', () => {
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    writeFileSync(join(tmpDir, '.mpl', 'state.json'), JSON.stringify({
+      schema_version: 2,
+      current_phase: 'phase2-sprint',
+    }));
+    readState(tmpDir);
+    const raw = JSON.parse(readFileSync(join(tmpDir, '.mpl', 'state.json'), 'utf-8'));
+    assert.equal(raw.schema_version, CURRENT_SCHEMA_VERSION);
+    assert.deepEqual(raw.fix_loop_history, []);
+    assert.equal(raw.user_intervention_count, 0);
+  });
+});

--- a/hooks/__tests__/mpl-fix-loop-history.test.mjs
+++ b/hooks/__tests__/mpl-fix-loop-history.test.mjs
@@ -80,12 +80,29 @@ describe('G5 (#114) fix_loop_history mirror', () => {
     assert.equal(state.fix_loop_history[0].phase, 'phase-3', 'concrete id beats lifecycle marker');
   });
 
-  it('decrement / reset does not corrupt history', () => {
+  it('PR #133 review #3: reset to 0 clears history (I5 atomic)', () => {
+    // The old "history retained for forensic value" framing left I5 in
+    // a violated state (count=0, sum>0). Forensic value lives in
+    // .mpl/archive/ snapshots taken by archivePreviousRun, not in the
+    // live state file.
     seed({});
     writeState(tmpDir, { fix_loop_count: 3 });
     const after = writeState(tmpDir, { fix_loop_count: 0 });
-    assert.equal(after.fix_loop_history.length, 1, 'history retained for forensic value');
-    assert.equal(after.fix_loop_history[0].count, 3);
+    assert.equal(after.fix_loop_count, 0);
+    assert.deepEqual(after.fix_loop_history, [], 'reset clears history');
+    // I5 holds: 0 == 0
+    const sum = after.fix_loop_history.reduce((acc, e) => acc + (e.count || 0), 0);
+    assert.equal(sum, after.fix_loop_count);
+  });
+
+  it('PR #133 review #3: partial decrement (not reset) refuses both fields', () => {
+    seed({});
+    writeState(tmpDir, { fix_loop_count: 5 });
+    const after = writeState(tmpDir, { fix_loop_count: 3 });
+    // Partial wind-back has no legitimate orchestrator caller → reverted.
+    assert.equal(after.fix_loop_count, 5, 'count reverted');
+    assert.equal(after.fix_loop_history.reduce((acc, e) => acc + e.count, 0), 5,
+      'history reverted to match');
   });
 
   it('non-numeric or absent fix_loop_count → no history change', () => {
@@ -118,6 +135,52 @@ describe('G5 (#114) fix_loop_history mirror', () => {
     // I5 holds: count(0) == sum(0).
     const sum = merged.fix_loop_history.reduce((acc, e) => acc + (e.count || 0), 0);
     assert.equal(sum, merged.fix_loop_count);
+  });
+
+  it('PR #133 review #3: phase-null + patch-supplied history reverts BOTH fields', () => {
+    // Reviewer's repro 1 — caller supplies a parallel history array but
+    // also clears the phase. Old code reverted only the count, leaving
+    // patch's history merged in (I5 desync). New code reverts both.
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    writeFileSync(join(tmpDir, '.mpl', 'state.json'), JSON.stringify({
+      schema_version: CURRENT_SCHEMA_VERSION,
+      current_phase: 'phase4-fix',
+      fix_loop_count: 0,
+      fix_loop_history: [],
+      user_intervention_count: 0,
+    }));
+    const after = writeState(tmpDir, {
+      current_phase: null,
+      fix_loop_count: 5,
+      fix_loop_history: [{ phase: 'manual', count: 5, started_at: 't' }],
+    });
+    assert.equal(after.fix_loop_count, 0, 'count reverted');
+    assert.deepEqual(after.fix_loop_history, [], 'history reverted to pre-merge');
+    // I5: 0 == 0.
+    const sum = after.fix_loop_history.reduce((acc, e) => acc + (e.count || 0), 0);
+    assert.equal(sum, after.fix_loop_count);
+  });
+
+  it('PR #133 review #3: patch with self-inconsistent history triggers final I5 revert', () => {
+    // Caller provides a history whose sum disagrees with the count delta
+    // → final I5 check catches it and reverts both atomically.
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    writeFileSync(join(tmpDir, '.mpl', 'state.json'), JSON.stringify({
+      schema_version: CURRENT_SCHEMA_VERSION,
+      current_phase: 'phase4-fix',
+      fix_loop_count: 2,
+      fix_loop_history: [{ phase: 'phase4-fix', count: 2, started_at: 't0' }],
+      user_intervention_count: 0,
+    }));
+    // Caller bumps count to 3 but supplies a history that sums to 99.
+    const after = writeState(tmpDir, {
+      fix_loop_count: 3,
+      fix_loop_history: [{ phase: 'phase4-fix', count: 99, started_at: 't1' }],
+    });
+    // Both reverted to prev so the live state stays consistent.
+    assert.equal(after.fix_loop_count, 2);
+    assert.equal(after.fix_loop_history[0].count, 2);
+    assert.equal(after.fix_loop_history.length, 1);
   });
 
   it('G3 invariant I5 equality holds across a sequence of writes', () => {

--- a/hooks/__tests__/mpl-fix-loop-history.test.mjs
+++ b/hooks/__tests__/mpl-fix-loop-history.test.mjs
@@ -161,6 +161,55 @@ describe('G5 (#114) fix_loop_history mirror', () => {
     assert.equal(sum, after.fix_loop_count);
   });
 
+  it('PR #133 review #4: increment ON TOP OF legacy numeric-entry history works', () => {
+    // G3 sumFixLoopHistory accepts bare numbers as legacy/compat entries.
+    // Reviewer's reproducer: history=[1,2] (sum=3), count=3, then
+    // increment to count=4 should add a new entry of count=1, leaving
+    // total sum=4 == count. Pre-fix the writer's final check summed
+    // only {count} objects (ignoring numbers), saw sum=1, mismatched
+    // count=4, and silently reverted.
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    writeFileSync(join(tmpDir, '.mpl', 'state.json'), JSON.stringify({
+      schema_version: CURRENT_SCHEMA_VERSION,
+      current_phase: 'phase4-fix',
+      fix_loop_count: 3,
+      fix_loop_history: [1, 2],
+      user_intervention_count: 0,
+    }));
+    const after = writeState(tmpDir, { fix_loop_count: 4 });
+    assert.equal(after.fix_loop_count, 4, 'increment landed (not silently reverted)');
+    // Last entry appended (we can't merge into a bare number — no phase)
+    assert.equal(after.fix_loop_history.length, 3);
+    assert.equal(after.fix_loop_history[2].phase, 'phase4-fix');
+    assert.equal(after.fix_loop_history[2].count, 1);
+    // I5 invariant equivalence: sum the same way G3 does.
+    const sum = after.fix_loop_history.reduce(
+      (acc, e) => acc + (typeof e === 'number' ? e : (e?.count ?? 0)),
+      0
+    );
+    assert.equal(sum, after.fix_loop_count);
+  });
+
+  it('PR #133 review #4: unparseable entry → revert (matches invariant "not measurable")', () => {
+    // Defensive: if any entry is neither a number nor a {count} object,
+    // sumFixLoopHistoryForCheck returns null and the writer reverts both
+    // fields. Mirrors sumFixLoopHistory's "return null" disposition.
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    writeFileSync(join(tmpDir, '.mpl', 'state.json'), JSON.stringify({
+      schema_version: CURRENT_SCHEMA_VERSION,
+      current_phase: 'phase4-fix',
+      fix_loop_count: 0,
+      fix_loop_history: [],
+      user_intervention_count: 0,
+    }));
+    const after = writeState(tmpDir, {
+      fix_loop_count: 5,
+      fix_loop_history: ['garbage', { phase: 'p', count: 5 }],
+    });
+    assert.equal(after.fix_loop_count, 0, 'unparseable entry → revert');
+    assert.deepEqual(after.fix_loop_history, []);
+  });
+
   it('PR #133 review #3: patch with self-inconsistent history triggers final I5 revert', () => {
     // Caller provides a history whose sum disagrees with the count delta
     // → final I5 check catches it and reverts both atomically.

--- a/hooks/__tests__/mpl-fix-loop-history.test.mjs
+++ b/hooks/__tests__/mpl-fix-loop-history.test.mjs
@@ -95,6 +95,31 @@ describe('G5 (#114) fix_loop_history mirror', () => {
     assert.equal(merged.fix_loop_history[0].count, 2);
   });
 
+  it('PR #133 review nit: increment with no determinable phase → revert to keep I5 clean', () => {
+    // Both current_phase and execution.phases.current absent → helper
+    // refuses the bump. fix_loop_count stays at the prior value, history
+    // is untouched, I5 invariant holds (count == sum == prior).
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    writeFileSync(join(tmpDir, '.mpl', 'state.json'), JSON.stringify({
+      schema_version: CURRENT_SCHEMA_VERSION,
+      current_phase: 'phase2-sprint',
+      fix_loop_count: 0,
+      fix_loop_history: [],
+      user_intervention_count: 0,
+    }));
+    // Patch sets fix_loop_count but explicitly clears current_phase to
+    // null and provides no execution.phases.current.
+    const merged = writeState(tmpDir, {
+      current_phase: null,
+      fix_loop_count: 5,
+    });
+    assert.equal(merged.fix_loop_count, 0, 'count reverted to prior value');
+    assert.deepEqual(merged.fix_loop_history, [], 'history untouched');
+    // I5 holds: count(0) == sum(0).
+    const sum = merged.fix_loop_history.reduce((acc, e) => acc + (e.count || 0), 0);
+    assert.equal(sum, merged.fix_loop_count);
+  });
+
   it('G3 invariant I5 equality holds across a sequence of writes', () => {
     seed({});
     writeState(tmpDir, { fix_loop_count: 1 });

--- a/hooks/__tests__/mpl-fix-loop-history.test.mjs
+++ b/hooks/__tests__/mpl-fix-loop-history.test.mjs
@@ -9,6 +9,7 @@ import {
   writeState,
   CURRENT_SCHEMA_VERSION,
 } from '../lib/mpl-state.mjs';
+import { checkInvariants, VIOLATION_IDS } from '../lib/mpl-state-invariant.mjs';
 
 let tmpDir;
 beforeEach(() => { tmpDir = mkdtempSync(join(tmpdir(), 'mpl-fix-loop-')); });
@@ -149,5 +150,59 @@ describe('v2 → v3 migration (#114): additive backfill', () => {
     assert.equal(raw.schema_version, CURRENT_SCHEMA_VERSION);
     assert.deepEqual(raw.fix_loop_history, []);
     assert.equal(raw.user_intervention_count, 0);
+  });
+
+  it('PR #133 review #1: v2 mid-run with fix_loop_count > 0 → conservative aggregate entry, I5 holds', () => {
+    // Pre-fix bug: backfilling [] when fix_loop_count > 0 would instantly
+    // trip G3 I5 (count=N, sum=0) on the first read after upgrade. Migration
+    // must synthesize an aggregate entry so the invariant survives.
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    writeFileSync(join(tmpDir, '.mpl', 'state.json'), JSON.stringify({
+      schema_version: 2,
+      current_phase: 'phase4-fix',
+      fix_loop_count: 4,
+    }));
+    const state = readState(tmpDir);
+
+    assert.equal(state.fix_loop_history.length, 1, 'one aggregate entry created');
+    const entry = state.fix_loop_history[0];
+    assert.equal(entry.count, 4, 'entry count matches fix_loop_count');
+    assert.equal(entry.phase, 'phase4-fix', 'phase attribution from current_phase');
+    assert.equal(entry.migrated_from_v2, true, 'forensic flag set');
+    assert.ok(typeof entry.started_at === 'string', 'started_at populated');
+
+    // The actual reviewer assertion: G3 I5 must NOT fire post-migration.
+    const r = checkInvariants(state, { cwd: tmpDir });
+    assert.ok(
+      !r.violations.some((v) => v.id === VIOLATION_IDS.FIX_LOOP_HISTORY_DESYNC),
+      `expected no I5 violation, got: ${JSON.stringify(r.violations, null, 2)}`,
+    );
+  });
+
+  it('PR #133 review #1: v2 with fix_loop_count = 0 still backfills to []', () => {
+    // Carry-forward only triggers when count > 0 — a fresh / untouched
+    // pipeline keeps the empty array.
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    writeFileSync(join(tmpDir, '.mpl', 'state.json'), JSON.stringify({
+      schema_version: 2,
+      current_phase: 'phase2-sprint',
+      fix_loop_count: 0,
+    }));
+    const state = readState(tmpDir);
+    assert.deepEqual(state.fix_loop_history, []);
+  });
+
+  it('PR #133 review #1: phase attribution prefers execution.phases.current', () => {
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    writeFileSync(join(tmpDir, '.mpl', 'state.json'), JSON.stringify({
+      schema_version: 2,
+      current_phase: 'phase4-fix',
+      fix_loop_count: 2,
+      execution: {
+        phases: { current: 'phase-7', total: 0, completed: 0, failed: 0, circuit_breaks: 0 },
+      },
+    }));
+    const state = readState(tmpDir);
+    assert.equal(state.fix_loop_history[0].phase, 'phase-7');
   });
 });

--- a/hooks/__tests__/mpl-state-invariant.test.mjs
+++ b/hooks/__tests__/mpl-state-invariant.test.mjs
@@ -11,7 +11,13 @@ import {
   formatViolations,
   TRIGGERS,
   VIOLATION_IDS,
+  CURRENT_SCHEMA_VERSION,
 } from '../lib/mpl-state-invariant.mjs';
+
+// Test fixtures must declare the version they're parameterized for so a
+// future bump doesn't trigger a migration mid-test (which mutates the
+// state file and breaks Edit-simulation lookups via stale old_string).
+const SCHEMA_V = CURRENT_SCHEMA_VERSION;
 
 const __filename = fileURLToPath(import.meta.url);
 const HOOK_PATH = join(dirname(__filename), '..', 'mpl-state-invariant.mjs');
@@ -54,7 +60,7 @@ describe('checkInvariants — basics', () => {
       current_phase: 'phase2-sprint',
       finalize_done: false,
       session_status: 'active',
-      schema_version: 2,
+      schema_version: SCHEMA_V,
       execution: { phases: { completed: 2 } },
       fix_loop_count: 3,
       fix_loop_history: [{ phase: 'p1', count: 2 }, { phase: 'p2', count: 1 }],
@@ -253,7 +259,7 @@ describe('I8 schema_version range', () => {
     assert.ok(r.violations.some((v) => v.id === VIOLATION_IDS.SCHEMA_VERSION_UNSUPPORTED));
   });
   it('matches current → ok', () => {
-    const r = checkInvariants({ schema_version: 2 }, { cwd: tmp });
+    const r = checkInvariants({ schema_version: SCHEMA_V }, { cwd: tmp });
     assert.ok(!r.violations.some((v) => v.id === VIOLATION_IDS.SCHEMA_VERSION_UNSUPPORTED));
   });
 });
@@ -279,7 +285,7 @@ describe('Multi-violation aggregation (exp15 4-way desync)', () => {
     // so this fixture picks the I1 branch.
     makePhaseFolders(2);
     const r = checkInvariants({
-      schema_version: 2,
+      schema_version: SCHEMA_V,
       session_status: 'paused_budget',
       finalize_done: true,                       // I1
       current_phase: 'phase-7',                  // I7 (no phase-7 folder)
@@ -329,7 +335,7 @@ describe('mpl-state-invariant hook integration', () => {
   }
 
   it('clean state → silent', () => {
-    const r = runHook('Stop', null, {}, { current_phase: 'phase2-sprint', schema_version: 2 });
+    const r = runHook('Stop', null, {}, { current_phase: 'phase2-sprint', schema_version: SCHEMA_V });
     assert.strictEqual(r.continue, true);
     assert.strictEqual(r.suppressOutput, true);
   });
@@ -402,7 +408,7 @@ describe('mpl-state-invariant hook integration', () => {
     const stateJsonPath = join(tmp, '.mpl', 'state.json');
     const ent = (e) => ({ command: 'npm test', exit_code: e, stdout_tail: '', timestamp: 'now' });
     const cleanState = {
-      schema_version: 2,
+      schema_version: SCHEMA_V,
       current_phase: 'phase3-gate',
       gate_results: {
         hard1_baseline: ent(0),
@@ -412,7 +418,7 @@ describe('mpl-state-invariant hook integration', () => {
     };
     writeFileSync(stateJsonPath, JSON.stringify(cleanState));
     const proposedDirty = {
-      schema_version: 2,
+      schema_version: SCHEMA_V,
       current_phase: 'phase3-gate',
       gate_results: { hard1_passed: true, hard2_passed: true, hard3_passed: true },
     };
@@ -431,7 +437,7 @@ describe('mpl-state-invariant hook integration', () => {
     const stateJsonPath = join(tmp, '.mpl', 'state.json');
     const ent = (e) => ({ command: 'npm test', exit_code: e, stdout_tail: '', timestamp: 'now' });
     const cleanState = {
-      schema_version: 2,
+      schema_version: SCHEMA_V,
       current_phase: 'phase3-gate',
       gate_results: {
         hard1_baseline: ent(0),
@@ -442,7 +448,7 @@ describe('mpl-state-invariant hook integration', () => {
     const cleanText = JSON.stringify(cleanState);
     writeFileSync(stateJsonPath, cleanText);
     const dirtyText = JSON.stringify({
-      schema_version: 2,
+      schema_version: SCHEMA_V,
       current_phase: 'phase3-gate',
       gate_results: { hard1_passed: true, hard2_passed: true, hard3_passed: true },
     });
@@ -463,12 +469,12 @@ describe('mpl-state-invariant hook integration', () => {
     const stateJsonPath = join(tmp, '.mpl', 'state.json');
     const ent = (e) => ({ command: 'npm test', exit_code: e, stdout_tail: '', timestamp: 'now' });
     writeFileSync(stateJsonPath, JSON.stringify({
-      schema_version: 2,
+      schema_version: SCHEMA_V,
       current_phase: 'phase3-gate',
       gate_results: {},
     }));
     const proposedClean = {
-      schema_version: 2,
+      schema_version: SCHEMA_V,
       current_phase: 'phase3-gate',
       gate_results: {
         hard1_baseline: ent(0),

--- a/hooks/__tests__/mpl-user-intervention.test.mjs
+++ b/hooks/__tests__/mpl-user-intervention.test.mjs
@@ -1,0 +1,94 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { tmpdir } from 'os';
+
+import { CURRENT_SCHEMA_VERSION } from '../lib/mpl-state.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const HOOK_PATH = join(dirname(__filename), '..', 'mpl-keyword-detector.mjs');
+
+let tmp;
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'mpl-uic-'));
+  mkdirSync(join(tmp, '.mpl'), { recursive: true });
+});
+afterEach(() => rmSync(tmp, { recursive: true, force: true }));
+
+function seedState(state) {
+  writeFileSync(join(tmp, '.mpl', 'state.json'), JSON.stringify({
+    schema_version: CURRENT_SCHEMA_VERSION,
+    current_phase: 'phase2-sprint',
+    run_mode: 'auto',
+    user_intervention_count: 0,
+    fix_loop_history: [],
+    ...state,
+  }));
+}
+
+function runHook(promptText) {
+  const stdin = JSON.stringify({
+    cwd: tmp,
+    hook_event_name: 'UserPromptSubmit',
+    prompt: promptText,
+  });
+  execFileSync('node', [HOOK_PATH], { input: stdin, encoding: 'utf-8' });
+}
+
+function readPersistedState() {
+  return JSON.parse(readFileSync(join(tmp, '.mpl', 'state.json'), 'utf-8'));
+}
+
+describe('G6 (#114) user_intervention_count', () => {
+  it('increments on UserPromptSubmit when MPL active + run_mode=auto', () => {
+    seedState({});
+    runHook('what is the status?');
+    assert.equal(readPersistedState().user_intervention_count, 1);
+  });
+
+  it('accumulates across multiple prompts', () => {
+    seedState({});
+    runHook('first nudge');
+    runHook('second nudge');
+    runHook('third nudge');
+    assert.equal(readPersistedState().user_intervention_count, 3);
+  });
+
+  it('does NOT increment when run_mode is full (manual)', () => {
+    seedState({ run_mode: 'full' });
+    runHook('regular driver prompt');
+    assert.equal(readPersistedState().user_intervention_count, 0);
+  });
+
+  it('does NOT increment when pipeline is completed', () => {
+    seedState({ current_phase: 'completed' });
+    runHook('post-pipeline prompt');
+    assert.equal(readPersistedState().user_intervention_count, 0);
+  });
+
+  it('does NOT increment when pipeline is cancelled', () => {
+    seedState({ current_phase: 'cancelled' });
+    runHook('post-cancel prompt');
+    assert.equal(readPersistedState().user_intervention_count, 0);
+  });
+
+  it('does NOT throw when no state file exists (fresh workspace)', () => {
+    // No seedState — .mpl/state.json absent.
+    assert.doesNotThrow(() => runHook('mpl new feature'));
+  });
+
+  it('counts /mpl:mpl-status, /mpl:mpl-resume, /mpl:mpl-cancel — every operator prompt', () => {
+    // Per spec G6 "sleep / nudge / cancel 모두 포함" — all interventions
+    // count, including status checks and slash commands. The keyword
+    // detector returns early for SLASH_NO_INIT but the increment fires
+    // BEFORE that branch.
+    seedState({});
+    runHook('/mpl:mpl-status');
+    runHook('/mpl:mpl-resume');
+    runHook('/mpl:mpl-cancel reason');
+    assert.equal(readPersistedState().user_intervention_count, 3);
+  });
+});

--- a/hooks/__tests__/mpl-user-intervention.test.mjs
+++ b/hooks/__tests__/mpl-user-intervention.test.mjs
@@ -75,6 +75,27 @@ describe('G6 (#114) user_intervention_count', () => {
     assert.equal(readPersistedState().user_intervention_count, 0);
   });
 
+  it('PR #133 review nit: does NOT increment when session_status=cancelled (even if current_phase still set)', () => {
+    // Defense for a desync between current_phase and session_status —
+    // mpl-cancel sets both, but a cancel-soft / race could leave only
+    // session_status=cancelled. Either alone should stop the counter.
+    seedState({ current_phase: 'phase2-sprint', session_status: 'cancelled' });
+    runHook('prompt during cancelled session');
+    assert.equal(readPersistedState().user_intervention_count, 0);
+  });
+
+  it('paused_budget / paused_checkpoint / verification_hang DO count (sleeps + nudges)', () => {
+    // Per spec the auto-mode telemetry counts every operator intervention,
+    // explicitly including sleeps and nudges — those exact statuses
+    // represent "auto-mode tripped, user prompted to resume".
+    for (const status of ['paused_budget', 'paused_checkpoint', 'verification_hang']) {
+      seedState({ session_status: status });
+      runHook(`prompt under ${status}`);
+      assert.equal(readPersistedState().user_intervention_count, 1,
+        `expected increment under session_status=${status}`);
+    }
+  });
+
   it('does NOT throw when no state file exists (fresh workspace)', () => {
     // No seedState — .mpl/state.json absent.
     assert.doesNotThrow(() => runHook('mpl new feature'));

--- a/hooks/lib/migrations/index.mjs
+++ b/hooks/lib/migrations/index.mjs
@@ -18,6 +18,7 @@
  */
 
 import v1ToV2 from './v1-to-v2.mjs';
+import v2ToV3 from './v2-to-v3.mjs';
 
 /**
  * Ordered registry. Add new entries here when bumping
@@ -25,6 +26,7 @@ import v1ToV2 from './v1-to-v2.mjs';
  */
 export const MIGRATIONS = Object.freeze([
   v1ToV2,
+  v2ToV3,
 ]);
 
 /**

--- a/hooks/lib/migrations/v2-to-v3.mjs
+++ b/hooks/lib/migrations/v2-to-v3.mjs
@@ -18,7 +18,24 @@
  * H8 migration policy this is an additive bump (patch-level on the
  * plugin). v2 state objects gain the defaults; v3 writers populate them
  * incrementally.
+ *
+ * **PR #133 review #1 fix** — `fix_loop_count > 0` carry-forward:
+ * a v2 pipeline mid-run can already have `fix_loop_count > 0`. Backfilling
+ * an empty `fix_loop_history` would land an instant I5 violation
+ * (`count != sum(history) = 0`) on the very first read post-upgrade. We
+ * synthesize a conservative aggregate entry so the invariant holds:
+ *
+ *   { phase: <best guess>, count: fix_loop_count,
+ *     started_at: <migration time>, migrated_from_v2: true }
+ *
+ * The `migrated_from_v2` flag tells operators (and any future analysis
+ * tooling) that this entry is aggregated, not per-iteration — phase
+ * attribution is best-effort because v2 didn't track it. From the next
+ * `writeState` onward, `recordFixLoopHistory` adds proper per-phase
+ * entries.
  */
+
+const MIGRATION_PHASE_FALLBACK = 'pre-migration';
 
 export default {
   from: 2,
@@ -28,7 +45,22 @@ export default {
     const merged = { ...state };
 
     if (!Array.isArray(merged.fix_loop_history)) {
-      merged.fix_loop_history = [];
+      const carryForward = typeof merged.fix_loop_count === 'number'
+        && Number.isFinite(merged.fix_loop_count)
+        && merged.fix_loop_count > 0;
+      if (carryForward) {
+        const phase = merged.execution?.phases?.current
+          ?? merged.current_phase
+          ?? MIGRATION_PHASE_FALLBACK;
+        merged.fix_loop_history = [{
+          phase,
+          count: merged.fix_loop_count,
+          started_at: new Date().toISOString(),
+          migrated_from_v2: true,
+        }];
+      } else {
+        merged.fix_loop_history = [];
+      }
     }
     if (typeof merged.user_intervention_count !== 'number') {
       merged.user_intervention_count = 0;

--- a/hooks/lib/migrations/v2-to-v3.mjs
+++ b/hooks/lib/migrations/v2-to-v3.mjs
@@ -1,0 +1,40 @@
+/**
+ * v2 → v3 (G5 + G6 / #114): additive telemetry hygiene fields.
+ *
+ * Adds two new fields to the unified state shape:
+ *
+ *   - `fix_loop_history: []` — G5 per-phase fix-loop entries.
+ *     Each entry: `{ phase, count, started_at, ended_at?, root_cause_summary? }`.
+ *     `mpl-phase-controller` appends/updates entries when `fix_loop_count`
+ *     changes. G3 invariant I5 enforces
+ *     `fix_loop_count == sum(fix_loop_history[].count)`.
+ *
+ *   - `user_intervention_count: 0` — G6 honest auto-mode telemetry.
+ *     `mpl-keyword-detector` (UserPromptSubmit) increments this when the
+ *     pipeline is active AND `state.run_mode === 'auto'`. Surfaces in
+ *     `/mpl-status` once G2 (#113) lands.
+ *
+ * Both fields are pure backfills — no breaking semantic change. Per the
+ * H8 migration policy this is an additive bump (patch-level on the
+ * plugin). v2 state objects gain the defaults; v3 writers populate them
+ * incrementally.
+ */
+
+export default {
+  from: 2,
+  to: 3,
+  description: 'Additive backfill — fix_loop_history + user_intervention_count (G5+G6 / #114)',
+  migrate(state, _cwd) {
+    const merged = { ...state };
+
+    if (!Array.isArray(merged.fix_loop_history)) {
+      merged.fix_loop_history = [];
+    }
+    if (typeof merged.user_intervention_count !== 'number') {
+      merged.user_intervention_count = 0;
+    }
+
+    merged.schema_version = 3;
+    return merged;
+  },
+};

--- a/hooks/lib/migrations/v3-to-v4.example.mjs
+++ b/hooks/lib/migrations/v3-to-v4.example.mjs
@@ -1,16 +1,16 @@
 /**
- * EXAMPLE migration template — v2 → v3.
+ * EXAMPLE migration template — v3 → v4.
  *
  * **NOT REGISTERED**: the `.example.` suffix means
  * `hooks/lib/migrations/index.mjs` will not pick this file up. It exists
  * so future authors can copy the shape without inventing it from scratch.
  *
- * To author a real v2 → v3 migration:
- *   1. Copy this file to `v2-to-v3.mjs` (drop `.example.`).
- *   2. Bump `CURRENT_SCHEMA_VERSION` in `hooks/lib/mpl-state.mjs` to 3.
+ * To author a real v3 → v4 migration:
+ *   1. Copy this file to `v3-to-v4.mjs` (drop `.example.`).
+ *   2. Bump `CURRENT_SCHEMA_VERSION` in `hooks/lib/mpl-state.mjs` to 4.
  *   3. Register the new module in `hooks/lib/migrations/index.mjs`.
- *   4. Add a unit test that feeds a v2 state through `readState` and
- *      asserts the v3 shape.
+ *   4. Add a unit test that feeds a v3 state through `readState` and
+ *      asserts the v4 shape.
  *   5. If the change is breaking (rename / remove / semantic shift), also
  *      update `docs/schemas/state.md` and any consumer hooks.
  *
@@ -22,21 +22,20 @@
  */
 
 export default {
-  from: 2,
-  to: 3,
+  from: 3,
+  to: 4,
   description: 'EXAMPLE — additive backfill (replace with real change)',
   migrate(state, _cwd) {
     const merged = { ...state };
 
-    // Example: backfill `fix_loop_history` (G5 #114).
-    // Real authors should either replace this body or delete it entirely
-    // and add their own fields — the registry will not run this stub
-    // because the file is not imported by index.mjs.
-    if (!Array.isArray(merged.fix_loop_history)) {
-      merged.fix_loop_history = [];
+    // Example: backfill a hypothetical new field. Replace with the actual
+    // change when used; the registry will not run this stub because the
+    // file is not imported by index.mjs.
+    if (typeof merged.example_new_field !== 'number') {
+      merged.example_new_field = 0;
     }
 
-    merged.schema_version = 3;
+    merged.schema_version = 4;
     return merged;
   },
 };

--- a/hooks/lib/mpl-state.mjs
+++ b/hooks/lib/mpl-state.mjs
@@ -474,11 +474,15 @@ export function writeState(cwd, patch) {
  *     bump that entry's count by the delta.
  *   - Increase under a different active phase (or no open entry) →
  *     append a new `{ phase, count, started_at }` entry.
+ *   - Increase but no determinable active phase (PR #133 review nit) →
+ *     **revert the fix_loop_count back to its prior value** so I5 stays
+ *     clean. Refusing the increment is safer than fabricating an
+ *     `'unknown'` phase entry — the orchestrator will retry the write
+ *     once `current_phase` is set, and no I5 desync slips through.
  *
  * Active phase derives from `merged.execution.phases.current` (concrete
  * phase id like `phase-3`) and falls back to `merged.current_phase`
- * (lifecycle marker, e.g. `phase4-fix`). When neither is meaningful the
- * helper skips the update.
+ * (lifecycle marker, e.g. `phase4-fix`).
  *
  * Once G3 invariant I5 sees `fix_loop_history` populated it activates
  * the equality check `fix_loop_count == sum(fix_loop_history[].count)`.
@@ -492,12 +496,21 @@ function recordFixLoopHistory(prev, merged) {
   if (next <= before) return; // not an increment
 
   const phase = merged?.execution?.phases?.current ?? merged?.current_phase ?? null;
-  if (!phase || typeof phase !== 'string') return;
+  if (!phase || typeof phase !== 'string') {
+    // PR #133 review nit: refuse the count bump rather than fabricate a
+    // phase. Otherwise I5 would desync (count↑ but history unchanged).
+    merged.fix_loop_count = before;
+    return;
+  }
 
   const delta = next - before;
   const history = Array.isArray(merged.fix_loop_history) ? [...merged.fix_loop_history] : [];
   const last = history[history.length - 1];
 
+  // `ended_at` is reserved for future wiring (G2 / #113 will close
+  // entries when the phase finalizes; G5 itself does not write it).
+  // Treating its absence as "open entry" lets the future close-emit
+  // land without changing this helper.
   if (last && typeof last === 'object' && last.phase === phase && !last.ended_at) {
     history[history.length - 1] = {
       ...last,

--- a/hooks/lib/mpl-state.mjs
+++ b/hooks/lib/mpl-state.mjs
@@ -462,30 +462,39 @@ export function writeState(cwd, patch) {
 }
 
 /**
- * G5 (#114): when a write increases `fix_loop_count`, mirror the delta
- * into `fix_loop_history`. Mutates `merged` in place.
+ * G5 (#114): keep `fix_loop_count` and `fix_loop_history` in lockstep so
+ * G3 invariant I5 (`count == sum(history[].count)`) holds atomically on
+ * every `writeState`. Mutates `merged` in place.
+ *
+ * The helper makes I5 **the** contract — there is no "count valid but
+ * history out of sync, surface as I5 later" path. PR #133 review #3
+ * surfaced two ways the old "best-effort mirror" framing leaked:
+ *   (a) caller patch supplies explicit `fix_loop_history` while
+ *       `phase` is null → count was reverted but history wasn't;
+ *   (b) caller patch resets `fix_loop_count: 0` while history retained
+ *       "for forensic value" → count=0, sum>0, I5 fails on next read.
  *
  * Behavior:
- *   - No change to fix_loop_count → no-op (transitions that preserve the
- *     count, e.g. phase3 → phase4-fix on gate failure, do NOT append).
- *   - Decrease/reset (fix_loop_count: 0 on init) → no append; the existing
- *     history is left intact for forensic value.
- *   - Increase under the same active phase as the last open entry →
- *     bump that entry's count by the delta.
- *   - Increase under a different active phase (or no open entry) →
- *     append a new `{ phase, count, started_at }` entry.
- *   - Increase but no determinable active phase (PR #133 review nit) →
- *     **revert the fix_loop_count back to its prior value** so I5 stays
- *     clean. Refusing the increment is safer than fabricating an
- *     `'unknown'` phase entry — the orchestrator will retry the write
- *     once `current_phase` is set, and no I5 desync slips through.
+ *   - No change → no-op.
+ *   - Reset to 0 → also clear history. (Forensic value lives in the
+ *     `.mpl/archive/` snapshot taken by `archivePreviousRun`, not in
+ *     the live state file.)
+ *   - Decrement (0 < next < before) → refuse: revert count + history.
+ *     There is no legitimate "wind back partially" caller; this guards
+ *     against accidental orchestrator math.
+ *   - Increment under a determinable active phase → append/update entry.
+ *   - Increment with no determinable phase → revert count AND restore
+ *     pre-merge history (any patch-supplied history is rolled back too
+ *     so I5 stays clean).
+ *   - Final invariant check: if any code path still leaves
+ *     `count != sum(history)` (e.g. patch supplied a self-inconsistent
+ *     history along with a matching count that breaks our delta math),
+ *     revert both fields to `prev` atomically. Better to drop a write
+ *     than ship a structurally broken state.
  *
  * Active phase derives from `merged.execution.phases.current` (concrete
  * phase id like `phase-3`) and falls back to `merged.current_phase`
  * (lifecycle marker, e.g. `phase4-fix`).
- *
- * Once G3 invariant I5 sees `fix_loop_history` populated it activates
- * the equality check `fix_loop_count == sum(fix_loop_history[].count)`.
  */
 function recordFixLoopHistory(prev, merged) {
   const next = merged?.fix_loop_count;
@@ -493,38 +502,64 @@ function recordFixLoopHistory(prev, merged) {
   const before = (typeof prev?.fix_loop_count === 'number' && Number.isFinite(prev.fix_loop_count))
     ? prev.fix_loop_count
     : 0;
-  if (next <= before) return; // not an increment
+  const prevHistory = Array.isArray(prev?.fix_loop_history) ? prev.fix_loop_history : [];
 
-  const phase = merged?.execution?.phases?.current ?? merged?.current_phase ?? null;
-  if (!phase || typeof phase !== 'string') {
-    // PR #133 review nit: refuse the count bump rather than fabricate a
-    // phase. Otherwise I5 would desync (count↑ but history unchanged).
+  if (next === before) {
+    // No count change. Don't touch history — caller may be patching
+    // unrelated fields. Final I5 check below still validates.
+  } else if (next === 0 && before > 0) {
+    // Reset → clear history so I5 holds (0 == 0).
+    merged.fix_loop_history = [];
+  } else if (next < before) {
+    // Decrement (not a reset) → refuse. Revert both fields atomically.
     merged.fix_loop_count = before;
-    return;
-  }
-
-  const delta = next - before;
-  const history = Array.isArray(merged.fix_loop_history) ? [...merged.fix_loop_history] : [];
-  const last = history[history.length - 1];
-
-  // `ended_at` is reserved for future wiring (G2 / #113 will close
-  // entries when the phase finalizes; G5 itself does not write it).
-  // Treating its absence as "open entry" lets the future close-emit
-  // land without changing this helper.
-  if (last && typeof last === 'object' && last.phase === phase && !last.ended_at) {
-    history[history.length - 1] = {
-      ...last,
-      count: (typeof last.count === 'number' ? last.count : 0) + delta,
-    };
+    merged.fix_loop_history = prevHistory;
   } else {
-    history.push({
-      phase,
-      count: delta,
-      started_at: new Date().toISOString(),
-    });
+    // Increment.
+    const phase = merged?.execution?.phases?.current ?? merged?.current_phase ?? null;
+    if (!phase || typeof phase !== 'string') {
+      // No phase → revert both. Without resetting history we'd let a
+      // patch-supplied `fix_loop_history` slip through with the
+      // increment refused (PR #133 review #3).
+      merged.fix_loop_count = before;
+      merged.fix_loop_history = prevHistory;
+    } else {
+      const delta = next - before;
+      const history = Array.isArray(merged.fix_loop_history) ? [...merged.fix_loop_history] : [];
+      const last = history[history.length - 1];
+      // `ended_at` is reserved for future wiring (G2 / #113 will close
+      // entries when the phase finalizes; G5 itself does not write it).
+      // Treating its absence as "open entry" lets the future close-emit
+      // land without changing this helper.
+      if (last && typeof last === 'object' && last.phase === phase && !last.ended_at) {
+        history[history.length - 1] = {
+          ...last,
+          count: (typeof last.count === 'number' ? last.count : 0) + delta,
+        };
+      } else {
+        history.push({
+          phase,
+          count: delta,
+          started_at: new Date().toISOString(),
+        });
+      }
+      merged.fix_loop_history = history;
+    }
   }
 
-  merged.fix_loop_history = history;
+  // Final I5 check. Anything that didn't end up consistent → revert
+  // both fields to prev. Catches caller-supplied histories that
+  // disagreed with what we computed (e.g. explicit array + delta math
+  // diverged).
+  const finalHistory = Array.isArray(merged.fix_loop_history) ? merged.fix_loop_history : [];
+  const sum = finalHistory.reduce(
+    (acc, e) => acc + ((typeof e?.count === 'number' && Number.isFinite(e.count)) ? e.count : 0),
+    0
+  );
+  if (sum !== merged.fix_loop_count) {
+    merged.fix_loop_count = before;
+    merged.fix_loop_history = prevHistory;
+  }
 }
 
 /**

--- a/hooks/lib/mpl-state.mjs
+++ b/hooks/lib/mpl-state.mjs
@@ -547,19 +547,33 @@ function recordFixLoopHistory(prev, merged) {
     }
   }
 
-  // Final I5 check. Anything that didn't end up consistent → revert
-  // both fields to prev. Catches caller-supplied histories that
-  // disagreed with what we computed (e.g. explicit array + delta math
-  // diverged).
-  const finalHistory = Array.isArray(merged.fix_loop_history) ? merged.fix_loop_history : [];
-  const sum = finalHistory.reduce(
-    (acc, e) => acc + ((typeof e?.count === 'number' && Number.isFinite(e.count)) ? e.count : 0),
-    0
-  );
-  if (sum !== merged.fix_loop_count) {
+  // Final I5 check. Mirrors the parsing rules of
+  // `mpl-state-invariant.mjs#sumFixLoopHistory` so the writer accepts
+  // every shape the invariant accepts — including bare-number entries
+  // (legacy/compat). Otherwise legitimate increments on top of a
+  // numeric history get silently dropped (PR #133 review #4).
+  //
+  // Returns null when any entry is unparseable; the writer treats that
+  // as "can't validate" and reverts both fields to `prev`, matching the
+  // invariant's "not measurable" disposition (refuse to vouch).
+  const sum = sumFixLoopHistoryForCheck(merged.fix_loop_history);
+  if (sum === null || sum !== merged.fix_loop_count) {
     merged.fix_loop_count = before;
     merged.fix_loop_history = prevHistory;
   }
+}
+
+function sumFixLoopHistoryForCheck(history) {
+  if (!Array.isArray(history)) return null;
+  let sum = 0;
+  for (const entry of history) {
+    const count = typeof entry === 'number'
+      ? entry
+      : (typeof entry?.count === 'number' ? entry.count : null);
+    if (count === null || !Number.isFinite(count)) return null;
+    sum += count;
+  }
+  return sum;
 }
 
 /**

--- a/hooks/lib/mpl-state.mjs
+++ b/hooks/lib/mpl-state.mjs
@@ -36,12 +36,15 @@ export const MAX_AMBIGUITY_HISTORY = 10;
  *   prompts.
  * - `2` = unified shape: everything in `.mpl/state.json`, execution-scope
  *   fields under the top-level `execution` subtree.
+ * - `3` = G5 + G6 (#114) telemetry hygiene fields: additive backfill for
+ *   `fix_loop_history` (per-phase fix-loop entries) and
+ *   `user_intervention_count` (auto-mode honesty counter).
  *
  * H8 (#116) routes per-version logic through `hooks/lib/migrations/`. To
  * bump this constant, register a new migration entry; see
  * `docs/schemas/migration-policy.md`.
  */
-export const CURRENT_SCHEMA_VERSION = 2;
+export const CURRENT_SCHEMA_VERSION = 3;
 
 /**
  * Legacy execution state file. Pre-P2-6 orchestrator prompts wrote to this
@@ -111,6 +114,16 @@ const DEFAULT_STATE = {
   // test_command. Consumed by finalize Step 5.0 and mpl-require-e2e.mjs hook.
   e2e_results: {},
   fix_loop_count: 0,
+  // G5 (#114): per-phase fix-loop entries appended by mpl-phase-controller
+  // when fix_loop_count changes. Each entry:
+  //   { phase: string, count: number, started_at: ISO, ended_at?: ISO,
+  //     root_cause_summary?: string }
+  // G3 invariant I5 enforces fix_loop_count == sum(fix_loop_history[].count).
+  fix_loop_history: [],
+  // G6 (#114): auto-mode honesty counter. mpl-keyword-detector
+  // (UserPromptSubmit) increments when MPL is active AND
+  // run_mode === 'auto'. Surfaces in /mpl-status (G2 / #113).
+  user_intervention_count: 0,
   max_fix_loops: 10,
   compaction_count: 0,
   last_phase_compaction_count: 0,
@@ -435,12 +448,70 @@ export function writeState(cwd, patch) {
     process.stderr.write(`[mpl-state] ambiguity_history ring-buffer truncated ${dropped} oldest entries (cap=${MAX_AMBIGUITY_HISTORY})\n`);
   }
 
+  // G5 (#114): mirror fix_loop_count increments into fix_loop_history.
+  // Catches both phase-controller writers and orchestrator mpl_state_write
+  // calls without each caller having to remember the bookkeeping.
+  recordFixLoopHistory(current, merged);
+
   // C2: Atomic write via temp file + rename
   const tmpPath = join(stateDir, `.state-${randomBytes(4).toString('hex')}.tmp`);
   writeFileSync(tmpPath, JSON.stringify(merged, null, 2), { mode: 0o600 });
   renameSync(tmpPath, join(stateDir, STATE_FILE));
 
   return merged;
+}
+
+/**
+ * G5 (#114): when a write increases `fix_loop_count`, mirror the delta
+ * into `fix_loop_history`. Mutates `merged` in place.
+ *
+ * Behavior:
+ *   - No change to fix_loop_count → no-op (transitions that preserve the
+ *     count, e.g. phase3 → phase4-fix on gate failure, do NOT append).
+ *   - Decrease/reset (fix_loop_count: 0 on init) → no append; the existing
+ *     history is left intact for forensic value.
+ *   - Increase under the same active phase as the last open entry →
+ *     bump that entry's count by the delta.
+ *   - Increase under a different active phase (or no open entry) →
+ *     append a new `{ phase, count, started_at }` entry.
+ *
+ * Active phase derives from `merged.execution.phases.current` (concrete
+ * phase id like `phase-3`) and falls back to `merged.current_phase`
+ * (lifecycle marker, e.g. `phase4-fix`). When neither is meaningful the
+ * helper skips the update.
+ *
+ * Once G3 invariant I5 sees `fix_loop_history` populated it activates
+ * the equality check `fix_loop_count == sum(fix_loop_history[].count)`.
+ */
+function recordFixLoopHistory(prev, merged) {
+  const next = merged?.fix_loop_count;
+  if (typeof next !== 'number' || !Number.isFinite(next)) return;
+  const before = (typeof prev?.fix_loop_count === 'number' && Number.isFinite(prev.fix_loop_count))
+    ? prev.fix_loop_count
+    : 0;
+  if (next <= before) return; // not an increment
+
+  const phase = merged?.execution?.phases?.current ?? merged?.current_phase ?? null;
+  if (!phase || typeof phase !== 'string') return;
+
+  const delta = next - before;
+  const history = Array.isArray(merged.fix_loop_history) ? [...merged.fix_loop_history] : [];
+  const last = history[history.length - 1];
+
+  if (last && typeof last === 'object' && last.phase === phase && !last.ended_at) {
+    history[history.length - 1] = {
+      ...last,
+      count: (typeof last.count === 'number' ? last.count : 0) + delta,
+    };
+  } else {
+    history.push({
+      phase,
+      count: delta,
+      started_at: new Date().toISOString(),
+    });
+  }
+
+  merged.fix_loop_history = history;
 }
 
 /**

--- a/hooks/mpl-keyword-detector.mjs
+++ b/hooks/mpl-keyword-detector.mjs
@@ -34,6 +34,13 @@ function maybeIncrementInterventionCount(cwd) {
     const state = readState(cwd);
     if (!state) return;
     if (state.current_phase === 'completed' || state.current_phase === 'cancelled') return;
+    // PR #133 review nit: also gate on session_status='cancelled' for
+    // symmetry. mpl-cancel sets BOTH current_phase and session_status,
+    // but a future cancel-soft path (or any race that touches only one)
+    // would otherwise keep counting after the pipeline is done. Pause /
+    // hang statuses are intentionally NOT excluded — those prompts ARE
+    // operator interventions per spec ("sleeps, nudges 모두 카운트").
+    if (state.session_status === 'cancelled') return;
     if (state.run_mode !== 'auto') return;
     const before = (typeof state.user_intervention_count === 'number')
       ? state.user_intervention_count

--- a/hooks/mpl-keyword-detector.mjs
+++ b/hooks/mpl-keyword-detector.mjs
@@ -18,9 +18,31 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 // Import shared MPL state utility
-const { initState, isMplActive } = await import(
+const { initState, isMplActive, readState, writeState } = await import(
   pathToFileURL(join(__dirname, 'lib', 'mpl-state.mjs')).href
 );
+
+/**
+ * G6 (#114): honest auto-mode telemetry. When the pipeline is active
+ * AND run_mode === 'auto', every UserPromptSubmit counts as a user
+ * intervention — sleeps, nudges, cancels, status checks, anything that
+ * required the operator to type. Best-effort; failures are swallowed
+ * because telemetry must never break the user's prompt flow.
+ */
+function maybeIncrementInterventionCount(cwd) {
+  try {
+    const state = readState(cwd);
+    if (!state) return;
+    if (state.current_phase === 'completed' || state.current_phase === 'cancelled') return;
+    if (state.run_mode !== 'auto') return;
+    const before = (typeof state.user_intervention_count === 'number')
+      ? state.user_intervention_count
+      : 0;
+    writeState(cwd, { user_intervention_count: before + 1 });
+  } catch {
+    // Non-fatal — telemetry must not block prompts.
+  }
+}
 
 // Import shared stdin reader
 const { readStdin } = await import(
@@ -94,6 +116,11 @@ async function main() {
       console.log(JSON.stringify({ continue: true, suppressOutput: true }));
       return;
     }
+
+    // G6 (#114): record the intervention BEFORE any of the content-based
+    // branches return. Counting only some prompts would defeat the
+    // "honest auto-mode telemetry" framing.
+    maybeIncrementInterventionCount(cwd);
 
     // v0.14.1 #36: Non-initializing MPL slash commands must NOT reset state.json.
     // These commands read or transform existing state — they never start a new pipeline.


### PR DESCRIPTION
## Summary

H8 (#116) closed the schema-version contract. G5+G6 are H8's first customers — two additive telemetry-hygiene fields gated by the new migration registry.

**Schema bump**: `CURRENT_SCHEMA_VERSION` 2 → 3 (additive per H8 policy = patch-level).

**Migration**: `hooks/lib/migrations/v2-to-v3.mjs` — promoted from H8's example template to a real registered entry. Backfills `fix_loop_history: []` and `user_intervention_count: 0`. The H8 example template rotated forward to `v3-to-v4.example.mjs` so the next-bump slot stays warm.

**G5 — fix_loop_history**:
- New field on `DEFAULT_STATE`. Each entry: `{phase, count, started_at, ended_at?, root_cause_summary?}`.
- `recordFixLoopHistory(prev, merged)` runs inside `writeState` and mirrors any `fix_loop_count` increase. Catches both `mpl-phase-controller` writers and orchestrator `mpl_state_write` calls without each caller having to remember the bookkeeping.
- Active phase derives from `merged.execution.phases.current` (concrete `phase-N` id) and falls back to `merged.current_phase` (lifecycle marker). Same active phase → bump existing entry. Different phase → append a new entry.
- G3 invariant I5 (already shipped in #108) activates organically — every write now satisfies `fix_loop_count == sum(fix_loop_history[].count)`.

**G6 — user_intervention_count**:
- New field on `DEFAULT_STATE`, default 0.
- `mpl-keyword-detector.mjs` (UserPromptSubmit) gains `maybeIncrementInterventionCount(cwd)` that fires BEFORE any content-based branch returns. Counted iff pipeline is active AND `state.run_mode === 'auto'`. Best-effort failures are swallowed so telemetry never blocks a prompt.
- Counts every operator prompt during auto-mode — sleeps, nudges, cancels, slash commands. Honest measurement per R-AUTO-MODE-PREMISE (exp15 surfaced 2 user nudges + 3 sleep slots while labeled auto-mode).

**Test fixture refactor**: `mpl-state-invariant.test.mjs` was hard-coding `schema_version: 2`, which now triggers v2→v3 migration mid-test and breaks Edit-simulation lookups. Imported `CURRENT_SCHEMA_VERSION` and replaced fixtures with a single `SCHEMA_V` constant — future bumps are zero-churn here.

## Spec matrix

| Issue requirement | Where landed |
|---|---|
| `state.fix_loop_history[]` per-phase with `started_at` | `DEFAULT_STATE` + `recordFixLoopHistory` |
| Phase-runner appends on fix-loop entry | `writeState` mirror catches both `mpl-phase-controller` (lines 449/607) and orchestrator `mpl_state_write` |
| G3 invariant `fix_loop_count == sum(history.count)` | I5 already shipped (#108); writers now populate |
| `state.user_intervention_count: int` | `DEFAULT_STATE` |
| UserPromptSubmit hook +1 in auto-mode | `mpl-keyword-detector.mjs` `maybeIncrementInterventionCount` |
| Sleep / nudge / cancel all included | helper fires before `SLASH_NO_INIT` branch returns |
| `/mpl-status` (G2) surface | deferred to G2 #113 (this PR ships the writer; reader is its own ticket) |

## Test plan

- 11 new tests in `mpl-fix-loop-history.test.mjs` — preserve write doesn't append; first increment appends; same-phase increment bumps existing; phase change opens new entry; `execution.phases.current` beats lifecycle marker; decrement doesn't corrupt; non-numeric ignored; G3 I5 equality across sequence; v2→v3 backfill defaults; preserves existing array; persists to disk
- 7 new tests in `mpl-user-intervention.test.mjs` — increment on prompt; accumulates; non-auto skipped; completed/cancelled skipped; missing state non-fatal; slash commands count
- Full regression: 615 → **633/633** (+18; 11 G5/migration + 7 G6)
- Doctor meta-self self-run: 0 hits
- Property-check self-run: only `enforcement.missing_artifact_schema` forward-compat unused (P0-K #115 not landed)

## Forward integration

- **G2 (#113)** `/mpl-status` will read `fix_loop_history` and `user_intervention_count` directly — both fields ready.
- **P0-K (#115)** artifact schema validator gets the H8-pattern reference (real `v2-to-v3.mjs` + still-warm `v3-to-v4.example.mjs`) for any per-file versioned artifacts.

Closes #114.

🤖 Generated with [Claude Code](https://claude.com/claude-code)