### PR TITLE
feat(#115): P0-K — artifact schema validator (hook + CLI + finalize re-check)

### DIFF
--- a/commands/mpl-run-finalize.md
+++ b/commands/mpl-run-finalize.md
@@ -154,6 +154,32 @@ Bash("npm run build")
 Bash("npm test")
 ```
 
+### 5.1.1: Artifact schema bulk re-check (P0-K / #115)
+
+Defense-in-depth pass over every phase artifact. The PostToolUse hook
+(`hooks/mpl-artifact-schema.mjs`) already validates each
+write at the moment it lands; this step re-runs the same validator
+across the whole workspace so a write that slipped through (e.g. a
+manual orchestrator edit while the hook was disabled, or an artifact
+that was valid at write time and later truncated) gets caught before
+`finalize_done = true`.
+
+```
+Bash("node ${CLAUDE_PLUGIN_ROOT}/hooks/mpl-artifact-schema.mjs $(pwd)", timeout: 10_000)
+```
+
+The CLI exits non-zero when any artifact is invalid and emits a JSON
+verdict (`{ totals: { files, valid, invalid }, results: [...] }`).
+
+- Exit 0 → proceed to Step 5.1.5.
+- Exit 1 → block finalize. Surface the missing-section list per file
+  to the user and re-emit the offending artifacts before retrying.
+  `enforcement.missing_artifact_schema = 'block'` will already have
+  surfaced these earlier; this step is the operator's last sanity
+  check.
+
+The same CLI is consumed by mpl-doctor's Category 6 read-only audit.
+
 ### 5.1.5: Scope Drift Report (V-05, v0.8.0)
 
 Compare declared scope vs actual changes to detect implementation drift:

--- a/hooks/__tests__/mpl-artifact-schema.test.mjs
+++ b/hooks/__tests__/mpl-artifact-schema.test.mjs
@@ -352,4 +352,21 @@ describe('mpl-artifact-schema PostToolUse hook (P0-K)', () => {
     assert.match(r.systemMessage || '', /pivot-points\.md.*PP_id/);
     assert.doesNotMatch(r.systemMessage || '', /state-summary\.md/);
   });
+
+  it('PR #135 review #2: processes mcp__*__write* tool names (matcher coverage)', () => {
+    // hooks.json matcher routes `mcp__.*__write.*` here; the internal
+    // allowlist must accept the toolName too, otherwise the hook
+    // silent-skips MCP filesystem writes (the gap Claude flagged).
+    writeFileSync(join(tmp, '.mpl', 'pivot-points.md'), '## Random Heading\n');
+    const stdin = JSON.stringify({
+      cwd: tmp,
+      hook_event_name: 'PostToolUse',
+      tool_name: 'mcp__filesystem__write_file',
+      tool_input: { file_path: '.mpl/pivot-points.md' },
+    });
+    const out = execFileSync('node', [HOOK_PATH], { input: stdin, encoding: 'utf-8' });
+    const r = JSON.parse(out);
+    assert.match(r.systemMessage || '', /artifact schema advisory/);
+    assert.match(r.systemMessage || '', /PP_id/);
+  });
 });

--- a/hooks/__tests__/mpl-artifact-schema.test.mjs
+++ b/hooks/__tests__/mpl-artifact-schema.test.mjs
@@ -1,0 +1,296 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync, readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { tmpdir } from 'os';
+
+import {
+  matchArtifactSchema,
+  validateArtifactFile,
+  validateAgainstSchema,
+  hasKey,
+  ARTIFACT_SCHEMAS,
+} from '../lib/mpl-artifact-schema.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const HOOK_PATH = join(dirname(__filename), '..', 'mpl-artifact-schema.mjs');
+
+let tmp;
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'mpl-art-'));
+  mkdirSync(join(tmp, '.mpl'), { recursive: true });
+  // Make MPL "active" so the hook proceeds.
+  writeFileSync(join(tmp, '.mpl', 'state.json'), JSON.stringify({
+    schema_version: 2,
+    current_phase: 'phase2-sprint',
+    started_at: '2026-05-05T01:00:00Z',
+  }));
+});
+afterEach(() => rmSync(tmp, { recursive: true, force: true }));
+
+/* ───────────────────── lib unit ─────────────────────────────── */
+
+describe('matchArtifactSchema', () => {
+  it('matches decomposition.yaml under .mpl/mpl/', () => {
+    assert.equal(matchArtifactSchema('.mpl/mpl/decomposition.yaml')?.artifact, 'decomposition');
+    assert.equal(matchArtifactSchema('.mpl/mpl/decomposition.yml')?.artifact, 'decomposition');
+  });
+
+  it('matches state-summary.md under any phase folder', () => {
+    assert.equal(matchArtifactSchema('.mpl/mpl/phases/phase-1/state-summary.md')?.artifact, 'state-summary');
+    assert.equal(matchArtifactSchema('.mpl/mpl/phases/phase-12/state-summary.md')?.artifact, 'state-summary');
+  });
+
+  it('matches verification.md per phase', () => {
+    assert.equal(matchArtifactSchema('.mpl/mpl/phases/phase-3/verification.md')?.artifact, 'verification');
+  });
+
+  it('matches pivot-points.md', () => {
+    assert.equal(matchArtifactSchema('.mpl/pivot-points.md')?.artifact, 'pivot-points');
+  });
+
+  it('matches user-contract.md under .mpl/requirements/', () => {
+    assert.equal(matchArtifactSchema('.mpl/requirements/user-contract.md')?.artifact, 'user-contract');
+  });
+
+  it('returns null for unrelated paths', () => {
+    assert.equal(matchArtifactSchema('src/foo.ts'), null);
+    assert.equal(matchArtifactSchema('.mpl/state.json'), null);
+    assert.equal(matchArtifactSchema(''), null);
+    assert.equal(matchArtifactSchema(null), null);
+  });
+});
+
+describe('hasKey', () => {
+  it('detects markdown headings (case + style insensitive)', () => {
+    assert.equal(hasKey('## Status', 'status', 'markdown'), true);
+    assert.equal(hasKey('### next phase context', 'next_phase_context', 'markdown'), true);
+    assert.equal(hasKey('## Files-Changed', 'files_changed', 'markdown'), true);
+    assert.equal(hasKey('# verification', 'verification', 'markdown'), true);
+  });
+
+  it('detects bold labels', () => {
+    assert.equal(hasKey('Some prose, then **PP_id**: PP-01', 'pp_id', 'markdown'), true);
+  });
+
+  it('detects key: lines', () => {
+    assert.equal(hasKey('status: completed\n', 'status', 'markdown'), true);
+  });
+
+  it('detects yaml top-level keys', () => {
+    assert.equal(hasKey('phase_id: phase-1\nimpact_scope: src/\n', 'phase_id', 'yaml'), true);
+  });
+
+  it('detects yaml list-element keys (- key:)', () => {
+    assert.equal(hasKey('phases:\n  - phase_id: phase-1\n    covers: [UC-1]\n', 'phase_id', 'yaml'), true);
+    assert.equal(hasKey('phases:\n  - phase_id: phase-1\n    covers: [UC-1]\n', 'covers', 'yaml'), true);
+  });
+
+  it('returns false when key absent', () => {
+    assert.equal(hasKey('## Status\n', 'next_phase_context', 'markdown'), false);
+  });
+});
+
+describe('validateAgainstSchema', () => {
+  it('flags all missing required keys', () => {
+    const schema = ARTIFACT_SCHEMAS.find((s) => s.artifact === 'state-summary');
+    const r = validateAgainstSchema('## status\n## decisions\n', schema);
+    assert.equal(r.valid, false);
+    assert.deepEqual(r.missing.sort(), ['files_changed', 'next_phase_context', 'verification'].sort());
+  });
+
+  it('passes when every required key present', () => {
+    const schema = ARTIFACT_SCHEMAS.find((s) => s.artifact === 'state-summary');
+    const content = '## Status\n## Files Changed\n## Verification\n## Decisions\n## Next Phase Context\n';
+    const r = validateAgainstSchema(content, schema);
+    assert.equal(r.valid, true);
+    assert.deepEqual(r.missing, []);
+    assert.deepEqual(r.missingAnyOf, []);
+  });
+
+  it('honors anyOf groups (verification: command|file|grep + result|exit_code)', () => {
+    const schema = ARTIFACT_SCHEMAS.find((s) => s.artifact === 'verification');
+    // Only command + result → satisfies both anyOf groups
+    const ok = '## criterion\n## evidence_type\n## command: pytest\n## result: pass\n';
+    assert.equal(validateAgainstSchema(ok, schema).valid, true);
+    // Missing the result/exit_code group entirely
+    const partial = '## criterion\n## evidence_type\n## command: pytest\n';
+    const r = validateAgainstSchema(partial, schema);
+    assert.equal(r.valid, false);
+    assert.equal(r.missing.length, 0, 'required keys all satisfied');
+    assert.equal(r.missingAnyOf.length, 1);
+    assert.deepEqual(r.missingAnyOf[0], ['result', 'exit_code']);
+  });
+});
+
+describe('validateArtifactFile', () => {
+  it('returns null for out-of-scope paths', () => {
+    assert.equal(validateArtifactFile('src/foo.ts', 'whatever'), null);
+  });
+
+  it('flags missing keys with the artifact name', () => {
+    const r = validateArtifactFile('.mpl/pivot-points.md', '## Some Heading\n');
+    assert.equal(r.artifact, 'pivot-points');
+    assert.equal(r.valid, false);
+    assert.deepEqual(r.missing.sort(), ['PP_id', 'constraint', 'source', 'status'].sort());
+  });
+});
+
+/* ──────────────── PostToolUse hook integration ──────────────── */
+
+describe('mpl-artifact-schema PostToolUse hook (P0-K)', () => {
+  function runHook({ toolName = 'Write', filePath, content }) {
+    if (content !== undefined) {
+      const abs = join(tmp, filePath);
+      mkdirSync(dirname(abs), { recursive: true });
+      writeFileSync(abs, content);
+    }
+    const stdin = JSON.stringify({
+      cwd: tmp,
+      hook_event_name: 'PostToolUse',
+      tool_name: toolName,
+      tool_input: { file_path: filePath },
+    });
+    const out = execFileSync('node', [HOOK_PATH], { input: stdin, encoding: 'utf-8' });
+    return JSON.parse(out);
+  }
+
+  it('silent for non-artifact paths', () => {
+    const r = runHook({ filePath: 'src/foo.ts', content: 'export {};\n' });
+    assert.equal(r.continue, true);
+    assert.equal(r.suppressOutput, true);
+  });
+
+  it('silent for valid artifact', () => {
+    const content = '## Status\n## Files Changed\n## Verification\n## Decisions\n## Next Phase Context\n';
+    const r = runHook({ filePath: '.mpl/mpl/phases/phase-1/state-summary.md', content });
+    assert.equal(r.continue, true);
+    assert.equal(r.suppressOutput, true);
+  });
+
+  it('default warn → systemMessage with missing sections', () => {
+    const r = runHook({
+      filePath: '.mpl/mpl/phases/phase-1/state-summary.md',
+      content: '## status\n## decisions\n',
+    });
+    assert.equal(r.continue, true);
+    assert.match(r.systemMessage || '', /artifact schema advisory/);
+    assert.match(r.systemMessage || '', /missing required:/);
+    assert.match(r.systemMessage || '', /files_changed/);
+  });
+
+  it('block when enforcement.missing_artifact_schema = "block"', () => {
+    writeFileSync(join(tmp, '.mpl', 'state.json'), JSON.stringify({
+      schema_version: 2,
+      current_phase: 'phase2-sprint',
+      enforcement: { missing_artifact_schema: 'block' },
+    }));
+    const r = runHook({
+      filePath: '.mpl/pivot-points.md',
+      content: '## Random heading\n',
+    });
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason || '', /artifact schema violation/);
+    assert.match(r.reason || '', /PP_id/);
+  });
+
+  it('off → silent + signal logged', () => {
+    writeFileSync(join(tmp, '.mpl', 'state.json'), JSON.stringify({
+      schema_version: 2,
+      current_phase: 'phase2-sprint',
+      enforcement: { missing_artifact_schema: 'off' },
+    }));
+    const r = runHook({
+      filePath: '.mpl/pivot-points.md',
+      content: '## Heading\n',
+    });
+    assert.equal(r.continue, true);
+    assert.equal(r.suppressOutput, true);
+    // Signal still logged for audit trail.
+    const signalsPath = join(tmp, '.mpl', 'signals', 'artifact-schema-hits.jsonl');
+    assert.ok(existsSync(signalsPath), 'signal logged even when off');
+    const line = readFileSync(signalsPath, 'utf-8').trim();
+    const entry = JSON.parse(line);
+    assert.equal(entry.action, 'off');
+    assert.equal(entry.valid, false);
+  });
+
+  it('silent when MPL inactive (no state.json)', () => {
+    rmSync(join(tmp, '.mpl', 'state.json'));
+    rmSync(join(tmp, '.mpl'), { recursive: true });
+    const r = runHook({
+      filePath: '.mpl/pivot-points.md',
+      content: '## Garbage\n',
+    });
+    assert.equal(r.continue, true);
+    assert.equal(r.suppressOutput, true);
+  });
+
+  it('CLI mode walks the workspace and reports per-file verdicts', () => {
+    // Two phase folders, one valid + one invalid state-summary; one
+    // valid pivot-points; one absent file is silently skipped.
+    const ss = '## Status\n## Files Changed\n## Verification\n## Decisions\n## Next Phase Context\n';
+    mkdirSync(join(tmp, '.mpl', 'mpl', 'phases', 'phase-1'), { recursive: true });
+    mkdirSync(join(tmp, '.mpl', 'mpl', 'phases', 'phase-2'), { recursive: true });
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'phases', 'phase-1', 'state-summary.md'), ss);
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'phases', 'phase-2', 'state-summary.md'), '## status only\n');
+    writeFileSync(join(tmp, '.mpl', 'pivot-points.md'),
+      '## PP_id\n## constraint\n## status\n## source\n');
+
+    let exit = 0;
+    let stdout = '';
+    try {
+      stdout = execFileSync('node', [HOOK_PATH, tmp], { encoding: 'utf-8' });
+    } catch (e) {
+      exit = e.status ?? -1;
+      stdout = e.stdout?.toString?.() ?? '';
+    }
+    assert.equal(exit, 1, 'exit 1 when at least one file is invalid');
+    const r = JSON.parse(stdout);
+    assert.equal(r.totals.files, 3);
+    assert.equal(r.totals.invalid, 1);
+    const phase2 = r.results.find((x) => x.file.endsWith('phase-2/state-summary.md'));
+    assert.equal(phase2.valid, false);
+    assert.ok(phase2.missing.includes('files_changed'));
+  });
+
+  it('CLI mode exits 0 when every artifact is valid (or absent)', () => {
+    // Empty workspace — no artifacts → totals.files=0, exit 0.
+    const stdout = execFileSync('node', [HOOK_PATH, tmp], { encoding: 'utf-8' });
+    const r = JSON.parse(stdout);
+    assert.equal(r.totals.files, 0);
+    assert.equal(r.totals.invalid, 0);
+  });
+
+  it('CLI mode exit 2 when the workspace path does not exist', () => {
+    let exit = 0;
+    try { execFileSync('node', [HOOK_PATH, '/nonexistent/path/zz']); }
+    catch (e) { exit = e.status ?? -1; }
+    assert.equal(exit, 2);
+  });
+
+  it('handles MultiEdit with multiple file_path entries', () => {
+    const stateSummary = '## Status\n## Files Changed\n## Verification\n## Decisions\n## Next Phase Context\n';
+    mkdirSync(join(tmp, '.mpl', 'mpl', 'phases', 'phase-1'), { recursive: true });
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'phases', 'phase-1', 'state-summary.md'), stateSummary);
+    writeFileSync(join(tmp, '.mpl', 'pivot-points.md'), '## Bad\n');
+    const stdin = JSON.stringify({
+      cwd: tmp,
+      hook_event_name: 'PostToolUse',
+      tool_name: 'MultiEdit',
+      tool_input: {
+        edits: [
+          { file_path: '.mpl/mpl/phases/phase-1/state-summary.md' },
+          { file_path: '.mpl/pivot-points.md' },
+        ],
+      },
+    });
+    const out = execFileSync('node', [HOOK_PATH], { input: stdin, encoding: 'utf-8' });
+    const r = JSON.parse(out);
+    // Only pivot-points.md is invalid.
+    assert.match(r.systemMessage || '', /pivot-points\.md.*PP_id/);
+    assert.doesNotMatch(r.systemMessage || '', /state-summary\.md/);
+  });
+});

--- a/hooks/__tests__/mpl-artifact-schema.test.mjs
+++ b/hooks/__tests__/mpl-artifact-schema.test.mjs
@@ -13,6 +13,12 @@ import {
   hasKey,
   ARTIFACT_SCHEMAS,
 } from '../lib/mpl-artifact-schema.mjs';
+import { CURRENT_SCHEMA_VERSION } from '../lib/mpl-state.mjs';
+
+// PR #135 nit (Claude): use the live schema_version constant in
+// fixtures so a future bump doesn't trigger a migration mid-test.
+// Same pattern as #133's mpl-state-invariant fixtures.
+const SCHEMA_V = CURRENT_SCHEMA_VERSION;
 
 const __filename = fileURLToPath(import.meta.url);
 const HOOK_PATH = join(dirname(__filename), '..', 'mpl-artifact-schema.mjs');
@@ -23,7 +29,7 @@ beforeEach(() => {
   mkdirSync(join(tmp, '.mpl'), { recursive: true });
   // Make MPL "active" so the hook proceeds.
   writeFileSync(join(tmp, '.mpl', 'state.json'), JSON.stringify({
-    schema_version: 2,
+    schema_version: SCHEMA_V,
     current_phase: 'phase2-sprint',
     started_at: '2026-05-05T01:00:00Z',
   }));
@@ -136,6 +142,59 @@ describe('validateArtifactFile', () => {
     assert.equal(r.valid, false);
     assert.deepEqual(r.missing.sort(), ['PP_id', 'constraint', 'source', 'status'].sort());
   });
+
+  it('PR #135 review #1: validates the actual decomposer output shape (id/scope/impact, not phase_id/impact_scope)', () => {
+    // Reproducer from the Codex review: a decomposition.yaml that
+    // exactly matches `agents/mpl-decomposer.md` <Output_Schema>. The
+    // pre-fix schema required `phase_id` + `impact_scope` and rejected
+    // every valid decomposer output.
+    const content =
+`architecture_anchor:
+  tech_stack: [typescript]
+  directory_pattern: src/
+  naming_convention: camelCase
+  key_decisions: []
+phases:
+  - id: "phase-1"
+    name: "Implement auth"
+    phase_domain: api
+    pp_proximity: pp_core
+    scope: "Add login API"
+    covers: [UC-01]
+    impact:
+      create:
+        - path: src/auth.ts
+          description: auth API
+      modify: []
+      affected_tests: []
+    interface_contract:
+      requires: []
+      produces: []
+      contract_files: []
+    success_criteria:
+      - type: test
+        command: npm test
+`;
+    const r = validateArtifactFile('.mpl/mpl/decomposition.yaml', content);
+    assert.equal(r.artifact, 'decomposition');
+    assert.equal(r.valid, true, `expected valid; missing=${JSON.stringify(r.missing)}`);
+    assert.deepEqual(r.missing, []);
+  });
+
+  it('PR #135 review #1: still rejects decomposition.yaml missing one required key', () => {
+    // Same shape as above but `interface_contract` removed → invalid.
+    const content =
+`phases:
+  - id: "phase-1"
+    scope: "Add login API"
+    covers: [UC-01]
+    impact: { create: [], modify: [], affected_tests: [] }
+    success_criteria: []
+`;
+    const r = validateArtifactFile('.mpl/mpl/decomposition.yaml', content);
+    assert.equal(r.valid, false);
+    assert.ok(r.missing.includes('interface_contract'));
+  });
 });
 
 /* ──────────────── PostToolUse hook integration ──────────────── */
@@ -183,7 +242,7 @@ describe('mpl-artifact-schema PostToolUse hook (P0-K)', () => {
 
   it('block when enforcement.missing_artifact_schema = "block"', () => {
     writeFileSync(join(tmp, '.mpl', 'state.json'), JSON.stringify({
-      schema_version: 2,
+      schema_version: SCHEMA_V,
       current_phase: 'phase2-sprint',
       enforcement: { missing_artifact_schema: 'block' },
     }));
@@ -198,7 +257,7 @@ describe('mpl-artifact-schema PostToolUse hook (P0-K)', () => {
 
   it('off → silent + signal logged', () => {
     writeFileSync(join(tmp, '.mpl', 'state.json'), JSON.stringify({
-      schema_version: 2,
+      schema_version: SCHEMA_V,
       current_phase: 'phase2-sprint',
       enforcement: { missing_artifact_schema: 'off' },
     }));

--- a/hooks/__tests__/mpl-property-check.test.mjs
+++ b/hooks/__tests__/mpl-property-check.test.mjs
@@ -253,9 +253,10 @@ describe('runBatch + CLI', () => {
     // Regression guard. The allow-list documents declarations whose consumer
     // is shipped by a later issue — when that issue lands, the key drops out
     // of unused naturally and any NEW unused declarations surface here.
-    const EXPECTED_UNUSED = [
-      'enforcement.missing_artifact_schema', // P0-K (#115) ships the consumer
-    ];
+    // Empty as of P0-K (#115) — `enforcement.missing_artifact_schema`
+    // gained its consumer in `hooks/mpl-artifact-schema.mjs`. Future
+    // forward-compat keys go here when introduced.
+    const EXPECTED_UNUSED = [];
     const out = execFileSync('node', [CLI_PATH, REAL_PLUGIN_ROOT, 'config/enforcement.json'], {
       encoding: 'utf-8',
     });

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -144,7 +144,7 @@
         ]
       },
       {
-        "matcher": "Edit|Write|MultiEdit",
+        "matcher": "Edit|Write|MultiEdit|mcp__.*__write.*",
         "hooks": [
           {
             "type": "command",

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -144,6 +144,16 @@
         ]
       },
       {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/mpl-artifact-schema.mjs\"",
+            "timeout": 3
+          }
+        ]
+      },
+      {
         "matcher": "Task|Agent",
         "hooks": [
           {

--- a/hooks/lib/mpl-artifact-schema.mjs
+++ b/hooks/lib/mpl-artifact-schema.mjs
@@ -34,7 +34,12 @@ const ARTIFACTS = [
     artifact: 'decomposition',
     pathMatch: (relPath) => /(^|\/)\.mpl\/mpl\/decomposition\.ya?ml$/.test(relPath),
     parser: 'yaml',
-    required: ['phase_id', 'impact_scope', 'success_criteria', 'covers', 'interface_contract'],
+    // PR #135 review #1 (Codex HIGH): keys must match the actual
+    // decomposer output (`agents/mpl-decomposer.md` <Output_Schema>):
+    // `id` (not `phase_id`), `scope` + `impact` (not `impact_scope`),
+    // `covers`, `interface_contract`, `success_criteria`. The earlier
+    // schema rejected every valid decomposition.yaml.
+    required: ['id', 'scope', 'impact', 'covers', 'interface_contract', 'success_criteria'],
   },
   {
     artifact: 'state-summary',
@@ -91,13 +96,29 @@ export function matchArtifactSchema(relPath) {
 /**
  * Test the presence of `key` in `content` per the schema's parser kind.
  *
- * - `markdown` → match a heading (`## key`, `### key`, etc.) or a
- *   `**key**:` style label. Case-insensitive. Underscores and spaces
- *   are interchangeable so `## next_phase_context` and
+ * - `markdown` → match a heading (`## key`, `### key`, etc.), a
+ *   `**key**:` bold label, OR a `key: value` line (presence-only;
+ *   the line could be a single-line stub — see "Known limitations"
+ *   below). Case-insensitive. Underscores and spaces are
+ *   interchangeable so `## next_phase_context` and
  *   `## Next Phase Context` both count.
  * - `yaml` → match `key:` at line start (any indentation), or
  *   `- key:` for list-of-objects shapes (decomposition.yaml's phase
  *   entries are list elements).
+ *
+ * **Known limitations** (PR #135 review notes — accepted trade-offs):
+ *   1. **Stub tolerance** (markdown): the `key: value` branch matches
+ *      one-line stubs, not just full sections. Schema validity ≠
+ *      content quality. The hook's job is to catch missing sections,
+ *      not police section depth — section-content review is the
+ *      adversarial reviewer's (P0-A / #103) responsibility.
+ *   2. **Global presence** (yaml): for list-of-objects artifacts like
+ *      `decomposition.yaml`, presence anywhere in the document
+ *      satisfies the check. Per-list-element coverage requires a real
+ *      YAML parser; tracked as a follow-up. Today, a key that any
+ *      single phase carries counts as "present" even when a different
+ *      phase omits it. `mpl-require-covers.mjs` covers the most
+ *      important field (`covers`) per-phase already.
  */
 export function hasKey(content, key, parser) {
   if (typeof content !== 'string' || typeof key !== 'string') return false;

--- a/hooks/lib/mpl-artifact-schema.mjs
+++ b/hooks/lib/mpl-artifact-schema.mjs
@@ -1,0 +1,172 @@
+/**
+ * Artifact schema validator (P0-K / #115).
+ *
+ * Pre-P0-K, the orchestrator and phase-runner emitted artifacts whose
+ * required sections were enforced only by prose ("each state-summary
+ * MUST include status, files_changed, verification, decisions,
+ * next_phase_context"). Real runs occasionally produced artifacts
+ * missing one or more sections — surfaced only when a downstream
+ * reader (mpl-adversarial-reviewer, finalize, gate-recorder) tripped
+ * on the missing field, often phases later. R-MISSING-ARTIFACT-SCHEMA
+ * (Evidence A) showed exp15 phase-9 state-summary lacked
+ * `next_phase_context`, and the next phase had to reverse-engineer it
+ * from git diff.
+ *
+ * P0-K moves the contract into a hook (`hooks/mpl-artifact-schema.mjs`,
+ * PostToolUse Edit|Write|MultiEdit) backed by this lib. Each artifact
+ * has a path matcher and a required-section list. A heading-style
+ * presence check is enough for markdown artifacts (orchestrator and
+ * agent prompts already write `## Status` / `## Files Changed` /
+ * etc.); YAML artifacts use top-level key presence.
+ *
+ * Action policy comes from
+ * `enforcement.missing_artifact_schema` (P0-2 / #110):
+ *   - `warn` (default) → surface missing sections as a system-reminder.
+ *   - `block` → exit-2 with the reason; the orchestrator must
+ *     re-emit before the write goes through.
+ *   - `off` → log to `.mpl/signals/artifact-schema-hits.jsonl` only.
+ *
+ * Pure functions. The hook handles I/O / signal emission.
+ */
+
+const ARTIFACTS = [
+  {
+    artifact: 'decomposition',
+    pathMatch: (relPath) => /(^|\/)\.mpl\/mpl\/decomposition\.ya?ml$/.test(relPath),
+    parser: 'yaml',
+    required: ['phase_id', 'impact_scope', 'success_criteria', 'covers', 'interface_contract'],
+  },
+  {
+    artifact: 'state-summary',
+    pathMatch: (relPath) => /(^|\/)\.mpl\/mpl\/phases\/phase-[\w.-]+\/state-summary\.md$/.test(relPath),
+    parser: 'markdown',
+    required: ['status', 'files_changed', 'verification', 'decisions', 'next_phase_context'],
+  },
+  {
+    artifact: 'verification',
+    pathMatch: (relPath) => /(^|\/)\.mpl\/mpl\/phases\/phase-[\w.-]+\/verification\.md$/.test(relPath),
+    parser: 'markdown',
+    // The spec lists `command|file|grep` and `result|exit_code` as
+    // "evidence + result" pairs. We accept either side of each pair as
+    // satisfying the requirement (verification artifacts vary in shape
+    // depending on whether the gate ran a command, grep, or static
+    // file check).
+    required: ['criterion', 'evidence_type'],
+    requiredAnyOf: [
+      ['command', 'file', 'grep'],
+      ['result', 'exit_code'],
+    ],
+  },
+  {
+    artifact: 'pivot-points',
+    pathMatch: (relPath) => /(^|\/)\.mpl\/pivot-points\.md$/.test(relPath),
+    parser: 'markdown',
+    required: ['PP_id', 'constraint', 'status', 'source'],
+  },
+  {
+    artifact: 'user-contract',
+    pathMatch: (relPath) => /(^|\/)\.mpl\/requirements\/user-contract\.md$/.test(relPath),
+    parser: 'markdown',
+    // The issue spec says "scenario coverage" (with a space). Treat
+    // either `scenario_coverage` (snake_case section heading) or
+    // `scenario coverage` (literal phrase) as satisfying the
+    // requirement so a writer who picks one form isn't blocked.
+    required: ['UC_id', 'status'],
+    requiredAnyOf: [
+      ['scenario_coverage', 'scenario coverage'],
+    ],
+  },
+];
+
+/**
+ * Find the schema definition that matches `relPath`. Path is workspace-
+ * relative (e.g. `.mpl/mpl/decomposition.yaml`). Returns null when no
+ * schema applies — caller should treat that as "out of scope".
+ */
+export function matchArtifactSchema(relPath) {
+  if (typeof relPath !== 'string' || relPath.length === 0) return null;
+  return ARTIFACTS.find((s) => s.pathMatch(relPath)) ?? null;
+}
+
+/**
+ * Test the presence of `key` in `content` per the schema's parser kind.
+ *
+ * - `markdown` → match a heading (`## key`, `### key`, etc.) or a
+ *   `**key**:` style label. Case-insensitive. Underscores and spaces
+ *   are interchangeable so `## next_phase_context` and
+ *   `## Next Phase Context` both count.
+ * - `yaml` → match `key:` at line start (any indentation), or
+ *   `- key:` for list-of-objects shapes (decomposition.yaml's phase
+ *   entries are list elements).
+ */
+export function hasKey(content, key, parser) {
+  if (typeof content !== 'string' || typeof key !== 'string') return false;
+  const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  // Allow underscore ↔ space ↔ dash interchange so heading style
+  // variations don't trip the check.
+  const flexible = escaped.replace(/[_\s-]/g, '[_\\s-]');
+
+  if (parser === 'yaml') {
+    const re = new RegExp(`^\\s*-?\\s*${flexible}\\s*:`, 'mi');
+    return re.test(content);
+  }
+
+  // markdown: heading OR bold label OR YAML-ish front-matter line.
+  const re = new RegExp(
+    `(?:^#+\\s*${flexible}\\b)` +    // ## key
+    `|(?:\\*\\*${flexible}\\*\\*)` + // **key**
+    `|(?:^\\s*${flexible}\\s*:)`,    // key:
+    'mi'
+  );
+  return re.test(content);
+}
+
+/**
+ * Validate `content` against `schema`. Returns
+ * `{ valid, missing, missingAnyOf }` — `missing` lists individual
+ * required keys that weren't found; `missingAnyOf` lists groups where
+ * none of the alternatives matched.
+ */
+export function validateAgainstSchema(content, schema) {
+  if (!schema) return { valid: true, missing: [], missingAnyOf: [] };
+  const missing = [];
+  for (const key of schema.required ?? []) {
+    if (!hasKey(content, key, schema.parser)) missing.push(key);
+  }
+  const missingAnyOf = [];
+  for (const group of schema.requiredAnyOf ?? []) {
+    if (!group.some((alt) => hasKey(content, alt, schema.parser))) {
+      missingAnyOf.push(group);
+    }
+  }
+  return {
+    valid: missing.length === 0 && missingAnyOf.length === 0,
+    missing,
+    missingAnyOf,
+  };
+}
+
+/**
+ * One-shot helper: match path → validate → return verdict object.
+ * Returns `null` when the path is out of scope.
+ */
+export function validateArtifactFile(relPath, content) {
+  const schema = matchArtifactSchema(relPath);
+  if (!schema) return null;
+  const { valid, missing, missingAnyOf } = validateAgainstSchema(content, schema);
+  return {
+    artifact: schema.artifact,
+    relPath,
+    valid,
+    missing,
+    missingAnyOf,
+  };
+}
+
+/**
+ * List of artifact-schema definitions. Exposed for tests and for
+ * doctor/finalize re-checks that want to walk all known artifacts.
+ */
+export const ARTIFACT_SCHEMAS = Object.freeze(
+  ARTIFACTS.map((s) => Object.freeze({ ...s }))
+);

--- a/hooks/mpl-artifact-schema.mjs
+++ b/hooks/mpl-artifact-schema.mjs
@@ -91,9 +91,14 @@ async function main() {
   try { data = JSON.parse(input); } catch { return silent(); }
 
   const toolName = data.tool_name || data.toolName || '';
-  if (!['Edit', 'edit', 'Write', 'write', 'MultiEdit', 'multiEdit'].includes(toolName)) {
-    return silent();
-  }
+  // PR #135 review #2 (Claude): hooks.json matcher routes
+  // `mcp__*__write*` tools to this hook, but the internal allowlist
+  // also has to accept them or the hook silent-skips. Mirror the
+  // matcher's regex shape here.
+  const isWriteTool =
+    ['Edit', 'edit', 'Write', 'write', 'MultiEdit', 'multiEdit'].includes(toolName)
+    || /^mcp__.*__write/i.test(toolName);
+  if (!isWriteTool) return silent();
 
   const cwd = data.cwd || data.directory || process.cwd();
   if (!isMplActive(cwd)) return silent();

--- a/hooks/mpl-artifact-schema.mjs
+++ b/hooks/mpl-artifact-schema.mjs
@@ -12,8 +12,11 @@
  * `lib/mpl-enforcement.mjs#resolveRuleAction` (P0-2 / #110):
  *   - `warn` (default) → emit a system-reminder listing missing
  *     sections.
- *   - `block` → exit with `decision: 'block'` so the orchestrator
- *     sees the failure and re-emits the artifact.
+ *   - `block` → return `decision: 'block'`. PR #135 nit: PostToolUse
+ *     fires AFTER the write lands on disk, so the offending file is
+ *     already there. `block` stops the orchestrator's NEXT step so it
+ *     re-emits an overwriting valid version — it doesn't prevent the
+ *     original write itself.
  *   - `off` → log to `.mpl/signals/artifact-schema-hits.jsonl` only;
  *     no hook-level surfacing.
  *

--- a/hooks/mpl-artifact-schema.mjs
+++ b/hooks/mpl-artifact-schema.mjs
@@ -1,0 +1,229 @@
+#!/usr/bin/env node
+/**
+ * MPL Artifact Schema Hook (PostToolUse Edit|Write|MultiEdit) — P0-K / #115.
+ *
+ * Validates phase artifacts (`decomposition.yaml`, `state-summary.md`,
+ * `verification.md`, `pivot-points.md`, `user-contract.md`) against
+ * required-section schemas immediately after they're written. Closes
+ * the consumer gap that left `enforcement.missing_artifact_schema` as
+ * a configured-but-unused rule (F5 #112 forward-compat allow-list).
+ *
+ * Action precedence: `enforcement.missing_artifact_schema` resolved by
+ * `lib/mpl-enforcement.mjs#resolveRuleAction` (P0-2 / #110):
+ *   - `warn` (default) → emit a system-reminder listing missing
+ *     sections.
+ *   - `block` → exit with `decision: 'block'` so the orchestrator
+ *     sees the failure and re-emits the artifact.
+ *   - `off` → log to `.mpl/signals/artifact-schema-hits.jsonl` only;
+ *     no hook-level surfacing.
+ *
+ * Audit signals are written regardless of policy so finalize / doctor
+ * can later replay them.
+ */
+
+import { dirname, join, resolve } from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+import { existsSync, readFileSync, mkdirSync, appendFileSync, readdirSync } from 'fs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const { isMplActive, readState } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-state.mjs')).href
+);
+const { readStdin } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'stdin.mjs')).href
+);
+const { resolveRuleAction } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-enforcement.mjs')).href
+);
+const { matchArtifactSchema, validateArtifactFile } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-artifact-schema.mjs')).href
+);
+
+const SIGNALS_RELATIVE = '.mpl/signals/artifact-schema-hits.jsonl';
+
+function silent() {
+  console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+}
+
+function workspaceRel(cwd, abs) {
+  const cwdAbs = resolve(cwd);
+  const path = resolve(abs);
+  return path.startsWith(cwdAbs + '/') ? path.slice(cwdAbs.length + 1) : abs;
+}
+
+function logHit(cwd, verdict, action) {
+  const sigDir = join(cwd, '.mpl', 'signals');
+  try { mkdirSync(sigDir, { recursive: true }); } catch {}
+  const ts = new Date().toISOString();
+  const line = JSON.stringify({
+    ts,
+    artifact: verdict.artifact,
+    file: verdict.relPath,
+    valid: verdict.valid,
+    missing: verdict.missing,
+    missing_any_of: verdict.missingAnyOf,
+    action,
+  }) + '\n';
+  try { appendFileSync(join(cwd, SIGNALS_RELATIVE), line); } catch {}
+}
+
+function formatVerdict(verdict) {
+  const parts = [];
+  if (verdict.missing.length > 0) {
+    parts.push(`missing required: ${verdict.missing.join(', ')}`);
+  }
+  if (verdict.missingAnyOf.length > 0) {
+    const groups = verdict.missingAnyOf.map((g) => `(any of: ${g.join(' | ')})`);
+    parts.push(`missing one-of: ${groups.join('; ')}`);
+  }
+  return `${verdict.relPath}: ${parts.join('; ') || 'unknown'}`;
+}
+
+async function main() {
+  const input = await readStdin();
+
+  let data;
+  try { data = JSON.parse(input); } catch { return silent(); }
+
+  const toolName = data.tool_name || data.toolName || '';
+  if (!['Edit', 'edit', 'Write', 'write', 'MultiEdit', 'multiEdit'].includes(toolName)) {
+    return silent();
+  }
+
+  const cwd = data.cwd || data.directory || process.cwd();
+  if (!isMplActive(cwd)) return silent();
+
+  const toolInput = data.tool_input || data.toolInput || {};
+  const filePaths = [];
+  if (toolInput.file_path) filePaths.push(toolInput.file_path);
+  else if (toolInput.filePath) filePaths.push(toolInput.filePath);
+  if (Array.isArray(toolInput.edits)) {
+    for (const e of toolInput.edits) {
+      if (e?.file_path) filePaths.push(e.file_path);
+      else if (e?.filePath) filePaths.push(e.filePath);
+    }
+  }
+  if (filePaths.length === 0) return silent();
+
+  const state = readState(cwd) || {};
+  const action = resolveRuleAction(cwd, state, 'missing_artifact_schema');
+
+  const failures = [];
+  for (const fp of filePaths) {
+    const abs = resolve(cwd, fp);
+    const rel = workspaceRel(cwd, abs);
+    if (!matchArtifactSchema(rel)) continue;
+    if (!existsSync(abs)) continue;
+    let content;
+    try { content = readFileSync(abs, 'utf-8'); } catch { continue; }
+    const verdict = validateArtifactFile(rel, content);
+    if (!verdict) continue;
+    // Always persist signals for audit trail, even when action='off'.
+    logHit(cwd, verdict, action);
+    if (!verdict.valid) failures.push(verdict);
+  }
+
+  if (action === 'off') return silent();
+  if (failures.length === 0) return silent();
+
+  const summary = failures.map(formatVerdict).join('\n');
+
+  if (action === 'block') {
+    console.log(JSON.stringify({
+      decision: 'block',
+      reason: `[MPL P0-K] artifact schema violation:\n${summary}\n` +
+        `Re-emit the artifact with the required sections. Schema: docs/schemas/ (or hooks/lib/mpl-artifact-schema.mjs#ARTIFACT_SCHEMAS).`,
+    }));
+    return;
+  }
+
+  console.log(JSON.stringify({
+    continue: true,
+    systemMessage: `[MPL P0-K] artifact schema advisory:\n${summary}`,
+  }));
+}
+
+/**
+ * CLI mode (P0-K finalize re-check / doctor support):
+ *
+ *   node hooks/mpl-artifact-schema.mjs <workspaceRoot>
+ *
+ * Walks every known artifact path under `workspaceRoot` and emits a
+ * JSON verdict: `{ totals, results: [{ artifact, file, valid,
+ * missing, missing_any_of }] }`. Exit code is 0 when every file is
+ * valid (or absent), 1 when at least one validation failed. Designed
+ * for finalize Step 5 to gate `finalize_done = true` and for
+ * mpl-doctor's Category 6 to surface drift.
+ *
+ * The CLI uses the same schema / validator the hook does; there is no
+ * second source of truth for which sections are required.
+ */
+function runCli(workspaceRoot) {
+  const root = resolve(workspaceRoot);
+  if (!existsSync(root)) {
+    process.stderr.write(`[mpl-artifact-schema] workspace root not found: ${root}\n`);
+    process.exit(2);
+  }
+
+  const candidates = enumerateArtifactPaths(root);
+  const results = [];
+  for (const rel of candidates) {
+    const abs = join(root, rel);
+    let content;
+    try { content = readFileSync(abs, 'utf-8'); }
+    catch { continue; }
+    const verdict = validateArtifactFile(rel, content);
+    if (!verdict) continue;
+    results.push({
+      artifact: verdict.artifact,
+      file: rel,
+      valid: verdict.valid,
+      missing: verdict.missing,
+      missing_any_of: verdict.missingAnyOf,
+    });
+  }
+  const totals = {
+    files: results.length,
+    valid: results.filter((r) => r.valid).length,
+    invalid: results.filter((r) => !r.valid).length,
+  };
+  process.stdout.write(JSON.stringify({ totals, results }, null, 2) + '\n');
+  process.exit(totals.invalid > 0 ? 1 : 0);
+}
+
+function enumerateArtifactPaths(root) {
+  const out = [];
+  // Singletons
+  if (existsSync(join(root, '.mpl/mpl/decomposition.yaml'))) out.push('.mpl/mpl/decomposition.yaml');
+  if (existsSync(join(root, '.mpl/mpl/decomposition.yml'))) out.push('.mpl/mpl/decomposition.yml');
+  if (existsSync(join(root, '.mpl/pivot-points.md'))) out.push('.mpl/pivot-points.md');
+  if (existsSync(join(root, '.mpl/requirements/user-contract.md'))) {
+    out.push('.mpl/requirements/user-contract.md');
+  }
+  // Per-phase artifacts
+  const phasesDir = join(root, '.mpl/mpl/phases');
+  if (existsSync(phasesDir)) {
+    let entries = [];
+    try { entries = readdirSync(phasesDir, { withFileTypes: true }); } catch {}
+    for (const e of entries) {
+      if (!e.isDirectory()) continue;
+      if (!/^phase-/.test(e.name)) continue;
+      const ssPath = `.mpl/mpl/phases/${e.name}/state-summary.md`;
+      const vPath = `.mpl/mpl/phases/${e.name}/verification.md`;
+      if (existsSync(join(root, ssPath))) out.push(ssPath);
+      if (existsSync(join(root, vPath))) out.push(vPath);
+    }
+  }
+  return out;
+}
+
+// Hook mode (default — invoked from hooks.json) reads stdin.
+// CLI mode triggers when at least one positional arg is present.
+const cliArg = process.argv[2];
+if (cliArg && !cliArg.startsWith('-')) {
+  runCli(cliArg);
+} else {
+  await main().catch(() => silent());
+}


### PR DESCRIPTION
## Summary

Pre-P0-K, artifact required sections (`state-summary.md` must have status / files_changed / verification / decisions / next_phase_context, etc.) were enforced only by prose in agent prompts. Real runs occasionally produced artifacts missing one or more sections — surfaced only when a downstream reader (adversarial reviewer, finalize, gate-recorder) tripped on the missing field, often phases later. R-MISSING-ARTIFACT-SCHEMA: exp15 phase-9 state-summary lacked `next_phase_context`, and the next phase had to reverse-engineer it from git diff.

P0-K closes the gap with:
- **PostToolUse hook** (`hooks/mpl-artifact-schema.mjs`) backed by `hooks/lib/mpl-artifact-schema.mjs`. Validates each Edit/Write/MultiEdit against the matching schema. Action policy via `enforcement.missing_artifact_schema` (P0-2 #110): warn → systemMessage; block → exit-2 reason; off → signal-only.
- **CLI mode** for finalize bulk re-check + doctor support: `node hooks/mpl-artifact-schema.mjs <workspaceRoot>` walks all known artifact paths and emits a JSON verdict.
- **Finalize Step 5.1.1** invokes the CLI as the operator's last sanity check before `finalize_done = true`.
- **Allow-list cleanup**: F5 (#112) `EXPECTED_UNUSED = ['enforcement.missing_artifact_schema']` is now empty — P0-K is the consumer.

## Schema coverage

| Artifact | Required keys | Notes |
|---|---|---|
| `decomposition.yaml` | `phase_id, impact_scope, success_criteria, covers, interface_contract` | YAML; matches both top-level and `- key:` list elements |
| `state-summary.md` (per phase) | `status, files_changed, verification, decisions, next_phase_context` | Markdown; heading / bold / `key:` |
| `verification.md` (per phase) | `criterion, evidence_type` + anyOf groups `[command\|file\|grep]` and `[result\|exit_code]` | Different gates use different evidence shapes |
| `pivot-points.md` | `PP_id, constraint, status, source` | |
| `user-contract.md` | `UC_id, status` + anyOf `[scenario_coverage \| scenario coverage]` | Tolerates both snake_case heading and the literal-phrase form the spec uses |

## Test plan

- 27 new tests in `mpl-artifact-schema.test.mjs`:
  - Path matcher (each of 5 + out-of-scope rejection)
  - `hasKey` (markdown heading / bold / `key:`, YAML top-level + list element, case + underscore-vs-space tolerance)
  - `validateAgainstSchema` (missing keys, valid pass, anyOf semantics)
  - Hook integration (silent for non-artifact / valid / inactive, warn → systemMessage, block → decision, off → signal-only, MultiEdit)
  - CLI (workspace walk + per-file verdicts, exit 0 / 1 / 2)
- Full regression: 666 → **693/693** (+27)
- Doctor meta-self self-run: 0 hits
- Property-check self-run: `unused: 0` (was 1; the F5 forward-compat allow-list is naturally satisfied)

## Forward integration

- mpl-doctor Category 6 can invoke the CLI for read-only validation of an in-flight pipeline.
- Adversarial reviewer (#103 P0-A) already reads `state-summary.md` / `verification.md` — P0-K guarantees both carry the sections it expects, shrinking the reviewer's failure paths.
- `.mpl/signals/artifact-schema-hits.jsonl` is a new audit trail that finalize can include in the post-execution report (T-10 / 5.1.8).

Closes #115. **v0.18.1 critical track: 5/5 (entire v0.18.1 ships).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)