### PR TITLE
feat: enforce goal trace coverage

### DIFF
--- a/agents/mpl-decomposer.md
+++ b/agents/mpl-decomposer.md
@@ -307,6 +307,8 @@ disallowedTools: Bash,Task,WebFetch,WebSearch,NotebookEdit
     Do NOT print the YAML body in the response — it lives on disk now. Validation hooks (`mpl-require-covers.mjs`, future `mpl-require-decomposition-fields.mjs`) run on your Write call; if blocked, surface the hook reason and re-emit a corrected YAML in a follow-up Write. Never re-route the Write through the orchestrator.
 
     ```yaml
+    goal_contract_hash: "sha256(.mpl/goal-contract.yaml)" # REQUIRED. Hook `mpl-require-goal-trace.mjs` blocks stale/missing hashes.
+
     architecture_anchor:
       tech_stack: [string]
       directory_pattern: string
@@ -335,8 +337,10 @@ disallowedTools: Bash,Task,WebFetch,WebSearch,NotebookEdit
           acceptance_criteria: [string] # AC-N ids from .mpl/goal-contract.yaml
           variation_axes: [string]      # AX-N ids this phase addresses or preserves
           ontology_entities: [string]   # goal-contract ontology entities touched
-          # REQUIRED. Use [] only when a phase is pure internal plumbing with no
-          # direct goal-contract surface; explain via covers:[internal] and rationale.
+          # REQUIRED. At least one of the three arrays must be non-empty for every
+          # phase, and the full decomposition must cover every AC/AX id from the
+          # Goal Contract. Hook `mpl-require-goal-trace.mjs` blocks missing,
+          # unknown, stale, or uncovered ids.
 
         impact:
           create:

--- a/commands/mpl-run-decompose.md
+++ b/commands/mpl-run-decompose.md
@@ -105,13 +105,14 @@ Task(subagent_type="mpl-decomposer", model="opus",
      CRITICAL: Do NOT scope down. Every feature, requirement, and component in the user's spec must be covered by at least one phase. If the spec describes 10 features, all 10 must appear in the decomposition. Create as many phases as needed — there is no hard cap on phase count.
 
      Use Phase 0 artifacts to inform decomposition decisions — they contain pre-analyzed API contracts, usage patterns, type policies, and error specifications. Use the Pre-Execution Analysis's Recommended Execution Order (section 7) to guide phase ordering, and its Gap Analysis (sections 1-4) to catch missing requirements. **Write the YAML directly to `.mpl/mpl/decomposition.yaml` using the Write tool**, then return a single confirmation line (e.g., `Wrote .mpl/mpl/decomposition.yaml — 5 phases, 3 tiers.`). Do NOT print the YAML body in your response.
+     Top-level `goal_contract_hash` is REQUIRED and MUST equal sha256(normalized `.mpl/goal-contract.yaml`). The write is blocked if the hash is stale or if phase `goal_trace` does not cover every Goal Contract AC/AX id.
      Each phase: id, name, phase_domain (F-28: db|api|ui|algorithm|test|ai|infra|general),
      pp_proximity (pp_core|pp_adjacent|non_pp — see classification rules below),
      phase_subdomain (F-39, optional: tech-stack e.g. react, prisma, langchain),
      phase_task_type (F-39, optional: greenfield|refactor|migration|bugfix|performance|security),
      phase_lang (F-39, optional: rust|go|python|typescript|java),
      scope, impact (create/modify/affected_tests/affected_config),
-     goal_trace (acceptance_criteria/variation_axes/ontology_entities), interface_contract (requires/produces/**contract_files**), success_criteria (typed: command/test/file_exists/grep/description),
+     goal_trace (acceptance_criteria/variation_axes/ontology_entities; every phase non-empty and graph-wide AC/AX coverage), interface_contract (requires/produces/**contract_files**), success_criteria (typed: command/test/file_exists/grep/description),
      estimated_complexity (S/M/L).
 
      **AD-01 (v0.13.0) — contract_files is REQUIRED** for every phase under `interface_contract.contract_files`. Enumerate one entry per cross-layer boundary between impact files (path, boundary_id, caller, callee, framework_rules, params key-type map, returns key-type map). Empty list `[]` only for phases with zero cross-layer boundaries (pure infra/docs). Omission is a validation error. See `agents/mpl-decomposer.md` Step 6.5 for the enumeration procedure and full sub-schema.

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -194,6 +194,7 @@ the immutable post-Phase-0 snapshot consumed by delta calculation and rollback.
 | Field | Type | Default | Description | Source |
 |-------|------|---------|-------------|--------|
 | `goal_contract_required` | boolean | `true` | Blocks decomposer dispatch until `.mpl/goal-contract.yaml` freezes source goal, project pivot, ontology, variation axes, acceptance criteria, E2E policy, security policy, and completion evidence. | `mpl-ambiguity-gate.mjs` |
+| `goal_trace_required` | boolean | `true` | Blocks `decomposition.yaml` writes unless top-level `goal_contract_hash` matches the frozen Goal Contract and phase `goal_trace` covers every AC/AX id. | `mpl-require-goal-trace.mjs` |
 | `finalize_artifacts_required` | boolean | `true` | Blocks `finalize_done=true` unless the goal contract's required artifacts, RUNBOOK final section, finalize timestamps, security evidence, and optional commit evidence are present. Override file: `.mpl/config/finalize-artifact-override.json`. | `mpl-require-finalize-artifacts.mjs` |
 
 ## Adversarial Reviewer (P0-A, #103)

--- a/docs/schemas/goal-contract.md
+++ b/docs/schemas/goal-contract.md
@@ -76,10 +76,15 @@ overrides: []
 - `hooks/mpl-ambiguity-gate.mjs` blocks `mpl-decomposer` dispatch when the
   contract is missing or incomplete, unless `.mpl/config.json` sets
   `goal_contract_required: false`.
+- `hooks/mpl-require-goal-trace.mjs` blocks `decomposition.yaml` writes when
+  top-level `goal_contract_hash` is missing/stale, any phase lacks non-empty
+  `goal_trace`, or any Goal Contract AC/AX id is not covered by the phase graph.
 - `hooks/mpl-require-e2e-authenticity.mjs` reads `e2e_policy` before allowing
   `finalize_done=true`.
 - `hooks/mpl-require-finalize-artifacts.mjs` reads `security_policy` and
-  `completion_evidence` before allowing `finalize_done=true`.
+  `completion_evidence` before allowing `finalize_done=true`; it also blocks
+  finalization when the current goal contract hash differs from the Phase 0
+  baseline hash.
 - `.mpl/mpl/baseline.yaml` snapshots the contract hash as Phase 0 ground truth.
 
 ## Parser Contract

--- a/hooks/__tests__/mpl-goal-trace.test.mjs
+++ b/hooks/__tests__/mpl-goal-trace.test.mjs
@@ -1,0 +1,213 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { tmpdir } from 'os';
+
+import {
+  parseDecompositionGoalTraceText,
+  validateGoalTraceCoverage,
+} from '../lib/mpl-goal-trace.mjs';
+import { readGoalContract } from '../lib/mpl-goal-contract.mjs';
+import { CURRENT_SCHEMA_VERSION } from '../lib/mpl-state.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const HOOK_PATH = join(dirname(__filename), '..', 'mpl-require-goal-trace.mjs');
+
+let tmp;
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'mpl-goal-trace-'));
+  mkdirSync(join(tmp, '.mpl', 'mpl'), { recursive: true });
+  writeFileSync(join(tmp, '.mpl', 'state.json'), JSON.stringify({
+    schema_version: CURRENT_SCHEMA_VERSION,
+    current_phase: 'mpl-decompose',
+  }));
+  writeFileSync(join(tmp, '.mpl', 'goal-contract.yaml'), goalContract());
+});
+afterEach(() => rmSync(tmp, { recursive: true, force: true }));
+
+function goalContract() {
+  return `
+source:
+  user_request: "Build app"
+  user_request_hash: "req"
+mission:
+  goal: "Ship goal traced phases"
+  project_pivot: "No false completion"
+  must_ship_outcomes:
+    - "all AC and AX covered"
+ontology:
+  entities:
+    - finalization
+    - runtime
+variation_axes:
+  - id: AX-1
+    name: runtime
+  - id: AX-2
+    name: security
+acceptance_criteria:
+  - id: AC-1
+    statement: "first"
+  - id: AC-2
+    statement: "second"
+e2e_policy:
+  real_runtime_required: true
+  mock_allowed: false
+  placeholder_assertions_allowed: false
+security_policy:
+  required: false
+completion_evidence:
+  required_artifacts:
+    - .mpl/mpl/audit-report.json
+    - .mpl/mpl/profile/run-summary.json
+    - .mpl/mpl/RUNBOOK.md
+  require_commit: false
+  require_finalize_timestamps: true
+`;
+}
+
+function goalHash() {
+  return readGoalContract(tmp).contract.content_sha256;
+}
+
+function decomposition(hash = goalHash()) {
+  return `
+goal_contract_hash: "${hash}"
+architecture_anchor:
+  tech_stack: [node]
+phases:
+  - id: phase-1
+    covers: [UC-01]
+    goal_trace:
+      acceptance_criteria: [AC-1]
+      variation_axes:
+        - AX-1
+      ontology_entities: [finalization]
+  - id: phase-2
+    covers: [UC-02]
+    goal_trace:
+      acceptance_criteria:
+        - AC-2
+      variation_axes: [AX-2]
+      ontology_entities:
+        - runtime
+`;
+}
+
+function runHook(decomp, opts = {}) {
+  if (opts.config) {
+    writeFileSync(join(tmp, '.mpl', 'config.json'), JSON.stringify(opts.config));
+  }
+  if (opts.baselineHash) {
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'baseline.yaml'), `
+artifacts:
+  goal_contract:
+    path: ".mpl/goal-contract.yaml"
+    sha256: "${opts.baselineHash}"
+`);
+  }
+  const input = {
+    cwd: tmp,
+    tool_name: opts.toolName || 'Write',
+    tool_input: opts.toolInput || {
+      file_path: '.mpl/mpl/decomposition.yaml',
+      content: decomp,
+    },
+  };
+  return JSON.parse(execFileSync('node', [HOOK_PATH], {
+    input: JSON.stringify(input),
+    encoding: 'utf-8',
+  }));
+}
+
+describe('goal trace parser', () => {
+  it('extracts top-level goal hash and per-phase goal_trace arrays', () => {
+    const parsed = parseDecompositionGoalTraceText(decomposition('abc'));
+    assert.equal(parsed.goal_contract_hash, 'abc');
+    assert.equal(parsed.phases.length, 2);
+    assert.deepEqual(parsed.phases[0].acceptance_criteria, ['AC-1']);
+    assert.deepEqual(parsed.phases[0].variation_axes, ['AX-1']);
+    assert.deepEqual(parsed.phases[1].ontology_entities, ['runtime']);
+  });
+
+  it('validates complete AC/AX coverage', () => {
+    const goal = readGoalContract(tmp);
+    const verdict = validateGoalTraceCoverage(
+      parseDecompositionGoalTraceText(decomposition()),
+      goal.contract,
+    );
+    assert.equal(verdict.valid, true, verdict.issues.join(', '));
+  });
+
+  it('reports missing coverage and unknown ids', () => {
+    const goal = readGoalContract(tmp);
+    const parsed = parseDecompositionGoalTraceText(`
+goal_contract_hash: "${goal.contract.content_sha256}"
+phases:
+  - id: phase-1
+    goal_trace:
+      acceptance_criteria: [AC-404]
+      variation_axes: [AX-1]
+      ontology_entities: [unknown]
+`);
+    const verdict = validateGoalTraceCoverage(parsed, goal.contract);
+    assert.equal(verdict.valid, false);
+    assert.ok(verdict.issues.includes('acceptance_criteria:uncovered:AC-1'));
+    assert.ok(verdict.issues.includes('acceptance_criteria:uncovered:AC-2'));
+    assert.ok(verdict.issues.includes('variation_axes:uncovered:AX-2'));
+    assert.ok(verdict.issues.includes('acceptance_criteria:unknown:AC-404'));
+    assert.ok(verdict.issues.includes('ontology_entities:unknown:unknown'));
+  });
+});
+
+describe('mpl-require-goal-trace hook integration', () => {
+  it('allows complete goal trace with matching hash', () => {
+    const r = runHook(decomposition());
+    assert.equal(r.continue, true);
+  });
+
+  it('blocks MultiEdit writes with missing top-level goal_contract_hash', () => {
+    const r = runHook(null, {
+      toolName: 'MultiEdit',
+      toolInput: {
+        file_path: '.mpl/mpl/decomposition.yaml',
+        edits: [{
+          old_string: 'old',
+          new_string: decomposition('').replace(/goal_contract_hash: ""\n/, ''),
+        }],
+      },
+    });
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason, /goal_contract_hash:missing/);
+  });
+
+  it('blocks when AC or AX coverage is incomplete', () => {
+    const r = runHook(`
+goal_contract_hash: "${goalHash()}"
+phases:
+  - id: phase-1
+    goal_trace:
+      acceptance_criteria: [AC-1]
+      variation_axes: [AX-1]
+      ontology_entities: [finalization]
+`);
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason, /acceptance_criteria:uncovered:AC-2/);
+    assert.match(r.reason, /variation_axes:uncovered:AX-2/);
+  });
+
+  it('blocks when baseline goal contract hash differs from current goal contract', () => {
+    const r = runHook(decomposition(), { baselineHash: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef' });
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason, /drifted from baseline/);
+  });
+
+  it('allows opt-out via goal_trace_required=false', () => {
+    const r = runHook('phases:\n  - id: phase-1\n', {
+      config: { goal_trace_required: false },
+    });
+    assert.equal(r.continue, true);
+  });
+});

--- a/hooks/__tests__/mpl-require-finalize-artifacts.test.mjs
+++ b/hooks/__tests__/mpl-require-finalize-artifacts.test.mjs
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'url';
 import { tmpdir } from 'os';
 
 import { CURRENT_SCHEMA_VERSION } from '../lib/mpl-state.mjs';
+import { readGoalContract } from '../lib/mpl-goal-contract.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const HOOK_PATH = join(dirname(__filename), '..', 'mpl-require-finalize-artifacts.mjs');
@@ -148,5 +149,20 @@ describe('mpl-require-finalize-artifacts hook', () => {
     assert.equal(r.decision, 'block');
     assert.match(r.reason, /state\.completed_at/);
     assert.match(r.reason, /state\.finalized_at/);
+  });
+
+  it('blocks when current goal contract hash drifted from baseline', () => {
+    writeArtifacts();
+    const currentHash = readGoalContract(tmp).contract.content_sha256;
+    assert.equal(currentHash.length, 64);
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'baseline.yaml'), `
+artifacts:
+  goal_contract:
+    path: ".mpl/goal-contract.yaml"
+    sha256: "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+`);
+    const r = runHook();
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason, /goal contract drifted from baseline/);
   });
 });

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -106,6 +106,16 @@
         "hooks": [
           {
             "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/mpl-require-goal-trace.mjs\"",
+            "timeout": 3
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/mpl-baseline-guard.mjs\"",
             "timeout": 3
           }

--- a/hooks/lib/mpl-config.mjs
+++ b/hooks/lib/mpl-config.mjs
@@ -64,6 +64,7 @@ const DEFAULTS = {
   gate1_strategy: 'auto',  // 'docker', 'native', 'skip'
   hitl_timeout_seconds: 30,
   goal_contract_required: true,
+  goal_trace_required: true,
   e2e_authenticity_required: true,
   finalize_artifacts_required: true,
   convergence: {

--- a/hooks/lib/mpl-goal-contract.mjs
+++ b/hooks/lib/mpl-goal-contract.mjs
@@ -19,6 +19,7 @@ import { join } from 'path';
 import { createHash } from 'crypto';
 
 export const GOAL_CONTRACT_REL_PATH = '.mpl/goal-contract.yaml';
+export const BASELINE_REL_PATH = '.mpl/mpl/baseline.yaml';
 
 const DEFAULT_REQUIRED_ARTIFACTS = [
   '.mpl/mpl/audit-report.json',
@@ -245,6 +246,21 @@ export function readGoalContract(cwd) {
       warnings: [],
       contract: null,
     };
+  }
+}
+
+export function readBaselineGoalContractHash(cwd) {
+  const path = join(cwd, BASELINE_REL_PATH);
+  if (!existsSync(path)) return { exists: false, hash: null };
+  try {
+    const text = readFileSync(path, 'utf-8');
+    const block = extractTopBlock(text, 'artifacts');
+    const goalBlockMatch = block.match(/^\s+goal_contract\s*:\s*\n((?:\s{4}.+\n?)*)/m);
+    const goalBlock = goalBlockMatch ? goalBlockMatch[1] : '';
+    const hash = scalarInBlock(goalBlock, 'sha256');
+    return { exists: true, hash };
+  } catch {
+    return { exists: true, hash: null };
   }
 }
 

--- a/hooks/lib/mpl-goal-trace.mjs
+++ b/hooks/lib/mpl-goal-trace.mjs
@@ -1,0 +1,182 @@
+/**
+ * Goal trace validation for `.mpl/mpl/decomposition.yaml`.
+ *
+ * The parser intentionally supports the prompt-controlled YAML subset emitted
+ * by `mpl-decomposer`: top-level `goal_contract_hash`, phase list entries, and
+ * `goal_trace` arrays in inline or block-list form.
+ */
+
+function normalizeScalar(value) {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (!trimmed || trimmed === 'null') return null;
+  return trimmed.replace(/^["']|["']$/g, '').trim() || null;
+}
+
+function parseInlineList(value) {
+  if (typeof value !== 'string') return [];
+  const trimmed = value.trim();
+  if (!trimmed.startsWith('[') || !trimmed.endsWith(']')) return null;
+  return trimmed
+    .slice(1, -1)
+    .split(',')
+    .map((s) => normalizeScalar(s))
+    .filter(Boolean);
+}
+
+function indentOf(line) {
+  const m = String(line || '').match(/^(\s*)/);
+  return m ? m[1].length : 0;
+}
+
+export function parseDecompositionGoalTraceText(text) {
+  const lines = String(text || '').split('\n').map((l) => l.replace(/\r$/, ''));
+  const phases = [];
+  let goalContractHash = null;
+  let cur = null;
+  let inGoalTrace = false;
+  let goalTraceIndent = -1;
+  let listField = null;
+  let listIndent = -1;
+
+  const flush = () => {
+    if (!cur) return;
+    phases.push(cur);
+    cur = null;
+  };
+
+  for (const line of lines) {
+    const hashMatch = line.match(/^goal_contract_hash\s*:\s*["']?([^"'\s#]+)["']?/);
+    if (hashMatch) {
+      goalContractHash = hashMatch[1];
+      continue;
+    }
+
+    const idMatch = line.match(/^\s*-\s+id:\s*["']?(phase-[\w-]+)["']?/);
+    if (idMatch) {
+      flush();
+      cur = {
+        id: idMatch[1],
+        has_goal_trace: false,
+        acceptance_criteria: [],
+        variation_axes: [],
+        ontology_entities: [],
+      };
+      inGoalTrace = false;
+      listField = null;
+      continue;
+    }
+    if (!cur) continue;
+
+    const gtMatch = line.match(/^(\s+)goal_trace\s*:\s*$/);
+    if (gtMatch) {
+      cur.has_goal_trace = true;
+      inGoalTrace = true;
+      goalTraceIndent = gtMatch[1].length;
+      listField = null;
+      continue;
+    }
+
+    if (inGoalTrace && line.trim() && indentOf(line) <= goalTraceIndent) {
+      inGoalTrace = false;
+      listField = null;
+    }
+    if (!inGoalTrace) continue;
+
+    const fieldMatch = line.match(/^(\s+)(acceptance_criteria|variation_axes|ontology_entities)\s*:\s*(.*?)\s*$/);
+    if (fieldMatch) {
+      const [, spaces, field, value] = fieldMatch;
+      const parsed = parseInlineList(value);
+      if (parsed) {
+        cur[field] = parsed;
+        listField = null;
+      } else if (value.trim()) {
+        const scalar = normalizeScalar(value);
+        cur[field] = scalar ? [scalar] : [];
+        listField = null;
+      } else {
+        cur[field] = [];
+        listField = field;
+        listIndent = spaces.length;
+      }
+      continue;
+    }
+
+    if (listField) {
+      const itemMatch = line.match(/^(\s*)-\s+(.+?)\s*$/);
+      if (itemMatch && itemMatch[1].length > listIndent) {
+        const item = normalizeScalar(itemMatch[2]);
+        if (item) cur[listField].push(item);
+        continue;
+      }
+      if (line.trim()) listField = null;
+    }
+  }
+  flush();
+
+  return {
+    goal_contract_hash: goalContractHash,
+    phases,
+  };
+}
+
+function difference(required, actual) {
+  const actualSet = new Set(actual);
+  return required.filter((id) => !actualSet.has(id));
+}
+
+function unknown(actual, allowed) {
+  const allowedSet = new Set(allowed);
+  return actual.filter((id) => !allowedSet.has(id));
+}
+
+export function validateGoalTraceCoverage(decomposition, contract) {
+  const issues = [];
+  const phases = decomposition?.phases || [];
+  const goalHash = contract?.content_sha256 || null;
+  const requiredAc = contract?.acceptance_criteria || [];
+  const requiredAx = contract?.variation_axes || [];
+  const allowedEntities = contract?.ontology?.entities || [];
+
+  if (!decomposition?.goal_contract_hash) {
+    issues.push('goal_contract_hash:missing');
+  } else if (goalHash && decomposition.goal_contract_hash !== goalHash) {
+    issues.push(`goal_contract_hash:mismatch:${decomposition.goal_contract_hash}->${goalHash}`);
+  }
+
+  if (phases.length === 0) issues.push('phases:missing');
+
+  const allAc = [];
+  const allAx = [];
+  const allEntities = [];
+  for (const phase of phases) {
+    const phaseRefs = [
+      ...(phase.acceptance_criteria || []),
+      ...(phase.variation_axes || []),
+      ...(phase.ontology_entities || []),
+    ];
+    if (!phase.has_goal_trace) {
+      issues.push(`${phase.id}:goal_trace:missing`);
+    } else if (phaseRefs.length === 0) {
+      issues.push(`${phase.id}:goal_trace:empty`);
+    }
+    allAc.push(...(phase.acceptance_criteria || []));
+    allAx.push(...(phase.variation_axes || []));
+    allEntities.push(...(phase.ontology_entities || []));
+  }
+
+  for (const id of difference(requiredAc, allAc)) issues.push(`acceptance_criteria:uncovered:${id}`);
+  for (const id of difference(requiredAx, allAx)) issues.push(`variation_axes:uncovered:${id}`);
+  for (const id of unknown([...new Set(allAc)], requiredAc)) issues.push(`acceptance_criteria:unknown:${id}`);
+  for (const id of unknown([...new Set(allAx)], requiredAx)) issues.push(`variation_axes:unknown:${id}`);
+  if (allowedEntities.length > 0) {
+    for (const id of unknown([...new Set(allEntities)], allowedEntities)) {
+      issues.push(`ontology_entities:unknown:${id}`);
+    }
+  }
+
+  return {
+    valid: issues.length === 0,
+    issues,
+  };
+}

--- a/hooks/mpl-require-finalize-artifacts.mjs
+++ b/hooks/mpl-require-finalize-artifacts.mjs
@@ -23,7 +23,7 @@ const { readState, isMplActive } = await import(
 const { loadConfig } = await import(
   pathToFileURL(join(__dirname, 'lib', 'mpl-config.mjs')).href
 );
-const { readGoalContract, defaultRequiredArtifacts } = await import(
+const { readGoalContract, readBaselineGoalContractHash, defaultRequiredArtifacts } = await import(
   pathToFileURL(join(__dirname, 'lib', 'mpl-goal-contract.mjs')).href
 );
 const { readStdin } = await import(
@@ -205,6 +205,18 @@ async function main() {
   }
 
   const contract = goal.valid ? goal.contract : null;
+  if (cfg.goal_contract_required !== false && contract?.content_sha256) {
+    const baseline = readBaselineGoalContractHash(cwd);
+    if (baseline.hash && baseline.hash !== contract.content_sha256) {
+      block(
+        `[MPL Finalize Guard] Cannot set finalize_done=true — goal contract drifted from baseline.yaml ` +
+          `(baseline=${baseline.hash.slice(0, 12)}, current=${contract.content_sha256.slice(0, 12)}). ` +
+          `Re-run Phase 0 renewal before finalizing.`
+      );
+      return;
+    }
+  }
+
   const requiredArtifacts = contract?.completion_evidence?.required_artifacts?.length
     ? contract.completion_evidence.required_artifacts
     : defaultRequiredArtifacts();

--- a/hooks/mpl-require-goal-trace.mjs
+++ b/hooks/mpl-require-goal-trace.mjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+/**
+ * MPL Require Goal Trace Hook (PreToolUse on Write|Edit|MultiEdit).
+ *
+ * Blocks `.mpl/mpl/decomposition.yaml` writes when the phase graph no longer
+ * proves the frozen Goal Contract: stale/missing goal_contract_hash, uncovered
+ * AC/AX ids, unknown ids, or phases with missing/empty `goal_trace`.
+ */
+
+import { dirname, join } from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const isMain = import.meta.url === pathToFileURL(process.argv[1] || '').href;
+
+const { isMplActive } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-state.mjs')).href
+);
+const { loadConfig } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-config.mjs')).href
+);
+const { readGoalContract, readBaselineGoalContractHash } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-goal-contract.mjs')).href
+);
+const { parseDecompositionGoalTraceText, validateGoalTraceCoverage } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-goal-trace.mjs')).href
+);
+const { collectFileWrites, isFileWriteTool } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'tool-input.mjs')).href
+);
+const { readStdin } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'stdin.mjs')).href
+);
+
+function ok() {
+  console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+}
+
+function block(reason) {
+  console.log(JSON.stringify({ continue: false, decision: 'block', reason }));
+}
+
+export function targetsDecompositionFile(filePath) {
+  if (!filePath || typeof filePath !== 'string') return false;
+  return /(^|\/)\.mpl\/mpl\/decomposition\.ya?ml$/.test(filePath);
+}
+
+function collectDecompositionTexts(toolInput) {
+  return collectFileWrites(toolInput)
+    .filter((entry) => targetsDecompositionFile(entry.filePath) && entry.text)
+    .map((entry) => entry.text);
+}
+
+async function main() {
+  const raw = await readStdin();
+  if (!raw.trim()) return ok();
+
+  let data;
+  try { data = JSON.parse(raw); } catch { return ok(); }
+
+  const toolName = data.tool_name || data.toolName || '';
+  if (!isFileWriteTool(toolName)) return ok();
+
+  const toolInput = data.tool_input || data.toolInput || {};
+  const texts = collectDecompositionTexts(toolInput);
+  if (texts.length === 0) return ok();
+
+  const cwd = data.cwd || data.directory || process.cwd();
+  if (!isMplActive(cwd)) return ok();
+
+  const cfg = loadConfig(cwd);
+  if (cfg.goal_contract_required === false || cfg.goal_trace_required === false) return ok();
+
+  const goal = readGoalContract(cwd);
+  if (!goal.exists || !goal.valid) {
+    block(`[MPL Goal Trace] Cannot write decomposition.yaml — goal contract missing or invalid: ${goal.missing.join(', ')}.`);
+    return;
+  }
+
+  const baseline = readBaselineGoalContractHash(cwd);
+  if (baseline.hash && baseline.hash !== goal.contract.content_sha256) {
+    block(
+      `[MPL Goal Trace] Cannot write decomposition.yaml — .mpl/goal-contract.yaml drifted from baseline.yaml ` +
+        `(baseline=${baseline.hash.slice(0, 12)}, current=${goal.contract.content_sha256.slice(0, 12)}). ` +
+        `Re-run Phase 0 renewal before recomposing.`
+    );
+    return;
+  }
+
+  const issues = [];
+  for (const text of texts) {
+    const decomposition = parseDecompositionGoalTraceText(text);
+    const verdict = validateGoalTraceCoverage(decomposition, goal.contract);
+    issues.push(...verdict.issues);
+  }
+
+  if (issues.length > 0) {
+    const shown = issues.slice(0, 12).join(', ');
+    const more = issues.length > 12 ? ` (+${issues.length - 12} more)` : '';
+    block(
+      `[MPL Goal Trace] decomposition.yaml does not cover the frozen Goal Contract: ${shown}${more}. ` +
+        `Each phase needs goal_trace and the graph must cover every AC/AX from .mpl/goal-contract.yaml.`
+    );
+    return;
+  }
+
+  ok();
+}
+
+if (isMain) {
+  await main().catch(() => ok());
+}


### PR DESCRIPTION
## Summary
- Add `mpl-require-goal-trace.mjs` to block decomposition writes when `goal_contract_hash` is missing/stale, AC/AX coverage is incomplete, ids are unknown, or phase `goal_trace` is missing/empty.
- Add goal trace parser/validator helpers for the decomposer YAML subset.
- Block finalization when the current goal contract hash drifts from the Phase 0 baseline hash.
- Document `goal_trace_required`, top-level `goal_contract_hash`, and runtime enforcement behavior.

## Verification
- npm test: 777 tests / 0 failures
- git diff --check