### PR TITLE
fix: harden phase 1 guard paths

### DIFF
--- a/hooks/__tests__/mpl-baseline-guard.test.mjs
+++ b/hooks/__tests__/mpl-baseline-guard.test.mjs
@@ -1,0 +1,42 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { tmpdir } from 'os';
+import { CURRENT_SCHEMA_VERSION } from '../lib/mpl-state.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const HOOK_PATH = join(dirname(__filename), '..', 'mpl-baseline-guard.mjs');
+
+describe('mpl-baseline-guard hook integration', () => {
+  it('denies MultiEdit rewrites of an existing baseline without renewal sentinel', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'mpl-baseline-guard-'));
+    try {
+      mkdirSync(join(tmp, '.mpl', 'mpl'), { recursive: true });
+      writeFileSync(join(tmp, '.mpl', 'state.json'), JSON.stringify({
+        schema_version: CURRENT_SCHEMA_VERSION,
+        current_phase: 'phase1-decompose',
+      }));
+      writeFileSync(join(tmp, '.mpl', 'mpl', 'baseline.yaml'), 'pipeline_id: old\n');
+
+      const input = {
+        cwd: tmp,
+        tool_name: 'MultiEdit',
+        tool_input: {
+          file_path: '.mpl/mpl/baseline.yaml',
+          edits: [{ old_string: 'old', new_string: 'new' }],
+        },
+      };
+      const r = JSON.parse(execFileSync('node', [HOOK_PATH], {
+        input: JSON.stringify(input),
+        encoding: 'utf-8',
+      }));
+      assert.equal(r.hookSpecificOutput?.permissionDecision, 'deny');
+      assert.match(r.hookSpecificOutput?.permissionDecisionReason || '', /Baseline Guard/);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/hooks/__tests__/mpl-require-covers.test.mjs
+++ b/hooks/__tests__/mpl-require-covers.test.mjs
@@ -1,11 +1,20 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { tmpdir } from 'os';
 import {
   targetsDecompositionFile,
   parsePhaseCovers,
   validatePhase,
   computeInternalRatio,
 } from '../mpl-require-covers.mjs';
+import { CURRENT_SCHEMA_VERSION } from '../lib/mpl-state.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const HOOK_PATH = join(dirname(__filename), '..', 'mpl-require-covers.mjs');
 
 describe('targetsDecompositionFile', () => {
   it('matches .mpl/mpl/decomposition.yaml', () => {
@@ -169,5 +178,40 @@ describe('computeInternalRatio', () => {
   it('returns 0 when no valid phases', () => {
     assert.equal(computeInternalRatio([]), 0);
     assert.equal(computeInternalRatio([{ id: 'a', covers: null }]), 0);
+  });
+});
+
+describe('mpl-require-covers hook integration', () => {
+  it('blocks MultiEdit writes to decomposition.yaml with missing covers', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'mpl-covers-'));
+    try {
+      mkdirSync(join(tmp, '.mpl', 'mpl'), { recursive: true });
+      mkdirSync(join(tmp, '.mpl', 'requirements'), { recursive: true });
+      writeFileSync(join(tmp, '.mpl', 'state.json'), JSON.stringify({
+        schema_version: CURRENT_SCHEMA_VERSION,
+        current_phase: 'phase1-decompose',
+      }));
+      writeFileSync(join(tmp, '.mpl', 'requirements', 'user-contract.md'), 'user_cases: []\n');
+
+      const input = {
+        cwd: tmp,
+        tool_name: 'MultiEdit',
+        tool_input: {
+          file_path: '.mpl/mpl/decomposition.yaml',
+          edits: [{
+            old_string: 'old',
+            new_string: 'phases:\n  - id: phase-1\n    name: Missing covers\n',
+          }],
+        },
+      };
+      const r = JSON.parse(execFileSync('node', [HOOK_PATH], {
+        input: JSON.stringify(input),
+        encoding: 'utf-8',
+      }));
+      assert.equal(r.decision, 'block');
+      assert.match(r.reason, /covers field missing/);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
   });
 });

--- a/hooks/__tests__/mpl-require-test-agent.test.mjs
+++ b/hooks/__tests__/mpl-require-test-agent.test.mjs
@@ -1,0 +1,50 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { tmpdir } from 'os';
+import { CURRENT_SCHEMA_VERSION } from '../lib/mpl-state.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const HOOK_PATH = join(dirname(__filename), '..', 'mpl-require-test-agent.mjs');
+
+describe('mpl-require-test-agent hook integration', () => {
+  it('returns a real block decision when required test-agent evidence is missing', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'mpl-test-agent-'));
+    try {
+      mkdirSync(join(tmp, '.mpl', 'mpl'), { recursive: true });
+      writeFileSync(join(tmp, '.mpl', 'state.json'), JSON.stringify({
+        schema_version: CURRENT_SCHEMA_VERSION,
+        current_phase: 'phase2-sprint',
+        test_agent_dispatched: {},
+      }));
+      writeFileSync(join(tmp, '.mpl', 'mpl', 'decomposition.yaml'), `
+phases:
+  - id: phase-1
+    test_agent_required: true
+    test_agent_rationale: "touches a boundary"
+`);
+
+      const input = {
+        cwd: tmp,
+        tool_name: 'Task',
+        tool_input: {
+          subagent_type: 'mpl-phase-runner',
+          prompt: 'Run phase-1 and report completion.',
+        },
+        tool_response: 'phase complete',
+      };
+      const r = JSON.parse(execFileSync('node', [HOOK_PATH], {
+        input: JSON.stringify(input),
+        encoding: 'utf-8',
+      }));
+      assert.equal(r.continue, false);
+      assert.equal(r.decision, 'block');
+      assert.match(r.reason, /mpl-test-agent was not dispatched/);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/hooks/__tests__/mpl-sentinel-pp-file.test.mjs
+++ b/hooks/__tests__/mpl-sentinel-pp-file.test.mjs
@@ -1,6 +1,15 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { tmpdir } from 'os';
 import { parsePivotPoints, matchFileToPP } from '../mpl-sentinel-pp-file.mjs';
+import { CURRENT_SCHEMA_VERSION } from '../lib/mpl-state.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const HOOK_PATH = join(dirname(__filename), '..', 'mpl-sentinel-pp-file.mjs');
 
 describe('parsePivotPoints', () => {
   it('should extract PP entries with file references', () => {
@@ -61,5 +70,39 @@ describe('matchFileToPP', () => {
     ];
     const matches = matchFileToPP('src/shared.ts', entries);
     assert.equal(matches.length, 2);
+  });
+});
+
+describe('mpl-sentinel-pp-file hook integration', () => {
+  it('emits PP context for MultiEdit targets', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'mpl-pp-file-'));
+    try {
+      mkdirSync(join(tmp, '.mpl'), { recursive: true });
+      writeFileSync(join(tmp, '.mpl', 'state.json'), JSON.stringify({
+        schema_version: CURRENT_SCHEMA_VERSION,
+        current_phase: 'phase2-sprint',
+      }));
+      writeFileSync(join(tmp, '.mpl', 'pivot-points.md'), `
+## PP-1: Auth tokens must use secure storage
+All token handling in \`src/auth/token.ts\` must use SecureStore.
+`);
+
+      const input = {
+        cwd: tmp,
+        tool_name: 'MultiEdit',
+        tool_input: {
+          file_path: 'src/auth/token.ts',
+          edits: [{ old_string: 'a', new_string: 'b' }],
+        },
+      };
+      const r = JSON.parse(execFileSync('node', [HOOK_PATH], {
+        input: JSON.stringify(input),
+        encoding: 'utf-8',
+      }));
+      assert.equal(r.continue, true);
+      assert.match(r.additionalContext || '', /PP-1/);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
   });
 });

--- a/hooks/__tests__/mpl-tool-input.test.mjs
+++ b/hooks/__tests__/mpl-tool-input.test.mjs
@@ -1,0 +1,52 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  collectFileWrites,
+  collectTargetPaths,
+  isFileWriteTool,
+} from '../lib/tool-input.mjs';
+
+describe('tool-input helpers', () => {
+  it('recognizes Write/Edit/MultiEdit file-write tools', () => {
+    assert.equal(isFileWriteTool('Write'), true);
+    assert.equal(isFileWriteTool('Edit'), true);
+    assert.equal(isFileWriteTool('MultiEdit'), true);
+    assert.equal(isFileWriteTool('Task'), false);
+  });
+
+  it('collects top-level Write content', () => {
+    assert.deepEqual(
+      collectFileWrites({ file_path: 'a.txt', content: 'body' }),
+      [{ filePath: 'a.txt', text: 'body' }],
+    );
+  });
+
+  it('collects MultiEdit entries with inherited top-level path', () => {
+    assert.deepEqual(
+      collectFileWrites({
+        file_path: 'a.txt',
+        edits: [
+          { old_string: 'a', new_string: 'b' },
+          { old_string: 'c', new_string: 'd' },
+        ],
+      }),
+      [
+        { filePath: 'a.txt', text: '' },
+        { filePath: 'a.txt', text: 'b' },
+        { filePath: 'a.txt', text: 'd' },
+      ],
+    );
+  });
+
+  it('collects per-edit paths for multi-file shapes', () => {
+    assert.deepEqual(
+      collectTargetPaths({
+        edits: [
+          { file_path: 'a.txt', new_string: 'a' },
+          { filePath: 'b.txt', newString: 'b' },
+        ],
+      }),
+      ['a.txt', 'b.txt'],
+    );
+  });
+});

--- a/hooks/__tests__/mpl-validate-pp-schema.test.mjs
+++ b/hooks/__tests__/mpl-validate-pp-schema.test.mjs
@@ -1,11 +1,19 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { tmpdir } from 'os';
 import {
   targetsPivotPointsFile,
   extractProposedContent,
   detectUcLeakage,
   formatBlockReason,
 } from '../mpl-validate-pp-schema.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const HOOK_PATH = join(dirname(__filename), '..', 'mpl-validate-pp-schema.mjs');
 
 describe('targetsPivotPointsFile', () => {
   it('matches .mpl/pivot-points.md at repo root', () => {
@@ -43,6 +51,19 @@ describe('extractProposedContent', () => {
 
   it('returns new_string for Edit', () => {
     assert.equal(extractProposedContent({ new_string: 'new body' }, 'Edit'), 'new body');
+  });
+
+  it('returns joined new_string values for MultiEdit', () => {
+    assert.equal(
+      extractProposedContent({
+        file_path: '.mpl/pivot-points.md',
+        edits: [
+          { old_string: 'a', new_string: 'first' },
+          { old_string: 'b', new_string: 'second' },
+        ],
+      }, 'MultiEdit'),
+      'first\nsecond',
+    );
   });
 
   it('returns empty for unknown tool', () => {
@@ -126,5 +147,32 @@ describe('formatBlockReason', () => {
   it('points to user-contract.md as correct location', () => {
     const reason = formatBlockReason([{ name: 'user_cases:' }]);
     assert.ok(reason.includes('user-contract.md'));
+  });
+});
+
+describe('mpl-validate-pp-schema hook integration', () => {
+  it('blocks MultiEdit writes that leak UC schema into pivot-points.md', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'mpl-pp-schema-'));
+    try {
+      const input = {
+        cwd: tmp,
+        tool_name: 'MultiEdit',
+        tool_input: {
+          file_path: '.mpl/pivot-points.md',
+          edits: [{
+            old_string: '# Pivot Points',
+            new_string: 'user_cases:\n  - id: UC-01',
+          }],
+        },
+      };
+      const r = JSON.parse(execFileSync('node', [HOOK_PATH], {
+        input: JSON.stringify(input),
+        encoding: 'utf-8',
+      }));
+      assert.equal(r.decision, 'block');
+      assert.match(r.reason, /UC-scoped schema/);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
   });
 });

--- a/hooks/__tests__/mpl-validate-seed-hook.test.mjs
+++ b/hooks/__tests__/mpl-validate-seed-hook.test.mjs
@@ -1,0 +1,45 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { tmpdir } from 'os';
+import { CURRENT_SCHEMA_VERSION } from '../lib/mpl-state.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const HOOK_PATH = join(dirname(__filename), '..', 'mpl-validate-seed.mjs');
+
+describe('mpl-validate-seed hook integration', () => {
+  it('validates MultiEdit writes to seed YAML files', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'mpl-seed-hook-'));
+    try {
+      mkdirSync(join(tmp, '.mpl'), { recursive: true });
+      writeFileSync(join(tmp, '.mpl', 'state.json'), JSON.stringify({
+        schema_version: CURRENT_SCHEMA_VERSION,
+        current_phase: 'phase2-sprint',
+      }));
+
+      const input = {
+        cwd: tmp,
+        tool_name: 'MultiEdit',
+        tool_input: {
+          file_path: '.mpl/seeds/phase-1.yaml',
+          edits: [{
+            old_string: 'old',
+            new_string: 'phase_seed:\n  goal: "ship"\n',
+          }],
+        },
+      };
+      const r = JSON.parse(execFileSync('node', [HOOK_PATH], {
+        input: JSON.stringify(input),
+        encoding: 'utf-8',
+      }));
+      assert.equal(r.continue, true);
+      assert.match(r.hookSpecificOutput?.additionalContext || '', /SEED VALIDATION FAILED/);
+      assert.match(r.hookSpecificOutput?.additionalContext || '', /acceptance_criteria/);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -82,7 +82,7 @@
         ]
       },
       {
-        "matcher": "Edit|Write",
+        "matcher": "Edit|Write|MultiEdit",
         "hooks": [
           {
             "type": "command",
@@ -92,7 +92,7 @@
         ]
       },
       {
-        "matcher": "Edit|Write",
+        "matcher": "Edit|Write|MultiEdit",
         "hooks": [
           {
             "type": "command",
@@ -102,7 +102,7 @@
         ]
       },
       {
-        "matcher": "Edit|Write",
+        "matcher": "Edit|Write|MultiEdit",
         "hooks": [
           {
             "type": "command",
@@ -204,7 +204,7 @@
         ]
       },
       {
-        "matcher": "Task|Agent|Write|Edit",
+        "matcher": "Task|Agent|Write|Edit|MultiEdit",
         "hooks": [
           {
             "type": "command",
@@ -214,7 +214,7 @@
         ]
       },
       {
-        "matcher": "Task|Agent|Write|Edit",
+        "matcher": "Task|Agent|Write|Edit|MultiEdit",
         "hooks": [
           {
             "type": "command",
@@ -253,7 +253,7 @@
         ]
       },
       {
-        "matcher": "Edit|Write",
+        "matcher": "Edit|Write|MultiEdit",
         "hooks": [
           {
             "type": "command",

--- a/hooks/lib/tool-input.mjs
+++ b/hooks/lib/tool-input.mjs
@@ -1,0 +1,45 @@
+/**
+ * Helpers for Claude/Codex file-write tool input shapes.
+ *
+ * Write/Edit expose a single `file_path` plus `content` or `new_string`.
+ * MultiEdit may expose a top-level `file_path` with `edits[]`, or per-edit
+ * `file_path` entries. Guards should treat all of those as write targets.
+ */
+
+export function isFileWriteTool(toolName) {
+  return ['Write', 'write', 'Edit', 'edit', 'MultiEdit', 'multiEdit', 'multiedit']
+    .includes(String(toolName || ''));
+}
+
+function proposedText(input) {
+  if (!input || typeof input !== 'object') return '';
+  for (const key of ['content', 'new_string', 'newString']) {
+    if (typeof input[key] === 'string') return input[key];
+  }
+  return '';
+}
+
+export function collectFileWrites(toolInput) {
+  if (!toolInput || typeof toolInput !== 'object') return [];
+
+  const topPath = toolInput.file_path || toolInput.filePath || '';
+  const entries = [];
+  const topText = proposedText(toolInput);
+  if (topPath || topText) entries.push({ filePath: topPath, text: topText });
+
+  if (Array.isArray(toolInput.edits)) {
+    for (const edit of toolInput.edits) {
+      if (!edit || typeof edit !== 'object') continue;
+      const filePath = edit.file_path || edit.filePath || topPath || '';
+      entries.push({ filePath, text: proposedText(edit) });
+    }
+  }
+
+  return entries;
+}
+
+export function collectTargetPaths(toolInput) {
+  return collectFileWrites(toolInput)
+    .map((entry) => entry.filePath)
+    .filter(Boolean);
+}

--- a/hooks/mpl-baseline-guard.mjs
+++ b/hooks/mpl-baseline-guard.mjs
@@ -2,7 +2,7 @@
 /**
  * MPL Baseline Guard — PreToolUse blocker for immutable baseline.yaml (#59)
  *
- * Blocks Edit/Write operations on `.mpl/mpl/baseline.yaml` after it has been
+ * Blocks Edit/Write/MultiEdit operations on `.mpl/mpl/baseline.yaml` after it has been
  * written, unless the renewal sentinel `.mpl/mpl/.baseline-renewal` exists.
  *
  * The baseline snapshot captured at Step 2.9 is ground truth for downstream
@@ -27,6 +27,9 @@ const { baselineExists, renewalAuthorized, BASELINE_FILE, RENEWAL_FLAG_FILE } = 
 const { readStdin } = await import(
   pathToFileURL(join(__dirname, 'lib', 'stdin.mjs')).href
 );
+const { collectTargetPaths, isFileWriteTool } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'tool-input.mjs')).href
+);
 
 function normalizeRel(cwd, filePath) {
   if (!filePath) return '';
@@ -50,7 +53,7 @@ async function main() {
   }
 
   const toolName = data.tool_name || data.toolName || '';
-  if (!['Edit', 'edit', 'Write', 'write'].includes(toolName)) {
+  if (!isFileWriteTool(toolName)) {
     console.log(JSON.stringify({ continue: true, suppressOutput: true }));
     return;
   }
@@ -62,14 +65,13 @@ async function main() {
   }
 
   const toolInput = data.tool_input || data.toolInput || {};
-  const filePath = toolInput.file_path || toolInput.filePath || '';
-  if (!filePath) {
+  const relTargets = collectTargetPaths(toolInput).map((filePath) => normalizeRel(cwd, filePath));
+  if (relTargets.length === 0) {
     console.log(JSON.stringify({ continue: true, suppressOutput: true }));
     return;
   }
 
-  const rel = normalizeRel(cwd, filePath);
-  if (rel !== BASELINE_FILE) {
+  if (!relTargets.includes(BASELINE_FILE)) {
     console.log(JSON.stringify({ continue: true, suppressOutput: true }));
     return;
   }

--- a/hooks/mpl-require-covers.mjs
+++ b/hooks/mpl-require-covers.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * MPL Require Covers Hook (PreToolUse on Write|Edit)
+ * MPL Require Covers Hook (PreToolUse on Write|Edit|MultiEdit)
  *
  * Validates the Tier B schema on `.mpl/mpl/decomposition.yaml` writes:
  *   - Every phase MUST have non-empty `covers: [...]`.
@@ -23,6 +23,10 @@ import { existsSync, readFileSync } from 'fs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
+
+const { collectFileWrites, isFileWriteTool } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'tool-input.mjs')).href
+);
 
 const DEFAULT_WARN_THRESHOLD = 0.4;
 const UC_ID_RE = /^UC-\d{2,}$/;
@@ -155,11 +159,10 @@ export function isLegacyMode(cwd) {
   return !existsSync(path);
 }
 
-function extractProposedContent(toolInput, toolName) {
-  if (!toolInput) return '';
-  if (toolName === 'Write') return toolInput.content || '';
-  if (toolName === 'Edit') return toolInput.new_string || '';
-  return '';
+function collectDecompositionContents(toolInput) {
+  return collectFileWrites(toolInput)
+    .filter((entry) => targetsDecompositionFile(entry.filePath) && entry.text)
+    .map((entry) => entry.text);
 }
 
 const isMain = import.meta.url === pathToFileURL(process.argv[1] || '').href;
@@ -189,19 +192,16 @@ if (isMain) {
     let input;
     try { input = JSON.parse(raw); } catch { ok(); process.exit(0); }
 
-    const toolName = input.tool_name || '';
-    if (toolName !== 'Write' && toolName !== 'Edit') { ok(); process.exit(0); }
+    const toolName = input.tool_name || input.toolName || '';
+    if (!isFileWriteTool(toolName)) { ok(); process.exit(0); }
 
     const toolInput = input.tool_input || {};
-    const target = toolInput.file_path || '';
-    if (!targetsDecompositionFile(target)) { ok(); process.exit(0); }
-
-    const content = extractProposedContent(toolInput, toolName);
-    if (!content) { ok(); process.exit(0); }
+    const contents = collectDecompositionContents(toolInput);
+    if (contents.length === 0) { ok(); process.exit(0); }
 
     const cwd = input.cwd || process.cwd();
     const legacy = isLegacyMode(cwd);
-    const phases = parsePhaseCovers(content);
+    const phases = contents.flatMap((content) => parsePhaseCovers(content));
 
     if (phases.length === 0) { ok(); process.exit(0); }
 

--- a/hooks/mpl-require-test-agent.mjs
+++ b/hooks/mpl-require-test-agent.mjs
@@ -47,7 +47,7 @@ function ok() {
 }
 
 function block(reason) {
-  console.log(JSON.stringify({ continue: true, decision: 'block', reason }));
+  console.log(JSON.stringify({ continue: false, decision: 'block', reason }));
 }
 
 /**

--- a/hooks/mpl-sentinel-pp-file.mjs
+++ b/hooks/mpl-sentinel-pp-file.mjs
@@ -2,7 +2,7 @@
 /**
  * MPL Sentinel PP-File — Pivot Point File Modification Detector (PostToolUse)
  *
- * Watches Edit/Write operations and checks if the modified file is referenced
+ * Watches Edit/Write/MultiEdit operations and checks if the modified file is referenced
  * by any active Pivot Point in .mpl/pivot-points.md. On match, injects
  * additionalContext so the Phase Runner knows it's touching PP-constrained code.
  *
@@ -25,6 +25,9 @@ const { isMplActive } = await import(
 
 const { readStdin } = await import(
   pathToFileURL(join(__dirname, 'lib', 'stdin.mjs')).href
+);
+const { collectTargetPaths, isFileWriteTool } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'tool-input.mjs')).href
 );
 
 let ppCache = null;
@@ -130,7 +133,7 @@ async function main() {
 
   const toolName = data.tool_name || data.toolName || '';
 
-  if (!['Edit', 'edit', 'Write', 'write'].includes(toolName)) {
+  if (!isFileWriteTool(toolName)) {
     console.log(JSON.stringify({ continue: true, suppressOutput: true }));
     return;
   }
@@ -142,8 +145,8 @@ async function main() {
   }
 
   const toolInput = data.tool_input || data.toolInput || {};
-  const filePath = toolInput.file_path || toolInput.filePath || '';
-  if (!filePath) {
+  const filePaths = collectTargetPaths(toolInput);
+  if (filePaths.length === 0) {
     console.log(JSON.stringify({ continue: true, suppressOutput: true }));
     return;
   }
@@ -154,7 +157,16 @@ async function main() {
     return;
   }
 
-  const matches = matchFileToPP(filePath, ppEntries);
+  const matches = [];
+  const seen = new Set();
+  for (const filePath of filePaths) {
+    for (const match of matchFileToPP(filePath, ppEntries)) {
+      const key = `${match.pp_id}:${match.constraint}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      matches.push(match);
+    }
+  }
   if (matches.length === 0) {
     console.log(JSON.stringify({ continue: true, suppressOutput: true }));
     return;

--- a/hooks/mpl-sentinel-s0.mjs
+++ b/hooks/mpl-sentinel-s0.mjs
@@ -35,6 +35,11 @@ const { isMplActive } = await import(
 const { readStdin } = await import(
   pathToFileURL(join(__dirname, 'lib', 'stdin.mjs')).href
 );
+const { collectFileWrites, isFileWriteTool } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'tool-input.mjs')).href
+);
+
+const SEED_PATH_RE = /\.mpl\/seeds\/[^/]+\.ya?ml$/;
 
 /**
  * Extract contract_snippet keys from Phase Seed YAML text using regex.
@@ -173,7 +178,7 @@ async function main() {
   const toolName = data.tool_name || data.toolName || '';
 
   // Intercept Task/Agent completions and file-write tools (seeds are now inline)
-  if (!['Task', 'task', 'Agent', 'agent', 'Write', 'write', 'Edit', 'edit'].includes(toolName)) {
+  if (!['Task', 'task', 'Agent', 'agent'].includes(toolName) && !isFileWriteTool(toolName)) {
     console.log(JSON.stringify({ continue: true, suppressOutput: true }));
     return;
   }
@@ -193,13 +198,16 @@ async function main() {
     : JSON.stringify(toolResponse);
 
   // For file-write tools, check content for seed YAML
-  if (['Write', 'write', 'Edit', 'edit'].includes(toolName)) {
-    const filePath = toolInput.file_path || toolInput.filePath || '';
-    if (!/\.mpl\/seeds\/[^/]+\.ya?ml$/.test(filePath)) {
+  if (isFileWriteTool(toolName)) {
+    const seedTexts = collectFileWrites(toolInput)
+      .filter((entry) => SEED_PATH_RE.test(entry.filePath))
+      .map((entry) => entry.text)
+      .filter(Boolean);
+    if (seedTexts.length === 0) {
       console.log(JSON.stringify({ continue: true, suppressOutput: true }));
       return;
     }
-    responseText = toolInput.content || toolInput.new_string || responseText;
+    responseText = seedTexts.join('\n') || responseText;
   }
 
   // For Task/Agent tools, only validate if output contains phase_seed/contract_snippet

--- a/hooks/mpl-validate-pp-schema.mjs
+++ b/hooks/mpl-validate-pp-schema.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * MPL Validate PP Schema Hook (PreToolUse on Write|Edit)
+ * MPL Validate PP Schema Hook (PreToolUse on Write|Edit|MultiEdit)
  *
  * Guards `.mpl/pivot-points.md` (immutable PP file) from UC-scoped schema
  * leakage. Pivot Points are design invariants; User Cases are mutable feature
@@ -9,8 +9,9 @@
  *   - pivot-points.md               → PP (immutable)
  *   - requirements/user-contract.md → UC (mutable, 0.16 Tier A')
  *
- * If a Write or Edit targets pivot-points.md and the proposed content contains
- * UC-specific schema keys or UC-N identifiers, the hook blocks the write.
+ * If a Write, Edit, or MultiEdit targets pivot-points.md and the proposed
+ * content contains UC-specific schema keys or UC-N identifiers, the hook blocks
+ * the write.
  *
  * This is the reverse of common drift: during interviews or fix loops the
  * orchestrator may mistakenly try to persist UC discoveries into the PP file.
@@ -24,6 +25,10 @@ import { fileURLToPath, pathToFileURL } from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
+
+const { collectFileWrites, isFileWriteTool } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'tool-input.mjs')).href
+);
 
 const UC_SCHEMA_PATTERNS = [
   { re: /^user_cases\s*:/m, name: 'user_cases:' },
@@ -41,9 +46,11 @@ export function targetsPivotPointsFile(filePath) {
 
 export function extractProposedContent(toolInput, toolName) {
   if (!toolInput) return '';
-  if (toolName === 'Write') return toolInput.content || '';
-  if (toolName === 'Edit') return toolInput.new_string || '';
-  return '';
+  if (!isFileWriteTool(toolName)) return '';
+  return collectFileWrites(toolInput)
+    .map((entry) => entry.text)
+    .filter(Boolean)
+    .join('\n');
 }
 
 export function detectUcLeakage(content) {
@@ -86,14 +93,15 @@ if (isMain) {
         ok();
         process.exit(0);
       }
-      const toolName = input.tool_name || '';
-      if (toolName !== 'Write' && toolName !== 'Edit') ok();
+      const toolName = input.tool_name || input.toolName || '';
+      if (!isFileWriteTool(toolName)) ok();
       else {
         const toolInput = input.tool_input || {};
-        const target = toolInput.file_path || '';
-        if (!targetsPivotPointsFile(target)) ok();
+        const entries = collectFileWrites(toolInput)
+          .filter((entry) => targetsPivotPointsFile(entry.filePath));
+        if (entries.length === 0) ok();
         else {
-          const content = extractProposedContent(toolInput, toolName);
+          const content = entries.map((entry) => entry.text).filter(Boolean).join('\n');
           if (!content) ok();
           else {
             const hits = detectUcLeakage(content);

--- a/hooks/mpl-validate-seed.mjs
+++ b/hooks/mpl-validate-seed.mjs
@@ -30,6 +30,9 @@ const { isMplActive } = await import(
 const { readStdin } = await import(
   pathToFileURL(join(__dirname, 'lib', 'stdin.mjs')).href
 );
+const { collectFileWrites, isFileWriteTool } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'tool-input.mjs')).href
+);
 
 // ---------------------------------------------------------------------------
 // YAML extraction (regex-based, no external parser — MPL minimal deps)
@@ -265,7 +268,7 @@ const SEED_PATH_RE = /\.mpl\/seeds\/[^/]+\.ya?ml$/;
 /**
  * Check whether a tool invocation is related to seed generation/writing.
  * Matches:
- *   1. File-write tools (Write, Edit) targeting a seed YAML path
+ *   1. File-write tools (Write, Edit, MultiEdit) targeting a seed YAML path
  *   2. Task/Agent completions whose output contains phase_seed YAML
  * @param {string} toolName
  * @param {object} toolInput
@@ -274,9 +277,8 @@ const SEED_PATH_RE = /\.mpl\/seeds\/[^/]+\.ya?ml$/;
  */
 export function isSeedRelated(toolName, toolInput, responseText) {
   // Case 1: Direct file write to seed path
-  if (['Write', 'write', 'Edit', 'edit'].includes(toolName)) {
-    const filePath = toolInput.file_path || toolInput.filePath || '';
-    if (SEED_PATH_RE.test(filePath)) return true;
+  if (isFileWriteTool(toolName)) {
+    if (collectFileWrites(toolInput).some((entry) => SEED_PATH_RE.test(entry.filePath))) return true;
   }
 
   // Case 2: Task/Agent output containing phase_seed YAML
@@ -328,8 +330,12 @@ async function main() {
 
   // For file-write tools, the content is in toolInput; for Task tools, in response
   let textToValidate = responseText;
-  if (['Write', 'write', 'Edit', 'edit'].includes(toolName)) {
-    textToValidate = toolInput.content || toolInput.new_string || responseText;
+  if (isFileWriteTool(toolName)) {
+    const seedTexts = collectFileWrites(toolInput)
+      .filter((entry) => SEED_PATH_RE.test(entry.filePath))
+      .map((entry) => entry.text)
+      .filter(Boolean);
+    textToValidate = seedTexts.join('\n') || responseText;
     // Wrap in yaml fence for extractYaml if raw YAML
     if (textToValidate && !textToValidate.includes('```yaml')) {
       textToValidate = '```yaml\n' + textToValidate + '\n```';


### PR DESCRIPTION
## Summary
- Extend remaining write-related hook matchers to include MultiEdit.
- Add a shared tool-input parser for Write/Edit/MultiEdit file paths and proposed text.
- Make mpl-require-test-agent return a real block decision when required test-agent evidence is missing.
- Add regression tests for MultiEdit coverage across baseline, covers, PP schema, seed validation, PP sentinel, and test-agent blocking.

## Verification
- npm test: 768 tests / 0 failures
- git diff --check