### PR TITLE
feat: add goal contract completion guards

### DIFF
--- a/agents/mpl-decomposer.md
+++ b/agents/mpl-decomposer.md
@@ -157,6 +157,8 @@ disallowedTools: Bash,Task,WebFetch,WebSearch,NotebookEdit
 
     Step 7.5: E2E Scenario Composition (AD-0008, v0.15.2)
       Read `.mpl/mpl/core-scenarios.yaml` (written by Phase 0 Enhanced Step 2.5.3).
+      Also read `.mpl/goal-contract.yaml`; its `e2e_policy` controls whether
+      a scenario is admissible completion evidence.
       If the file is missing OR empty, SKIP this step (pipeline proceeds without
       AD-0008 enforcement; doctor audit [h] will flag as WARN).
 
@@ -171,6 +173,14 @@ disallowedTools: Bash,Task,WebFetch,WebSearch,NotebookEdit
         - test_command MUST be executable (e.g., "pnpm playwright test e2e/
           scenario-1.spec.ts"), NEVER a placeholder like "TODO(integration-ci)"
           or "manual verification"
+        - If goal_contract.e2e_policy.real_runtime_required is true, emit:
+          runtime_class: one of real_desktop|real_web|real_browser|real_mobile|real_api
+          launcher_evidence: the actual launcher/runtime proving this is not a unit/mock run
+        - If goal_contract.e2e_policy.mock_allowed is false, emit mock_allowed: false
+          and do not use mock/stub/fake flags in test_command
+        - If placeholder assertions are forbidden, emit assertion_evidence OR
+          test_files pointing at real assertion files. Placeholder `expect(true)`
+          style tests are not admissible.
 
       Infrastructure detection:
         - Scan provided-specs + decomposition for existing E2E stack:
@@ -320,6 +330,13 @@ disallowedTools: Bash,Task,WebFetch,WebSearch,NotebookEdit
           # phases carry `covers: [internal]`, the hook emits a warn (not block).
           # If no user-contract.md exists (legacy project, graceful skip mode), the hook
           # accepts any non-empty covers (including `["internal"]`) and only warns on ratio.
+
+        goal_trace:
+          acceptance_criteria: [string] # AC-N ids from .mpl/goal-contract.yaml
+          variation_axes: [string]      # AX-N ids this phase addresses or preserves
+          ontology_entities: [string]   # goal-contract ontology entities touched
+          # REQUIRED. Use [] only when a phase is pure internal plumbing with no
+          # direct goal-contract surface; explain via covers:[internal] and rationale.
 
         impact:
           create:
@@ -473,6 +490,11 @@ disallowedTools: Bash,Task,WebFetch,WebSearch,NotebookEdit
         phases_involved: [string]       # phase ids this scenario exercises
         test_command: string            # EXECUTABLE command, NOT "TODO(ci)" placeholder
         acceptance_criteria: string     # observable exit-0 criterion
+        runtime_class: string           # real_desktop|real_web|real_browser|real_mobile|real_api|mock|unit
+        mock_allowed: boolean           # must match goal_contract.e2e_policy
+        launcher_evidence: string       # e.g., "electron.launch", "tauri-driver", "playwright chromium"
+        assertion_evidence: string      # real assertion being made, not "expect(true)"
+        test_files: [string]            # optional file paths scanned by authenticity hook
         required: boolean               # default true when composed_from includes must_work core
         rationale: string               # why this composition matters
     # Composition rule (Step 7.5):

--- a/agents/mpl-doctor.md
+++ b/agents/mpl-doctor.md
@@ -185,7 +185,7 @@ disallowedTools: Write, Edit, Task
     - WARN if missing (functional but undocumented)
 
     ### Category 12: Measurement Integrity Audit (AD-0006, v0.15.0)
-    - **Scope**: `.mpl/state.json`, `.mpl/mpl/phases/**`, `.mpl/config/test-agent-override.json`, `.mpl/config/e2e-scenario-override.json`
+    - **Scope**: `.mpl/state.json`, `.mpl/goal-contract.yaml`, `.mpl/mpl/baseline.yaml`, `.mpl/mpl/phases/**`, `.mpl/config/test-agent-override.json`, `.mpl/config/e2e-scenario-override.json`
     This category runs only when invoked as `mpl-doctor audit` (not default). Validates that a **completed** pipeline produced machine-evidence gate records and that Anti-rationalization guardrails held. Run against `.mpl/state.json` and `.mpl/mpl/` of a finalized run.
 
     **Preconditions**: `.mpl/state.json.current_phase == "completed"` AND `.mpl/state.json.finalize_done == true`. Otherwise report "NOT APPLICABLE (pipeline not finalized)" and skip.
@@ -228,6 +228,15 @@ disallowedTools: Write, Edit, Task
       - WARN if any override lacks `test_command_hash` AND scenario's current test_command doesn't match the override's recorded form (legacy shape, recommend re-recording)
       - WARN if `<80%` of e2e_scenarios have `composed_from.length >= 2` (weak cross-feature coverage per AD-0008 composition rule)
 
+    - **[i] goal_contract integrity** — enforce the goal-first harness layer:
+      - Read `.mpl/goal-contract.yaml` via `hooks/lib/mpl-goal-contract.mjs#readGoalContract`
+      - FAIL if the file is missing while `.mpl/config.json.goal_contract_required != false`
+      - FAIL if `readGoalContract.valid == false`; evidence is the `missing[]` list
+      - FAIL if `state.goal_contract_hash` exists and differs from `readGoalContract.contract.content_sha256`
+      - FAIL if `.mpl/mpl/baseline.yaml artifacts.goal_contract.sha256` exists and differs from the current contract hash
+      - WARN if `goal_contract_required:false` is configured on a finalized run (legacy opt-out; completion evidence is weaker)
+      - WARN if `deferred_uncertainties` or `overrides` are non-empty; include them in the audit output as accepted goal debt
+
     - **[g] test_agent dispatch coverage (AD-0007, v0.15.1)** — enforce the enforcement:
       - Count `required = decomposition.phases[].filter(p => p.test_agent_required != false)`
       - Count `dispatched = Object.keys(state.test_agent_dispatched)` intersecting required ids
@@ -248,7 +257,9 @@ disallowedTools: Write, Edit, Task
     [e] null state PASS claim:      ✓ 0건     or ✗ 2건: hard3 PASS claimed but state.hard3_resilience=null
     [f] chain_seed integrity:       ✓         or ✗ enabled=true but chain-assignment.yaml missing
     [g] test_agent coverage:        ✓ N건     or ✗ 0건 despite {M} mandatory-domain phases
-    Result: PASS (7/7) / FAIL (X/7) / WARN (Y/7)
+    [h] E2E scenario coverage:      ✓ N건     or ✗ missing/failing E2E-N
+    [i] goal_contract integrity:    ✓ hash ok or ✗ missing fields: mission.goal
+    Result: PASS (9/9) / FAIL (X/9) / WARN (Y/9)
     ```
 
     ### Category 15: Property Check (F5, #112)

--- a/commands/mpl-run-decompose.md
+++ b/commands/mpl-run-decompose.md
@@ -80,6 +80,8 @@ Task(subagent_type="mpl-decomposer", model="opus",
      {user_request}
      ### Pivot Points
      {pivot_points content from .mpl/pivot-points.md}
+     ### Goal Contract
+     {goal_contract from .mpl/goal-contract.yaml}
      ### Codebase Analysis
      {codebase_analysis JSON from .mpl/mpl/codebase-analysis.json}
 
@@ -99,7 +101,7 @@ Task(subagent_type="mpl-decomposer", model="opus",
      per-phase rules. See agents/mpl-decomposer.md Step 5.5 / 5.6.
 
      ## Task
-     Break the user request into ordered phases that cover the ENTIRE scope of the request.
+     Break the user request into ordered phases that cover the ENTIRE scope of the request and the Goal Contract.
      CRITICAL: Do NOT scope down. Every feature, requirement, and component in the user's spec must be covered by at least one phase. If the spec describes 10 features, all 10 must appear in the decomposition. Create as many phases as needed — there is no hard cap on phase count.
 
      Use Phase 0 artifacts to inform decomposition decisions — they contain pre-analyzed API contracts, usage patterns, type policies, and error specifications. Use the Pre-Execution Analysis's Recommended Execution Order (section 7) to guide phase ordering, and its Gap Analysis (sections 1-4) to catch missing requirements. **Write the YAML directly to `.mpl/mpl/decomposition.yaml` using the Write tool**, then return a single confirmation line (e.g., `Wrote .mpl/mpl/decomposition.yaml — 5 phases, 3 tiers.`). Do NOT print the YAML body in your response.
@@ -109,7 +111,7 @@ Task(subagent_type="mpl-decomposer", model="opus",
      phase_task_type (F-39, optional: greenfield|refactor|migration|bugfix|performance|security),
      phase_lang (F-39, optional: rust|go|python|typescript|java),
      scope, impact (create/modify/affected_tests/affected_config),
-     interface_contract (requires/produces/**contract_files**), success_criteria (typed: command/test/file_exists/grep/description),
+     goal_trace (acceptance_criteria/variation_axes/ontology_entities), interface_contract (requires/produces/**contract_files**), success_criteria (typed: command/test/file_exists/grep/description),
      estimated_complexity (S/M/L).
 
      **AD-01 (v0.13.0) — contract_files is REQUIRED** for every phase under `interface_contract.contract_files`. Enumerate one entry per cross-layer boundary between impact files (path, boundary_id, caller, callee, framework_rules, params key-type map, returns key-type map). Empty list `[]` only for phases with zero cross-layer boundaries (pure infra/docs). Omission is a validation error. See `agents/mpl-decomposer.md` Step 6.5 for the enumeration procedure and full sub-schema.
@@ -515,6 +517,22 @@ for s in scenarios:
     Hard-fail decomposition:
     announce: "[MPL AD-0008] Scenario {s.id} has placeholder test_command '{s.test_command}'. Decomposer must emit executable commands. Re-running Step 3 with constraint."
     re-run Decomposer with explicit prompt: "No placeholder test_commands."
+
+  if goal_contract.e2e_policy.real_runtime_required == true:
+    require s.runtime_class in ["real_desktop", "real_web", "real_browser", "real_mobile", "real_api"]
+    require s.launcher_evidence is non-empty
+
+  if goal_contract.e2e_policy.mock_allowed == false:
+    require s.mock_allowed != true
+    require s.test_command does not contain mock/stub/fake flags
+
+  if goal_contract.e2e_policy.placeholder_assertions_allowed == false:
+    require s.assertion_evidence is non-empty OR s.test_files contains real test file paths
+
+  if any authenticity requirement fails:
+    Hard-fail decomposition:
+    announce: "[MPL E2E Authenticity] Scenario {s.id} is not admissible real E2E evidence. Re-running Step 3 with runtime_class/launcher_evidence/assertion_evidence fields."
+    re-run Decomposer with explicit prompt: "Every required E2E scenario must satisfy goal_contract.e2e_policy."
 
 announce: "[MPL AD-0008] E2E scenarios written: {scenarios.length} scenarios covering {phases_involved union} phases."
 ```

--- a/commands/mpl-run-finalize.md
+++ b/commands/mpl-run-finalize.md
@@ -751,6 +751,37 @@ Append final section to `.mpl/mpl/RUNBOOK.md`:
 - **Completed At**: {ISO timestamp}
 ```
 
+### 5.6.4: Completion Evidence Guard
+
+Before writing `finalize_done = true`, re-check the Goal Contract evidence.
+The hook `hooks/mpl-require-finalize-artifacts.mjs` enforces this on the
+actual state write, but finalize should prepare the evidence explicitly:
+
+```
+goal_contract = Read(".mpl/goal-contract.yaml")
+
+require exists(".mpl/mpl/audit-report.json")        # Step 5.1.7 Codex audit
+require exists(".mpl/mpl/profile/run-summary.json") # Step 5.4 profile
+require ".mpl/mpl/RUNBOOK.md" contains "## Pipeline Complete"
+
+if goal_contract.security_policy.required:
+  for check in goal_contract.security_policy.checks:
+    require state.security_results[check].exit_code == 0
+       OR .mpl/mpl/security-report.json checks[check] PASS
+
+if goal_contract.completion_evidence.require_commit:
+  require git rev-list --count baseline.git.base_sha..HEAD > 0
+
+next_state_update must include:
+  completed_at: now_iso()
+  finalized_at: now_iso()
+  finalize_done: true
+```
+
+Override escape hatch: `.mpl/config/finalize-artifact-override.json` with a
+user-authored `reason`. Overrides are audit debt and must be surfaced in the
+Completion Report.
+
 > **Step 5.6.5 (F-22 Routing Pattern Recording) removed in v0.17 (#60)**:
 > Write side deleted along with the read site (ex-Step 0.1.5a, removed in #55).
 > Jaccard similarity matching on user_request strings was too noisy to drive
@@ -759,7 +790,10 @@ Append final section to `.mpl/mpl/RUNBOOK.md`:
 
 ### 5.7: Update State
 
-Pipeline `current_phase = "completed"`, MPL `status = "completed"`, `completed_at = timestamp`.
+Pipeline `current_phase = "completed"`, MPL `status = "completed"`,
+`completed_at = timestamp`, `finalized_at = timestamp`, `finalize_done = true`.
+The write is blocked unless AD-0008 E2E coverage, E2E authenticity, and
+completion-evidence hooks all pass.
 
 ---
 

--- a/commands/mpl-run-phase0.md
+++ b/commands/mpl-run-phase0.md
@@ -9,7 +9,7 @@ Load this when `current_phase` is in the pre-execution stages (before decomposit
 
 **Structural changes vs v0.16** (see issue #55):
 - Removed: Step -1 LSP warm-up (moved to `hooks/mpl-lsp-warmup.mjs`), Step 0.0.5 artifact freshness + field classification, Step 0.1 Quick Scope Scan + pp_proximity, Step 0.1.5a F-22 routing pattern matching, Step 0.2 interview_depth (light/full dual-track), Step 1-B Pre-Exec gap/tradeoff, Uncertainty Scan (3×3 cross-axis).
-- Moved: Core Scenarios (ex-Step 3 in phase0-analysis.md) → Stage 1.1. Intent Invariants (ex-Step 3.6) → Stage 1.2. User Contract (ex-Step 1.5) → Stage 1.3. Stage 2 Ambiguity Resolution Loop → after Step 2 Codebase (so `codebase_context` is populated).
+- Moved: Core Scenarios (ex-Step 3 in phase0-analysis.md) → Stage 1.1. Intent Invariants (ex-Step 3.6) → Stage 1.2. User Contract (ex-Step 1.5) → Stage 1.3. Goal Contract → Stage 1.4. Stage 2 Ambiguity Resolution Loop → after Step 2 Codebase (so `codebase_context` is populated).
 - Added: Step 2.9 Branch Main State Snapshot (baseline.yaml) — immutable ground-truth checkpoint after Stage 2 closes.
 
 ---
@@ -86,7 +86,7 @@ Load adaptive memory. Details in `mpl-run-phase0-memory.md`.
 
 ## Step 1: Interview Block (PP-derived, codebase-independent)
 
-All four stages below depend only on `pivot-points.md` + accumulated user responses. **None of them consume codebase analysis** — they run before Step 2 so the interview is not biased by existing code.
+All five stages below depend only on the user request, `pivot-points.md`, user contract, and accumulated user responses. **None of them consume codebase analysis** — they run before Step 2 so the interview is not biased by existing code.
 
 ### Stage 1: PP Discovery Interview (mpl-interviewer)
 
@@ -279,6 +279,74 @@ Announce: `[MPL] Stage 1.3 complete. user_cases=${result.user_cases.length} defe
 | `scenarios[*]` | Decomposer Step 3-H, Test Agent | E2E scenario seeds |
 | `ambiguity_hints[]` | Stage 2 Ambiguity Resolution | Targeted questions |
 
+### Stage 1.4: Goal Contract Freeze
+
+Create `.mpl/goal-contract.yaml` as the pipeline constitution. This is the
+MPL equivalent of an Ouroboros Seed: one artifact that ties the Codex goal /
+raw request to the project pivot, ontology, variation axes, acceptance
+criteria, E2E authenticity policy, security policy, and finalize evidence.
+
+```
+goal_contract = {
+  version: 1,
+  source: {
+    codex_goal: active Codex goal text if available else null,
+    user_request: user_request,
+    user_request_hash: sha256(normalize(user_request)),
+  },
+  mission: {
+    goal: one concrete objective,
+    project_pivot: the main importance / success pivot,
+    non_goals: explicit exclusions,
+    must_ship_outcomes: observable outcomes that must exist,
+  },
+  ontology: {
+    entities: core domain/product entities,
+    relationships: key relations between entities,
+    state_transitions: lifecycle transitions that must not drift,
+  },
+  variation_axes: [
+    { id: "AX-1", name, required_coverage: true|false, values: [...] }
+  ],
+  acceptance_criteria: [
+    { id: "AC-1", statement, evidence_required: ["e2e", "unit", "security"] }
+  ],
+  e2e_policy: {
+    real_runtime_required: true,
+    mock_allowed: false,
+    placeholder_assertions_allowed: false,
+  },
+  security_policy: {
+    required: project_has_security_surface,
+    checks: ["dependency_audit", "secret_scan", "injection_review", ...],
+  },
+  completion_evidence: {
+    required_artifacts: [
+      ".mpl/mpl/audit-report.json",
+      ".mpl/mpl/profile/run-summary.json",
+      ".mpl/mpl/RUNBOOK.md",
+    ],
+    require_commit: true,
+    require_finalize_timestamps: true,
+  },
+  deferred_uncertainties: unresolved-but-accepted ambiguity,
+  overrides: [],
+}
+
+Write(".mpl/goal-contract.yaml", serialize(goal_contract))
+mpl_state_write({
+  goal_contract_set: true,
+  goal_contract_path: ".mpl/goal-contract.yaml",
+  goal_contract_hash: sha256(file(".mpl/goal-contract.yaml")),
+})
+```
+
+**Readiness gate**: `hooks/mpl-ambiguity-gate.mjs` blocks
+`Task(mpl-decomposer)` when the goal contract is missing or incomplete. Legacy
+opt-out: `.mpl/config.json { "goal_contract_required": false }`.
+
+See `docs/schemas/goal-contract.md` for the required shape.
+
 ### Stage 1.9: Interview Snapshot Save (F-36)
 
 Back up interview results to file before Step 2. Preserves key information across compaction events during Step 2/2.5.
@@ -299,6 +367,9 @@ Write(".mpl/mpl/interview-snapshot.md"):
 
   ## User Contract Summary
   {user-contract.md UC count + key scenarios}
+
+  ## Goal Contract Summary
+  {goal-contract.yaml goal + project_pivot + AC/AX counts + e2e/security policies}
 
   ## User Request (Original)
   {user_request verbatim}
@@ -491,8 +562,8 @@ while true:
 # end while
 
 # After Stage 2 completes, proceed to Step 2.9 baseline snapshot.
-# Gate enforcement: mpl-ambiguity-gate.mjs allows decomposer dispatch when
-# ambiguity_score <= 0.2 OR ambiguity_override.active.
+# Gate enforcement: mpl-ambiguity-gate.mjs allows decomposer dispatch only when
+# (ambiguity_score <= 0.2 OR ambiguity_override.active) AND the goal contract is ready.
 ```
 
 **Re-entry**: when reached via `mpl-ambiguity-resolve` (router maps it here), this loop resumes. `ambiguity_history` persists across session boundaries, so stagnation detection is robust.
@@ -555,11 +626,15 @@ mpl_state_write(cwd, {
 Announce: "[MPL #59] Step 2.9 baseline.yaml recorded. git_base_sha=${baseline.git.base_sha.slice(0,7)}, artifacts=${countNonNull(baseline.artifacts)}. Advancing to decomposition."
 ```
 
+`buildBaseline()` includes `.mpl/goal-contract.yaml` as
+`artifacts.goal_contract`. Downstream drift/audit must treat that hash as the
+Phase 0 goal truth.
+
 ### Schema
 
 > See [`commands/schemas/baseline.yaml`](schemas/baseline.yaml) for the full schema with field documentation.
 >
-> **Top-level keys**: `created_at` · `pipeline_id` · `git` (base_sha/base_branch/working_tree_clean) · `artifacts` (per Phase 0 artifact: path + sha256, plus `skipped` for codebase_analysis) · `ambiguity` (final_score/threshold_met/override/rounds) · `spec` (user_request_hash + resolved_spec_hash, both normalized SHA-256).
+> **Top-level keys**: `created_at` · `pipeline_id` · `git` (base_sha/base_branch/working_tree_clean) · `artifacts` (per Phase 0 artifact, including `goal_contract`, path + sha256, plus `skipped` for codebase_analysis) · `ambiguity` (final_score/threshold_met/override/rounds) · `spec` (user_request_hash + resolved_spec_hash, both normalized SHA-256).
 
 ### Immutability (write-guard)
 

--- a/commands/schemas/baseline.yaml
+++ b/commands/schemas/baseline.yaml
@@ -16,6 +16,7 @@ git:
 
 artifacts:
   # Each entry: { path, sha256 } | null (absent) — sha256 normalized SHA-256
+  goal_contract:    { path: ".mpl/goal-contract.yaml",    sha256: "<hash>" } # required after Goal Contract readiness
   pivot_points:      { path: ".mpl/pivot-points.md",         sha256: "<hash>" } # null if absent
   core_scenarios:    { path: ".mpl/mpl/core-scenarios.yaml", sha256: "<hash>" } # null if absent
   design_intent:     { path: ".mpl/mpl/phase0/design-intent.yaml", sha256: "<hash>" } # null if absent

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -187,6 +187,14 @@ the immutable post-Phase-0 snapshot consumed by delta calculation and rollback.
 | Field | Type | Default | Description | Source |
 |-------|------|---------|-------------|--------|
 | `e2e_timeout` | number | `60000` | Timeout per E2E scenario in milliseconds | `mpl-run-finalize.md` Step 5.0 |
+| `e2e_authenticity_required` | boolean | `true` | Blocks `finalize_done=true` when required E2E scenarios are mock/unit/placeholder evidence instead of the real runtime evidence declared by `.mpl/goal-contract.yaml`. Override file: `.mpl/config/e2e-authenticity-override.json`. | `mpl-require-e2e-authenticity.mjs` |
+
+## Goal Contract & Finalize Evidence
+
+| Field | Type | Default | Description | Source |
+|-------|------|---------|-------------|--------|
+| `goal_contract_required` | boolean | `true` | Blocks decomposer dispatch until `.mpl/goal-contract.yaml` freezes source goal, project pivot, ontology, variation axes, acceptance criteria, E2E policy, security policy, and completion evidence. | `mpl-ambiguity-gate.mjs` |
+| `finalize_artifacts_required` | boolean | `true` | Blocks `finalize_done=true` unless the goal contract's required artifacts, RUNBOOK final section, finalize timestamps, security evidence, and optional commit evidence are present. Override file: `.mpl/config/finalize-artifact-override.json`. | `mpl-require-finalize-artifacts.mjs` |
 
 ## Adversarial Reviewer (P0-A, #103)
 

--- a/docs/schemas/goal-contract.md
+++ b/docs/schemas/goal-contract.md
@@ -1,0 +1,97 @@
+# Goal Contract Schema
+
+File: `.mpl/goal-contract.yaml`
+
+The Goal Contract is the MPL pipeline constitution. Phase 0 freezes it before
+decomposition, and hooks use it to decide whether a later completion claim is
+admissible. It is the bridge from a Codex goal or raw user request to machine
+evidence.
+
+## Required Shape
+
+```yaml
+version: 1
+source:
+  codex_goal: "string or null"
+  user_request: "string"
+  user_request_hash: "sha256 of normalized user request"
+
+mission:
+  goal: "concrete project objective"
+  project_pivot: "main importance / success pivot"
+  non_goals:
+    - "explicitly excluded scope"
+  must_ship_outcomes:
+    - "observable outcome the final product must satisfy"
+
+ontology:
+  entities:
+    - "domain entity"
+  relationships:
+    - "entity relationship"
+  state_transitions:
+    - "important lifecycle transition"
+
+variation_axes:
+  - id: AX-1
+    name: "runtime_mode"
+    required_coverage: true
+    values:
+      - "desktop"
+      - "web"
+
+acceptance_criteria:
+  - id: AC-1
+    statement: "completion condition"
+    evidence_required:
+      - e2e
+      - security
+
+e2e_policy:
+  real_runtime_required: true
+  mock_allowed: false
+  placeholder_assertions_allowed: false
+
+security_policy:
+  required: true
+  checks:
+    - dependency_audit
+    - secret_scan
+    - injection_review
+
+completion_evidence:
+  required_artifacts:
+    - .mpl/mpl/audit-report.json
+    - .mpl/mpl/profile/run-summary.json
+    - .mpl/mpl/RUNBOOK.md
+  require_commit: true
+  require_finalize_timestamps: true
+
+deferred_uncertainties: []
+overrides: []
+```
+
+## Runtime Enforcement
+
+- `hooks/mpl-ambiguity-gate.mjs` blocks `mpl-decomposer` dispatch when the
+  contract is missing or incomplete, unless `.mpl/config.json` sets
+  `goal_contract_required: false`.
+- `hooks/mpl-require-e2e-authenticity.mjs` reads `e2e_policy` before allowing
+  `finalize_done=true`.
+- `hooks/mpl-require-finalize-artifacts.mjs` reads `security_policy` and
+  `completion_evidence` before allowing `finalize_done=true`.
+- `.mpl/mpl/baseline.yaml` snapshots the contract hash as Phase 0 ground truth.
+
+## Minimum Readiness
+
+The hook-level readiness check requires:
+
+- source goal or user request plus `user_request_hash`
+- `mission.goal`, `mission.project_pivot`, and at least one
+  `must_ship_outcomes` entry
+- at least one ontology entity
+- at least one `variation_axes[].id`
+- at least one `acceptance_criteria[].id`
+- explicit booleans for the three `e2e_policy` fields
+- explicit `security_policy.required`
+- required completion artifacts and finalize timestamp policy

--- a/docs/schemas/goal-contract.md
+++ b/docs/schemas/goal-contract.md
@@ -82,6 +82,20 @@ overrides: []
   `completion_evidence` before allowing `finalize_done=true`.
 - `.mpl/mpl/baseline.yaml` snapshots the contract hash as Phase 0 ground truth.
 
+## Parser Contract
+
+Runtime hooks intentionally parse a small YAML-shaped subset rather than
+shipping a general YAML dependency. Keep `goal-contract.yaml` inside this
+prompt-controlled shape:
+
+- plain scalar values
+- block lists or inline scalar lists
+- list-of-object entries with an `id:` key anywhere inside the item
+- no block scalar (`|`, `>`), anchors, aliases, or arbitrary YAML expressions
+
+Prompt drift outside this subset should be fixed at artifact authoring time,
+not by accepting a looser completion contract.
+
 ## Minimum Readiness
 
 The hook-level readiness check requires:

--- a/docs/schemas/state.md
+++ b/docs/schemas/state.md
@@ -22,6 +22,9 @@
 | `fix_loop_count` | sprint-aggregated | Total fix-loop iterations across the active sprint. Equal to `sum(fix_loop_history[].count)` (G3 I5; writers populate via `writeState` mirror in `mpl-state.mjs#recordFixLoopHistory`). |
 | `fix_loop_history[]` | per-phase | `{phase, count, started_at, ended_at?, root_cause_summary?}` entries. Populated by `writeState` whenever `fix_loop_count` increases (G5 / #114). |
 | `user_intervention_count` | per-pipeline | Honest auto-mode telemetry. `mpl-keyword-detector` (UserPromptSubmit) increments by 1 on every prompt while pipeline is active and `run_mode === 'auto'` (G6 / #114). Surfaces in `/mpl-status` once G2 / #113 lands. |
+| `completed_at` / `finalized_at` | per-pipeline | Finalize timestamps required by Goal Contract completion evidence when `require_finalize_timestamps: true`. |
+| `goal_contract_set` / `goal_contract_path` / `goal_contract_hash` | per-pipeline | Goal Contract readiness mirror for `.mpl/goal-contract.yaml`; disk artifact remains the source of truth. |
+| `security_results.*` | per-pipeline | Structured security gate evidence consumed by `mpl-require-finalize-artifacts.mjs`. |
 | `session_status` | per-session | `null \| active \| paused_budget \| paused_checkpoint \| verification_hang \| cancelled`. Single-valued — pause / hang / cancel states are mutually exclusive (G3 I9). |
 | `last_tool_at` | per-session | ISO-8601 stamp from `mpl-tool-tracker.mjs`. Powers G4 (#109). |
 | `enforcement.*` | per-pipeline override | P0-2 (#110) per-rule policy. Top of the precedence chain. |
@@ -56,9 +59,10 @@ strict mode elevates `warn → block`.
 
 ## Schema version
 
-- `CURRENT_SCHEMA_VERSION = 3` (G5+G6 / #114 — additive backfill: `fix_loop_history`, `user_intervention_count`).
+- `CURRENT_SCHEMA_VERSION = 4` (Goal Contract / finalize evidence — additive backfill: `completed_at`, `finalized_at`, `goal_contract_*`, `security_results`).
   - v2 (P2-6 / #84) — unified state, `execution` subtree absorbs the legacy `.mpl/mpl/state.json`.
   - v3 (G5+G6 / #114) — telemetry hygiene fields.
+  - v4 — Goal Contract readiness + finalize/security evidence fields.
 - The migration registry (`hooks/lib/migrations/`) walks any older state up to current on `readState`. Newer-than-supported writes are **fail-closed** by `readState` (returns `null` + diagnostic stderr) and additionally surfaced by G3 I8.
 - `writeState` also fail-closes (throws `UnsupportedSchemaVersionError`) when on-disk `schema_version > CURRENT` so a stale plugin can't downgrade a fresher state.
 - Bump policy and authoring workflow: `docs/schemas/migration-policy.md`.

--- a/hooks/__tests__/mpl-ambiguity-gate.test.mjs
+++ b/hooks/__tests__/mpl-ambiguity-gate.test.mjs
@@ -1,0 +1,91 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { tmpdir } from 'os';
+
+import { CURRENT_SCHEMA_VERSION } from '../lib/mpl-state.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const HOOK_PATH = join(dirname(__filename), '..', 'mpl-ambiguity-gate.mjs');
+const SCHEMA_V = CURRENT_SCHEMA_VERSION;
+
+let tmp;
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'mpl-amb-goal-'));
+  mkdirSync(join(tmp, '.mpl'), { recursive: true });
+  writeFileSync(join(tmp, '.mpl', 'state.json'), JSON.stringify({
+    schema_version: SCHEMA_V,
+    current_phase: 'mpl-decompose',
+    user_contract_set: true,
+    ambiguity_score: 0.1,
+  }));
+});
+afterEach(() => rmSync(tmp, { recursive: true, force: true }));
+
+function goalContract() {
+  return `
+source:
+  user_request: "Build app"
+  user_request_hash: "req"
+mission:
+  goal: "Build with a frozen goal"
+  project_pivot: "Goal consistency"
+  must_ship_outcomes:
+    - "goal contract is ready"
+ontology:
+  entities:
+    - goal_contract
+variation_axes:
+  - id: AX-1
+acceptance_criteria:
+  - id: AC-1
+e2e_policy:
+  real_runtime_required: true
+  mock_allowed: false
+  placeholder_assertions_allowed: false
+security_policy:
+  required: false
+completion_evidence:
+  required_artifacts:
+    - .mpl/mpl/audit-report.json
+    - .mpl/mpl/profile/run-summary.json
+    - .mpl/mpl/RUNBOOK.md
+  require_commit: false
+  require_finalize_timestamps: true
+`;
+}
+
+function runHook() {
+  const input = {
+    cwd: tmp,
+    tool_name: 'Task',
+    tool_input: {
+      subagent_type: 'mpl-decomposer',
+    },
+  };
+  return JSON.parse(execFileSync('node', [HOOK_PATH], {
+    input: JSON.stringify(input),
+    encoding: 'utf-8',
+  }));
+}
+
+describe('mpl-ambiguity-gate goal contract readiness', () => {
+  it('blocks decomposer dispatch when goal contract is missing', () => {
+    const r = runHook();
+    assert.equal(r.continue, false);
+    assert.match(r.reason, /goal contract is missing or incomplete/);
+  });
+
+  it('allows decomposer dispatch and syncs goal contract state when valid', () => {
+    writeFileSync(join(tmp, '.mpl', 'goal-contract.yaml'), goalContract());
+    const r = runHook();
+    assert.equal(r.continue, true);
+    const state = JSON.parse(readFileSync(join(tmp, '.mpl', 'state.json'), 'utf-8'));
+    assert.equal(state.goal_contract_set, true);
+    assert.equal(state.goal_contract_path, '.mpl/goal-contract.yaml');
+    assert.equal(state.goal_contract_hash.length, 64);
+  });
+});

--- a/hooks/__tests__/mpl-artifact-schema.test.mjs
+++ b/hooks/__tests__/mpl-artifact-schema.test.mjs
@@ -39,6 +39,11 @@ afterEach(() => rmSync(tmp, { recursive: true, force: true }));
 /* ───────────────────── lib unit ─────────────────────────────── */
 
 describe('matchArtifactSchema', () => {
+  it('matches goal-contract.yaml under .mpl/', () => {
+    assert.equal(matchArtifactSchema('.mpl/goal-contract.yaml')?.artifact, 'goal-contract');
+    assert.equal(matchArtifactSchema('.mpl/goal-contract.yml')?.artifact, 'goal-contract');
+  });
+
   it('matches decomposition.yaml under .mpl/mpl/', () => {
     assert.equal(matchArtifactSchema('.mpl/mpl/decomposition.yaml')?.artifact, 'decomposition');
     assert.equal(matchArtifactSchema('.mpl/mpl/decomposition.yml')?.artifact, 'decomposition');

--- a/hooks/__tests__/mpl-baseline.test.mjs
+++ b/hooks/__tests__/mpl-baseline.test.mjs
@@ -63,6 +63,7 @@ describe('buildBaseline', () => {
 
   it('captures git base_sha and artifact hashes', () => {
     mkdirSync(join(dir, '.mpl'), { recursive: true });
+    writeFileSync(join(dir, '.mpl/goal-contract.yaml'), 'mission:\n  goal: test\n');
     writeFileSync(join(dir, '.mpl/pivot-points.md'), '## PP-1\nAuth is immutable');
 
     const b = buildBaseline(dir, {
@@ -77,6 +78,8 @@ describe('buildBaseline', () => {
     assert.ok(b.git.base_sha);
     assert.equal(b.git.base_branch.length > 0, true);
     assert.ok(b.artifacts.pivot_points);
+    assert.ok(b.artifacts.goal_contract);
+    assert.equal(b.artifacts.goal_contract.sha256.length, 64);
     assert.equal(b.artifacts.pivot_points.sha256.length, 64);
     assert.equal(b.artifacts.core_scenarios, null);  // file absent
     assert.equal(b.ambiguity.final_score, 0.18);
@@ -120,6 +123,7 @@ describe('serializeBaseline', () => {
       pipeline_id: 'mpl-x',
       git: { base_sha: 'abc123', base_branch: 'main', working_tree_clean: true },
       artifacts: {
+        goal_contract: { path: '.mpl/goal-contract.yaml', sha256: 'hg' },
         pivot_points: { path: '.mpl/pivot-points.md', sha256: 'h1' },
         core_scenarios: null,
         design_intent: null,
@@ -136,6 +140,7 @@ describe('serializeBaseline', () => {
     assert.ok(yaml.includes('base_sha: "abc123"'));
     assert.ok(yaml.includes('working_tree_clean: true'));
     assert.ok(yaml.includes('pivot_points:'));
+    assert.ok(yaml.includes('goal_contract:'));
     assert.ok(yaml.includes('skipped: true'));
     assert.ok(yaml.includes('final_score: 0.18'));
     assert.ok(yaml.includes('user_request_hash: "req-h"'));

--- a/hooks/__tests__/mpl-goal-contract.test.mjs
+++ b/hooks/__tests__/mpl-goal-contract.test.mjs
@@ -1,0 +1,103 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+import {
+  GOAL_CONTRACT_REL_PATH,
+  parseGoalContractText,
+  readGoalContract,
+  validateGoalContractText,
+} from '../lib/mpl-goal-contract.mjs';
+
+let tmp;
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'mpl-goal-contract-'));
+});
+afterEach(() => rmSync(tmp, { recursive: true, force: true }));
+
+function validGoalContract() {
+  return `
+version: 1
+source:
+  codex_goal: "Ship goal-first MPL"
+  user_request: "Improve MPL"
+  user_request_hash: "abc123"
+mission:
+  goal: "MPL completion must be evidence-based"
+  project_pivot: "Avoid false completion"
+  non_goals:
+    - "Rewrite every phase"
+  must_ship_outcomes:
+    - "Goal contract exists before decomposition"
+ontology:
+  entities:
+    - goal_contract
+    - e2e_scenario
+  relationships:
+    - goal_contract covers acceptance_criteria
+variation_axes:
+  - id: AX-1
+    name: runtime_mode
+acceptance_criteria:
+  - id: AC-1
+    statement: "finalize is blocked without evidence"
+e2e_policy:
+  real_runtime_required: true
+  mock_allowed: false
+  placeholder_assertions_allowed: false
+security_policy:
+  required: true
+  checks:
+    - dependency_audit
+completion_evidence:
+  required_artifacts:
+    - .mpl/mpl/audit-report.json
+    - .mpl/mpl/profile/run-summary.json
+    - .mpl/mpl/RUNBOOK.md
+  require_commit: false
+  require_finalize_timestamps: true
+`;
+}
+
+describe('goal contract parsing', () => {
+  it('extracts the readiness fields MPL gates consume', () => {
+    const c = parseGoalContractText(validGoalContract());
+    assert.equal(c.mission.goal, 'MPL completion must be evidence-based');
+    assert.equal(c.mission.project_pivot, 'Avoid false completion');
+    assert.deepEqual(c.ontology.entities, ['goal_contract', 'e2e_scenario']);
+    assert.deepEqual(c.variation_axes, ['AX-1']);
+    assert.deepEqual(c.acceptance_criteria, ['AC-1']);
+    assert.equal(c.e2e_policy.real_runtime_required, true);
+    assert.equal(c.e2e_policy.mock_allowed, false);
+    assert.equal(c.security_policy.required, true);
+    assert.deepEqual(c.security_policy.checks, ['dependency_audit']);
+    assert.equal(c.completion_evidence.require_finalize_timestamps, true);
+    assert.equal(c.content_sha256.length, 64);
+  });
+
+  it('validates a complete contract', () => {
+    const verdict = validateGoalContractText(validGoalContract());
+    assert.equal(verdict.valid, true);
+    assert.deepEqual(verdict.missing, []);
+  });
+
+  it('reports missing goal-readiness fields', () => {
+    const verdict = validateGoalContractText('mission:\n  goal: "x"\n');
+    assert.equal(verdict.valid, false);
+    assert.ok(verdict.missing.includes('mission.project_pivot'));
+    assert.ok(verdict.missing.includes('ontology.entities'));
+    assert.ok(verdict.missing.includes('acceptance_criteria[].id'));
+    assert.ok(verdict.missing.includes('completion_evidence.required_artifacts'));
+  });
+
+  it('reads .mpl/goal-contract.yaml from disk', () => {
+    mkdirSync(join(tmp, '.mpl'), { recursive: true });
+    writeFileSync(join(tmp, GOAL_CONTRACT_REL_PATH), validGoalContract());
+    const verdict = readGoalContract(tmp);
+    assert.equal(verdict.exists, true);
+    assert.equal(verdict.valid, true);
+    assert.equal(verdict.contract.mission.project_pivot, 'Avoid false completion');
+  });
+});

--- a/hooks/__tests__/mpl-goal-contract.test.mjs
+++ b/hooks/__tests__/mpl-goal-contract.test.mjs
@@ -77,6 +77,15 @@ describe('goal contract parsing', () => {
     assert.equal(c.content_sha256.length, 64);
   });
 
+  it('extracts list ids even when id is not the first key in the list item', () => {
+    const text = validGoalContract()
+      .replace('- id: AX-1\n    name: runtime_mode', '- name: runtime_mode\n    id: AX-1')
+      .replace('- id: AC-1\n    statement: "finalize is blocked without evidence"', '- statement: "finalize is blocked without evidence"\n    id: AC-1');
+    const c = parseGoalContractText(text);
+    assert.deepEqual(c.variation_axes, ['AX-1']);
+    assert.deepEqual(c.acceptance_criteria, ['AC-1']);
+  });
+
   it('validates a complete contract', () => {
     const verdict = validateGoalContractText(validGoalContract());
     assert.equal(verdict.valid, true);

--- a/hooks/__tests__/mpl-require-e2e-authenticity.test.mjs
+++ b/hooks/__tests__/mpl-require-e2e-authenticity.test.mjs
@@ -1,0 +1,164 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { tmpdir } from 'os';
+
+import { parseE2EScenariosText } from '../mpl-require-e2e-authenticity.mjs';
+import { CURRENT_SCHEMA_VERSION } from '../lib/mpl-state.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const HOOK_PATH = join(dirname(__filename), '..', 'mpl-require-e2e-authenticity.mjs');
+const SCHEMA_V = CURRENT_SCHEMA_VERSION;
+
+let tmp;
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'mpl-e2e-auth-'));
+  mkdirSync(join(tmp, '.mpl', 'mpl'), { recursive: true });
+  writeFileSync(join(tmp, '.mpl', 'state.json'), JSON.stringify({
+    schema_version: SCHEMA_V,
+    current_phase: 'phase5-finalize',
+  }));
+  writeFileSync(join(tmp, '.mpl', 'goal-contract.yaml'), goalContract());
+});
+afterEach(() => rmSync(tmp, { recursive: true, force: true }));
+
+function goalContract() {
+  return `
+source:
+  user_request: "Build app"
+  user_request_hash: "req"
+mission:
+  goal: "Build with real E2E"
+  project_pivot: "No mock completion"
+  must_ship_outcomes:
+    - "real E2E"
+ontology:
+  entities:
+    - app
+variation_axes:
+  - id: AX-1
+acceptance_criteria:
+  - id: AC-1
+e2e_policy:
+  real_runtime_required: true
+  mock_allowed: false
+  placeholder_assertions_allowed: false
+security_policy:
+  required: false
+completion_evidence:
+  required_artifacts:
+    - .mpl/mpl/audit-report.json
+    - .mpl/mpl/profile/run-summary.json
+    - .mpl/mpl/RUNBOOK.md
+  require_commit: false
+  require_finalize_timestamps: true
+`;
+}
+
+function writeScenarios(text) {
+  writeFileSync(join(tmp, '.mpl', 'mpl', 'e2e-scenarios.yaml'), text);
+}
+
+function runHook() {
+  const input = {
+    cwd: tmp,
+    tool_name: 'Write',
+    tool_input: {
+      file_path: '.mpl/state.json',
+      content: JSON.stringify({ current_phase: 'phase5-finalize', finalize_done: true }),
+    },
+  };
+  return JSON.parse(execFileSync('node', [HOOK_PATH], {
+    input: JSON.stringify(input),
+    encoding: 'utf-8',
+  }));
+}
+
+describe('parseE2EScenariosText', () => {
+  it('parses authenticity fields', () => {
+    const scenarios = parseE2EScenariosText(`
+e2e_scenarios:
+  - id: E2E-1
+    required: true
+    test_command: "npm run e2e"
+    runtime_class: real_desktop
+    mock_allowed: false
+    launcher_evidence: "electron.launch"
+    assertion_evidence: "persists after restart"
+    test_files:
+      - tests/e2e/app.spec.ts
+`);
+    assert.equal(scenarios.length, 1);
+    assert.equal(scenarios[0].runtime_class, 'real_desktop');
+    assert.deepEqual(scenarios[0].test_files, ['tests/e2e/app.spec.ts']);
+  });
+});
+
+describe('mpl-require-e2e-authenticity hook', () => {
+  it('allows real runtime scenarios with assertion evidence', () => {
+    writeScenarios(`
+e2e_scenarios:
+  - id: E2E-1
+    required: true
+    test_command: "npm run e2e"
+    runtime_class: real_desktop
+    mock_allowed: false
+    launcher_evidence: "electron.launch"
+    assertion_evidence: "restart survival assertion"
+`);
+    const r = runHook();
+    assert.equal(r.continue, true);
+  });
+
+  it('blocks missing runtime class', () => {
+    writeScenarios(`
+e2e_scenarios:
+  - id: E2E-1
+    required: true
+    test_command: "npm run e2e"
+    launcher_evidence: "playwright chromium"
+    assertion_evidence: "visible result"
+`);
+    const r = runHook();
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason, /runtime_class=missing/);
+  });
+
+  it('blocks mock-token commands when mock_allowed is false', () => {
+    writeScenarios(`
+e2e_scenarios:
+  - id: E2E-1
+    required: true
+    test_command: "VITE_E2E_MOCK=1 npm run e2e"
+    runtime_class: real_web
+    mock_allowed: false
+    launcher_evidence: "playwright"
+    assertion_evidence: "visible result"
+`);
+    const r = runHook();
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason, /mock_token_in_command/);
+  });
+
+  it('blocks placeholder assertions in declared test files', () => {
+    mkdirSync(join(tmp, 'tests', 'e2e'), { recursive: true });
+    writeFileSync(join(tmp, 'tests', 'e2e', 'app.spec.ts'), 'test("x", () => expect(true).toBe(true));\n');
+    writeScenarios(`
+e2e_scenarios:
+  - id: E2E-1
+    required: true
+    test_command: "npm run e2e"
+    runtime_class: real_web
+    mock_allowed: false
+    launcher_evidence: "playwright"
+    test_files:
+      - tests/e2e/app.spec.ts
+`);
+    const r = runHook();
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason, /placeholder_assertion/);
+  });
+});

--- a/hooks/__tests__/mpl-require-e2e-authenticity.test.mjs
+++ b/hooks/__tests__/mpl-require-e2e-authenticity.test.mjs
@@ -62,11 +62,11 @@ function writeScenarios(text) {
   writeFileSync(join(tmp, '.mpl', 'mpl', 'e2e-scenarios.yaml'), text);
 }
 
-function runHook() {
+function runHook({ toolName = 'Write', toolInput = null } = {}) {
   const input = {
     cwd: tmp,
-    tool_name: 'Write',
-    tool_input: {
+    tool_name: toolName,
+    tool_input: toolInput || {
       file_path: '.mpl/state.json',
       content: JSON.stringify({ current_phase: 'phase5-finalize', finalize_done: true }),
     },
@@ -123,6 +123,29 @@ e2e_scenarios:
     assertion_evidence: "visible result"
 `);
     const r = runHook();
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason, /runtime_class=missing/);
+  });
+
+  it('blocks MultiEdit finalize writes', () => {
+    writeScenarios(`
+e2e_scenarios:
+  - id: E2E-1
+    required: true
+    test_command: "npm run e2e"
+    launcher_evidence: "playwright chromium"
+    assertion_evidence: "visible result"
+`);
+    const r = runHook({
+      toolName: 'MultiEdit',
+      toolInput: {
+        file_path: '.mpl/state.json',
+        edits: [{
+          old_string: '"finalize_done": false',
+          new_string: '"finalize_done": true',
+        }],
+      },
+    });
     assert.equal(r.decision, 'block');
     assert.match(r.reason, /runtime_class=missing/);
   });

--- a/hooks/__tests__/mpl-require-e2e.test.mjs
+++ b/hooks/__tests__/mpl-require-e2e.test.mjs
@@ -1,9 +1,18 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { tmpdir } from 'os';
 import {
   parseUserContractText,
   computeUncoveredUcs,
 } from '../mpl-require-e2e.mjs';
+import { CURRENT_SCHEMA_VERSION } from '../lib/mpl-state.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const HOOK_PATH = join(dirname(__filename), '..', 'mpl-require-e2e.mjs');
 
 describe('parseUserContractText', () => {
   it('extracts included UC ids with explicit status', () => {
@@ -148,5 +157,44 @@ describe('computeUncoveredUcs', () => {
   it('returns empty when no included UCs', () => {
     const uncovered = computeUncoveredUcs([], [{ id: 'SC-1', covers: ['UC-01'] }]);
     assert.deepEqual(uncovered, []);
+  });
+});
+
+describe('mpl-require-e2e hook integration', () => {
+  it('blocks MultiEdit finalize writes when a required scenario never ran', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'mpl-require-e2e-'));
+    try {
+      mkdirSync(join(tmp, '.mpl', 'mpl'), { recursive: true });
+      writeFileSync(join(tmp, '.mpl', 'state.json'), JSON.stringify({
+        schema_version: CURRENT_SCHEMA_VERSION,
+        current_phase: 'phase5-finalize',
+        e2e_results: {},
+      }));
+      writeFileSync(join(tmp, '.mpl', 'mpl', 'e2e-scenarios.yaml'), `
+e2e_scenarios:
+  - id: E2E-1
+    required: true
+    test_command: "npm run e2e"
+`);
+      const input = {
+        cwd: tmp,
+        tool_name: 'MultiEdit',
+        tool_input: {
+          file_path: '.mpl/state.json',
+          edits: [{
+            old_string: '"finalize_done": false',
+            new_string: '"finalize_done": true',
+          }],
+        },
+      };
+      const r = JSON.parse(execFileSync('node', [HOOK_PATH], {
+        input: JSON.stringify(input),
+        encoding: 'utf-8',
+      }));
+      assert.equal(r.decision, 'block');
+      assert.match(r.reason, /E2E-1/);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
   });
 });

--- a/hooks/__tests__/mpl-require-finalize-artifacts.test.mjs
+++ b/hooks/__tests__/mpl-require-finalize-artifacts.test.mjs
@@ -1,0 +1,135 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { tmpdir } from 'os';
+
+import { CURRENT_SCHEMA_VERSION } from '../lib/mpl-state.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const HOOK_PATH = join(dirname(__filename), '..', 'mpl-require-finalize-artifacts.mjs');
+const SCHEMA_V = CURRENT_SCHEMA_VERSION;
+
+let tmp;
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'mpl-finalize-art-'));
+  mkdirSync(join(tmp, '.mpl', 'mpl', 'profile'), { recursive: true });
+  writeFileSync(join(tmp, '.mpl', 'state.json'), JSON.stringify({
+    schema_version: SCHEMA_V,
+    current_phase: 'phase5-finalize',
+    security_results: {
+      dependency_audit: { command: 'npm audit --omit=dev', exit_code: 0 },
+    },
+  }));
+  writeFileSync(join(tmp, '.mpl', 'goal-contract.yaml'), goalContract());
+});
+afterEach(() => rmSync(tmp, { recursive: true, force: true }));
+
+function goalContract() {
+  return `
+source:
+  user_request: "Build app"
+  user_request_hash: "req"
+mission:
+  goal: "Finalize with machine evidence"
+  project_pivot: "No false completion"
+  must_ship_outcomes:
+    - "final artifacts exist"
+ontology:
+  entities:
+    - finalization
+variation_axes:
+  - id: AX-1
+acceptance_criteria:
+  - id: AC-1
+e2e_policy:
+  real_runtime_required: true
+  mock_allowed: false
+  placeholder_assertions_allowed: false
+security_policy:
+  required: true
+  checks:
+    - dependency_audit
+completion_evidence:
+  required_artifacts:
+    - .mpl/mpl/audit-report.json
+    - .mpl/mpl/profile/run-summary.json
+    - .mpl/mpl/RUNBOOK.md
+  require_commit: false
+  require_finalize_timestamps: true
+`;
+}
+
+function writeArtifacts() {
+  writeFileSync(join(tmp, '.mpl', 'mpl', 'audit-report.json'), JSON.stringify({ verdict: 'pass' }));
+  writeFileSync(join(tmp, '.mpl', 'mpl', 'profile', 'run-summary.json'), JSON.stringify({ run_id: 'r1' }));
+  writeFileSync(join(tmp, '.mpl', 'mpl', 'RUNBOOK.md'), '# MPL Pipeline RUNBOOK\n\n## Pipeline Complete\n');
+}
+
+function runHook(content = null) {
+  const stateContent = content || JSON.stringify({
+    current_phase: 'phase5-finalize',
+    finalize_done: true,
+    completed_at: '2026-05-17T00:00:00Z',
+    finalized_at: '2026-05-17T00:00:01Z',
+  });
+  const input = {
+    cwd: tmp,
+    tool_name: 'Write',
+    tool_input: {
+      file_path: '.mpl/state.json',
+      content: stateContent,
+    },
+  };
+  return JSON.parse(execFileSync('node', [HOOK_PATH], {
+    input: JSON.stringify(input),
+    encoding: 'utf-8',
+  }));
+}
+
+describe('mpl-require-finalize-artifacts hook', () => {
+  it('allows finalize when declared artifacts, timestamps, and security evidence exist', () => {
+    writeArtifacts();
+    const r = runHook();
+    assert.equal(r.continue, true);
+  });
+
+  it('blocks when run-summary is missing', () => {
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'audit-report.json'), JSON.stringify({ verdict: 'pass' }));
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'RUNBOOK.md'), '# MPL Pipeline RUNBOOK\n\n## Pipeline Complete\n');
+    const r = runHook();
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason, /run-summary\.json/);
+  });
+
+  it('blocks when RUNBOOK lacks the final section', () => {
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'audit-report.json'), JSON.stringify({ verdict: 'pass' }));
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'profile', 'run-summary.json'), JSON.stringify({ run_id: 'r1' }));
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'RUNBOOK.md'), '# MPL Pipeline RUNBOOK\n');
+    const r = runHook();
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason, /Pipeline Complete/);
+  });
+
+  it('blocks when required security evidence is missing', () => {
+    writeFileSync(join(tmp, '.mpl', 'state.json'), JSON.stringify({
+      schema_version: SCHEMA_V,
+      current_phase: 'phase5-finalize',
+      security_results: {},
+    }));
+    writeArtifacts();
+    const r = runHook();
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason, /security:dependency_audit/);
+  });
+
+  it('blocks when finalize timestamps are not in the candidate state', () => {
+    writeArtifacts();
+    const r = runHook(JSON.stringify({ current_phase: 'phase5-finalize', finalize_done: true }));
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason, /state\.completed_at/);
+    assert.match(r.reason, /state\.finalized_at/);
+  });
+});

--- a/hooks/__tests__/mpl-require-finalize-artifacts.test.mjs
+++ b/hooks/__tests__/mpl-require-finalize-artifacts.test.mjs
@@ -68,7 +68,7 @@ function writeArtifacts() {
   writeFileSync(join(tmp, '.mpl', 'mpl', 'RUNBOOK.md'), '# MPL Pipeline RUNBOOK\n\n## Pipeline Complete\n');
 }
 
-function runHook(content = null) {
+function runHook(content = null, { toolName = 'Write', toolInput = null } = {}) {
   const stateContent = content || JSON.stringify({
     current_phase: 'phase5-finalize',
     finalize_done: true,
@@ -77,8 +77,8 @@ function runHook(content = null) {
   });
   const input = {
     cwd: tmp,
-    tool_name: 'Write',
-    tool_input: {
+    tool_name: toolName,
+    tool_input: toolInput || {
       file_path: '.mpl/state.json',
       content: stateContent,
     },
@@ -100,6 +100,23 @@ describe('mpl-require-finalize-artifacts hook', () => {
     writeFileSync(join(tmp, '.mpl', 'mpl', 'audit-report.json'), JSON.stringify({ verdict: 'pass' }));
     writeFileSync(join(tmp, '.mpl', 'mpl', 'RUNBOOK.md'), '# MPL Pipeline RUNBOOK\n\n## Pipeline Complete\n');
     const r = runHook();
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason, /run-summary\.json/);
+  });
+
+  it('blocks MultiEdit finalize writes', () => {
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'audit-report.json'), JSON.stringify({ verdict: 'pass' }));
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'RUNBOOK.md'), '# MPL Pipeline RUNBOOK\n\n## Pipeline Complete\n');
+    const r = runHook(null, {
+      toolName: 'MultiEdit',
+      toolInput: {
+        file_path: '.mpl/state.json',
+        edits: [{
+          old_string: '"finalize_done": false',
+          new_string: '"finalize_done": true',
+        }],
+      },
+    });
     assert.equal(r.decision, 'block');
     assert.match(r.reason, /run-summary\.json/);
   });

--- a/hooks/__tests__/mpl-state.test.mjs
+++ b/hooks/__tests__/mpl-state.test.mjs
@@ -369,6 +369,29 @@ describe('P2-6 unified state: schema_version + execution subtree', () => {
   });
 });
 
+describe('v3 → v4 migration: goal contract fields', () => {
+  let tmpDir;
+  beforeEach(() => { tmpDir = mkdtempSync(join(tmpdir(), 'mpl-v4-')); });
+  afterEach(() => { rmSync(tmpDir, { recursive: true, force: true }); });
+
+  it('backfills goal contract, finalize timestamp, and security evidence fields', () => {
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    writeFileSync(join(tmpDir, '.mpl', 'state.json'), JSON.stringify({
+      schema_version: 3,
+      current_phase: 'phase5-finalize',
+    }));
+
+    const state = readState(tmpDir);
+    assert.strictEqual(state.schema_version, CURRENT_SCHEMA_VERSION);
+    assert.strictEqual(state.completed_at, null);
+    assert.strictEqual(state.finalized_at, null);
+    assert.strictEqual(state.goal_contract_set, false);
+    assert.strictEqual(state.goal_contract_path, '.mpl/goal-contract.yaml');
+    assert.strictEqual(state.goal_contract_hash, null);
+    assert.deepStrictEqual(state.security_results, {});
+  });
+});
+
 describe('P2-6 unified state: legacy migration', () => {
   let tmpDir;
   beforeEach(() => { tmpDir = mkdtempSync(join(tmpdir(), 'mpl-migrate-')); });

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -52,7 +52,7 @@
         ]
       },
       {
-        "matcher": "Edit|Write",
+        "matcher": "Edit|Write|MultiEdit",
         "hooks": [
           {
             "type": "command",
@@ -62,7 +62,7 @@
         ]
       },
       {
-        "matcher": "Edit|Write",
+        "matcher": "Edit|Write|MultiEdit",
         "hooks": [
           {
             "type": "command",
@@ -72,7 +72,7 @@
         ]
       },
       {
-        "matcher": "Edit|Write",
+        "matcher": "Edit|Write|MultiEdit",
         "hooks": [
           {
             "type": "command",

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -66,6 +66,26 @@
         "hooks": [
           {
             "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/mpl-require-e2e-authenticity.mjs\"",
+            "timeout": 3
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/mpl-require-finalize-artifacts.mjs\"",
+            "timeout": 3
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/mpl-validate-pp-schema.mjs\"",
             "timeout": 3
           }

--- a/hooks/lib/migrations/index.mjs
+++ b/hooks/lib/migrations/index.mjs
@@ -19,6 +19,7 @@
 
 import v1ToV2 from './v1-to-v2.mjs';
 import v2ToV3 from './v2-to-v3.mjs';
+import v3ToV4 from './v3-to-v4.mjs';
 
 /**
  * Ordered registry. Add new entries here when bumping
@@ -27,6 +28,7 @@ import v2ToV3 from './v2-to-v3.mjs';
 export const MIGRATIONS = Object.freeze([
   v1ToV2,
   v2ToV3,
+  v3ToV4,
 ]);
 
 /**

--- a/hooks/lib/migrations/v3-to-v4.mjs
+++ b/hooks/lib/migrations/v3-to-v4.mjs
@@ -1,0 +1,29 @@
+/**
+ * v3 → v4: Goal Contract + finalize evidence fields.
+ *
+ * Adds additive defaults for the goal-first harness layer:
+ * - `completed_at`, `finalized_at`
+ * - `goal_contract_set`, `goal_contract_path`, `goal_contract_hash`
+ * - `security_results`
+ */
+
+export default {
+  from: 3,
+  to: 4,
+  description: 'Additive backfill — Goal Contract readiness + finalize/security evidence fields',
+  migrate(state, _cwd) {
+    const merged = { ...state };
+
+    if (!Object.prototype.hasOwnProperty.call(merged, 'completed_at')) merged.completed_at = null;
+    if (!Object.prototype.hasOwnProperty.call(merged, 'finalized_at')) merged.finalized_at = null;
+    if (typeof merged.goal_contract_set !== 'boolean') merged.goal_contract_set = false;
+    if (typeof merged.goal_contract_path !== 'string') merged.goal_contract_path = '.mpl/goal-contract.yaml';
+    if (!Object.prototype.hasOwnProperty.call(merged, 'goal_contract_hash')) merged.goal_contract_hash = null;
+    if (!merged.security_results || typeof merged.security_results !== 'object' || Array.isArray(merged.security_results)) {
+      merged.security_results = {};
+    }
+
+    merged.schema_version = 4;
+    return merged;
+  },
+};

--- a/hooks/lib/mpl-artifact-schema.mjs
+++ b/hooks/lib/mpl-artifact-schema.mjs
@@ -31,6 +31,23 @@
 
 const ARTIFACTS = [
   {
+    artifact: 'goal-contract',
+    pathMatch: (relPath) => /(^|\/)\.mpl\/goal-contract\.ya?ml$/.test(relPath),
+    parser: 'yaml',
+    required: [
+      'source',
+      'mission',
+      'goal',
+      'project_pivot',
+      'ontology',
+      'variation_axes',
+      'acceptance_criteria',
+      'e2e_policy',
+      'security_policy',
+      'completion_evidence',
+    ],
+  },
+  {
     artifact: 'decomposition',
     pathMatch: (relPath) => /(^|\/)\.mpl\/mpl\/decomposition\.ya?ml$/.test(relPath),
     parser: 'yaml',

--- a/hooks/lib/mpl-baseline.mjs
+++ b/hooks/lib/mpl-baseline.mjs
@@ -15,6 +15,7 @@
  *     base_branch: git rev-parse --abbrev-ref HEAD
  *     working_tree_clean: boolean (git status --porcelain empty?)
  *   artifacts:
+ *     goal_contract:      { path, sha256 }
  *     pivot_points:       { path, sha256 }
  *     core_scenarios:     { path, sha256 }
  *     design_intent:      { path, sha256 }
@@ -115,6 +116,7 @@ export function buildBaseline(cwd, {
       working_tree_clean: workingTreeClean,
     },
     artifacts: {
+      goal_contract: artifactFor('.mpl/goal-contract.yaml'),
       pivot_points: artifactFor('.mpl/pivot-points.md'),
       core_scenarios: artifactFor('.mpl/mpl/core-scenarios.yaml'),
       design_intent: artifactFor('.mpl/mpl/phase0/design-intent.yaml'),

--- a/hooks/lib/mpl-config.mjs
+++ b/hooks/lib/mpl-config.mjs
@@ -63,6 +63,9 @@ const DEFAULTS = {
   max_fix_loops: 10,
   gate1_strategy: 'auto',  // 'docker', 'native', 'skip'
   hitl_timeout_seconds: 30,
+  goal_contract_required: true,
+  e2e_authenticity_required: true,
+  finalize_artifacts_required: true,
   convergence: {
     stagnation_window: 3,
     min_improvement: 0.05,

--- a/hooks/lib/mpl-goal-contract.mjs
+++ b/hooks/lib/mpl-goal-contract.mjs
@@ -7,7 +7,11 @@
  *
  * This intentionally uses a small YAML-shaped parser instead of a dependency.
  * MPL artifact schemas are controlled by the prompts, and the hook only needs
- * presence/boolean/list checks for hard-gate readiness.
+ * presence/boolean/list checks for hard-gate readiness. Supported YAML is a
+ * prompt-controlled subset: scalar keys, block lists, inline scalar lists, and
+ * list-of-object `id:` fields. Block scalars, anchors, aliases, and arbitrary
+ * YAML expressions are out of scope; use the schema examples in
+ * docs/schemas/goal-contract.md to avoid prompt drift.
  */
 
 import { existsSync, readFileSync } from 'fs';
@@ -93,10 +97,26 @@ function listAfterKey(block, key) {
 function idsInTopList(text, key, prefixRe) {
   const block = extractTopBlock(text, key);
   const out = [];
-  for (const line of block.split('\n')) {
-    const match = line.match(/^\s*-\s+id:\s*["']?([^"'\s#]+)["']?/);
+  let current = null;
+
+  const flush = () => {
+    if (!current) return;
+    const itemText = current.join('\n');
+    const match = itemText.match(/(?:^|\n)\s*id\s*:\s*["']?([^"'\s#]+)["']?/);
     if (match && (!prefixRe || prefixRe.test(match[1]))) out.push(match[1]);
+    current = null;
+  };
+
+  for (const line of block.split('\n')) {
+    const itemStart = line.match(/^\s*-\s+(.+?)\s*$/);
+    if (itemStart) {
+      flush();
+      current = [itemStart[1]];
+      continue;
+    }
+    if (current) current.push(line);
   }
+  flush();
   return out;
 }
 

--- a/hooks/lib/mpl-goal-contract.mjs
+++ b/hooks/lib/mpl-goal-contract.mjs
@@ -1,0 +1,233 @@
+/**
+ * Goal Contract utilities.
+ *
+ * The goal contract is the pipeline-level constitution: the source goal,
+ * project pivot, ontology, variation axes, acceptance criteria, and completion
+ * evidence that later gates must prove before `finalize_done=true`.
+ *
+ * This intentionally uses a small YAML-shaped parser instead of a dependency.
+ * MPL artifact schemas are controlled by the prompts, and the hook only needs
+ * presence/boolean/list checks for hard-gate readiness.
+ */
+
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { createHash } from 'crypto';
+
+export const GOAL_CONTRACT_REL_PATH = '.mpl/goal-contract.yaml';
+
+const DEFAULT_REQUIRED_ARTIFACTS = [
+  '.mpl/mpl/audit-report.json',
+  '.mpl/mpl/profile/run-summary.json',
+  '.mpl/mpl/RUNBOOK.md',
+];
+
+function normalizeScalar(value) {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (!trimmed || trimmed === 'null') return null;
+  return trimmed.replace(/^["']|["']$/g, '').trim() || null;
+}
+
+function extractTopBlock(text, key) {
+  const lines = String(text || '').split('\n').map((l) => l.replace(/\r$/, ''));
+  const out = [];
+  let inBlock = false;
+  for (const line of lines) {
+    if (new RegExp(`^${key}\\s*:\\s*$`).test(line)) {
+      inBlock = true;
+      continue;
+    }
+    if (inBlock && /^[A-Za-z_][\w-]*\s*:/.test(line)) break;
+    if (inBlock) out.push(line);
+  }
+  return out.join('\n');
+}
+
+function scalarInBlock(block, key) {
+  const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const re = new RegExp(`^\\s+${escaped}\\s*:\\s*(.+?)\\s*$`, 'm');
+  const match = block.match(re);
+  return match ? normalizeScalar(match[1]) : null;
+}
+
+function booleanInBlock(block, key) {
+  const raw = scalarInBlock(block, key);
+  if (raw === 'true') return true;
+  if (raw === 'false') return false;
+  return null;
+}
+
+function listAfterKey(block, key) {
+  const lines = String(block || '').split('\n');
+  const out = [];
+  let inList = false;
+  let baseIndent = -1;
+  const keyRe = new RegExp(`^(\\s+)${key}\\s*:\\s*(?:\\[(.*)\\])?\\s*$`);
+
+  for (const line of lines) {
+    const inline = line.match(keyRe);
+    if (inline) {
+      inList = true;
+      baseIndent = inline[1].length;
+      if (inline[2] !== undefined) {
+        return inline[2]
+          .split(',')
+          .map((s) => normalizeScalar(s))
+          .filter(Boolean);
+      }
+      continue;
+    }
+    if (!inList) continue;
+
+    const item = line.match(/^(\s*)-\s+(.+?)\s*$/);
+    if (item && item[1].length > baseIndent) {
+      out.push(normalizeScalar(item[2]));
+      continue;
+    }
+    if (line.trim() && item === null && line.match(/^\s*\w[\w-]*\s*:/)) break;
+  }
+  return out.filter(Boolean);
+}
+
+function idsInTopList(text, key, prefixRe) {
+  const block = extractTopBlock(text, key);
+  const out = [];
+  for (const line of block.split('\n')) {
+    const match = line.match(/^\s*-\s+id:\s*["']?([^"'\s#]+)["']?/);
+    if (match && (!prefixRe || prefixRe.test(match[1]))) out.push(match[1]);
+  }
+  return out;
+}
+
+function sha256(text) {
+  return createHash('sha256').update(String(text || '').replace(/\r\n/g, '\n').trim()).digest('hex');
+}
+
+export function parseGoalContractText(text) {
+  const source = extractTopBlock(text, 'source');
+  const mission = extractTopBlock(text, 'mission');
+  const ontology = extractTopBlock(text, 'ontology');
+  const e2ePolicy = extractTopBlock(text, 'e2e_policy');
+  const securityPolicy = extractTopBlock(text, 'security_policy');
+  const completionEvidence = extractTopBlock(text, 'completion_evidence');
+
+  return {
+    source: {
+      codex_goal: scalarInBlock(source, 'codex_goal'),
+      user_request: scalarInBlock(source, 'user_request'),
+      user_request_hash: scalarInBlock(source, 'user_request_hash'),
+    },
+    mission: {
+      goal: scalarInBlock(mission, 'goal'),
+      project_pivot: scalarInBlock(mission, 'project_pivot'),
+      non_goals: listAfterKey(mission, 'non_goals'),
+      must_ship_outcomes: listAfterKey(mission, 'must_ship_outcomes'),
+    },
+    ontology: {
+      entities: listAfterKey(ontology, 'entities'),
+      relationships: listAfterKey(ontology, 'relationships'),
+      state_transitions: listAfterKey(ontology, 'state_transitions'),
+    },
+    variation_axes: idsInTopList(text, 'variation_axes', /^AX-/),
+    acceptance_criteria: idsInTopList(text, 'acceptance_criteria', /^AC-/),
+    e2e_policy: {
+      real_runtime_required: booleanInBlock(e2ePolicy, 'real_runtime_required'),
+      mock_allowed: booleanInBlock(e2ePolicy, 'mock_allowed'),
+      placeholder_assertions_allowed: booleanInBlock(e2ePolicy, 'placeholder_assertions_allowed'),
+    },
+    security_policy: {
+      required: booleanInBlock(securityPolicy, 'required'),
+      checks: listAfterKey(securityPolicy, 'checks'),
+    },
+    completion_evidence: {
+      required_artifacts: listAfterKey(completionEvidence, 'required_artifacts'),
+      require_commit: booleanInBlock(completionEvidence, 'require_commit'),
+      require_finalize_timestamps: booleanInBlock(completionEvidence, 'require_finalize_timestamps'),
+    },
+    content_sha256: sha256(text),
+  };
+}
+
+export function validateGoalContractText(text) {
+  const contract = parseGoalContractText(text);
+  const missing = [];
+  const warnings = [];
+
+  if (!contract.source.codex_goal && !contract.source.user_request) {
+    missing.push('source.codex_goal_or_user_request');
+  }
+  if (!contract.source.user_request_hash) missing.push('source.user_request_hash');
+  if (!contract.mission.goal) missing.push('mission.goal');
+  if (!contract.mission.project_pivot) missing.push('mission.project_pivot');
+  if (contract.mission.must_ship_outcomes.length === 0) missing.push('mission.must_ship_outcomes');
+  if (contract.ontology.entities.length === 0) missing.push('ontology.entities');
+  if (contract.variation_axes.length === 0) missing.push('variation_axes[].id');
+  if (contract.acceptance_criteria.length === 0) missing.push('acceptance_criteria[].id');
+
+  for (const key of ['real_runtime_required', 'mock_allowed', 'placeholder_assertions_allowed']) {
+    if (contract.e2e_policy[key] === null) missing.push(`e2e_policy.${key}`);
+  }
+  if (contract.security_policy.required === null) missing.push('security_policy.required');
+  if (contract.security_policy.required === true && contract.security_policy.checks.length === 0) {
+    missing.push('security_policy.checks');
+  }
+  if (contract.completion_evidence.required_artifacts.length === 0) {
+    missing.push('completion_evidence.required_artifacts');
+  }
+  if (contract.completion_evidence.require_commit === null) {
+    missing.push('completion_evidence.require_commit');
+  }
+  if (contract.completion_evidence.require_finalize_timestamps === null) {
+    missing.push('completion_evidence.require_finalize_timestamps');
+  }
+
+  for (const artifact of DEFAULT_REQUIRED_ARTIFACTS) {
+    if (!contract.completion_evidence.required_artifacts.includes(artifact)) {
+      warnings.push(`completion_evidence.required_artifacts missing recommended ${artifact}`);
+    }
+  }
+
+  return {
+    valid: missing.length === 0,
+    missing,
+    warnings,
+    contract,
+  };
+}
+
+export function readGoalContract(cwd) {
+  const path = join(cwd, GOAL_CONTRACT_REL_PATH);
+  if (!existsSync(path)) {
+    return {
+      exists: false,
+      path: GOAL_CONTRACT_REL_PATH,
+      valid: false,
+      missing: ['file'],
+      warnings: [],
+      contract: null,
+    };
+  }
+  try {
+    const text = readFileSync(path, 'utf-8');
+    const verdict = validateGoalContractText(text);
+    return {
+      exists: true,
+      path: GOAL_CONTRACT_REL_PATH,
+      ...verdict,
+    };
+  } catch {
+    return {
+      exists: true,
+      path: GOAL_CONTRACT_REL_PATH,
+      valid: false,
+      missing: ['readable_file'],
+      warnings: [],
+      contract: null,
+    };
+  }
+}
+
+export function defaultRequiredArtifacts() {
+  return [...DEFAULT_REQUIRED_ARTIFACTS];
+}

--- a/hooks/lib/mpl-state.mjs
+++ b/hooks/lib/mpl-state.mjs
@@ -40,12 +40,14 @@ export const MAX_AMBIGUITY_HISTORY = 10;
  * - `3` = G5 + G6 (#114) telemetry hygiene fields: additive backfill for
  *   `fix_loop_history` (per-phase fix-loop entries) and
  *   `user_intervention_count` (auto-mode honesty counter).
+ * - `4` = Goal Contract readiness fields and finalize/security evidence
+ *   backfills.
  *
  * H8 (#116) routes per-version logic through `hooks/lib/migrations/`. To
  * bump this constant, register a new migration entry; see
  * `docs/schemas/migration-policy.md`.
  */
-export const CURRENT_SCHEMA_VERSION = 3;
+export const CURRENT_SCHEMA_VERSION = 4;
 
 /**
  * Legacy execution state file. Pre-P2-6 orchestrator prompts wrote to this
@@ -82,6 +84,8 @@ const DEFAULT_STATE = {
   worktree_history: [],      // History of worktree switches
   current_phase: 'phase1-plan',
   started_at: null,
+  completed_at: null,
+  finalized_at: null,
   finalize_done: false,      // Set to true when Step 5 finalization completes
   sprint_status: {
     total_todos: 0,
@@ -114,6 +118,17 @@ const DEFAULT_STATE = {
   // Populated by mpl-gate-recorder.mjs when Bash command matches a scenario's
   // test_command. Consumed by finalize Step 5.0 and mpl-require-e2e.mjs hook.
   e2e_results: {},
+  // Goal Contract (Ouroboros-style Seed / MPL constitution) readiness.
+  // `.mpl/goal-contract.yaml` freezes the goal, project pivot, ontology,
+  // variation axes, acceptance criteria, E2E policy, security policy, and
+  // finalize evidence before decomposition. The ambiguity gate treats the file
+  // as the disk truth and syncs these fields when it is valid.
+  goal_contract_set: false,
+  goal_contract_path: '.mpl/goal-contract.yaml',
+  goal_contract_hash: null,
+  // Structured security evidence consumed by finalize artifact guard when the
+  // goal contract declares `security_policy.required: true`.
+  security_results: {},
   fix_loop_count: 0,
   // G5 (#114): per-phase fix-loop entries appended by mpl-phase-controller
   // when fix_loop_count changes. Each entry:
@@ -700,6 +715,7 @@ const PIPELINE_SCOPE_PATHS = [
   // Root-level pipeline artifacts
   '.mpl/state.json',
   '.mpl/PLAN.md',
+  '.mpl/goal-contract.yaml',
   '.mpl/auto-permit-learned.json',
   // Signals (transient)
   '.mpl/signals',
@@ -756,6 +772,7 @@ function archivePreviousRun(cwd) {
     const toArchive = [
       ['state.json', '.mpl/state.json'],
       ['PLAN.md', '.mpl/PLAN.md'],
+      ['goal-contract.yaml', '.mpl/goal-contract.yaml'],
     ];
 
     for (const [name, relPath] of toArchive) {
@@ -912,4 +929,3 @@ export function checkConvergence(state) {
 
   return { status: 'improving', delta: improvement };
 }
-

--- a/hooks/mpl-ambiguity-gate.mjs
+++ b/hooks/mpl-ambiguity-gate.mjs
@@ -22,6 +22,9 @@ const __dirname = dirname(__filename);
 const { isMplActive, readState, writeState } = await import(
   pathToFileURL(join(__dirname, 'lib', 'mpl-state.mjs')).href
 );
+const { readGoalContract } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-goal-contract.mjs')).href
+);
 
 /**
  * 0.16 Tier A' opt-out: legacy projects can disable the user-contract
@@ -33,6 +36,22 @@ function isUserContractRequired(cwd) {
     if (!existsSync(cfgPath)) return true;
     const cfg = JSON.parse(readFileSync(cfgPath, 'utf-8'));
     if (cfg && cfg.user_contract_required === false) return false;
+  } catch {
+    // fall through
+  }
+  return true;
+}
+
+/**
+ * Goal Contract opt-out: legacy projects can disable the readiness gate via
+ * .mpl/config.json { "goal_contract_required": false }. Default true.
+ */
+function isGoalContractRequired(cwd) {
+  try {
+    const cfgPath = join(cwd, '.mpl', 'config.json');
+    if (!existsSync(cfgPath)) return true;
+    const cfg = JSON.parse(readFileSync(cfgPath, 'utf-8'));
+    if (cfg && cfg.goal_contract_required === false) return false;
   } catch {
     // fall through
   }
@@ -104,6 +123,33 @@ async function main() {
         'To opt out in legacy projects: set user_contract_required=false in .mpl/config.json.'
     }));
     return;
+  }
+
+  // Goal Contract readiness: the ambiguity score is necessary but not
+  // sufficient. Before decomposition, freeze a contract that carries the
+  // goal/pivot/ontology/variation axes/evidence policy, then validate the disk
+  // artifact. This is the MPL counterpart to a Seed readiness gate.
+  if (isGoalContractRequired(cwd)) {
+    const goal = readGoalContract(cwd);
+    if (!goal.exists || !goal.valid) {
+      writeState(cwd, { current_phase: 'mpl-ambiguity-resolve' });
+      console.log(JSON.stringify({
+        continue: false,
+        reason: '[MPL] ⛔ Decomposer BLOCKED: goal contract is missing or incomplete. ' +
+          `Write .mpl/goal-contract.yaml before decomposition. Missing: ${goal.missing.join(', ')}. ` +
+          'It must freeze source goal/user request, project pivot, ontology, variation axes, acceptance criteria, E2E policy, security policy, and completion evidence. ' +
+          'To opt out in legacy projects: set goal_contract_required=false in .mpl/config.json.'
+      }));
+      return;
+    }
+
+    if (state.goal_contract_set !== true || state.goal_contract_hash !== goal.contract.content_sha256) {
+      writeState(cwd, {
+        goal_contract_set: true,
+        goal_contract_path: goal.path,
+        goal_contract_hash: goal.contract.content_sha256,
+      });
+    }
   }
 
   // Issue #51: override takes precedence over score. When the orchestrator

--- a/hooks/mpl-artifact-schema.mjs
+++ b/hooks/mpl-artifact-schema.mjs
@@ -2,8 +2,8 @@
 /**
  * MPL Artifact Schema Hook (PostToolUse Edit|Write|MultiEdit) — P0-K / #115.
  *
- * Validates phase artifacts (`decomposition.yaml`, `state-summary.md`,
- * `verification.md`, `pivot-points.md`, `user-contract.md`) against
+ * Validates phase artifacts (`goal-contract.yaml`, `decomposition.yaml`,
+ * `state-summary.md`, `verification.md`, `pivot-points.md`, `user-contract.md`) against
  * required-section schemas immediately after they're written. Closes
  * the consumer gap that left `enforcement.missing_artifact_schema` as
  * a configured-but-unused rule (F5 #112 forward-compat allow-list).
@@ -206,6 +206,8 @@ function enumerateArtifactPaths(root) {
   // Singletons
   if (existsSync(join(root, '.mpl/mpl/decomposition.yaml'))) out.push('.mpl/mpl/decomposition.yaml');
   if (existsSync(join(root, '.mpl/mpl/decomposition.yml'))) out.push('.mpl/mpl/decomposition.yml');
+  if (existsSync(join(root, '.mpl/goal-contract.yaml'))) out.push('.mpl/goal-contract.yaml');
+  if (existsSync(join(root, '.mpl/goal-contract.yml'))) out.push('.mpl/goal-contract.yml');
   if (existsSync(join(root, '.mpl/pivot-points.md'))) out.push('.mpl/pivot-points.md');
   if (existsSync(join(root, '.mpl/requirements/user-contract.md'))) {
     out.push('.mpl/requirements/user-contract.md');

--- a/hooks/mpl-require-e2e-authenticity.mjs
+++ b/hooks/mpl-require-e2e-authenticity.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * MPL E2E Authenticity Guard (PreToolUse on Write|Edit targeting state.json).
+ * MPL E2E Authenticity Guard (PreToolUse on Write|Edit|MultiEdit targeting state.json).
  *
  * `mpl-require-e2e.mjs` proves required scenarios ran and exited 0. This hook
  * proves the scenarios are admissible evidence for the goal contract: real
@@ -63,11 +63,40 @@ function parseInlineList(value) {
     .filter(Boolean);
 }
 
+function targetPaths(toolInput) {
+  const paths = [];
+  if (toolInput.file_path) paths.push(toolInput.file_path);
+  if (toolInput.filePath) paths.push(toolInput.filePath);
+  if (Array.isArray(toolInput.edits)) {
+    for (const edit of toolInput.edits) {
+      if (edit?.file_path) paths.push(edit.file_path);
+      if (edit?.filePath) paths.push(edit.filePath);
+    }
+  }
+  return paths;
+}
+
+function proposedTexts(toolInput) {
+  const texts = [];
+  for (const key of ['new_string', 'newString', 'content']) {
+    if (typeof toolInput[key] === 'string') texts.push(toolInput[key]);
+  }
+  if (Array.isArray(toolInput.edits)) {
+    for (const edit of toolInput.edits) {
+      for (const key of ['new_string', 'newString', 'content']) {
+        if (typeof edit?.[key] === 'string') texts.push(edit[key]);
+      }
+    }
+  }
+  return texts;
+}
+
 function isFinalizeDoneWrite(toolInput) {
-  const filePath = toolInput.file_path || toolInput.filePath || '';
-  if (!/\.mpl\/state\.json$/.test(filePath)) return false;
-  const newText = toolInput.new_string || toolInput.newString || toolInput.content || '';
-  return /"finalize_done"\s*:\s*true/.test(newText);
+  if (!targetPaths(toolInput).some((p) => /\.mpl\/state\.json$/.test(p))) return false;
+  // Intentionally re-check any proposed state text that contains
+  // finalize_done=true, including state re-serializations after completion:
+  // evidence can be deleted or invalidated between final writes.
+  return proposedTexts(toolInput).some((text) => /"finalize_done"\s*:\s*true/.test(text));
 }
 
 export function parseE2EScenariosText(text) {
@@ -215,7 +244,7 @@ async function main() {
   if (!isMplActive(cwd)) return ok();
 
   const toolName = String(data.tool_name || data.toolName || '');
-  if (!['Write', 'write', 'Edit', 'edit'].includes(toolName)) return ok();
+  if (!['Write', 'write', 'Edit', 'edit', 'MultiEdit', 'multiEdit'].includes(toolName)) return ok();
 
   const toolInput = data.tool_input || data.toolInput || {};
   if (!isFinalizeDoneWrite(toolInput)) return ok();

--- a/hooks/mpl-require-e2e-authenticity.mjs
+++ b/hooks/mpl-require-e2e-authenticity.mjs
@@ -1,0 +1,251 @@
+#!/usr/bin/env node
+/**
+ * MPL E2E Authenticity Guard (PreToolUse on Write|Edit targeting state.json).
+ *
+ * `mpl-require-e2e.mjs` proves required scenarios ran and exited 0. This hook
+ * proves the scenarios are admissible evidence for the goal contract: real
+ * runtime when required, no mock substitution when mock_allowed=false, and no
+ * placeholder assertions when placeholder assertions are forbidden.
+ */
+
+import { dirname, join } from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+import { existsSync, readFileSync } from 'fs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const isMain = import.meta.url === pathToFileURL(process.argv[1] || '').href;
+
+const { isMplActive } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-state.mjs')).href
+);
+const { loadConfig } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-config.mjs')).href
+);
+const { readGoalContract } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-goal-contract.mjs')).href
+);
+const { readStdin } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'stdin.mjs')).href
+);
+
+const REAL_RUNTIME_CLASSES = new Set([
+  'real_desktop',
+  'real_web',
+  'real_browser',
+  'real_mobile',
+  'real_api',
+]);
+
+const MOCK_PATTERN = /\b(mock|stub|fake|msw|mockIPC|VITE_E2E_MOCK|__mocks__)\b/i;
+const PLACEHOLDER_PATTERN = /\b(expect\s*\(\s*true\s*\)|assert\s*\(\s*true\s*\)|\.toBe\s*\(\s*true\s*\)|test\.skip\s*\(|it\.skip\s*\(|describe\.skip\s*\()/;
+
+function ok() {
+  console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+}
+
+function block(reason) {
+  console.log(JSON.stringify({ continue: false, decision: 'block', reason }));
+}
+
+function normalizeScalar(value) {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (!trimmed || trimmed === 'null') return null;
+  return trimmed.replace(/^["']|["']$/g, '').trim() || null;
+}
+
+function parseInlineList(value) {
+  if (typeof value !== 'string') return [];
+  return value
+    .split(',')
+    .map((s) => normalizeScalar(s))
+    .filter(Boolean);
+}
+
+function isFinalizeDoneWrite(toolInput) {
+  const filePath = toolInput.file_path || toolInput.filePath || '';
+  if (!/\.mpl\/state\.json$/.test(filePath)) return false;
+  const newText = toolInput.new_string || toolInput.newString || toolInput.content || '';
+  return /"finalize_done"\s*:\s*true/.test(newText);
+}
+
+export function parseE2EScenariosText(text) {
+  const out = [];
+  let cur = null;
+  let listField = null;
+  let listIndent = -1;
+
+  for (const rawLine of String(text || '').split('\n')) {
+    const line = rawLine.replace(/\r$/, '');
+    const idMatch = line.match(/^\s*-\s+id:\s*["']?(E2E-[\w-]+)["']?/);
+    if (idMatch) {
+      if (cur) out.push(cur);
+      cur = {
+        id: idMatch[1],
+        required: true,
+        test_command: null,
+        runtime_class: null,
+        mock_allowed: null,
+        launcher_evidence: null,
+        assertion_evidence: null,
+        test_files: [],
+        forbidden_patterns: [],
+      };
+      listField = null;
+      continue;
+    }
+    if (!cur) continue;
+
+    const scalar = line.match(/^\s+([a-zA-Z_][\w-]*)\s*:\s*(.+?)\s*$/);
+    if (scalar) {
+      const [, key, value] = scalar;
+      if (value.startsWith('[') && value.endsWith(']')) {
+        cur[key] = parseInlineList(value.slice(1, -1));
+        listField = null;
+        continue;
+      }
+      if (key === 'required' || key === 'mock_allowed') {
+        const normalized = normalizeScalar(value);
+        cur[key] = normalized === 'true' ? true : (normalized === 'false' ? false : null);
+        listField = null;
+        continue;
+      }
+      if (key in cur) {
+        cur[key] = normalizeScalar(value);
+        listField = null;
+      }
+      continue;
+    }
+
+    const listStart = line.match(/^(\s+)(test_files|forbidden_patterns)\s*:\s*$/);
+    if (listStart) {
+      listIndent = listStart[1].length;
+      listField = listStart[2];
+      continue;
+    }
+
+    if (listField) {
+      const item = line.match(/^(\s*)-\s+(.+?)\s*$/);
+      if (item && item[1].length > listIndent) {
+        cur[listField].push(normalizeScalar(item[2]));
+        continue;
+      }
+      listField = null;
+    }
+  }
+  if (cur) out.push(cur);
+  return out;
+}
+
+function loadScenarios(cwd) {
+  const path = join(cwd, '.mpl', 'mpl', 'e2e-scenarios.yaml');
+  if (!existsSync(path)) return [];
+  try {
+    return parseE2EScenariosText(readFileSync(path, 'utf-8'));
+  } catch {
+    return [];
+  }
+}
+
+function loadOverride(cwd) {
+  const path = join(cwd, '.mpl', 'config', 'e2e-authenticity-override.json');
+  if (!existsSync(path)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf-8'));
+    if (typeof parsed?.reason === 'string' && parsed.reason.trim()) return parsed;
+  } catch {
+    // fall through
+  }
+  return null;
+}
+
+function scanTestFiles(cwd, scenario) {
+  const hits = [];
+  for (const rel of scenario.test_files || []) {
+    const abs = join(cwd, rel);
+    if (!existsSync(abs)) {
+      hits.push(`${scenario.id}:test_file_missing:${rel}`);
+      continue;
+    }
+    let text;
+    try { text = readFileSync(abs, 'utf-8'); } catch { continue; }
+    if (PLACEHOLDER_PATTERN.test(text)) hits.push(`${scenario.id}:placeholder_assertion:${rel}`);
+    for (const pattern of scenario.forbidden_patterns || []) {
+      if (pattern && text.includes(pattern)) hits.push(`${scenario.id}:forbidden_pattern:${pattern}:${rel}`);
+    }
+  }
+  return hits;
+}
+
+function evaluateScenarioAuthenticity(cwd, scenarios, policy) {
+  const issues = [];
+  const required = scenarios.filter((s) => s.required !== false && s.test_command);
+
+  for (const scenario of required) {
+    if (policy.real_runtime_required !== false && !REAL_RUNTIME_CLASSES.has(scenario.runtime_class)) {
+      issues.push(`${scenario.id}:runtime_class=${scenario.runtime_class || 'missing'}`);
+    }
+    if (policy.real_runtime_required !== false && !scenario.launcher_evidence) {
+      issues.push(`${scenario.id}:launcher_evidence_missing`);
+    }
+    if (policy.mock_allowed === false) {
+      if (scenario.mock_allowed === true) issues.push(`${scenario.id}:mock_allowed=true`);
+      if (MOCK_PATTERN.test(String(scenario.test_command || ''))) issues.push(`${scenario.id}:mock_token_in_command`);
+    }
+    if (policy.placeholder_assertions_allowed === false) {
+      if (!scenario.assertion_evidence && (!scenario.test_files || scenario.test_files.length === 0)) {
+        issues.push(`${scenario.id}:assertion_evidence_missing`);
+      }
+      issues.push(...scanTestFiles(cwd, scenario));
+    }
+  }
+
+  return issues;
+}
+
+async function main() {
+  const raw = await readStdin();
+  if (!raw.trim()) return ok();
+
+  let data;
+  try { data = JSON.parse(raw); } catch { return ok(); }
+
+  const cwd = data.cwd || data.directory || process.cwd();
+  if (!isMplActive(cwd)) return ok();
+
+  const toolName = String(data.tool_name || data.toolName || '');
+  if (!['Write', 'write', 'Edit', 'edit'].includes(toolName)) return ok();
+
+  const toolInput = data.tool_input || data.toolInput || {};
+  if (!isFinalizeDoneWrite(toolInput)) return ok();
+
+  const cfg = loadConfig(cwd);
+  if (cfg.e2e_authenticity_required === false) return ok();
+  if (loadOverride(cwd)) return ok();
+
+  const goal = readGoalContract(cwd);
+  const policy = goal.valid
+    ? goal.contract.e2e_policy
+    : {
+        real_runtime_required: true,
+        mock_allowed: false,
+        placeholder_assertions_allowed: false,
+      };
+
+  const scenarios = loadScenarios(cwd);
+  const issues = evaluateScenarioAuthenticity(cwd, scenarios, policy);
+  if (issues.length > 0) {
+    block(
+      `[MPL E2E Authenticity] Cannot set finalize_done=true — required E2E evidence is not authentic: ${issues.join(', ')}. ` +
+        'Use real runtime scenarios, remove mock/placeholder substitutes, or record a user-approved override in .mpl/config/e2e-authenticity-override.json.'
+    );
+    return;
+  }
+
+  ok();
+}
+
+if (isMain) {
+  await main().catch(() => ok());
+}

--- a/hooks/mpl-require-e2e.mjs
+++ b/hooks/mpl-require-e2e.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * MPL Require E2E Hook (PreToolUse on Write|Edit targeting state.json)
+ * MPL Require E2E Hook (PreToolUse on Write|Edit|MultiEdit targeting state.json)
  *
  * Guards the transition to `finalize_done: true`. Reads the declared required
  * E2E scenarios from `.mpl/mpl/e2e-scenarios.yaml` and blocks the state write
@@ -295,16 +295,27 @@ export function computeUncoveredUcs(includedUcIds, scenarios) {
  * actually missing, so innocent state edits pass through.
  */
 function isFinalizeDoneWrite(toolInput) {
-  const filePath = toolInput.file_path || toolInput.filePath || '';
-  if (!/\.mpl\/state\.json$/.test(filePath)) return false;
-
-  const newText =
-    toolInput.new_string ||
-    toolInput.newString ||
-    toolInput.content ||
-    '';
-  // Match "finalize_done": true in either quoted-JSON or unquoted source
-  return /"finalize_done"\s*:\s*true/.test(newText);
+  const paths = [];
+  if (toolInput.file_path) paths.push(toolInput.file_path);
+  if (toolInput.filePath) paths.push(toolInput.filePath);
+  const texts = [];
+  for (const key of ['new_string', 'newString', 'content']) {
+    if (typeof toolInput[key] === 'string') texts.push(toolInput[key]);
+  }
+  if (Array.isArray(toolInput.edits)) {
+    for (const edit of toolInput.edits) {
+      if (edit?.file_path) paths.push(edit.file_path);
+      if (edit?.filePath) paths.push(edit.filePath);
+      for (const key of ['new_string', 'newString', 'content']) {
+        if (typeof edit?.[key] === 'string') texts.push(edit[key]);
+      }
+    }
+  }
+  if (!paths.some((p) => /\.mpl\/state\.json$/.test(p))) return false;
+  // Match "finalize_done": true in either quoted-JSON or unquoted source.
+  // Re-serialized writes are intentionally rechecked because E2E evidence can
+  // be deleted or invalidated between final state writes.
+  return texts.some((text) => /"finalize_done"\s*:\s*true/.test(text));
 }
 
 async function runHook() {
@@ -329,7 +340,7 @@ async function runHook() {
   }
 
   const toolName = String(data.tool_name || data.toolName || '');
-  if (!['Write', 'write', 'Edit', 'edit'].includes(toolName)) {
+  if (!['Write', 'write', 'Edit', 'edit', 'MultiEdit', 'multiEdit'].includes(toolName)) {
     ok();
     return;
   }

--- a/hooks/mpl-require-finalize-artifacts.mjs
+++ b/hooks/mpl-require-finalize-artifacts.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * MPL Finalize Artifact Guard (PreToolUse on Write|Edit targeting state.json).
+ * MPL Finalize Artifact Guard (PreToolUse on Write|Edit|MultiEdit targeting state.json).
  *
  * E2E pass/fail is necessary but not sufficient for completion. This hook
  * blocks `finalize_done=true` unless the goal contract's declared completion
@@ -38,15 +38,44 @@ function block(reason) {
   console.log(JSON.stringify({ continue: false, decision: 'block', reason }));
 }
 
+function targetPaths(toolInput) {
+  const paths = [];
+  if (toolInput.file_path) paths.push(toolInput.file_path);
+  if (toolInput.filePath) paths.push(toolInput.filePath);
+  if (Array.isArray(toolInput.edits)) {
+    for (const edit of toolInput.edits) {
+      if (edit?.file_path) paths.push(edit.file_path);
+      if (edit?.filePath) paths.push(edit.filePath);
+    }
+  }
+  return paths;
+}
+
+function proposedTexts(toolInput) {
+  const texts = [];
+  for (const key of ['new_string', 'newString', 'content']) {
+    if (typeof toolInput[key] === 'string') texts.push(toolInput[key]);
+  }
+  if (Array.isArray(toolInput.edits)) {
+    for (const edit of toolInput.edits) {
+      for (const key of ['new_string', 'newString', 'content']) {
+        if (typeof edit?.[key] === 'string') texts.push(edit[key]);
+      }
+    }
+  }
+  return texts;
+}
+
 function isFinalizeDoneWrite(toolInput) {
-  const filePath = toolInput.file_path || toolInput.filePath || '';
-  if (!/\.mpl\/state\.json$/.test(filePath)) return false;
-  const newText = toolInput.new_string || toolInput.newString || toolInput.content || '';
-  return /"finalize_done"\s*:\s*true/.test(newText);
+  if (!targetPaths(toolInput).some((p) => /\.mpl\/state\.json$/.test(p))) return false;
+  // Intentionally re-check any proposed state text that contains
+  // finalize_done=true, including state re-serializations after completion:
+  // evidence can be deleted or invalidated between final writes.
+  return proposedTexts(toolInput).some((text) => /"finalize_done"\s*:\s*true/.test(text));
 }
 
 function incomingText(toolInput) {
-  return String(toolInput.new_string || toolInput.newString || toolInput.content || '');
+  return proposedTexts(toolInput).join('\n');
 }
 
 function hasTimestamp(state, text, key) {
@@ -156,7 +185,7 @@ async function main() {
   if (!isMplActive(cwd)) return ok();
 
   const toolName = String(data.tool_name || data.toolName || '');
-  if (!['Write', 'write', 'Edit', 'edit'].includes(toolName)) return ok();
+  if (!['Write', 'write', 'Edit', 'edit', 'MultiEdit', 'multiEdit'].includes(toolName)) return ok();
 
   const toolInput = data.tool_input || data.toolInput || {};
   if (!isFinalizeDoneWrite(toolInput)) return ok();

--- a/hooks/mpl-require-finalize-artifacts.mjs
+++ b/hooks/mpl-require-finalize-artifacts.mjs
@@ -1,0 +1,218 @@
+#!/usr/bin/env node
+/**
+ * MPL Finalize Artifact Guard (PreToolUse on Write|Edit targeting state.json).
+ *
+ * E2E pass/fail is necessary but not sufficient for completion. This hook
+ * blocks `finalize_done=true` unless the goal contract's declared completion
+ * evidence exists: audit report, run summary, RUNBOOK final section, finalize
+ * timestamps, security evidence, and optional commit evidence.
+ */
+
+import { dirname, join } from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+import { existsSync, readFileSync } from 'fs';
+import { execFileSync } from 'child_process';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const isMain = import.meta.url === pathToFileURL(process.argv[1] || '').href;
+
+const { readState, isMplActive } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-state.mjs')).href
+);
+const { loadConfig } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-config.mjs')).href
+);
+const { readGoalContract, defaultRequiredArtifacts } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-goal-contract.mjs')).href
+);
+const { readStdin } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'stdin.mjs')).href
+);
+
+function ok() {
+  console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+}
+
+function block(reason) {
+  console.log(JSON.stringify({ continue: false, decision: 'block', reason }));
+}
+
+function isFinalizeDoneWrite(toolInput) {
+  const filePath = toolInput.file_path || toolInput.filePath || '';
+  if (!/\.mpl\/state\.json$/.test(filePath)) return false;
+  const newText = toolInput.new_string || toolInput.newString || toolInput.content || '';
+  return /"finalize_done"\s*:\s*true/.test(newText);
+}
+
+function incomingText(toolInput) {
+  return String(toolInput.new_string || toolInput.newString || toolInput.content || '');
+}
+
+function hasTimestamp(state, text, key) {
+  if (typeof state?.[key] === 'string' && state[key].trim()) return true;
+  const re = new RegExp(`"${key}"\\s*:\\s*"[^"]+"`);
+  return re.test(text);
+}
+
+function loadOverride(cwd) {
+  const path = join(cwd, '.mpl', 'config', 'finalize-artifact-override.json');
+  if (!existsSync(path)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf-8'));
+    if (typeof parsed?.reason === 'string' && parsed.reason.trim()) return parsed;
+  } catch {
+    // fall through
+  }
+  return null;
+}
+
+function readJsonIfExists(cwd, relPath) {
+  const path = join(cwd, relPath);
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, 'utf-8'));
+  } catch {
+    return null;
+  }
+}
+
+function isPassRecord(record) {
+  if (!record || typeof record !== 'object') return false;
+  if (record.exit_code === 0) return true;
+  if (record.verdict === 'pass' || record.status === 'pass' || record.status === 'PASS') return true;
+  return false;
+}
+
+function securityEvidenceMissing(cwd, state, contract) {
+  if (contract?.security_policy?.required !== true) return [];
+
+  const checks = contract.security_policy.checks || [];
+  const report = readJsonIfExists(cwd, '.mpl/mpl/security-report.json');
+  const stateResults = state?.security_results && typeof state.security_results === 'object'
+    ? state.security_results
+    : {};
+
+  if (checks.length === 0) {
+    if (isPassRecord(report)) return [];
+    return ['security_report_or_checks'];
+  }
+
+  const missing = [];
+  for (const check of checks) {
+    const stateRecord = stateResults[check];
+    const reportRecord = report?.checks?.[check];
+    if (!isPassRecord(stateRecord) && !isPassRecord(reportRecord)) missing.push(check);
+  }
+  return missing;
+}
+
+function readBaselineSha(cwd) {
+  const path = join(cwd, '.mpl', 'mpl', 'baseline.yaml');
+  if (!existsSync(path)) return null;
+  try {
+    const text = readFileSync(path, 'utf-8');
+    const match = text.match(/base_sha:\s*["']?([0-9a-f]{7,40})["']?/i);
+    return match ? match[1] : null;
+  } catch {
+    return null;
+  }
+}
+
+function hasCommitSinceBaseline(cwd) {
+  const base = readBaselineSha(cwd);
+  if (!base) return { ok: false, reason: 'baseline_sha_missing' };
+  try {
+    const count = execFileSync('git', ['rev-list', '--count', `${base}..HEAD`], {
+      cwd,
+      encoding: 'utf-8',
+      timeout: 1000,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    return { ok: Number(count) > 0, reason: Number(count) > 0 ? null : 'no_commit_since_baseline' };
+  } catch {
+    return { ok: false, reason: 'git_commit_check_failed' };
+  }
+}
+
+function runbookFinalized(cwd) {
+  const path = join(cwd, '.mpl', 'mpl', 'RUNBOOK.md');
+  if (!existsSync(path)) return false;
+  try {
+    return /(^|\n)##\s+Pipeline Complete\b/.test(readFileSync(path, 'utf-8'));
+  } catch {
+    return false;
+  }
+}
+
+async function main() {
+  const raw = await readStdin();
+  if (!raw.trim()) return ok();
+
+  let data;
+  try { data = JSON.parse(raw); } catch { return ok(); }
+
+  const cwd = data.cwd || data.directory || process.cwd();
+  if (!isMplActive(cwd)) return ok();
+
+  const toolName = String(data.tool_name || data.toolName || '');
+  if (!['Write', 'write', 'Edit', 'edit'].includes(toolName)) return ok();
+
+  const toolInput = data.tool_input || data.toolInput || {};
+  if (!isFinalizeDoneWrite(toolInput)) return ok();
+
+  const cfg = loadConfig(cwd);
+  if (cfg.finalize_artifacts_required === false) return ok();
+
+  const override = loadOverride(cwd);
+  if (override) return ok();
+
+  const state = readState(cwd) || {};
+  const text = incomingText(toolInput);
+  const goal = readGoalContract(cwd);
+  if (cfg.goal_contract_required !== false && (!goal.exists || !goal.valid)) {
+    block(`[MPL Goal Contract] Cannot set finalize_done=true — goal contract missing or invalid: ${goal.missing.join(', ')}.`);
+    return;
+  }
+
+  const contract = goal.valid ? goal.contract : null;
+  const requiredArtifacts = contract?.completion_evidence?.required_artifacts?.length
+    ? contract.completion_evidence.required_artifacts
+    : defaultRequiredArtifacts();
+
+  const missing = [];
+  for (const rel of requiredArtifacts) {
+    if (!existsSync(join(cwd, rel))) missing.push(rel);
+  }
+
+  if (requiredArtifacts.includes('.mpl/mpl/RUNBOOK.md') && !runbookFinalized(cwd)) {
+    missing.push('.mpl/mpl/RUNBOOK.md#Pipeline Complete');
+  }
+
+  if (contract?.completion_evidence?.require_finalize_timestamps !== false) {
+    if (!hasTimestamp(state, text, 'completed_at')) missing.push('state.completed_at');
+    if (!hasTimestamp(state, text, 'finalized_at')) missing.push('state.finalized_at');
+  }
+
+  const securityMissing = securityEvidenceMissing(cwd, state, contract);
+  for (const check of securityMissing) missing.push(`security:${check}`);
+
+  if (contract?.completion_evidence?.require_commit === true) {
+    const commit = hasCommitSinceBaseline(cwd);
+    if (!commit.ok) missing.push(`git:${commit.reason}`);
+  }
+
+  if (missing.length > 0) {
+    block(
+      `[MPL Finalize Guard] Cannot set finalize_done=true — missing completion evidence: ${missing.join(', ')}. ` +
+        'Create the declared artifacts/evidence or record a user-approved override in .mpl/config/finalize-artifact-override.json.'
+    );
+    return;
+  }
+
+  ok();
+}
+
+if (isMain) {
+  await main().catch(() => ok());
+}


### PR DESCRIPTION
## Summary
- add goal-contract.yaml schema and ambiguity gate readiness
- add finalize artifact and E2E authenticity guards before finalize_done=true
- add state schema v4 migration, baseline hash, and protocol docs

## Verification
- npm test (753 tests / 0 failures)
- git diff --check