### PR TITLE
Add phase contract graph guard

### DIFF
--- a/agents/mpl-decomposer.md
+++ b/agents/mpl-decomposer.md
@@ -307,6 +307,10 @@ disallowedTools: Bash,Task,WebFetch,WebSearch,NotebookEdit
     Do NOT print the YAML body in the response — it lives on disk now. Validation hooks (`mpl-require-covers.mjs`, future `mpl-require-decomposition-fields.mjs`) run on your Write call; if blocked, surface the hook reason and re-emit a corrected YAML in a follow-up Write. Never re-route the Write through the orchestrator.
 
     ```yaml
+    graph_version: 1
+    generated_by: mpl-decomposer
+    recompose_count: 0
+    completed_phase_policy: immutable_by_default
     goal_contract_hash: "sha256(.mpl/goal-contract.yaml)" # REQUIRED. Hook `mpl-require-goal-trace.mjs` blocks stale/missing hashes.
 
     architecture_anchor:
@@ -322,6 +326,11 @@ disallowedTools: Bash,Task,WebFetch,WebSearch,NotebookEdit
         pp_proximity: string        # pp_core|pp_adjacent|non_pp
         scope: string               # 1-2 sentence scope
         rationale: string           # why this position
+        evidence_required:          # REQUIRED. What proof latches phase completion.
+          - command
+          - test_agent
+          - goal_trace
+        change_policy: append_delta_only # REQUIRED. Phase contract changes go through decomposition-delta/recompose.
 
         covers:                     # 0.16 Tier B: which UCs this phase advances (REQUIRED)
           - string                  # UC-NN id from .mpl/requirements/user-contract.md, or "internal"

--- a/commands/mpl-run-decompose.md
+++ b/commands/mpl-run-decompose.md
@@ -105,13 +105,13 @@ Task(subagent_type="mpl-decomposer", model="opus",
      CRITICAL: Do NOT scope down. Every feature, requirement, and component in the user's spec must be covered by at least one phase. If the spec describes 10 features, all 10 must appear in the decomposition. Create as many phases as needed — there is no hard cap on phase count.
 
      Use Phase 0 artifacts to inform decomposition decisions — they contain pre-analyzed API contracts, usage patterns, type policies, and error specifications. Use the Pre-Execution Analysis's Recommended Execution Order (section 7) to guide phase ordering, and its Gap Analysis (sections 1-4) to catch missing requirements. **Write the YAML directly to `.mpl/mpl/decomposition.yaml` using the Write tool**, then return a single confirmation line (e.g., `Wrote .mpl/mpl/decomposition.yaml — 5 phases, 3 tiers.`). Do NOT print the YAML body in your response.
-     Top-level `goal_contract_hash` is REQUIRED and MUST equal sha256(normalized `.mpl/goal-contract.yaml`). The write is blocked if the hash is stale or if phase `goal_trace` does not cover every Goal Contract AC/AX id.
+     Top-level graph metadata is REQUIRED: `graph_version`, `generated_by: mpl-decomposer`, `recompose_count`, `completed_phase_policy`, and `goal_contract_hash` (MUST equal sha256(normalized `.mpl/goal-contract.yaml`)). The write is blocked if graph metadata is missing, the hash is stale, phase `goal_trace` does not cover every Goal Contract AC/AX id, or any `interface_contract.requires[].from_phase` points to an unknown/self phase.
      Each phase: id, name, phase_domain (F-28: db|api|ui|algorithm|test|ai|infra|general),
      pp_proximity (pp_core|pp_adjacent|non_pp — see classification rules below),
      phase_subdomain (F-39, optional: tech-stack e.g. react, prisma, langchain),
      phase_task_type (F-39, optional: greenfield|refactor|migration|bugfix|performance|security),
      phase_lang (F-39, optional: rust|go|python|typescript|java),
-     scope, impact (create/modify/affected_tests/affected_config),
+     scope, evidence_required, change_policy, impact (create/modify/affected_tests/affected_config),
      goal_trace (acceptance_criteria/variation_axes/ontology_entities; every phase non-empty and graph-wide AC/AX coverage), interface_contract (requires/produces/**contract_files**), success_criteria (typed: command/test/file_exists/grep/description),
      estimated_complexity (S/M/L).
 

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -195,6 +195,7 @@ the immutable post-Phase-0 snapshot consumed by delta calculation and rollback.
 |-------|------|---------|-------------|--------|
 | `goal_contract_required` | boolean | `true` | Blocks decomposer dispatch until `.mpl/goal-contract.yaml` freezes source goal, project pivot, ontology, variation axes, acceptance criteria, E2E policy, security policy, and completion evidence. | `mpl-ambiguity-gate.mjs` |
 | `goal_trace_required` | boolean | `true` | Blocks `decomposition.yaml` writes unless top-level `goal_contract_hash` matches the frozen Goal Contract and phase `goal_trace` covers every AC/AX id. | `mpl-require-goal-trace.mjs` |
+| `phase_contract_graph_required` | boolean | `true` | Blocks `decomposition.yaml` writes unless graph metadata, per-phase evidence/change policy, and non-dangling phase dependencies are present. | `mpl-require-phase-contract-graph.mjs` |
 | `finalize_artifacts_required` | boolean | `true` | Blocks `finalize_done=true` unless the goal contract's required artifacts, RUNBOOK final section, finalize timestamps, security evidence, and optional commit evidence are present. Override file: `.mpl/config/finalize-artifact-override.json`. | `mpl-require-finalize-artifacts.mjs` |
 
 ## Adversarial Reviewer (P0-A, #103)

--- a/docs/schemas/goal-contract.md
+++ b/docs/schemas/goal-contract.md
@@ -79,6 +79,9 @@ overrides: []
 - `hooks/mpl-require-goal-trace.mjs` blocks `decomposition.yaml` writes when
   top-level `goal_contract_hash` is missing/stale, any phase lacks non-empty
   `goal_trace`, or any Goal Contract AC/AX id is not covered by the phase graph.
+- `hooks/mpl-require-phase-contract-graph.mjs` blocks decomposition writes that
+  lack graph metadata, phase evidence/change policy, or valid phase dependency
+  references.
 - `hooks/mpl-require-e2e-authenticity.mjs` reads `e2e_policy` before allowing
   `finalize_done=true`.
 - `hooks/mpl-require-finalize-artifacts.mjs` reads `security_policy` and

--- a/docs/schemas/phase-contract-graph.md
+++ b/docs/schemas/phase-contract-graph.md
@@ -1,0 +1,60 @@
+# Phase Contract Graph Schema
+
+File: `.mpl/mpl/decomposition.yaml`
+
+The decomposition is a contract graph, not just a task list. Each phase must
+carry the evidence and change policy needed for later phase completion and
+controlled recomposition.
+
+## Required Top-Level Metadata
+
+```yaml
+graph_version: 1
+generated_by: mpl-decomposer
+recompose_count: 0
+completed_phase_policy: immutable_by_default
+goal_contract_hash: "<sha256 .mpl/goal-contract.yaml>"
+```
+
+## Required Per-Phase Surface
+
+```yaml
+phases:
+  - id: phase-1
+    evidence_required:
+      - command
+      - test_agent
+      - goal_trace
+    change_policy: append_delta_only
+    goal_trace:
+      acceptance_criteria: [AC-1]
+      variation_axes: [AX-1]
+      ontology_entities: [entity]
+    interface_contract:
+      requires:
+        - type: artifact
+          name: previous_output
+          from_phase: phase-0
+      produces:
+        - type: artifact
+          name: current_output
+```
+
+## Runtime Enforcement
+
+- `hooks/mpl-require-phase-contract-graph.mjs` blocks
+  `decomposition.yaml` writes when:
+  - top-level graph metadata is missing
+  - `generated_by` is not `mpl-decomposer`
+  - any phase lacks non-empty `evidence_required`
+  - any phase lacks non-empty `change_policy`
+  - `interface_contract.requires[].from_phase` points to the same phase or an
+    unknown phase
+- `.mpl/config.json { "phase_contract_graph_required": false }` is an explicit
+  migration opt-out.
+
+## Notes
+
+`contract_hash` is reserved for a later post-processing phase that can compute a
+real hash from canonical phase content. Do not ask the decomposer to fabricate a
+cryptographic value.

--- a/hooks/__tests__/mpl-phase-contract-graph.test.mjs
+++ b/hooks/__tests__/mpl-phase-contract-graph.test.mjs
@@ -1,0 +1,146 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { tmpdir } from 'os';
+
+import {
+  parsePhaseContractGraphText,
+  validatePhaseContractGraph,
+} from '../lib/mpl-phase-contract-graph.mjs';
+import { CURRENT_SCHEMA_VERSION } from '../lib/mpl-state.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const HOOK_PATH = join(dirname(__filename), '..', 'mpl-require-phase-contract-graph.mjs');
+
+let tmp;
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'mpl-contract-graph-'));
+  mkdirSync(join(tmp, '.mpl', 'mpl'), { recursive: true });
+  writeFileSync(join(tmp, '.mpl', 'state.json'), JSON.stringify({
+    schema_version: CURRENT_SCHEMA_VERSION,
+    current_phase: 'mpl-decompose',
+  }));
+});
+afterEach(() => rmSync(tmp, { recursive: true, force: true }));
+
+function validGraph() {
+  return `
+graph_version: 1
+generated_by: mpl-decomposer
+recompose_count: 0
+completed_phase_policy: immutable_by_default
+goal_contract_hash: abc
+phases:
+  - id: phase-1
+    evidence_required:
+      - command
+      - goal_trace
+    change_policy: append_delta_only
+    interface_contract:
+      requires: []
+      produces:
+        - type: artifact
+          name: bootstrap
+  - id: phase-2
+    evidence_required: [command, test_agent]
+    change_policy: append_delta_only
+    interface_contract:
+      requires:
+        - type: artifact
+          name: bootstrap
+          from_phase: phase-1
+      produces: []
+`;
+}
+
+function runHook(content, opts = {}) {
+  if (opts.config) {
+    writeFileSync(join(tmp, '.mpl', 'config.json'), JSON.stringify(opts.config));
+  }
+  const input = {
+    cwd: tmp,
+    tool_name: opts.toolName || 'Write',
+    tool_input: opts.toolInput || {
+      file_path: '.mpl/mpl/decomposition.yaml',
+      content,
+    },
+  };
+  return JSON.parse(execFileSync('node', [HOOK_PATH], {
+    input: JSON.stringify(input),
+    encoding: 'utf-8',
+  }));
+}
+
+describe('phase contract graph parser', () => {
+  it('extracts metadata, phase policies, and requires.from_phase refs', () => {
+    const graph = parsePhaseContractGraphText(validGraph());
+    assert.equal(graph.graph_version, '1');
+    assert.equal(graph.generated_by, 'mpl-decomposer');
+    assert.equal(graph.recompose_count, '0');
+    assert.equal(graph.completed_phase_policy, 'immutable_by_default');
+    assert.equal(graph.phases.length, 2);
+    assert.deepEqual(graph.phases[1].requires_from_phases, ['phase-1']);
+  });
+
+  it('validates a complete graph', () => {
+    const verdict = validatePhaseContractGraph(parsePhaseContractGraphText(validGraph()));
+    assert.equal(verdict.valid, true, verdict.issues.join(', '));
+  });
+
+  it('reports missing metadata and dangling dependencies', () => {
+    const graph = parsePhaseContractGraphText(`
+generated_by: orchestrator
+phases:
+  - id: phase-1
+    interface_contract:
+      requires:
+        - from_phase: phase-99
+`);
+    const verdict = validatePhaseContractGraph(graph);
+    assert.equal(verdict.valid, false);
+    assert.ok(verdict.issues.includes('graph_version:missing'));
+    assert.ok(verdict.issues.includes('generated_by:orchestrator'));
+    assert.ok(verdict.issues.includes('phase-1:evidence_required:missing'));
+    assert.ok(verdict.issues.includes('phase-1:change_policy:missing'));
+    assert.ok(verdict.issues.includes('phase-1:requires:unknown:phase-99'));
+  });
+});
+
+describe('mpl-require-phase-contract-graph hook integration', () => {
+  it('allows a valid graph', () => {
+    const r = runHook(validGraph());
+    assert.equal(r.continue, true);
+  });
+
+  it('blocks missing graph metadata and missing phase policy', () => {
+    const r = runHook('phases:\n  - id: phase-1\n');
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason, /graph_version:missing/);
+    assert.match(r.reason, /phase-1:evidence_required:missing/);
+  });
+
+  it('blocks MultiEdit writes with dangling requires.from_phase', () => {
+    const r = runHook(null, {
+      toolName: 'MultiEdit',
+      toolInput: {
+        file_path: '.mpl/mpl/decomposition.yaml',
+        edits: [{
+          old_string: 'old',
+          new_string: validGraph().replace('from_phase: phase-1', 'from_phase: phase-404'),
+        }],
+      },
+    });
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason, /phase-2:requires:unknown:phase-404/);
+  });
+
+  it('allows migration opt-out', () => {
+    const r = runHook('phases:\n  - id: phase-1\n', {
+      config: { phase_contract_graph_required: false },
+    });
+    assert.equal(r.continue, true);
+  });
+});

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -116,6 +116,16 @@
         "hooks": [
           {
             "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/mpl-require-phase-contract-graph.mjs\"",
+            "timeout": 3
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/mpl-baseline-guard.mjs\"",
             "timeout": 3
           }

--- a/hooks/lib/mpl-config.mjs
+++ b/hooks/lib/mpl-config.mjs
@@ -65,6 +65,7 @@ const DEFAULTS = {
   hitl_timeout_seconds: 30,
   goal_contract_required: true,
   goal_trace_required: true,
+  phase_contract_graph_required: true,
   e2e_authenticity_required: true,
   finalize_artifacts_required: true,
   convergence: {

--- a/hooks/lib/mpl-phase-contract-graph.mjs
+++ b/hooks/lib/mpl-phase-contract-graph.mjs
@@ -1,0 +1,108 @@
+/**
+ * Minimal validator for decomposition.yaml as a phase contract graph.
+ *
+ * This validates the contract graph surface that is cheap to prove from the
+ * prompt-controlled YAML subset: graph metadata, per-phase evidence/change
+ * policy, and dangling `requires.from_phase` references.
+ */
+
+function normalizeScalar(value) {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (!trimmed || trimmed === 'null') return null;
+  return trimmed.replace(/^["']|["']$/g, '').trim() || null;
+}
+
+function topScalar(text, key) {
+  const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const m = String(text || '').match(new RegExp(`^${escaped}\\s*:\\s*(.+?)\\s*$`, 'm'));
+  return m ? normalizeScalar(m[1]) : null;
+}
+
+function phaseBlocks(text) {
+  const blocks = [];
+  let cur = null;
+
+  const flush = () => {
+    if (cur) blocks.push(cur);
+    cur = null;
+  };
+
+  for (const line of String(text || '').split('\n').map((l) => l.replace(/\r$/, ''))) {
+    const idMatch = line.match(/^\s*-\s+id:\s*["']?(phase-[\w-]+)["']?/);
+    if (idMatch) {
+      flush();
+      cur = { id: idMatch[1], text: `${line}\n` };
+      continue;
+    }
+    if (cur) cur.text += `${line}\n`;
+  }
+  flush();
+  return blocks;
+}
+
+function hasNonEmptyField(block, key) {
+  const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const inline = block.match(new RegExp(`^\\s+${escaped}\\s*:\\s*(.+?)\\s*$`, 'm'));
+  if (inline) {
+    const value = inline[1].trim();
+    if (value === '[]' || value === '{}' || value === 'null' || value === '""' || value === "''") return false;
+    if (value) return true;
+  }
+
+  const nested = block.match(new RegExp(`^(\\s+)${escaped}\\s*:\\s*\\n((?:\\1\\s+.+\\n?)*)`, 'm'));
+  if (!nested) return false;
+  return nested[2].split('\n').some((line) => line.trim() && line.trim() !== '[]' && line.trim() !== '{}');
+}
+
+function extractRequiresFromPhases(block) {
+  const out = [];
+  const refs = String(block || '').matchAll(/^\s+(?:-\s+)?from_phase\s*:\s*["']?(phase-[\w-]+)["']?/gm);
+  for (const ref of refs) out.push(ref[1]);
+  return out;
+}
+
+export function parsePhaseContractGraphText(text) {
+  const phases = phaseBlocks(text).map((block) => ({
+    id: block.id,
+    has_evidence_required: hasNonEmptyField(block.text, 'evidence_required'),
+    has_change_policy: hasNonEmptyField(block.text, 'change_policy'),
+    requires_from_phases: extractRequiresFromPhases(block.text),
+  }));
+
+  return {
+    graph_version: topScalar(text, 'graph_version'),
+    generated_by: topScalar(text, 'generated_by'),
+    recompose_count: topScalar(text, 'recompose_count'),
+    completed_phase_policy: topScalar(text, 'completed_phase_policy'),
+    phases,
+  };
+}
+
+export function validatePhaseContractGraph(graph) {
+  const issues = [];
+  if (!graph?.graph_version) issues.push('graph_version:missing');
+  if (graph?.generated_by !== 'mpl-decomposer') {
+    issues.push(`generated_by:${graph?.generated_by || 'missing'}`);
+  }
+  if (graph?.recompose_count === null || graph?.recompose_count === undefined) {
+    issues.push('recompose_count:missing');
+  }
+  if (!graph?.completed_phase_policy) issues.push('completed_phase_policy:missing');
+  if (!Array.isArray(graph?.phases) || graph.phases.length === 0) issues.push('phases:missing');
+
+  const knownPhases = new Set((graph?.phases || []).map((p) => p.id));
+  for (const phase of graph?.phases || []) {
+    if (!phase.has_evidence_required) issues.push(`${phase.id}:evidence_required:missing`);
+    if (!phase.has_change_policy) issues.push(`${phase.id}:change_policy:missing`);
+    for (const fromPhase of phase.requires_from_phases || []) {
+      if (fromPhase === phase.id) issues.push(`${phase.id}:requires:self:${fromPhase}`);
+      else if (!knownPhases.has(fromPhase)) issues.push(`${phase.id}:requires:unknown:${fromPhase}`);
+    }
+  }
+
+  return {
+    valid: issues.length === 0,
+    issues,
+  };
+}

--- a/hooks/mpl-require-phase-contract-graph.mjs
+++ b/hooks/mpl-require-phase-contract-graph.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+/**
+ * MPL Require Phase Contract Graph Hook (PreToolUse on Write|Edit|MultiEdit).
+ *
+ * Blocks decomposition writes when the file is only a task list instead of a
+ * contract graph: missing graph metadata, missing phase evidence/change policy,
+ * or dangling phase dependencies.
+ */
+
+import { dirname, join } from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const isMain = import.meta.url === pathToFileURL(process.argv[1] || '').href;
+
+const { isMplActive } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-state.mjs')).href
+);
+const { loadConfig } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-config.mjs')).href
+);
+const { parsePhaseContractGraphText, validatePhaseContractGraph } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-phase-contract-graph.mjs')).href
+);
+const { collectFileWrites, isFileWriteTool } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'tool-input.mjs')).href
+);
+const { readStdin } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'stdin.mjs')).href
+);
+
+function ok() {
+  console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+}
+
+function block(reason) {
+  console.log(JSON.stringify({ continue: false, decision: 'block', reason }));
+}
+
+export function targetsDecompositionFile(filePath) {
+  if (!filePath || typeof filePath !== 'string') return false;
+  return /(^|\/)\.mpl\/mpl\/decomposition\.ya?ml$/.test(filePath);
+}
+
+function collectDecompositionTexts(toolInput) {
+  return collectFileWrites(toolInput)
+    .filter((entry) => targetsDecompositionFile(entry.filePath) && entry.text)
+    .map((entry) => entry.text);
+}
+
+async function main() {
+  const raw = await readStdin();
+  if (!raw.trim()) return ok();
+
+  let data;
+  try { data = JSON.parse(raw); } catch { return ok(); }
+
+  const toolName = data.tool_name || data.toolName || '';
+  if (!isFileWriteTool(toolName)) return ok();
+
+  const toolInput = data.tool_input || data.toolInput || {};
+  const texts = collectDecompositionTexts(toolInput);
+  if (texts.length === 0) return ok();
+
+  const cwd = data.cwd || data.directory || process.cwd();
+  if (!isMplActive(cwd)) return ok();
+
+  const cfg = loadConfig(cwd);
+  if (cfg.phase_contract_graph_required === false) return ok();
+
+  const issues = [];
+  for (const text of texts) {
+    const graph = parsePhaseContractGraphText(text);
+    const verdict = validatePhaseContractGraph(graph);
+    issues.push(...verdict.issues);
+  }
+
+  if (issues.length > 0) {
+    const shown = issues.slice(0, 12).join(', ');
+    const more = issues.length > 12 ? ` (+${issues.length - 12} more)` : '';
+    block(
+      `[MPL Phase Contract Graph] decomposition.yaml is not a valid phase contract graph: ${shown}${more}. ` +
+        `Add graph metadata, per-phase evidence_required/change_policy, and valid interface requires.from_phase refs.`
+    );
+    return;
+  }
+
+  ok();
+}
+
+if (isMain) {
+  await main().catch(() => ok());
+}


### PR DESCRIPTION
## Summary
- add a phase contract graph parser and PreToolUse guard for `.mpl/mpl/decomposition.yaml`
- require decomposer graph metadata, per-phase evidence requirements, change policy, and valid phase dependencies
- document the graph schema and config flag, and update decomposer prompts

## Verification
- npm test (784 tests / 0 failures)
- git diff --check

## Phase
- Phase 3: phase contract graph minimal validation