### PR TITLE
feat(#117): F6 — codex auditor (Tier 4 last-mile audit)

### DIFF
--- a/agents/mpl-codex-auditor.md
+++ b/agents/mpl-codex-auditor.md
@@ -1,0 +1,181 @@
+---
+name: mpl-codex-auditor
+description: Tier 4 codex audit agent — finalize-time intent vs implementation diff (F6, #117). Runs `hooks/mpl-codex-audit.mjs`, surfaces audit-report.json findings, and decides PASS/FAIL based on the residual surfaces.
+model: haiku
+disallowedTools: Write, Edit, Task
+---
+
+<Agent_Prompt>
+  <Role>
+    You are the MPL Codex Auditor — the Tier 4 last-mile audit dispatched
+    once at finalize-time (Step 5.1.6). Tier 1+2+3 (F2 hook scan, F3 anti-
+    pattern registry, F5 property check) caught roughly 7/8 of MPL spec
+    violations during execution. Your job is to surface the remaining 1/8
+    by cross-referencing **intent** (decomposition.yaml + user-contract.md)
+    against **implementation** (declared impact files + git diff).
+
+    You are a read-only auditor. You do NOT fix issues, re-run phases, or
+    edit artifacts. You report findings with PASS/FAIL verdict and let the
+    orchestrator (or the user, in non-strict mode) decide whether to act.
+  </Role>
+
+  <Constraints>
+    - Read-only: no Write, Edit, or NotebookEdit. The audit lib + CLI do
+      all the I/O — your job is dispatch, surface, and verdict.
+    - Single dispatch per finalize. Do NOT run the audit mid-phase; per-
+      phase artifacts are still being written.
+    - Trust the CLI verdict. Do not second-guess `verdict: pass` by
+      re-scanning manually. The audit is mechanical; LLM judgment is for
+      surface formatting only.
+    - Honor `enforcement.audit_residual`. The CLI exit code already
+      reflects the policy (warn → 0, block → 1 on fail). Do not override.
+  </Constraints>
+
+  <Inputs>
+    - `cwd` — workspace root (project being audited, NOT the plugin root).
+    - `pluginRoot` — `${CLAUDE_PLUGIN_ROOT}` for locating
+      `commands/references/anti-patterns.md`.
+    - Implicit: `.mpl/mpl/decomposition.yaml`, `.mpl/requirements/user-contract.md`,
+      git history (for diff scope).
+  </Inputs>
+
+  <Reasoning_Steps>
+    Step 1: Run the audit CLI.
+
+    ```
+    Bash("node ${CLAUDE_PLUGIN_ROOT}/hooks/mpl-codex-audit.mjs $(pwd)", timeout: 30_000)
+    ```
+
+    The CLI:
+    - Persists `audit-report.json` to `.mpl/mpl/audit-report.json`
+    - Emits the same JSON to stdout
+    - Exits 0 on pass / warn-on-fail; exits 1 only when verdict=fail AND
+      `enforcement.audit_residual === 'block'`
+    - Exits 2 on usage error (missing workspaceRoot)
+
+    Step 2: Parse the JSON envelope:
+
+    ```json
+    {
+      "schema_version": 1,
+      "tier": 4,
+      "generated_at": "ISO-8601",
+      "verdict": "pass" | "fail",
+      "summary": {
+        "anti_pattern_residual": <int>,
+        "missing_covers": <int>,
+        "dangling_covers": <int>,
+        "drift_undeclared": <int>,
+        "drift_unimplemented": <int>
+      },
+      "surfaces": { ... },
+      "inputs": { "decomposition_phases": <int>, "included_ucs": <int> }
+    }
+    ```
+
+    Step 3: Surface findings to the user.
+
+    PASS — single line:
+    ```
+    [F6 Codex Audit] PASS — 0 residual anti-patterns, 0 missing covers,
+    0 dangling covers across {phases} phases / {ucs} UCs.
+    ```
+
+    FAIL — structured surface (markdown):
+    ```
+    [F6 Codex Audit] FAIL
+
+    ## Residual anti-patterns ({count})
+    | Phase | File | Pattern | Line |
+    |---|---|---|---|
+    | phase-N | path | id | line |
+
+    ## Missing covers ({count})
+    | UC | Title | Reason |
+    |---|---|---|
+    | UC-NN | ... | no phase covers this included UC |
+
+    ## Dangling covers ({count})
+    | Phase | UC | Reason |
+    |---|---|---|
+    | phase-N | UC-NN | phase claims UC not in included user_cases |
+
+    ## Drift (informational)
+    - Undeclared: {count} — files touched but not in any phase scope
+    - Unimplemented: {count} — declared paths with no diff footprint
+    ```
+
+    Step 4: Decide next-step recommendation.
+
+    - `verdict: pass` → "PASS — finalize may continue."
+    - `verdict: fail`, exit 0 (warn) → "FAIL (advisory) — review residuals
+      and decide whether to address before commit/PR. Finalize will
+      continue."
+    - `verdict: fail`, exit 1 (block) → "FAIL (strict) — finalize halted.
+      Address residual anti-patterns and missing covers, then re-run
+      `/mpl-run-finalize`."
+  </Reasoning_Steps>
+
+  <Output_Format>
+    Return a structured response with:
+    1. The single-line PASS / FAIL header
+    2. The structured surface table (only if FAIL)
+    3. The next-step recommendation
+    4. The raw audit-report.json path (`.mpl/mpl/audit-report.json`)
+       so downstream consumers (Post-Execution Review, RUNBOOK Finalize)
+       can ingest the verdict.
+
+    Do NOT print the full JSON envelope inline — it's persisted to disk
+    and stdout already; surface the structured tables instead.
+  </Output_Format>
+
+  <Drift_Notes>
+    Drift surface (`drift.undeclared` / `drift.unimplemented`) is
+    INFORMATIONAL only and does NOT contribute to the FAIL verdict.
+    Step 5.1.5's Scope Drift Report already surfaces this for the
+    RUNBOOK; F6 collapses the same data into the audit envelope so
+    a single artifact captures the Tier 4 view.
+
+    Test artifacts (`__tests__/` directories and `*.test.*` files)
+    are filtered from drift detection — they're auto-derived from
+    implementation files and trivially undeclared.
+  </Drift_Notes>
+
+  <Examples>
+    ### Example 1 — clean run
+
+    ```
+    [F6 Codex Audit] PASS — 0 residual anti-patterns, 0 missing covers,
+    0 dangling covers across 8 phases / 5 UCs.
+
+    PASS — finalize may continue.
+    Audit report: .mpl/mpl/audit-report.json
+    ```
+
+    ### Example 2 — residual anti-pattern + missing cover
+
+    ```
+    [F6 Codex Audit] FAIL
+
+    ## Residual anti-patterns (1)
+    | Phase | File | Pattern | Line |
+    |---|---|---|---|
+    | phase-3 | src/lib/util.mjs | D1.a | 42 |
+
+    ## Missing covers (1)
+    | UC | Title | Reason |
+    |---|---|---|
+    | UC-04 | Dark mode toggle | no phase covers this included UC |
+
+    ## Dangling covers (0)
+
+    ## Drift (informational)
+    - Undeclared: 0
+    - Unimplemented: 1 — src/components/Dropdown.tsx
+
+    FAIL (advisory) — review residuals and decide whether to address
+    before commit/PR. Finalize will continue.
+    Audit report: .mpl/mpl/audit-report.json
+    ```
+  </Examples>
+</Agent_Prompt>

--- a/agents/mpl-codex-auditor.md
+++ b/agents/mpl-codex-auditor.md
@@ -2,13 +2,13 @@
 name: mpl-codex-auditor
 description: Tier 4 codex audit agent — finalize-time intent vs implementation diff (F6, #117). Runs `hooks/mpl-codex-audit.mjs`, surfaces audit-report.json findings, and decides PASS/FAIL based on the residual surfaces.
 model: haiku
-disallowedTools: Write, Edit, Task
+disallowedTools: Write, Edit, NotebookEdit, Task
 ---
 
 <Agent_Prompt>
   <Role>
     You are the MPL Codex Auditor — the Tier 4 last-mile audit dispatched
-    once at finalize-time (Step 5.1.6). Tier 1+2+3 (F2 hook scan, F3 anti-
+    once at finalize-time (Step 5.1.7). Tier 1+2+3 (F2 hook scan, F3 anti-
     pattern registry, F5 property check) caught roughly 7/8 of MPL spec
     violations during execution. Your job is to surface the remaining 1/8
     by cross-referencing **intent** (decomposition.yaml + user-contract.md)
@@ -20,8 +20,12 @@ disallowedTools: Write, Edit, Task
   </Role>
 
   <Constraints>
-    - Read-only: no Write, Edit, or NotebookEdit. The audit lib + CLI do
-      all the I/O — your job is dispatch, surface, and verdict.
+    - Read-only artifact-side: no direct file mutation via Write / Edit /
+      NotebookEdit (these are blocked at the frontmatter level). Bash IS
+      enabled because the audit CLI (`hooks/mpl-codex-audit.mjs`) is the
+      sole authorized writer — it persists `audit-report.json` and emits
+      the same JSON to stdout. Never invoke any Bash command other than
+      that CLI; never run the audit mid-phase.
     - Single dispatch per finalize. Do NOT run the audit mid-phase; per-
       phase artifacts are still being written.
     - Trust the CLI verdict. Do not second-guess `verdict: pass` by

--- a/agents/mpl-doctor.md
+++ b/agents/mpl-doctor.md
@@ -42,11 +42,12 @@ disallowedTools: Write, Edit, Task
     - List all .md files in `MPL/agents/`
     - For each: verify YAML frontmatter has `name`, `description`, `model`
     - Verify `model` is one of: haiku, sonnet, opus
-    - Expected agents (8 total, v2.0):
-      mpl-codebase-analyzer, mpl-decomposer, mpl-doctor, mpl-git-master,
-      mpl-interviewer, mpl-phase-runner, mpl-phase0-analyzer, mpl-test-agent
+    - Expected agents (11 total, v0.18.1):
+      mpl-adversarial-reviewer, mpl-codebase-analyzer, mpl-codex-auditor,
+      mpl-decomposer, mpl-doctor, mpl-git-master, mpl-interviewer,
+      mpl-phase-runner, mpl-phase0-analyzer, mpl-seed-generator, mpl-test-agent
     - FAIL if any agent has invalid frontmatter
-    - WARN if count != 8
+    - WARN if count != 11
 
     ### Category 4: Skills
     - **Scope**: `skills/**/SKILL.md`

--- a/commands/mpl-run-finalize.md
+++ b/commands/mpl-run-finalize.md
@@ -218,6 +218,61 @@ announce: "[MPL] Scope Drift: {(drift_ratio * 100).toFixed(0)}% ({added_files.le
 // No blocking — data collection for future Gate integration
 ```
 
+### 5.1.6: Codex Audit (F6, #117) — Tier 4 last-mile sweep
+
+Single dispatch of the codex auditor. Tier 1 (F2 hook scan), Tier 2 (F3
+anti-pattern registry), and Tier 3 (F5 property check) catch ~7/8 of MPL
+spec violations during execution. F6 is the finalize-time sweep that
+catches the remaining 1/8 by cross-referencing intent (decomposition.yaml
++ user-contract.md) against implementation (declared impact files + git
+diff).
+
+Dispatch via Task to `mpl-codex-auditor`:
+
+```
+Task("mpl-codex-auditor", "Run finalize-time Tier 4 audit. Workspace: $(pwd). Plugin: ${CLAUDE_PLUGIN_ROOT}.")
+```
+
+The agent invokes:
+
+```
+Bash("node ${CLAUDE_PLUGIN_ROOT}/hooks/mpl-codex-audit.mjs $(pwd)", timeout: 30_000)
+```
+
+Audit envelope (`.mpl/mpl/audit-report.json`):
+
+```json
+{
+  "schema_version": 1,
+  "tier": 4,
+  "verdict": "pass" | "fail",
+  "summary": { "anti_pattern_residual": N, "missing_covers": N,
+                "dangling_covers": N, "drift_undeclared": N,
+                "drift_unimplemented": N },
+  "surfaces": { ... },
+  "inputs": { "decomposition_phases": N, "included_ucs": N }
+}
+```
+
+Exit code policy (mirrors P0-2 enforcement):
+- Exit 0 → `verdict: pass` OR (`verdict: fail` AND
+  `enforcement.audit_residual !== 'block'`). Continue to Step 5.1.8 with
+  findings surfaced as advisory.
+- Exit 1 → `verdict: fail` AND `enforcement.audit_residual === 'block'`.
+  Halt finalize. User must address residual anti-patterns and missing
+  covers before re-running `/mpl-run-finalize`.
+- Exit 2 → usage error (missing or invalid workspaceRoot). Treat as
+  audit-skip with warning; continue.
+
+Drift surface is INFORMATIONAL only and does not contribute to the FAIL
+verdict — Step 5.1.5 already publishes drift to RUNBOOK; F6 collapses it
+into the audit envelope so Post-Execution Review (5.1.8) and RUNBOOK
+Finalize (5.6) can ingest a single Tier 4 artifact.
+
+The orchestrator surfaces the agent's structured table (residual anti-
+patterns, missing covers, dangling covers) to the user via systemMessage
+and includes the verdict in the Completion Report (Step 5.5).
+
 ### 5.1.8: Post-Execution Review Report (T-10, v3.9)
 
 > **Note**: This step was previously numbered 5.5. Renumbered to 5.1.8 in v0.8.3 to fix ordering

--- a/commands/mpl-run-finalize.md
+++ b/commands/mpl-run-finalize.md
@@ -218,7 +218,7 @@ announce: "[MPL] Scope Drift: {(drift_ratio * 100).toFixed(0)}% ({added_files.le
 // No blocking — data collection for future Gate integration
 ```
 
-### 5.1.6: Codex Audit (F6, #117) — Tier 4 last-mile sweep
+### 5.1.7: Codex Audit (F6, #117) — Tier 4 last-mile sweep
 
 Single dispatch of the codex auditor. Tier 1 (F2 hook scan), Tier 2 (F3
 anti-pattern registry), and Tier 3 (F5 property check) catch ~7/8 of MPL

--- a/config/enforcement.json
+++ b/config/enforcement.json
@@ -8,7 +8,8 @@
     "missing_artifact_schema": "warn",
     "anti_pattern_match": "warn",
     "state_invariant_violation": "warn",
-    "bash_timeout_violation": "warn"
+    "bash_timeout_violation": "warn",
+    "audit_residual": "warn"
   },
   "overrides": []
 }

--- a/hooks/__tests__/mpl-codex-audit.test.mjs
+++ b/hooks/__tests__/mpl-codex-audit.test.mjs
@@ -618,15 +618,21 @@ describe('PR #136 review regressions', () => {
     assert.deepStrictEqual(dangling, []);
   });
 
-  it('Codex HIGH: enforced mode (file present + empty user_cases) still surfaces dangling', () => {
-    // Distinguish "no contract file" (legacy_skip) from "empty contract" —
-    // the latter is an explicit author choice and dangling claims are real.
+  it('Codex HIGH follow-up: empty_skip mode (file present + user_cases: []) suppresses dangling', () => {
+    // Phase 0 graceful-skip writes a real `user-contract.md` with
+    // `user_cases: []` for legacy projects (see commands/mpl-run-phase0.md
+    // line 228: "Skip condition: Legacy projects (pre-0.16) ... write
+    // graceful-skip user-contract.md with user_cases: []"). Pre-followup-fix
+    // this case was treated as `enforced` and reported dangling — Codex's
+    // follow-up reproducer flagged that as still conflicting with
+    // mpl-require-covers.mjs graceful semantics.
     scaffold(tmp, {
-      '.mpl/requirements/user-contract.md': `# UC
+      '.mpl/requirements/user-contract.md': `# User Contract
 
 \`\`\`yaml
 schema_version: 1
 user_cases: []
+scenarios: []
 \`\`\`
 `,
       '.mpl/mpl/decomposition.yaml': `phases:
@@ -638,9 +644,19 @@ user_cases: []
 `,
     });
     const report = runCodexAudit(tmp, REAL_PLUGIN_ROOT, { now: 'NOW' });
+    assert.equal(report.contract_mode, 'empty_skip');
+    assert.equal(report.verdict, 'pass');
+    assert.equal(report.summary.dangling_covers, 0);
+    assert.equal(report.summary.missing_covers, 0);
+  });
+
+  it('contract_mode: enforced when at least one UC is included', () => {
+    scaffold(tmp, {
+      '.mpl/requirements/user-contract.md': SAMPLE_USER_CONTRACT,
+      '.mpl/mpl/decomposition.yaml': SAMPLE_DECOMPOSITION,
+    });
+    const report = runCodexAudit(tmp, REAL_PLUGIN_ROOT, { now: 'NOW' });
     assert.equal(report.contract_mode, 'enforced');
-    assert.equal(report.verdict, 'fail');
-    assert.equal(report.summary.dangling_covers, 1);
   });
 
   /* Codex MEDIUM --------------------------------------------------------- */

--- a/hooks/__tests__/mpl-codex-audit.test.mjs
+++ b/hooks/__tests__/mpl-codex-audit.test.mjs
@@ -15,8 +15,11 @@ import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { tmpdir } from 'os';
 
+import { execSync } from 'node:child_process';
+
 import {
   enumerateIncludedUserCases,
+  isLegacyContractMode,
   parseDecompositionPhases,
   findMissingCovers,
   findScopeDrift,
@@ -571,3 +574,156 @@ deferred_cases:`,
     assert.equal(report.verdict, 'fail');
   });
 });
+
+/* ────────────────────────── PR #136 review regressions ───────────────────── */
+
+describe('PR #136 review regressions', () => {
+  let tmp;
+  beforeEach(() => { tmp = mkdtempSync(join(tmpdir(), 'mpl-f6-')); });
+  afterEach(() => { rmSync(tmp, { recursive: true, force: true }); });
+
+  /* Codex HIGH ----------------------------------------------------------- */
+
+  it('isLegacyContractMode returns true when user-contract.md is absent', () => {
+    assert.equal(isLegacyContractMode(tmp), true);
+    scaffold(tmp, { '.mpl/requirements/user-contract.md': SAMPLE_USER_CONTRACT });
+    assert.equal(isLegacyContractMode(tmp), false);
+  });
+
+  it('Codex HIGH: legacy mode (no user-contract.md) suppresses dangling covers', () => {
+    // Decomposition claims UC-01 but no user-contract.md exists — pre-fix
+    // emitted a dangling-covers fail; post-fix mirrors mpl-require-covers
+    // graceful-skip semantics and returns no surfaces.
+    scaffold(tmp, {
+      '.mpl/mpl/decomposition.yaml': `phases:
+  - id: phase-1
+    covers: [UC-01]
+    impact:
+      create:
+        - path: src/a.ts
+`,
+    });
+    const report = runCodexAudit(tmp, REAL_PLUGIN_ROOT, { now: 'NOW' });
+    assert.equal(report.contract_mode, 'legacy_skip');
+    assert.equal(report.verdict, 'pass');
+    assert.equal(report.summary.dangling_covers, 0);
+    assert.equal(report.summary.missing_covers, 0);
+  });
+
+  it('Codex HIGH: findMissingCovers honours legacy:true opts flag', () => {
+    const ucs = []; // pretend the file is absent
+    const phases = [{ id: 'p1', covers: ['UC-01', 'UC-99'], impact_files: [] }];
+    const { uncovered, dangling } = findMissingCovers(ucs, phases, { legacy: true });
+    assert.deepStrictEqual(uncovered, []);
+    assert.deepStrictEqual(dangling, []);
+  });
+
+  it('Codex HIGH: enforced mode (file present + empty user_cases) still surfaces dangling', () => {
+    // Distinguish "no contract file" (legacy_skip) from "empty contract" —
+    // the latter is an explicit author choice and dangling claims are real.
+    scaffold(tmp, {
+      '.mpl/requirements/user-contract.md': `# UC
+
+\`\`\`yaml
+schema_version: 1
+user_cases: []
+\`\`\`
+`,
+      '.mpl/mpl/decomposition.yaml': `phases:
+  - id: phase-1
+    covers: [UC-01]
+    impact:
+      create:
+        - path: src/a.ts
+`,
+    });
+    const report = runCodexAudit(tmp, REAL_PLUGIN_ROOT, { now: 'NOW' });
+    assert.equal(report.contract_mode, 'enforced');
+    assert.equal(report.verdict, 'fail');
+    assert.equal(report.summary.dangling_covers, 1);
+  });
+
+  /* Codex MEDIUM --------------------------------------------------------- */
+
+  it('Codex MEDIUM: drift probe sees unstaged created files (finalize-time scenario)', () => {
+    // F6 runs before Git Master commit, so the impl is in the working tree
+    // unstaged. Pre-fix probe chain (merge-base / HEAD~20 / --cached) all
+    // missed unstaged content; declared impact reported as `unimplemented`
+    // even though the file existed.
+    execSync('git init -q', { cwd: tmp });
+    execSync('git config user.email a@b.c', { cwd: tmp });
+    execSync('git config user.name t', { cwd: tmp });
+    writeFileSync(join(tmp, 'README.md'), '# init');
+    execSync('git add README.md && git commit -q -m init', { cwd: tmp });
+
+    scaffold(tmp, {
+      'src/a.ts': 'export const a = 1;\n',
+    });
+    const phases = [{ id: 'p1', covers: ['internal'], impact_files: ['src/a.ts'] }];
+    const drift = findScopeDrift(tmp, phases);
+    assert.ok(!drift.unimplemented.includes('src/a.ts'),
+      `unstaged created file must not be reported as unimplemented; got ${JSON.stringify(drift)}`);
+  });
+
+  it('Codex MEDIUM: drift probe sees staged-but-uncommitted changes', () => {
+    execSync('git init -q', { cwd: tmp });
+    execSync('git config user.email a@b.c', { cwd: tmp });
+    execSync('git config user.name t', { cwd: tmp });
+    writeFileSync(join(tmp, 'README.md'), '# init');
+    execSync('git add README.md && git commit -q -m init', { cwd: tmp });
+
+    scaffold(tmp, { 'src/b.ts': 'export const b = 2;\n' });
+    execSync('git add src/b.ts', { cwd: tmp });
+    const phases = [{ id: 'p1', covers: ['internal'], impact_files: ['src/b.ts'] }];
+    const drift = findScopeDrift(tmp, phases);
+    assert.ok(!drift.unimplemented.includes('src/b.ts'));
+  });
+
+  /* Claude #1 + #2 indent fragility ------------------------------------- */
+
+  it('Claude #1: parseDecompositionPhases tolerates deeper-indented phases', () => {
+    // Future schema may wrap phases under a meta layer (e.g. `task:`).
+    // Pre-fix `^  - id:` (exact 2-space) silently returned [].
+    scaffold(tmp, {
+      '.mpl/mpl/decomposition.yaml': `task:
+  phases:
+    - id: phase-1
+      covers: [internal]
+      impact:
+        create:
+          - path: src/x.ts
+        modify:
+          - path: src/y.ts
+`,
+    });
+    const phases = parseDecompositionPhases(tmp);
+    assert.equal(phases.length, 1);
+    assert.equal(phases[0].id, 'phase-1');
+    assert.deepStrictEqual(phases[0].impact_files.sort(), ['src/x.ts', 'src/y.ts']);
+  });
+
+  /* Claude #3 indent tolerance for user_cases --------------------------- */
+
+  it('Claude #3: enumerateIncludedUserCases tolerates indented user_cases section', () => {
+    // YAML inside a markdown fence with author-added indent.
+    scaffold(tmp, {
+      '.mpl/requirements/user-contract.md': `# UC
+
+\`\`\`yaml
+metadata:
+  schema_version: 1
+
+  user_cases:
+    - id: "UC-01"
+      title: "Indented case"
+      status: "included"
+      covers_pp: ["PP-A"]
+\`\`\`
+`,
+    });
+    const ucs = enumerateIncludedUserCases(tmp);
+    assert.equal(ucs.length, 1);
+    assert.equal(ucs[0].id, 'UC-01');
+  });
+});
+

--- a/hooks/__tests__/mpl-codex-audit.test.mjs
+++ b/hooks/__tests__/mpl-codex-audit.test.mjs
@@ -1,0 +1,573 @@
+/**
+ * F6 (#117) — codex auditor unit tests.
+ *
+ * Covers all three audit surfaces (anti-pattern residual, missing covers,
+ * drift) plus the runner envelope verdict logic plus the CLI smoke path.
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import {
+  mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync,
+} from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { tmpdir } from 'os';
+
+import {
+  enumerateIncludedUserCases,
+  parseDecompositionPhases,
+  findMissingCovers,
+  findScopeDrift,
+  auditAntiPatternResidual,
+  runCodexAudit,
+} from '../lib/mpl-codex-audit.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const CLI_PATH = join(dirname(__filename), '..', 'mpl-codex-audit.mjs');
+const REAL_PLUGIN_ROOT = join(dirname(__filename), '..', '..');
+
+/* ────────────────────────── Helpers ──────────────────────────────────────── */
+
+function scaffold(root, files) {
+  for (const [rel, body] of Object.entries(files)) {
+    const abs = join(root, rel);
+    mkdirSync(dirname(abs), { recursive: true });
+    writeFileSync(abs, body);
+  }
+}
+
+const SAMPLE_USER_CONTRACT = `# User Contract
+
+\`\`\`yaml
+schema_version: 1
+created_at: "2026-05-05T00:00:00Z"
+iterations: 1
+
+user_cases:
+  - id: "UC-01"
+    title: "Sign in with Google"
+    user_delta: ""
+    priority: "P0"
+    status: "included"
+    covers_pp: ["PP-A"]
+    acceptance_hint: "OAuth flow returns to /home"
+  - id: "UC-02"
+    title: "Sign out"
+    user_delta: ""
+    priority: "P0"
+    status: "included"
+    covers_pp: ["PP-A"]
+
+deferred_cases:
+  - id: "UC-09"
+    title: "Profile picture upload"
+    reason: "post-MVP"
+    revisit_at: "post-v0.17"
+    source_round: 2
+
+cut_cases: []
+scenarios: []
+\`\`\`
+`;
+
+const SAMPLE_DECOMPOSITION = `phases:
+  - id: phase-1
+    scope: "Auth scaffolding"
+    covers: ["UC-01"]
+    impact:
+      create:
+        - path: "src/auth/google.ts"
+        - path: "src/auth/index.ts"
+      modify:
+        - path: "src/main.ts"
+      affected_tests:
+        - path: "src/auth/__tests__/google.test.ts"
+    interface_contract:
+      contract_files: []
+    success_criteria:
+      - command: "npm test src/auth"
+
+  - id: phase-2
+    scope: "Sign out"
+    covers:
+      - "UC-02"
+    impact:
+      create:
+        - path: "src/auth/signout.ts"
+      modify:
+        - path: "src/auth/index.ts"
+    interface_contract:
+      contract_files: []
+    success_criteria:
+      - command: "npm test"
+`;
+
+/* ────────────────────────── enumerateIncludedUserCases ───────────────────── */
+
+describe('enumerateIncludedUserCases', () => {
+  let tmp;
+  beforeEach(() => { tmp = mkdtempSync(join(tmpdir(), 'mpl-f6-')); });
+  afterEach(() => { rmSync(tmp, { recursive: true, force: true }); });
+
+  it('returns empty when user-contract.md is missing', () => {
+    assert.deepStrictEqual(enumerateIncludedUserCases(tmp), []);
+  });
+
+  it('extracts only included UCs (filters deferred/cut)', () => {
+    scaffold(tmp, { '.mpl/requirements/user-contract.md': SAMPLE_USER_CONTRACT });
+    const ucs = enumerateIncludedUserCases(tmp);
+    assert.deepStrictEqual(ucs.map(u => u.id), ['UC-01', 'UC-02']);
+    assert.equal(ucs[0].title, 'Sign in with Google');
+  });
+
+  it('treats UC without explicit status as included (schema: section is included-only)', () => {
+    scaffold(tmp, {
+      '.mpl/requirements/user-contract.md': `# UC
+
+\`\`\`yaml
+user_cases:
+  - id: "UC-77"
+    title: "Implicit included"
+    priority: "P0"
+\`\`\`
+`,
+    });
+    const ucs = enumerateIncludedUserCases(tmp);
+    assert.equal(ucs.length, 1);
+    assert.equal(ucs[0].id, 'UC-77');
+  });
+
+  it('returns empty when user_cases section is absent', () => {
+    scaffold(tmp, {
+      '.mpl/requirements/user-contract.md': `# User Contract
+
+No user_cases here.
+`,
+    });
+    assert.deepStrictEqual(enumerateIncludedUserCases(tmp), []);
+  });
+
+  it('does not bleed into deferred_cases', () => {
+    scaffold(tmp, { '.mpl/requirements/user-contract.md': SAMPLE_USER_CONTRACT });
+    const ucs = enumerateIncludedUserCases(tmp);
+    const ids = ucs.map(u => u.id);
+    assert.ok(!ids.includes('UC-09'), 'UC-09 is deferred and must not appear as included');
+  });
+});
+
+/* ────────────────────────── parseDecompositionPhases ─────────────────────── */
+
+describe('parseDecompositionPhases', () => {
+  let tmp;
+  beforeEach(() => { tmp = mkdtempSync(join(tmpdir(), 'mpl-f6-')); });
+  afterEach(() => { rmSync(tmp, { recursive: true, force: true }); });
+
+  it('returns empty when decomposition.yaml is missing', () => {
+    assert.deepStrictEqual(parseDecompositionPhases(tmp), []);
+  });
+
+  it('parses inline covers array', () => {
+    scaffold(tmp, { '.mpl/mpl/decomposition.yaml': SAMPLE_DECOMPOSITION });
+    const phases = parseDecompositionPhases(tmp);
+    const phase1 = phases.find(p => p.id === 'phase-1');
+    assert.deepStrictEqual(phase1.covers, ['UC-01']);
+  });
+
+  it('parses YAML-list-form covers', () => {
+    scaffold(tmp, { '.mpl/mpl/decomposition.yaml': SAMPLE_DECOMPOSITION });
+    const phases = parseDecompositionPhases(tmp);
+    const phase2 = phases.find(p => p.id === 'phase-2');
+    assert.deepStrictEqual(phase2.covers, ['UC-02']);
+  });
+
+  it('extracts create + modify paths into impact_files (excludes affected_tests)', () => {
+    scaffold(tmp, { '.mpl/mpl/decomposition.yaml': SAMPLE_DECOMPOSITION });
+    const phases = parseDecompositionPhases(tmp);
+    const phase1 = phases.find(p => p.id === 'phase-1');
+    assert.deepStrictEqual(
+      phase1.impact_files.sort(),
+      ['src/auth/google.ts', 'src/auth/index.ts', 'src/main.ts'].sort(),
+    );
+    // affected_tests must NOT appear in impact_files
+    assert.ok(!phase1.impact_files.includes('src/auth/__tests__/google.test.ts'));
+  });
+
+  it('handles `internal` covers escape', () => {
+    scaffold(tmp, {
+      '.mpl/mpl/decomposition.yaml': `phases:
+  - id: phase-3
+    scope: "Plumbing only"
+    covers: ["internal"]
+    impact:
+      create:
+        - path: "src/util/index.ts"
+`,
+    });
+    const phases = parseDecompositionPhases(tmp);
+    assert.deepStrictEqual(phases[0].covers, ['internal']);
+  });
+});
+
+/* ────────────────────────── findMissingCovers ────────────────────────────── */
+
+describe('findMissingCovers', () => {
+  it('reports uncovered UCs', () => {
+    const ucs = [
+      { id: 'UC-01', title: 'A' },
+      { id: 'UC-02', title: 'B' },
+      { id: 'UC-03', title: 'C' },
+    ];
+    const phases = [
+      { id: 'p1', covers: ['UC-01'], impact_files: [] },
+      { id: 'p2', covers: ['UC-02'], impact_files: [] },
+    ];
+    const { uncovered, dangling } = findMissingCovers(ucs, phases);
+    assert.equal(uncovered.length, 1);
+    assert.equal(uncovered[0].uc_id, 'UC-03');
+    assert.deepStrictEqual(dangling, []);
+  });
+
+  it('reports dangling claims (phase covers UC not in included)', () => {
+    const ucs = [{ id: 'UC-01', title: 'A' }];
+    const phases = [
+      { id: 'p1', covers: ['UC-01', 'UC-99'], impact_files: [] },
+    ];
+    const { uncovered, dangling } = findMissingCovers(ucs, phases);
+    assert.deepStrictEqual(uncovered, []);
+    assert.equal(dangling.length, 1);
+    assert.equal(dangling[0].uc_id, 'UC-99');
+    assert.equal(dangling[0].phase_id, 'p1');
+  });
+
+  it('honours `internal` escape (no dangling, no contribution to coverage)', () => {
+    const ucs = [{ id: 'UC-01', title: 'A' }];
+    const phases = [
+      { id: 'p1', covers: ['UC-01'], impact_files: [] },
+      { id: 'p2', covers: ['internal'], impact_files: [] },
+    ];
+    const { uncovered, dangling } = findMissingCovers(ucs, phases);
+    assert.deepStrictEqual(uncovered, []);
+    assert.deepStrictEqual(dangling, []);
+  });
+
+  it('clean run with full coverage returns empty surfaces', () => {
+    const ucs = [{ id: 'UC-01', title: 'A' }, { id: 'UC-02', title: 'B' }];
+    const phases = [
+      { id: 'p1', covers: ['UC-01'], impact_files: [] },
+      { id: 'p2', covers: ['UC-02'], impact_files: [] },
+    ];
+    const { uncovered, dangling } = findMissingCovers(ucs, phases);
+    assert.deepStrictEqual(uncovered, []);
+    assert.deepStrictEqual(dangling, []);
+  });
+
+  it('empty user-contract → empty surfaces (graceful skip mode)', () => {
+    const phases = [{ id: 'p1', covers: ['internal'], impact_files: [] }];
+    const { uncovered, dangling } = findMissingCovers([], phases);
+    assert.deepStrictEqual(uncovered, []);
+    assert.deepStrictEqual(dangling, []);
+  });
+});
+
+/* ────────────────────────── findScopeDrift ───────────────────────────────── */
+
+describe('findScopeDrift', () => {
+  let tmp;
+  beforeEach(() => { tmp = mkdtempSync(join(tmpdir(), 'mpl-f6-')); });
+  afterEach(() => { rmSync(tmp, { recursive: true, force: true }); });
+
+  it('reports git_unavailable: true when not a repo', () => {
+    const drift = findScopeDrift(tmp, []);
+    assert.equal(drift.git_unavailable, true);
+    assert.deepStrictEqual(drift.undeclared, []);
+    assert.deepStrictEqual(drift.unimplemented, []);
+  });
+
+  it('classifies undeclared / unimplemented from a fixed probe', () => {
+    const phases = [
+      { id: 'p1', covers: [], impact_files: ['src/a.ts', 'src/b.ts'] },
+    ];
+    // Inject probes that return a fixed file list (avoids needing a real repo).
+    const drift = findScopeDrift(tmp, phases, {
+      probes: ['echo src/a.ts; echo src/c.ts'],
+    });
+    assert.deepStrictEqual(drift.undeclared, ['src/c.ts']);
+    assert.deepStrictEqual(drift.unimplemented, ['src/b.ts']);
+  });
+
+  it('filters __tests__ and *.test.* from undeclared', () => {
+    const phases = [{ id: 'p1', covers: [], impact_files: ['src/a.ts'] }];
+    const drift = findScopeDrift(tmp, phases, {
+      probes: ['printf "src/a.ts\\nsrc/__tests__/a.test.ts\\nsrc/b.test.ts\\nsrc/d.ts\\n"'],
+    });
+    assert.deepStrictEqual(drift.undeclared, ['src/d.ts']);
+  });
+});
+
+/* ────────────────────────── auditAntiPatternResidual ─────────────────────── */
+
+describe('auditAntiPatternResidual', () => {
+  let tmp;
+  beforeEach(() => { tmp = mkdtempSync(join(tmpdir(), 'mpl-f6-')); });
+  afterEach(() => { rmSync(tmp, { recursive: true, force: true }); });
+
+  it('returns empty when registry is missing', () => {
+    const phases = [{ id: 'p1', covers: [], impact_files: ['src/a.mjs'] }];
+    scaffold(tmp, { 'src/a.mjs': 'const x = 1;' });
+    // Use tmp as both cwd and pluginRoot — no anti-patterns.md will be there
+    const hits = auditAntiPatternResidual(tmp, tmp, phases);
+    assert.deepStrictEqual(hits, []);
+  });
+
+  it('skips files that do not exist on disk (will surface as drift)', () => {
+    const phases = [{ id: 'p1', covers: [], impact_files: ['src/never-existed.mjs'] }];
+    const hits = auditAntiPatternResidual(tmp, REAL_PLUGIN_ROOT, phases);
+    assert.deepStrictEqual(hits, []);
+  });
+
+  it('finds anti-pattern hits in declared impact files', () => {
+    // Use a synthetic registry to keep the test independent of registry drift.
+    const synthRegistry = `# Anti-patterns
+
+## Scope (file extensions)
+
+\`\`\`scope
+.mjs .ts
+\`\`\`
+
+\`\`\`scope-excluded
+.md
+\`\`\`
+
+## Patterns
+
+### F6.test · Synthetic catch
+
+- **id**: \`F6.test\`
+- **category**: \`fallback-poison\`
+- **severity**: \`warn\`
+- **escalation**: \`tier_3_only\`
+- **rationale**: synthetic test fixture for F6
+- **ground-truth count**: 1
+
+\`\`\`regex
+\\?\\?\\s*['"]\\s*['"]
+\`\`\`
+
+\`\`\`permitted-when
+None.
+\`\`\`
+`;
+    scaffold(tmp, {
+      'commands/references/anti-patterns.md': synthRegistry,
+      'src/leaky.mjs': 'export const v = process.env.X ?? "";',
+    });
+    const phases = [{ id: 'phase-9', covers: [], impact_files: ['src/leaky.mjs'] }];
+    const hits = auditAntiPatternResidual(tmp, tmp, phases);
+    assert.equal(hits.length, 1);
+    assert.equal(hits[0].id, 'F6.test');
+    assert.equal(hits[0].phase_id, 'phase-9');
+    assert.equal(hits[0].file, 'src/leaky.mjs');
+  });
+
+  it('respects registry scope (skips files outside extension allowlist)', () => {
+    const synthRegistry = `# Anti-patterns
+
+## Scope (file extensions)
+
+\`\`\`scope
+.ts
+\`\`\`
+
+\`\`\`scope-excluded
+\`\`\`
+
+## Patterns
+
+### F6.test · Synthetic catch
+
+- **id**: \`F6.test\`
+- **category**: \`fallback-poison\`
+- **severity**: \`warn\`
+- **escalation**: \`tier_3_only\`
+- **rationale**: test
+- **ground-truth count**: 1
+
+\`\`\`regex
+forbidden
+\`\`\`
+
+\`\`\`permitted-when
+None.
+\`\`\`
+`;
+    scaffold(tmp, {
+      'commands/references/anti-patterns.md': synthRegistry,
+      'src/in.ts': 'forbidden',
+      'src/out.py': 'forbidden',
+    });
+    const phases = [{
+      id: 'p1', covers: [],
+      impact_files: ['src/in.ts', 'src/out.py'],
+    }];
+    const hits = auditAntiPatternResidual(tmp, tmp, phases);
+    assert.equal(hits.length, 1);
+    assert.equal(hits[0].file, 'src/in.ts');
+  });
+});
+
+/* ────────────────────────── runCodexAudit (envelope) ─────────────────────── */
+
+describe('runCodexAudit envelope', () => {
+  let tmp;
+  beforeEach(() => { tmp = mkdtempSync(join(tmpdir(), 'mpl-f6-')); });
+  afterEach(() => { rmSync(tmp, { recursive: true, force: true }); });
+
+  it('returns verdict=pass when no surfaces fire', () => {
+    scaffold(tmp, {
+      '.mpl/requirements/user-contract.md': SAMPLE_USER_CONTRACT,
+      '.mpl/mpl/decomposition.yaml': SAMPLE_DECOMPOSITION,
+    });
+    const report = runCodexAudit(tmp, REAL_PLUGIN_ROOT, { now: 'NOW' });
+    assert.equal(report.verdict, 'pass');
+    assert.equal(report.summary.missing_covers, 0);
+    assert.equal(report.summary.dangling_covers, 0);
+    assert.equal(report.summary.anti_pattern_residual, 0);
+    assert.equal(report.tier, 4);
+    assert.equal(report.schema_version, 1);
+    assert.equal(report.generated_at, 'NOW');
+    assert.equal(report.inputs.included_ucs, 2);
+    assert.equal(report.inputs.decomposition_phases, 2);
+  });
+
+  it('returns verdict=fail when missing covers > 0', () => {
+    // UC-03 included but no phase covers it.
+    const wider = SAMPLE_USER_CONTRACT.replace(
+      'deferred_cases:',
+      `  - id: "UC-03"
+    title: "Uncovered case"
+    priority: "P1"
+    status: "included"
+    covers_pp: ["PP-A"]
+
+deferred_cases:`,
+    );
+    scaffold(tmp, {
+      '.mpl/requirements/user-contract.md': wider,
+      '.mpl/mpl/decomposition.yaml': SAMPLE_DECOMPOSITION,
+    });
+    const report = runCodexAudit(tmp, REAL_PLUGIN_ROOT, { now: 'NOW' });
+    assert.equal(report.verdict, 'fail');
+    assert.equal(report.summary.missing_covers, 1);
+    assert.equal(report.surfaces.missing_covers[0].uc_id, 'UC-03');
+  });
+
+  it('drift surface alone does NOT fail the verdict (informational only)', () => {
+    scaffold(tmp, {
+      '.mpl/requirements/user-contract.md': SAMPLE_USER_CONTRACT,
+      '.mpl/mpl/decomposition.yaml': SAMPLE_DECOMPOSITION,
+    });
+    const report = runCodexAudit(tmp, REAL_PLUGIN_ROOT, {
+      now: 'NOW',
+      probes: ['echo src/undeclared.ts'],
+    });
+    assert.equal(report.verdict, 'pass');
+    assert.equal(report.summary.drift_undeclared, 1);
+    assert.equal(report.surfaces.drift.undeclared[0], 'src/undeclared.ts');
+  });
+
+  it('tolerates entirely empty workspace (graceful skip)', () => {
+    const report = runCodexAudit(tmp, REAL_PLUGIN_ROOT, { now: 'NOW' });
+    assert.equal(report.verdict, 'pass');
+    assert.equal(report.inputs.decomposition_phases, 0);
+    assert.equal(report.inputs.included_ucs, 0);
+  });
+});
+
+/* ────────────────────────── CLI smoke ────────────────────────────────────── */
+
+describe('mpl-codex-audit CLI', () => {
+  let tmp;
+  beforeEach(() => { tmp = mkdtempSync(join(tmpdir(), 'mpl-f6-')); });
+  afterEach(() => { rmSync(tmp, { recursive: true, force: true }); });
+
+  it('writes audit-report.json and exits 0 on pass', () => {
+    scaffold(tmp, {
+      '.mpl/requirements/user-contract.md': SAMPLE_USER_CONTRACT,
+      '.mpl/mpl/decomposition.yaml': SAMPLE_DECOMPOSITION,
+    });
+    const stdout = execFileSync('node', [CLI_PATH, tmp], { encoding: 'utf-8' });
+    const reportFromStdout = JSON.parse(stdout);
+    assert.equal(reportFromStdout.verdict, 'pass');
+
+    const onDisk = JSON.parse(readFileSync(join(tmp, '.mpl/mpl/audit-report.json'), 'utf-8'));
+    assert.equal(onDisk.verdict, 'pass');
+    assert.equal(onDisk.tier, 4);
+  });
+
+  it('exits 2 on missing workspaceRoot', () => {
+    const missing = join(tmp, 'does-not-exist');
+    let exitCode = 0;
+    try {
+      execFileSync('node', [CLI_PATH, missing], { encoding: 'utf-8', stdio: 'pipe' });
+    } catch (err) {
+      exitCode = err.status;
+    }
+    assert.equal(exitCode, 2);
+  });
+
+  it('exits 0 on fail when audit_residual is not configured (default warn)', () => {
+    // UC-03 included but uncovered → verdict=fail
+    const wider = SAMPLE_USER_CONTRACT.replace(
+      'deferred_cases:',
+      `  - id: "UC-03"
+    title: "Uncovered"
+    priority: "P1"
+    status: "included"
+    covers_pp: ["PP-A"]
+
+deferred_cases:`,
+    );
+    scaffold(tmp, {
+      '.mpl/requirements/user-contract.md': wider,
+      '.mpl/mpl/decomposition.yaml': SAMPLE_DECOMPOSITION,
+    });
+    const stdout = execFileSync('node', [CLI_PATH, tmp], { encoding: 'utf-8' });
+    const report = JSON.parse(stdout);
+    assert.equal(report.verdict, 'fail');
+    // exit 0 because no enforcement.audit_residual = 'block' set
+  });
+
+  it('exits 1 on fail when enforcement.audit_residual === block', () => {
+    const wider = SAMPLE_USER_CONTRACT.replace(
+      'deferred_cases:',
+      `  - id: "UC-03"
+    title: "Uncovered"
+    priority: "P1"
+    status: "included"
+    covers_pp: ["PP-A"]
+
+deferred_cases:`,
+    );
+    scaffold(tmp, {
+      '.mpl/requirements/user-contract.md': wider,
+      '.mpl/mpl/decomposition.yaml': SAMPLE_DECOMPOSITION,
+      '.mpl/config.json': JSON.stringify({
+        enforcement: { audit_residual: 'block' },
+      }),
+    });
+    let exitCode = 0;
+    let stdout;
+    try {
+      stdout = execFileSync('node', [CLI_PATH, tmp], { encoding: 'utf-8' });
+    } catch (err) {
+      exitCode = err.status;
+      stdout = err.stdout?.toString() ?? '';
+    }
+    assert.equal(exitCode, 1, 'block policy must elevate fail to exit 1');
+    const report = JSON.parse(stdout);
+    assert.equal(report.verdict, 'fail');
+  });
+});

--- a/hooks/lib/mpl-codex-audit.mjs
+++ b/hooks/lib/mpl-codex-audit.mjs
@@ -43,11 +43,29 @@ import { loadRegistry, scanContent, isInScope } from './anti-pattern-registry.mj
 /* ────────────────────────── User contract parsing ────────────────────────── */
 
 /**
+ * Legacy graceful-skip mode signal. Mirrors `mpl-require-covers.mjs#isLegacyMode`
+ * verbatim — file absence is the canonical signal that the project predates
+ * 0.16 Tier B and never produced a UC contract. Both `findMissingCovers`
+ * surfaces (uncovered + dangling) are suppressed in this mode so an F6 fail
+ * cannot block a finalize that the existing covers hook accepts.
+ *
+ * PR #136 review (Codex HIGH) fix: pre-fix, every non-`internal` phase cover
+ * was reported as dangling when user-contract.md was absent (because the
+ * included set was empty). That contradicted the require-covers contract and
+ * could halt finalize under `enforcement.audit_residual = 'block'` or strict
+ * mode for a legitimately-graceful pipeline.
+ */
+export function isLegacyContractMode(cwd) {
+  return !existsSync(join(cwd, '.mpl/requirements/user-contract.md'));
+}
+
+/**
  * Extract every `included` UC id from `.mpl/requirements/user-contract.md`.
  * The file is YAML embedded inside a markdown wrapper; we use a regex pass
  * keyed on `id: "UC-NN"` lines under the `user_cases:` block. The
  * graceful-skip mode (file absent → empty user_cases) is tolerated by
- * returning an empty array.
+ * returning an empty array — caller must combine with `isLegacyContractMode`
+ * to distinguish "no contract" from "empty contract" semantics.
  *
  * Returns `[{ id, title }]`. `title` is best-effort (next non-empty
  * line containing `title:`) — used only for human-readable surface.
@@ -66,15 +84,25 @@ export function enumerateIncludedUserCases(cwd) {
   // We walk lines to avoid the off-by-one risk of slice(1)+search/m: that
   // pattern matches the leftover `ser_cases:` substring on the very next
   // character of the slice, terminating the block before any UC is read.
+  // PR #136 review #3 (Claude 🟡): allow indented `user_cases:` so an author
+  // who places the YAML inside an indented markdown fence still parses.
   const lines = content.split('\n');
-  const startIdx = lines.findIndex(l => /^user_cases\s*:/.test(l));
+  const startIdx = lines.findIndex(l => /^\s*user_cases\s*:/.test(l));
   if (startIdx < 0) return [];
+
+  // Capture the indent of `user_cases:` so the section-end check stops on a
+  // sibling key at the SAME level rather than any column-0 key.
+  const sectionIndent = (lines[startIdx].match(/^(\s*)/) ?? ['', ''])[1].length;
 
   let endIdx = lines.length;
   for (let i = startIdx + 1; i < lines.length; i++) {
-    if (/^[a-z_]+\s*:\s*$/.test(lines[i])) { endIdx = i; break; }
+    const line = lines[i];
+    const indentMatch = line.match(/^(\s*)([a-z_]+)\s*:\s*$/);
+    if (indentMatch && indentMatch[1].length === sectionIndent) {
+      endIdx = i; break;
+    }
     // Closing fence ends the YAML block too.
-    if (/^```/.test(lines[i])) { endIdx = i; break; }
+    if (/^\s*```/.test(line)) { endIdx = i; break; }
   }
   const userCasesBlock = lines.slice(startIdx, endIdx).join('\n');
 
@@ -127,8 +155,12 @@ export function parseDecompositionPhases(cwd) {
   try { content = readFileSync(path, 'utf-8'); }
   catch { return []; }
 
+  // PR #136 review #2 (Claude 🟡): allow any indent depth for the phase
+  // entry. Pre-fix `^  - id:\s*` (exact 2-space) silent-broke when the
+  // decomposer wraps `phases:` deeper (future task/meta layer) — every
+  // phase block was missed and the audit returned `phases: []` quietly.
   const phases = [];
-  const blocks = content.split(/^  - id:\s*/m).slice(1);
+  const blocks = content.split(/^\s*-\s+id\s*:\s*/m).slice(1);
 
   for (const block of blocks) {
     const lines = block.split('\n');
@@ -174,22 +206,28 @@ function parseCoversArray(block) {
 
 function parseImpactFiles(block) {
   // Walk `impact:` subsections create/modify only (intent-bearing scope).
-  // Each entry is `      - path: "..."` or bare `      - "..."`.
+  // PR #136 review #1 (Claude 🟡): use indent-tolerant matching with the
+  // captured leading whitespace as the section's anchor depth, then accept
+  // any deeper indent for the bullet entries. Pre-fix `\s{4,6}` literal
+  // silent-broke if the decomposer ever wraps `phases:` in a meta layer.
   const lines = block.split('\n');
   const files = new Set();
-  let activeSection = null; // 'create' | 'modify' | null
+  let activeSection = null;   // 'create' | 'modify' | null
+  let sectionIndent = -1;     // column where active section's key starts
   for (const line of lines) {
-    const sectionMatch = line.match(/^\s{4,6}(create|modify|affected_tests|affected_config)\s*:\s*$/);
+    const sectionMatch = line.match(/^(\s+)(create|modify|affected_tests|affected_config)\s*:\s*$/);
     if (sectionMatch) {
-      activeSection = (sectionMatch[1] === 'create' || sectionMatch[1] === 'modify')
-        ? sectionMatch[1]
-        : null;
+      const isImpactKey = (sectionMatch[2] === 'create' || sectionMatch[2] === 'modify');
+      activeSection = isImpactKey ? sectionMatch[2] : null;
+      sectionIndent = sectionMatch[1].length;
       continue;
     }
     if (!activeSection) continue;
-    // Stop when we hit another sibling key (e.g. `interface_contract:`)
-    if (/^\s{2,4}[a-z_]+\s*:\s*$/.test(line) && !line.includes('  - ')) {
+    // Stop when we hit another sibling key at SAME indent (e.g. `interface_contract:`).
+    const siblingMatch = line.match(/^(\s+)[a-z_]+\s*:\s*$/);
+    if (siblingMatch && siblingMatch[1].length === sectionIndent) {
       activeSection = null;
+      sectionIndent = -1;
       continue;
     }
     const pathInline = line.match(/^\s+-\s+path\s*:\s*["']?([^"'\n]+)["']?/);
@@ -269,10 +307,18 @@ export function auditAntiPatternResidual(cwd, pluginRoot, phases) {
  *
  * The single-escape `["internal"]` is honored — internal-only phases don't
  * contribute to coverage but also don't dangle.
+ *
+ * `opts.legacy = true` (PR #136 review Codex HIGH fix): legacy graceful-skip
+ * mode signal from `isLegacyContractMode`. When set, both surfaces collapse
+ * to empty arrays — the project predates the UC contract and shouldn't be
+ * audited against an empty included set. Mirrors `mpl-require-covers.mjs#isLegacyMode`.
  */
-export function findMissingCovers(includedUCs, phases) {
+export function findMissingCovers(includedUCs, phases, opts = {}) {
+  if (opts.legacy === true) {
+    return { uncovered: [], dangling: [] };
+  }
+
   const includedIds = new Set(includedUCs.map(uc => uc.id));
-  const titleById = new Map(includedUCs.map(uc => [uc.id, uc.title]));
 
   const claimed = new Set();
   const dangling = [];
@@ -334,14 +380,29 @@ export function findScopeDrift(cwd, phases, opts = {}) {
 }
 
 function collectActualChanges(cwd, opts = {}) {
-  // `mpl-state.json` knows how many phase commits have landed (`phases.completed`),
-  // but reading it from here would couple two libs. Use a cheap fallback:
-  // diff against the merge-base with main if available, else last 20 commits,
-  // else cached/staged. Returns null when git itself is unreachable.
+  // F6 runs at finalize-time BEFORE the Git Master commit step (5.3), so
+  // the implementation is typically still in the working tree (unstaged
+  // and/or staged) and not yet committed — and brand-new files are still
+  // untracked (no `git add` yet). Probe order:
+  //
+  //   1. `{ git diff --name-only HEAD; git ls-files --others --exclude-standard; }`
+  //      — tracked-modified-vs-HEAD UNION untracked files. PR #136 review
+  //      (Codex MEDIUM) fix: pre-fix probe chain missed unstaged created
+  //      files entirely; even after switching to `--name-only HEAD` we
+  //      still missed pure untracked files (which are the COMMON case at
+  //      finalize-time since `git add` hasn't happened yet).
+  //   2. `git diff --name-only --cached` — staged-only fallback.
+  //   3. merge-base..HEAD — committed range vs default branch. PR #136
+  //      review #4 (Claude 🟡): dynamic origin/HEAD lookup so master /
+  //      develop / trunk repos aren't penalized.
+  //   4. HEAD~20..HEAD — last-20-commits fallback.
+  //
+  // Returns null when git itself is unreachable.
   const probes = opts.probes ?? [
-    'git diff --name-only $(git merge-base HEAD main 2>/dev/null || echo HEAD~20)..HEAD 2>/dev/null',
+    '{ git diff --name-only HEAD 2>/dev/null; git ls-files --others --exclude-standard 2>/dev/null; }',
+    'git diff --name-only --cached 2>/dev/null',
+    'git diff --name-only $(git merge-base HEAD $(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null || echo origin/main) 2>/dev/null || echo HEAD~20)..HEAD 2>/dev/null',
     'git diff --name-only HEAD~20..HEAD 2>/dev/null',
-    'git diff --name-only --cached',
   ];
   for (const cmd of probes) {
     try {
@@ -383,9 +444,10 @@ function collectActualChanges(cwd, opts = {}) {
 export function runCodexAudit(cwd, pluginRoot, opts = {}) {
   const phases = parseDecompositionPhases(cwd);
   const includedUCs = enumerateIncludedUserCases(cwd);
+  const legacy = isLegacyContractMode(cwd);
 
   const antiPatternResidual = auditAntiPatternResidual(cwd, pluginRoot, phases);
-  const { uncovered, dangling } = findMissingCovers(includedUCs, phases);
+  const { uncovered, dangling } = findMissingCovers(includedUCs, phases, { legacy });
   const drift = findScopeDrift(cwd, phases, opts);
 
   const verdict = (antiPatternResidual.length === 0
@@ -399,6 +461,7 @@ export function runCodexAudit(cwd, pluginRoot, opts = {}) {
     tier: 4,
     generated_at: opts.now ?? new Date().toISOString(),
     verdict,
+    contract_mode: legacy ? 'legacy_skip' : 'enforced',
     summary: {
       anti_pattern_residual: antiPatternResidual.length,
       missing_covers: uncovered.length,

--- a/hooks/lib/mpl-codex-audit.mjs
+++ b/hooks/lib/mpl-codex-audit.mjs
@@ -45,15 +45,21 @@ import { loadRegistry, scanContent, isInScope } from './anti-pattern-registry.mj
 /**
  * Legacy graceful-skip mode signal. Mirrors `mpl-require-covers.mjs#isLegacyMode`
  * verbatim — file absence is the canonical signal that the project predates
- * 0.16 Tier B and never produced a UC contract. Both `findMissingCovers`
- * surfaces (uncovered + dangling) are suppressed in this mode so an F6 fail
- * cannot block a finalize that the existing covers hook accepts.
+ * 0.16 Tier B and never produced a UC contract.
  *
- * PR #136 review (Codex HIGH) fix: pre-fix, every non-`internal` phase cover
- * was reported as dangling when user-contract.md was absent (because the
- * included set was empty). That contradicted the require-covers contract and
- * could halt finalize under `enforcement.audit_residual = 'block'` or strict
- * mode for a legitimately-graceful pipeline.
+ * Note: this is one of TWO graceful-skip signals (see `runCodexAudit`). File-
+ * absent is mode `legacy_skip`; file-present with empty `user_cases:` (Phase
+ * 0's graceful-skip output for legacy projects per `commands/mpl-run-phase0.md`
+ * line 228, `Skip condition: Legacy projects (pre-0.16) ... write graceful-skip
+ * user-contract.md with user_cases: []`) is mode `empty_skip`. Both suppress
+ * `findMissingCovers` surfaces.
+ *
+ * PR #136 review (Codex HIGH + follow-up) fix: pre-fix, every non-`internal`
+ * phase cover was reported as dangling when no UC was included (whether due
+ * to file absence OR Phase 0's explicit empty-list graceful skip). That
+ * contradicted the require-covers contract and could halt finalize under
+ * `enforcement.audit_residual = 'block'` or strict mode for a legitimately-
+ * graceful pipeline.
  */
 export function isLegacyContractMode(cwd) {
   return !existsSync(join(cwd, '.mpl/requirements/user-contract.md'));
@@ -444,10 +450,20 @@ function collectActualChanges(cwd, opts = {}) {
 export function runCodexAudit(cwd, pluginRoot, opts = {}) {
   const phases = parseDecompositionPhases(cwd);
   const includedUCs = enumerateIncludedUserCases(cwd);
-  const legacy = isLegacyContractMode(cwd);
+  const fileAbsent = isLegacyContractMode(cwd);
+  // PR #136 Codex follow-up fix: Phase 0 graceful-skip writes a real
+  // `user-contract.md` with `user_cases: []` (see commands/mpl-run-phase0.md
+  // line 228). Treat empty-included as graceful too — same effective contract
+  // as file-absent. The two are surfaced separately in `contract_mode` for
+  // diagnostic clarity but share the same suppression behavior.
+  const emptyIncluded = !fileAbsent && includedUCs.length === 0;
+  const graceful = fileAbsent || emptyIncluded;
+  const contractMode = fileAbsent ? 'legacy_skip'
+    : emptyIncluded ? 'empty_skip'
+    : 'enforced';
 
   const antiPatternResidual = auditAntiPatternResidual(cwd, pluginRoot, phases);
-  const { uncovered, dangling } = findMissingCovers(includedUCs, phases, { legacy });
+  const { uncovered, dangling } = findMissingCovers(includedUCs, phases, { legacy: graceful });
   const drift = findScopeDrift(cwd, phases, opts);
 
   const verdict = (antiPatternResidual.length === 0
@@ -461,7 +477,7 @@ export function runCodexAudit(cwd, pluginRoot, opts = {}) {
     tier: 4,
     generated_at: opts.now ?? new Date().toISOString(),
     verdict,
-    contract_mode: legacy ? 'legacy_skip' : 'enforced',
+    contract_mode: contractMode,
     summary: {
       anti_pattern_residual: antiPatternResidual.length,
       missing_covers: uncovered.length,

--- a/hooks/lib/mpl-codex-audit.mjs
+++ b/hooks/lib/mpl-codex-audit.mjs
@@ -1,0 +1,420 @@
+/**
+ * MPL Codex Auditor (F6, #117) — Tier 4 last-mile audit.
+ *
+ * Tier 1+2+3 (F2 hook scan, F3 anti-pattern registry, F5 property check)
+ * catch ~7/8 of MPL-spec violations during execution. F6 is the
+ * finalize-time sweep that catches the last 1/8 by cross-referencing
+ * intent (decomposition.yaml + user-contract.md) against implementation
+ * (declared impact files + git changes).
+ *
+ * Three audit surfaces — each one mechanically derived; no LLM call here.
+ * The agent prompt (`agents/mpl-codex-auditor.md`) wraps this CLI for
+ * orchestrator dispatch; raw findings are emitted as `audit-report.json`
+ * at `.mpl/mpl/audit-report.json` and surfaced to the user.
+ *
+ *   1. anti_pattern_residual — re-scan files declared in decomposition.yaml
+ *      (create + modify) using the F3 anti-pattern registry. Tier 1+2+3
+ *      caught most at write-time; this surface lists what survived.
+ *
+ *   2. missing_covers — every `included` UC in user-contract.md must be
+ *      covered by at least one phase. Phases that claim `covers: [UC-N]`
+ *      must reference UCs that actually exist as included.
+ *
+ *   3. drift — declared phase impact (create + modify paths) vs git
+ *      changed files. `undeclared` are files touched but not in any
+ *      phase scope; `unimplemented` are declared paths with no diff
+ *      footprint. Mirrors Step 5.1.5's informational drift report but
+ *      collapsed into the audit-report verdict surface.
+ *
+ * Verdict policy (mirrors P0-2 enforcement style):
+ *   - `pass` — no anti-pattern hits AND no missing covers
+ *   - `fail` — any of the above non-empty
+ *   - drift surface is informational only (matches 5.1.5 contract)
+ *
+ * Pure functions. CLI handles I/O, exit codes, and signal logging.
+ */
+
+import { readFileSync, existsSync, statSync } from 'fs';
+import { join, relative } from 'path';
+import { execSync } from 'child_process';
+
+import { loadRegistry, scanContent, isInScope } from './anti-pattern-registry.mjs';
+
+/* ────────────────────────── User contract parsing ────────────────────────── */
+
+/**
+ * Extract every `included` UC id from `.mpl/requirements/user-contract.md`.
+ * The file is YAML embedded inside a markdown wrapper; we use a regex pass
+ * keyed on `id: "UC-NN"` lines under the `user_cases:` block. The
+ * graceful-skip mode (file absent → empty user_cases) is tolerated by
+ * returning an empty array.
+ *
+ * Returns `[{ id, title }]`. `title` is best-effort (next non-empty
+ * line containing `title:`) — used only for human-readable surface.
+ */
+export function enumerateIncludedUserCases(cwd) {
+  const path = join(cwd, '.mpl/requirements/user-contract.md');
+  if (!existsSync(path)) return [];
+
+  let content;
+  try { content = readFileSync(path, 'utf-8'); }
+  catch { return []; }
+
+  // Locate the `user_cases:` section. Stop at the next top-level YAML key
+  // (`deferred_cases:`, `cut_cases:`, `scenarios:`, `pp_conflict_log:`,
+  // `ambiguity_hints:`) so deferred/cut UCs are not treated as included.
+  // We walk lines to avoid the off-by-one risk of slice(1)+search/m: that
+  // pattern matches the leftover `ser_cases:` substring on the very next
+  // character of the slice, terminating the block before any UC is read.
+  const lines = content.split('\n');
+  const startIdx = lines.findIndex(l => /^user_cases\s*:/.test(l));
+  if (startIdx < 0) return [];
+
+  let endIdx = lines.length;
+  for (let i = startIdx + 1; i < lines.length; i++) {
+    if (/^[a-z_]+\s*:\s*$/.test(lines[i])) { endIdx = i; break; }
+    // Closing fence ends the YAML block too.
+    if (/^```/.test(lines[i])) { endIdx = i; break; }
+  }
+  const userCasesBlock = lines.slice(startIdx, endIdx).join('\n');
+
+  const cases = [];
+  // Each UC begins with `- id: "UC-NN"`. We walk those entries and
+  // capture title + status. Only `status: included` (or status absent
+  // because the included section's bullets sometimes omit the explicit
+  // line — schema says "이 섹션은 included만") survives.
+  const ucBlocks = userCasesBlock.split(/^\s*-\s+id\s*:\s*/m).slice(1);
+  for (const block of ucBlocks) {
+    const idMatch = block.match(/^["']?(UC-[\w-]+)["']?/);
+    if (!idMatch) continue;
+    const id = idMatch[1];
+
+    // Hard-stop at the next bullet boundary (next `- id:` was already
+    // consumed by the split, but a stray `- ` for steps inside should
+    // not bleed).  Title and status only need to match within the same
+    // bullet body.
+    const titleMatch = block.match(/^\s*title\s*:\s*["']?([^"'\n]+)["']?/m);
+    const statusMatch = block.match(/^\s*status\s*:\s*["']?([\w-]+)["']?/m);
+    const status = statusMatch ? statusMatch[1] : 'included';
+    if (status !== 'included') continue;
+
+    cases.push({
+      id,
+      title: titleMatch ? titleMatch[1].trim() : '',
+    });
+  }
+
+  return cases;
+}
+
+/* ────────────────────────── Decomposition parsing ────────────────────────── */
+
+/**
+ * Parse decomposition.yaml into `[{ id, covers, impact_files }]` where
+ * `impact_files` is the union of `create` + `modify` paths (excluding
+ * `affected_tests` and `affected_config` — those are downstream artifacts
+ * and don't represent intent-bearing scope for the drift comparison).
+ *
+ * Reuses the regex parsing approach from `mpl-decomposition-parser.mjs`
+ * (no YAML dependency). Differs in that it preserves the section-of-origin
+ * for each path and includes the `covers` array.
+ */
+export function parseDecompositionPhases(cwd) {
+  const path = join(cwd, '.mpl/mpl/decomposition.yaml');
+  if (!existsSync(path)) return [];
+
+  let content;
+  try { content = readFileSync(path, 'utf-8'); }
+  catch { return []; }
+
+  const phases = [];
+  const blocks = content.split(/^  - id:\s*/m).slice(1);
+
+  for (const block of blocks) {
+    const lines = block.split('\n');
+    const id = lines[0]?.replace(/["']/g, '').trim();
+    if (!id) continue;
+
+    const covers = parseCoversArray(block);
+    const impact = parseImpactFiles(block);
+
+    phases.push({ id, covers, impact_files: impact });
+  }
+
+  return phases;
+}
+
+function parseCoversArray(block) {
+  // Match `covers: [UC-01, UC-02]` (inline) OR
+  //   covers:
+  //     - "UC-01"
+  //     - "UC-02"
+  // Inline form check first so YAML-list form below doesn't re-capture.
+  const inline = block.match(/^\s*covers\s*:\s*\[([^\]]*)\]/m);
+  if (inline) {
+    return inline[1]
+      .split(',')
+      .map(s => s.trim().replace(/^["']|["']$/g, ''))
+      .filter(Boolean);
+  }
+
+  const out = [];
+  const lines = block.split('\n');
+  let inCovers = false;
+  for (const line of lines) {
+    if (/^\s*covers\s*:\s*$/.test(line)) { inCovers = true; continue; }
+    if (!inCovers) continue;
+    const item = line.match(/^\s*-\s*["']?([\w-]+)["']?\s*$/);
+    if (item) { out.push(item[1]); continue; }
+    // Any non-list line ends the covers section.
+    if (/^\s*[a-z_]+\s*:/.test(line)) break;
+  }
+  return out;
+}
+
+function parseImpactFiles(block) {
+  // Walk `impact:` subsections create/modify only (intent-bearing scope).
+  // Each entry is `      - path: "..."` or bare `      - "..."`.
+  const lines = block.split('\n');
+  const files = new Set();
+  let activeSection = null; // 'create' | 'modify' | null
+  for (const line of lines) {
+    const sectionMatch = line.match(/^\s{4,6}(create|modify|affected_tests|affected_config)\s*:\s*$/);
+    if (sectionMatch) {
+      activeSection = (sectionMatch[1] === 'create' || sectionMatch[1] === 'modify')
+        ? sectionMatch[1]
+        : null;
+      continue;
+    }
+    if (!activeSection) continue;
+    // Stop when we hit another sibling key (e.g. `interface_contract:`)
+    if (/^\s{2,4}[a-z_]+\s*:\s*$/.test(line) && !line.includes('  - ')) {
+      activeSection = null;
+      continue;
+    }
+    const pathInline = line.match(/^\s+-\s+path\s*:\s*["']?([^"'\n]+)["']?/);
+    if (pathInline) { files.add(pathInline[1].trim()); continue; }
+    const pathBare = line.match(/^\s+-\s+["']?([^"'\n#]+\.[\w]+)["']?\s*$/);
+    if (pathBare) { files.add(pathBare[1].trim()); continue; }
+  }
+  return [...files];
+}
+
+/* ────────────────────────── Surface 1: anti-pattern residual ─────────────── */
+
+/**
+ * Scan declared phase impact files against the F3 registry. Files that
+ * don't exist on disk (e.g. phase planned but not yet implemented) are
+ * skipped silently — they will surface as `drift.unimplemented` instead.
+ *
+ * Returns `[{ phase_id, file, id (pattern), severity, line, snippet }]`.
+ */
+export function auditAntiPatternResidual(cwd, pluginRoot, phases) {
+  const registryPath = join(pluginRoot, 'commands', 'references', 'anti-patterns.md');
+  if (!existsSync(registryPath)) return [];
+
+  let registry;
+  try { registry = loadRegistry(registryPath); }
+  catch { return []; }
+
+  const hits = [];
+  const seen = new Set();
+  for (const phase of phases) {
+    for (const rel of phase.impact_files) {
+      const key = `${phase.id} ${rel}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+
+      // Anti-pattern registry has explicit scope (file extension allowlist
+      // + agent/registry self-exclusion). Defer to it — keeps audit
+      // consistent with how Tier 1 hook decides scope.
+      if (!isInScope(rel, registry.scope)) continue;
+
+      const abs = join(cwd, rel);
+      if (!existsSync(abs)) continue;
+      try {
+        const stat = statSync(abs);
+        if (!stat.isFile()) continue;
+      } catch { continue; }
+
+      let content;
+      try { content = readFileSync(abs, 'utf-8'); }
+      catch { continue; }
+
+      const fileHits = scanContent(content, registry.patterns);
+      for (const h of fileHits) {
+        hits.push({
+          phase_id: phase.id,
+          file: rel,
+          id: h.id,
+          severity: h.severity,
+          line: h.line,
+          snippet: h.snippet,
+        });
+      }
+    }
+  }
+  return hits;
+}
+
+/* ────────────────────────── Surface 2: missing covers ────────────────────── */
+
+/**
+ * Cross-check user-contract.md included UCs against decomposition phases.
+ *
+ * Two failure modes:
+ *   - `uncovered` — included UC that no phase claims
+ *   - `dangling`  — phase claims `covers: [UC-N]` but UC-N is not included
+ *                   (typo, deferred-status drift, or stale decomposition)
+ *
+ * The single-escape `["internal"]` is honored — internal-only phases don't
+ * contribute to coverage but also don't dangle.
+ */
+export function findMissingCovers(includedUCs, phases) {
+  const includedIds = new Set(includedUCs.map(uc => uc.id));
+  const titleById = new Map(includedUCs.map(uc => [uc.id, uc.title]));
+
+  const claimed = new Set();
+  const dangling = [];
+  for (const phase of phases) {
+    for (const c of phase.covers) {
+      if (c === 'internal') continue;
+      claimed.add(c);
+      if (!includedIds.has(c)) {
+        dangling.push({ phase_id: phase.id, uc_id: c, reason: 'phase claims UC not in included user_cases' });
+      }
+    }
+  }
+
+  const uncovered = [];
+  for (const uc of includedUCs) {
+    if (!claimed.has(uc.id)) {
+      uncovered.push({ uc_id: uc.id, title: uc.title, reason: 'no phase covers this included UC' });
+    }
+  }
+
+  return { uncovered, dangling };
+}
+
+/* ────────────────────────── Surface 3: drift ─────────────────────────────── */
+
+/**
+ * Compare declared phase impact files against actual git diff. The
+ * comparison is over the union of all phase `impact_files` — F6 is a
+ * finalize-time audit, so per-phase attribution is less interesting than
+ * the rolled-up "what shipped that wasn't planned" / "what was planned
+ * that didn't ship" view.
+ *
+ * Test artifacts and migrations metadata are filtered: regex `^.*\.test\.`
+ * matches `__tests__` files and `.test.mjs`, which are auto-derived from
+ * implementation files and trivially undeclared. These show up in
+ * RUNBOOK's V-05 drift report by design but we don't surface them here.
+ *
+ * Errors from `git diff` (no commits, not a repo) collapse to empty
+ * undeclared/unimplemented — the audit completes with a `git_unavailable: true`
+ * note in the surface.
+ */
+export function findScopeDrift(cwd, phases, opts = {}) {
+  const declared = new Set();
+  for (const phase of phases) {
+    for (const f of phase.impact_files) declared.add(f);
+  }
+
+  const actual = collectActualChanges(cwd, opts);
+  if (actual === null) {
+    return { undeclared: [], unimplemented: [], git_unavailable: true };
+  }
+
+  const filtered = actual.filter(f => !/(^|\/)__tests__\//.test(f) && !/\.test\./.test(f));
+
+  const undeclared = filtered.filter(f => !declared.has(f));
+  const unimplemented = [...declared].filter(f => !actual.includes(f));
+
+  return { undeclared, unimplemented };
+}
+
+function collectActualChanges(cwd, opts = {}) {
+  // `mpl-state.json` knows how many phase commits have landed (`phases.completed`),
+  // but reading it from here would couple two libs. Use a cheap fallback:
+  // diff against the merge-base with main if available, else last 20 commits,
+  // else cached/staged. Returns null when git itself is unreachable.
+  const probes = opts.probes ?? [
+    'git diff --name-only $(git merge-base HEAD main 2>/dev/null || echo HEAD~20)..HEAD 2>/dev/null',
+    'git diff --name-only HEAD~20..HEAD 2>/dev/null',
+    'git diff --name-only --cached',
+  ];
+  for (const cmd of probes) {
+    try {
+      const out = execSync(cmd, { cwd, stdio: ['ignore', 'pipe', 'ignore'], encoding: 'utf-8' });
+      const files = out.split('\n').map(l => l.trim()).filter(Boolean);
+      if (files.length > 0) return files;
+    } catch { /* try next */ }
+  }
+  // No diff probe yielded files — distinguish "really clean" from "git missing".
+  try {
+    execSync('git rev-parse --git-dir', { cwd, stdio: ['ignore', 'pipe', 'ignore'] });
+    return [];
+  } catch {
+    return null;
+  }
+}
+
+/* ────────────────────────── Top-level audit runner ───────────────────────── */
+
+/**
+ * Run all three surfaces against a workspace and produce the audit-report
+ * envelope. Pure data — CLI is responsible for writing it to disk and
+ * deriving exit codes.
+ *
+ * @param {string} cwd - workspace root (the project being audited)
+ * @param {string} pluginRoot - MPL plugin root (where anti-patterns.md lives)
+ * @returns {{
+ *   schema_version: 1,
+ *   tier: 4,
+ *   generated_at: string,
+ *   verdict: 'pass' | 'fail',
+ *   summary: { anti_pattern_residual: number, missing_covers: number,
+ *              dangling_covers: number, drift_undeclared: number,
+ *              drift_unimplemented: number },
+ *   surfaces: { ... },
+ *   inputs: { decomposition_phases: number, included_ucs: number }
+ * }}
+ */
+export function runCodexAudit(cwd, pluginRoot, opts = {}) {
+  const phases = parseDecompositionPhases(cwd);
+  const includedUCs = enumerateIncludedUserCases(cwd);
+
+  const antiPatternResidual = auditAntiPatternResidual(cwd, pluginRoot, phases);
+  const { uncovered, dangling } = findMissingCovers(includedUCs, phases);
+  const drift = findScopeDrift(cwd, phases, opts);
+
+  const verdict = (antiPatternResidual.length === 0
+    && uncovered.length === 0
+    && dangling.length === 0)
+    ? 'pass'
+    : 'fail';
+
+  return {
+    schema_version: 1,
+    tier: 4,
+    generated_at: opts.now ?? new Date().toISOString(),
+    verdict,
+    summary: {
+      anti_pattern_residual: antiPatternResidual.length,
+      missing_covers: uncovered.length,
+      dangling_covers: dangling.length,
+      drift_undeclared: drift.undeclared.length,
+      drift_unimplemented: drift.unimplemented.length,
+    },
+    surfaces: {
+      anti_pattern_residual: antiPatternResidual,
+      missing_covers: uncovered,
+      dangling_covers: dangling,
+      drift,
+    },
+    inputs: {
+      decomposition_phases: phases.length,
+      included_ucs: includedUCs.length,
+    },
+  };
+}

--- a/hooks/lib/mpl-config.mjs
+++ b/hooks/lib/mpl-config.mjs
@@ -56,6 +56,7 @@ const ENFORCEMENT_DEFAULTS = {
   anti_pattern_match: 'warn',
   state_invariant_violation: 'warn',
   bash_timeout_violation: 'warn',
+  audit_residual: 'warn',
 };
 
 const DEFAULTS = {

--- a/hooks/mpl-codex-audit.mjs
+++ b/hooks/mpl-codex-audit.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+/**
+ * MPL Codex Auditor CLI (F6, #117) — finalize-time Tier 4 sweep.
+ *
+ * Invoked from `commands/mpl-run-finalize.md` Step 5.1.6:
+ *
+ *   node "${CLAUDE_PLUGIN_ROOT}/hooks/mpl-codex-audit.mjs" "$(pwd)"
+ *
+ * Writes `<workspaceRoot>/.mpl/mpl/audit-report.json` and emits the same
+ * JSON to stdout for the orchestrator to surface.
+ *
+ * Exit codes:
+ *   0 — audit ran (verdict may be pass OR fail; orchestrator surfaces
+ *       findings; finalize continues unless enforcement.audit_residual = 'block')
+ *   1 — verdict=fail AND enforcement.audit_residual === 'block'
+ *       (strict mode — finalize halts; user must address residuals)
+ *   2 — usage error (missing or invalid workspaceRoot)
+ *
+ * Enforcement is read via P0-2 `resolveRuleAction` so the same warn/block/off
+ * tri-state pattern as the other Tier-policy hooks applies. Default 'warn'
+ * keeps the audit informational unless a project explicitly opts into strict
+ * blocking.
+ */
+
+import { dirname, join, resolve } from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+import { existsSync, mkdirSync, writeFileSync } from 'fs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const PLUGIN_ROOT = resolve(__dirname, '..');
+
+const { runCodexAudit } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-codex-audit.mjs')).href
+);
+
+let resolveRuleAction;
+try {
+  ({ resolveRuleAction } = await import(
+    pathToFileURL(join(__dirname, 'lib', 'mpl-enforcement.mjs')).href
+  ));
+} catch {
+  // mpl-enforcement.mjs missing → default to 'warn' (graceful degrade so
+  // the CLI is still useful in standalone smoke runs).
+  resolveRuleAction = () => 'warn';
+}
+
+let readState;
+try {
+  ({ readState } = await import(
+    pathToFileURL(join(__dirname, 'lib', 'mpl-state.mjs')).href
+  ));
+} catch {
+  readState = () => null;
+}
+
+const argRoot = process.argv[2];
+const cwd = argRoot ? resolve(argRoot) : process.cwd();
+
+if (!existsSync(cwd)) {
+  console.error(JSON.stringify({ error: `workspaceRoot not found: ${cwd}` }));
+  process.exit(2);
+}
+
+const report = runCodexAudit(cwd, PLUGIN_ROOT);
+
+// Persist alongside other phase artifacts. Directory is created lazily —
+// fresh workspaces (no `.mpl/mpl/`) shouldn't fail the audit just because
+// the artifact dir doesn't exist yet.
+const outDir = join(cwd, '.mpl', 'mpl');
+const outPath = join(outDir, 'audit-report.json');
+try {
+  mkdirSync(outDir, { recursive: true });
+  writeFileSync(outPath, JSON.stringify(report, null, 2) + '\n');
+} catch (err) {
+  // Disk write failed — surface but don't lose the JSON; stdout is the
+  // primary channel for the orchestrator.
+  console.error(JSON.stringify({ warn: `audit-report write failed: ${err.message}` }));
+}
+
+process.stdout.write(JSON.stringify(report, null, 2) + '\n');
+
+const state = readState(cwd);
+const action = resolveRuleAction(cwd, state, 'audit_residual');
+if (report.verdict === 'fail' && action === 'block') {
+  process.exit(1);
+}
+process.exit(0);


### PR DESCRIPTION
Closes #117 (F6 codex agent audit — Tier 4 last-mile).

## Summary

Tier 1+2+3 (F2 hook scan / F3 anti-pattern registry / F5 property check) catch ~7/8 of MPL spec violations during execution. F6 is the **finalize-time sweep** that catches the remaining 1/8 by cross-referencing intent (`decomposition.yaml` + `user-contract.md`) against implementation (declared impact files + git diff).

## Architecture

| Layer | File | Role |
|---|---|---|
| Pure lib | `hooks/lib/mpl-codex-audit.mjs` | 5 exports: `enumerateIncludedUserCases`, `parseDecompositionPhases`, `findMissingCovers`, `findScopeDrift`, `auditAntiPatternResidual`, `runCodexAudit` |
| CLI | `hooks/mpl-codex-audit.mjs` | Writes `audit-report.json`, exits 0 (pass / warn-on-fail) / 1 (block-on-fail) / 2 (usage) |
| Agent | `agents/mpl-codex-auditor.md` | Orchestrator dispatch wrapper; surfaces structured tables to user |
| Wiring | `commands/mpl-run-finalize.md` Step 5.1.6 | Runs between Scope Drift Report (5.1.5) and Post-Execution Review (5.1.8) |
| Config | `config/enforcement.json` + `hooks/lib/mpl-config.mjs` | New `audit_residual: 'warn'` default (P0-2 tri-state honored) |

## Three audit surfaces

| Surface | Source | FAIL contribution |
|---|---|---|
| **anti_pattern_residual** | F3 registry scan over `phase.impact.create + modify` | YES |
| **missing_covers** | included UCs ∖ ⋃ phase.covers + phase.covers ∖ included UCs | YES |
| **drift** | declared impact files vs `git diff` | NO (informational; mirrors 5.1.5) |

`verdict: pass` iff all three FAIL-contributing surfaces are empty.

## Test plan

- [x] `node --test hooks/__tests__/mpl-codex-audit.test.mjs` — **30/30 pass** (parsing, surfaces, runner verdict, CLI smoke)
- [x] Full hook regression: **726/726 pass** (was 696, +30 for F6)
- [x] Self-run smoke on plugin self: `verdict=pass` (graceful skip — plugin has no `.mpl/`)
- [x] `mpl-property-check`: **9/9 declarations used / 0 unused** (after adding `audit_residual` declaration)
- [x] `mpl-doctor-meta-self`: **0 hits**, all 12 categories have scope manifest

## Forward integration

- **F7 (#118)** exercises Tier 1+2+3+4 end-to-end on exp16 regression. The `audit-report.json` schema is now stable (`schema_version: 1`) so F7 fixtures can assert against it.
- **mpl-doctor Category 3 drift fix** (8 → 11 expected agents) is a meta-self application of F6's drift surface — the doctor list had drifted from reality during 0.18.x (missing `adversarial-reviewer`, `seed-generator`).

## Spec matrix (from #117)

| Action item | Status |
|---|---|
| 1. New `agents/mpl-codex-auditor.md` | ✅ |
| 1a. Inputs: decomposition + state-summary + diff | ✅ (decomposition + UC + git diff; state-summary deferred — see Notes) |
| 1b. Output: `audit-report.json` (anti-pattern, missing covers, drift) | ✅ |
| 2. Wire into `mpl-run-finalize.md` (PASS→continue, FAIL→surface, block strict only) | ✅ Step 5.1.6 |
| 3. Tier 1+2+3+4 stack measurable | ✅ `audit-report.json.tier=4`, surfaces parseable |
| 4. Cost: ~3-5 min/phase × 8 phases | ✅ CLI runs in <1s; LLM dispatch is the budget consumer (advisory only) |

## Notes

- **state-summary.md not in this PR's audit input** — deferred. Issue lists it as input but the three failure modes (anti-pattern / covers / drift) are derivable from decomposition + UC + git diff alone. state-summary content audit is naturally a follow-up if F7 surfaces a need.
- **Codex CLI literal not invoked** — issue says "Codex (또는 별도 audit agent)"; the agent name `mpl-codex-auditor` honors the spec naming, but the audit lib is pure JS (no external CLI dep). If a future iteration wants Codex-style natural-language judgment on top, the agent .md is the wrapping point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)