### PR TITLE
chore: bump plugin version 0.17.2 → 0.18.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "mpl",
       "description": "Decomposes tasks into micro-phases with independent plan-execute-verify mini-loops. Orchestrator-Worker separation enforced via hooks.",
-      "version": "0.17.2",
+      "version": "0.18.1",
       "author": {
         "name": "KyubumShin"
       },
@@ -25,5 +25,5 @@
       ]
     }
   ],
-  "version": "0.17.2"
+  "version": "0.18.1"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mpl",
-  "version": "0.17.2",
+  "version": "0.18.1",
   "description": "Micro-Phase Loop - Coherence-first autonomous coding pipeline with decomposition, phase execution, and verification",
   "author": {
     "name": "KyubumShin"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# MPL (Micro-Phase Loop) v0.17.2
+# MPL (Micro-Phase Loop) v0.18.1
 
 **Prevention over cure. Specification over debugging.**
 

--- a/README_ko.md
+++ b/README_ko.md
@@ -1,4 +1,4 @@
-# MPL (Micro-Phase Loop) v0.17.2
+# MPL (Micro-Phase Loop) v0.18.1
 
 **예방이 치료보다 낫다. 명세가 디버깅보다 낫다.**
 

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -2,8 +2,8 @@
 
 All fields for `.mpl/config.json`. Single source of truth for configuration.
 
-> **Version**: v0.17.2 (v0.17.1 + decomposer Write authority refactor — `mpl-decomposer` agent now writes `.mpl/mpl/decomposition.yaml` directly; orchestrator no longer authors that file in main context)
-> **Last updated**: 2026-05-02
+> **Version**: v0.18.1 (v0.17.2 + v3.10 P0 enforcement track: P0-1/P0-2/P0-3/P0-A/P0-K + G1~G6 + H8 + F2~F6 — gate-evidence desync fix, enforcement tri-state, write-guard hard block, adversarial reviewer, artifact schema validator, Bash timeout, RUNBOOK auto-update, fix-loop history + intervention counter, hang detection, state invariant, schema migration registry, hook-tier scan, anti-pattern registry, doctor meta-self, property check, codex auditor)
+> **Last updated**: 2026-05-06
 
 ---
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,4 +1,4 @@
-# MPL (Micro-Phase Loop) v0.17.2 Design Document
+# MPL (Micro-Phase Loop) v0.18.1 Design Document
 
 ## 1. Overview
 
@@ -484,6 +484,43 @@ The following options are supported in `.mpl/config.json`:
 ---
 
 ## 9. Version History
+
+### v0.18.1 — v3.10 P0 Enforcement Track (2026-05-06)
+
+Coherence-recovery release closing the v3.10 §3.1 retrofit findings. Where v0.17.2 made decomposer the sole Writer of decomposition.yaml, v0.18.0 + v0.18.1 wire the Tier 1+2+3+4 enforcement stack that catches what slips through anyway — fake gates, silent fallbacks, gap-as-PASS test patterns, scope drift, missing covers. v0.18.1 ships the `enforced` 16-item baseline.
+
+| Change | Before | After | Type | Rationale |
+|--------|--------|-------|------|-----------|
+| Enforcement config | Hardcoded warn/block per hook | `config/enforcement.json` 9-key tri-state (warn/block/off) + strict-mode elevation; precedence `state.enforcement` > `.mpl/config.json` > plugin baseline | Hook + config (P0-2 #110, F5 #112) | Single source of truth; per-rule + per-pipeline override; `mpl-property-check` enforces no orphan keys |
+| Anti-pattern coverage | Ad-hoc `mpl-fallback-grep` regex set | `commands/references/anti-patterns.md` registry (BNF parsed) + `mpl-fallback-grep` Tier 1 hook + Tier 3 property check + `commands/anti-patterns.md` self-application | Protocol + hook (F2 #104, F3 #105) | Single registry consumed by 3 tiers; doctor self-audits its own scope |
+| Doctor self-audit | doctor agent excluded from anti-pattern grep | `mpl-doctor-meta-self.mjs` enumerates doctor sources, applies registry, surfaces `inverse_audit_hits` (anti-patterns OUTSIDE registry scope that doctor should still audit) + `R-DOCTOR-SCOPE-LEAK` declaration | Hook (F4 #106) | Closes meta-self exclusion hole |
+| Bash verification timeout | None — long-running build/test could hang phase | `mpl-bash-timeout.mjs` PostToolUse Bash matcher with category-specific budgets (`config/verification-tool-paths.json`) + tier 3 enforcement | Hook (G1 #107) | Hang prevention without false-positive on legitimate long builds |
+| State invariant | None | `mpl-state-invariant.mjs` 8 invariants (I1-I8) verified on every PreToolUse + Stop; hard-block on writeState if violated | Hook (G3+H1 #108) | Catches state corruption before it propagates |
+| Hang detection | None | `mpl-hang-detector.mjs` PreCompact + UserPromptSubmit detection of stalled phases; surfaces banner + counts | Hook (G4 #109) | Diagnostic for "MPL is alive but not progressing" |
+| Write-guard | Edit/Write blocked outside scope (P0-3 / #111) | + MultiEdit + `mcp__.*__write.*` tools matched (closing #129 review #1 bypass class) | Hook (P0-3 #111) | Single matcher across CC's full write surface |
+| Adversarial reviewer | None | `agents/mpl-adversarial-reviewer.md` finalize-time signal-driven dispatch + `parseScore` tri-modal range support + history reason capture | Agent + protocol (P0-A #103) | Tier 4 third-pass on the merge candidate |
+| Schema migration | Inline `mpl-state.mjs` v1→v2 path | `hooks/lib/migrations/` registry — ordered chain runner + per-version migrations + `readState` fail-closed on `state.schema_version > CURRENT` + `writeState` fail-closed on `UnsupportedSchemaVersionError` | Hook (H8 #116) | Forward + backward safety; new bumps drop in as new files |
+| Fix-loop history | `state.fix_loop_count` (single counter) | + `state.fix_loop_history[]` per-phase entries `{phase, count, started_at}` with G3 I5 invariant `fix_loop_count == sum(history.count)`; carry-forward migration v2→v3; archive snapshots preserve forensic value | Hook + state (G5+G6 #114) | Per-phase forensic trail for fix-loop investigation |
+| User intervention counter | Not tracked | `state.user_intervention_count` UserPromptSubmit-time increment iff (MPL active + auto mode + non-cancelled + non-completed) | Hook (G6 #114) | Auto-mode autonomy metric |
+| Observability bundle | RUNBOOK manual + state-summary partial | `RUNBOOK.md` auto-row on phase transition (compaction-snapshot rows skipped from chain inference) + `/mpl-status` 3-source merge view (state.json + per-phase state-summary + RUNBOOK) | Hook + skill (G2 #113) | Single timeline view spanning compaction boundaries |
+| Artifact schema validator | Required fields enforced only by prose | `mpl-artifact-schema.mjs` PostToolUse + finalize bulk re-check; 5 artifact schemas (decomposition, state-summary, verification, pivot-points, user-contract); markdown heading + YAML key presence checks | Hook (P0-K #115) | Closes "valid at write, missing later" failure mode |
+| Codex auditor | None | `agents/mpl-codex-auditor.md` + `mpl-codex-audit.mjs` Tier 4 finalize-time intent-vs-implementation diff: anti-pattern residual on declared impact files + missing covers (uncovered + dangling) + drift; 3-way `contract_mode` (legacy_skip / empty_skip / enforced) honoring Phase 0 graceful protocol | Agent + hook (F6 #117) | Last-mile catch for the ~1/8 that slips Tier 1+2+3 |
+
+**Affected files:**
+
+Hooks: `mpl-bash-timeout.mjs`, `mpl-codex-audit.mjs`, `mpl-fallback-grep.mjs`, `mpl-hang-detector.mjs`, `mpl-doctor-meta-self.mjs`, `mpl-property-check.mjs`, `mpl-state-invariant.mjs`, `mpl-keyword-detector.mjs` (intervention counter), `mpl-write-guard.mjs` (MultiEdit + MCP matcher), `mpl-artifact-schema.mjs`, `mpl-compaction-tracker.mjs` (RUNBOOK in-flight snapshot), plus `lib/anti-pattern-registry.mjs`, `lib/migrations/{index,v1-to-v2,v2-to-v3,v3-to-v4.example}.mjs`, `lib/mpl-codex-audit.mjs`, `lib/mpl-enforcement.mjs`, `lib/mpl-meta-self.mjs`, `lib/mpl-property-check.mjs`, `lib/mpl-runbook.mjs`, `lib/mpl-state-merge.mjs`.
+
+Agents: `mpl-adversarial-reviewer.md`, `mpl-codex-auditor.md` (new), `mpl-doctor.md` (Category 3 expected count 8 → 11, Category 8 enforcement subsection, Category 14 meta-self, Category 15 property check).
+
+Protocols: `mpl-run-finalize.md` (5.1.1 P0-K bulk re-check, 5.1.5 V-05 informational drift, 5.1.7 F6 codex audit dispatch), `mpl-run-execute-gates.md` (state invariant gate), `mpl-run-execute.md` (fix-loop history wiring), `references/anti-patterns.md` (BNF registry).
+
+Skills: `mpl-status` (3-source merge view + G5/G6 metrics).
+
+Config: `config/enforcement.json`, `config/verification-tool-paths.json`.
+
+**Breaking changes:** None at user-facing surface. State `schema_version` bumped 2 → 3 (G5 fix_loop_history) — auto-migrates on first read via H8 registry chain. `enforcement.audit_residual` is a new key with default 'warn' — projects that explicitly set strict mode will now elevate F6 fail to block (per design intent).
+
+**Tests:** 595 → 735 (+140 across the v0.18 stack). Self-run smoke clean: doctor meta-self 0 hits, property-check 9/9 used / 0 unused, codex-audit verdict=pass on plugin self.
 
 ### v0.17.2 — Decomposer Write Authority (2026-05-02)
 

--- a/docs/roadmap/overview.md
+++ b/docs/roadmap/overview.md
@@ -2,7 +2,7 @@
 
 > **Version notation (v0.9.4)**: This file uses legacy major-version notation (v1.0, v3.0, v4.0) from the original roadmap. Actual release versions follow the `v0.x.y` semver series. Mapping: v1.0 = initial design, v3.x ≈ v0.3.x, v4.x ≈ v0.4.x. See `design.md` for the canonical version reference.
 >
-> **Currency note (2026-05-06)**: Plugin version is `0.18.1` (v0.17.x → v0.18.x = v3.10 P0 enforcement track: P0-1 gate-evidence desync fix, P0-2 enforcement tri-state, P0-3 write-guard hard block, P0-A adversarial reviewer, P0-K artifact schema validator, G1 Bash timeout, G2 RUNBOOK auto-update, G3+H1 state invariant, G4 hang detection, G5+G6 fix-loop history + intervention counter, H8 schema migration registry, F2 hook-tier scan, F3 anti-pattern registry, F4 doctor meta-self, F5 property check, F6 codex auditor). v0.18.0 critical path 10/10 closed (#102~#111), v0.18.1 hardening 5/5 closed (#112~#117). Per-version detail in `docs/design.md` §9.
+> **Currency note (2026-05-06)**: Plugin version is `0.18.1` (v0.17.x → v0.18.x = v3.10 P0 enforcement track: P0-1 gate-evidence desync fix, P0-2 enforcement tri-state, P0-3 write-guard hard block, P0-A adversarial reviewer, P0-K artifact schema validator, G1 Bash timeout, G2 RUNBOOK auto-update, G3+H1 state invariant, G4 hang detection, G5+G6 fix-loop history + intervention counter, H8 schema migration registry, F2 hook-tier scan, F3 anti-pattern registry, F4 doctor meta-self, F5 property check, F6 codex auditor). v0.18.0 critical path 10/10 closed (#102~#111), v0.18.1 hardening 6/6 closed (#112~#117). Per-version detail in `docs/design.md` §9.
 
 ## Vision: "Phase 0 Enhanced + Phase 5 Minimized"
 

--- a/docs/roadmap/overview.md
+++ b/docs/roadmap/overview.md
@@ -2,7 +2,7 @@
 
 > **Version notation (v0.9.4)**: This file uses legacy major-version notation (v1.0, v3.0, v4.0) from the original roadmap. Actual release versions follow the `v0.x.y` semver series. Mapping: v1.0 = initial design, v3.x ≈ v0.3.x, v4.x ≈ v0.4.x. See `design.md` for the canonical version reference.
 >
-> **Currency note (2026-05-02)**: Plugin version is `0.17.2` (v0.17.0 released 2026-04-26; v0.17.1 patch 2026-05-02 added `.mpl/metrics/e2e-recovery.jsonl` emission + design.md cleanup; v0.17.2 patch 2026-05-02 moves `.mpl/mpl/decomposition.yaml` Write authority to the `mpl-decomposer` agent — orchestrator can no longer fabricate decomposition in main context). The roadmap-level summary for v0.15.x → v0.16.0 → v0.17 is the first release section below. Per-version detail for v0.15.x → v0.17.2 lives in `docs/design.md` §9 to avoid duplication.
+> **Currency note (2026-05-06)**: Plugin version is `0.18.1` (v0.17.x → v0.18.x = v3.10 P0 enforcement track: P0-1 gate-evidence desync fix, P0-2 enforcement tri-state, P0-3 write-guard hard block, P0-A adversarial reviewer, P0-K artifact schema validator, G1 Bash timeout, G2 RUNBOOK auto-update, G3+H1 state invariant, G4 hang detection, G5+G6 fix-loop history + intervention counter, H8 schema migration registry, F2 hook-tier scan, F3 anti-pattern registry, F4 doctor meta-self, F5 property check, F6 codex auditor). v0.18.0 critical path 10/10 closed (#102~#111), v0.18.1 hardening 5/5 closed (#112~#117). Per-version detail in `docs/design.md` §9.
 
 ## Vision: "Phase 0 Enhanced + Phase 5 Minimized"
 

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mpl-mcp-server",
-  "version": "0.13.1",
+  "version": "0.18.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mpl-mcp-server",
-      "version": "0.13.1",
+      "version": "0.18.1",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.81",
         "@modelcontextprotocol/sdk": "^1.0.0"

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mpl-mcp-server",
-  "version": "0.17.2",
+  "version": "0.18.1",
   "description": "MPL MCP Server — deterministic scoring + active state access",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
v0.18.1 release boundary cut — closes v3.10 P0 enforcement track.

## Scope

Single version bump covering 16 P0 / G / H / F items merged across 2 sessions:

| Track | Items | Status |
|---|---|---|
| **v0.18.0 critical** | #102 P0-1, #103 P0-A, #104 F2, #105 F3, #106 F4, #107 G1, #108 G3+H1, #109 G4, #110 P0-2, #111 P0-3 | ✅ 10/10 |
| **v0.18.1 hardening** | #112 F5, #113 G2, #114 G5+G6, #115 P0-K, #116 H8, #117 F6 | ✅ 6/6 (#112~#117) |
| **v0.19.0 outstanding** | #118 F7 — Phase 1 (rubric) merged in harness-lab#3, Phase 2 (actual run + report) deferred | ⏳ partial |

## Files updated (8)

| File | Change |
|---|---|
| `.claude-plugin/plugin.json` | `"version": "0.17.2"` → `"0.18.1"` |
| `.claude-plugin/marketplace.json` | top-level + plugin entry both → `"0.18.1"` |
| `mcp-server/package.json` | `"version": "0.17.2"` → `"0.18.1"` |
| `docs/design.md` | title `v0.17.2` → `v0.18.1`; new §9 entry with 14-row change matrix |
| `docs/config-schema.md` | Version field rewritten to summarize the v3.10 P0 stack |
| `README.md` / `README_ko.md` | title `v0.17.2` → `v0.18.1` |
| `docs/roadmap/overview.md` | Currency note 2026-05-02 → 2026-05-06 with v0.18 stack summary |

## Verification

- [x] Mandatory grep: 0 stale `0.17.2` in `.claude-plugin/*.json` / `mcp-server/package.json` / `README*.md`
- [x] Historical anchors preserved: design.md §9 v0.17.2/v0.17.1 entries, agents/mpl-decomposer.md:291 \"Authoring authority (v0.17.2)\", commands/mpl-run-decompose.md feature-anchor refs
- [x] Hook regression: 735/735 pass on main HEAD `2e27440` (no code change; docs + refs only)
- [x] Self-run smoke: doctor meta-self 0 hits, property-check 9/9 used / 0 unused, codex-audit verdict=pass

## Breaking changes

None at the user surface.

- State `schema_version` 2 → 3 (G5 fix_loop_history) — H8 registry chain auto-migrates on first `readState` for legacy projects
- `enforcement.audit_residual` is a new key (default `'warn'`) — projects that opt into strict mode elevate F6 verdict=fail to block (per design intent, not regression)

## Notes

- This is a docs/config-only PR. No new tests, no test changes. All test count claims trace to MPL main HEAD post-#136 merge.
- F7 Phase 2 (actual exp16 regression run + report) is deferred and does NOT block v0.18.1. Umbrella #101 #118 remains unchecked until Phase 2 lands a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)