### PR TITLE
Add decomposition delta guard

### DIFF
--- a/agents/mpl-decomposer.md
+++ b/agents/mpl-decomposer.md
@@ -36,7 +36,7 @@ disallowedTools: Bash,Task,WebFetch,WebSearch,NotebookEdit
 
     8. **Vertical slice for multi-layer projects**: If 2+ layers detected (frontend/backend/DB/IPC), decompose by feature, not by layer. Each phase implements ONE feature across ALL layers. Scaffold/infrastructure phases remain horizontal.
 
-    9. **APPEND-MODE (0.16 S3-4)**: When the dispatch prompt begins with `APPEND-MODE:`, do NOT re-generate the full decomposition. Instead, keep every existing phase in `.mpl/mpl/decomposition.yaml` intact (ids, contract_files, covers, verification_plan all unchanged) and append 1-3 new phases derived from the supplied `append_phases` hints. Rules: (a) new phase ids must not collide with existing — use the pattern `{anchor}b`, `{anchor}c`, etc. (e.g., `phase-3b` after `phase-3`); (b) each appended phase MUST include `covers:[UC-N]` per 0.16 Tier B and `test_agent_required:true`; (c) preserve `execution_tiers` ordering by inserting the new phase ids immediately after their anchor; (d) emit the FULL updated decomposition.yaml (existing + appended), not a diff. Trigger: Finalize Step 5.0.4 auto-recovery (Classification A) passes `append_phases` from `mpl_diagnose_e2e_failure`.
+    9. **RECOMPOSE-MODE / APPEND-MODE (controlled recomposition)**: When the dispatch prompt begins with `RECOMPOSE-MODE:` or `APPEND-MODE:`, never patch `.mpl/mpl/decomposition.yaml` in place. First read the existing graph, keep existing phases intact unless the delta explicitly names an operation, and write `.mpl/mpl/decomposition-deltas/recompose-{N}.yaml` where `N = existing recompose_count + 1`. Then write the FULL updated `.mpl/mpl/decomposition.yaml` with `recompose_count: N`. APPEND-MODE is a restricted RECOMPOSE-MODE that may only append 1-3 phases from `append_phases` hints. New phase ids must not collide — use `{anchor}b`, `{anchor}c`, etc. (e.g., `phase-3b` after `phase-3`); each appended phase MUST include `covers:[UC-N]` and `test_agent_required:true`; preserve `execution_tiers` by inserting new ids immediately after the anchor.
   </Rules>
 
   <Reasoning_Steps>
@@ -301,10 +301,10 @@ disallowedTools: Bash,Task,WebFetch,WebSearch,NotebookEdit
     **Authoring authority (v0.17.2)**: YOU are the sole writer of `.mpl/mpl/decomposition.yaml`. The orchestrator no longer persists this file — it dispatches you, reads what you wrote, and runs post-processing (contract JSON file extraction, e2e-scenarios.yaml split). Your job:
 
       1. Construct the full YAML below in your reasoning.
-      2. **Write it to `.mpl/mpl/decomposition.yaml`** using the Write tool (overwrite if it exists; APPEND-MODE re-emits the full updated file per Rule 9).
+      2. **Write it to `.mpl/mpl/decomposition.yaml`** using the Write tool. Initial decomposition writes the file once with `recompose_count: 0`. RECOMPOSE-MODE/APPEND-MODE must first write `.mpl/mpl/decomposition-deltas/recompose-{N}.yaml`, then write the full updated graph with `recompose_count: N` per Rule 9.
       3. Return a single-line response confirming the write: `Wrote .mpl/mpl/decomposition.yaml — N phases, M tiers.`
 
-    Do NOT print the YAML body in the response — it lives on disk now. Validation hooks (`mpl-require-covers.mjs`, future `mpl-require-decomposition-fields.mjs`) run on your Write call; if blocked, surface the hook reason and re-emit a corrected YAML in a follow-up Write. Never re-route the Write through the orchestrator.
+    Do NOT print the YAML body in the response — it lives on disk now. Validation hooks (`mpl-require-covers.mjs`, `mpl-require-goal-trace.mjs`, `mpl-require-phase-contract-graph.mjs`, `mpl-require-decomposition-delta.mjs`) run on your Write call; if blocked, surface the hook reason and re-emit a corrected YAML in a follow-up Write. Never re-route the Write through the orchestrator.
 
     ```yaml
     graph_version: 1
@@ -533,6 +533,24 @@ disallowedTools: Bash,Task,WebFetch,WebSearch,NotebookEdit
       re_interview_questions:
         - question: string
           evidence: string
+    ```
+
+    Recomposition delta schema (write this before changing an existing decomposition graph):
+
+    ```yaml
+    delta_version: 1
+    generated_by: mpl-decomposer
+    base_recompose_count: 0
+    target_recompose_count: 1
+    reason: "why the graph must change"
+    change_policy: decomposition_delta_then_recompose
+    operations:
+      - op: append_phase # append_phase|split_phase|modify_phase|retire_phase|reorder_phase|update_dependency|update_evidence
+        target_phase: phase-3b
+        rationale: "what this operation preserves or fixes"
+        goal_trace:
+          acceptance_criteria: [AC-1]
+          variation_axes: [AX-1]
     ```
   </Output_Schema>
 

--- a/commands/mpl-run-decompose.md
+++ b/commands/mpl-run-decompose.md
@@ -23,11 +23,11 @@ Load this when transitioning from pre-execution analysis to phase decomposition.
 
 The orchestrator never holds a Write authority on `decomposition.yaml` for the **initial creation path** (3.0 → 3.1 → "After Receiving Output"). If validation fails, surface the failure and re-dispatch the agent with the diagnostics; do not patch the file by hand.
 
-**Known carve-out (Step 3-F mechanical patches)**: the feedback path at Step 3-F currently performs surgical in-place patches (Types A/C/E: phase_domain swap, risk_notes append, ai_complexity default) without re-dispatching the agent. These are deterministic field-level edits informed by Pre-Execution feedback, not fabricated decompositions. They remain orchestrator-Write for now to avoid full re-dispatch cost. Treat this as an inherited exception to be revisited (TODO: route 3-F through the agent for purity). Type B (phase split) and Type D (unmapped requirements) already re-dispatch the agent.
+**Recomposition path**: once `.mpl/mpl/decomposition.yaml` exists, every graph change is a decomposer-owned recomposition. The decomposer must first write `.mpl/mpl/decomposition-deltas/recompose-{N}.yaml`, then write the full updated `.mpl/mpl/decomposition.yaml` with `recompose_count: N`. The orchestrator must not perform Step 3-F field patches, phase splits, or APPEND-MODE recovery edits itself.
 
 **Why this rule exists**: an earlier autonomous-mode shortcut had the orchestrator write a 5-phase decomposition itself ("pragmatic decomposition"). It was caught by `mpl-require-covers.mjs` (covers missing) but only because covers happened to be missing — main-context fabrications can also pass schema-checks while silently omitting the agent's Step 5.5 / 5.6 / 6.5 / 9.7 synthesis (type_policy, error_spec, contract_files, intent invariants). Moving the Write into the agent removes the orchestrator's ability to fabricate at all.
 
-**How this rule applies under autonomous mandates**: a user instruction like "no questions, run autonomously" authorizes the agent to skip *user-facing prompts*, never to skip *agent dispatches*. Phase 0 artifacts (PP, core-scenarios, design-intent, user-contract) remain orchestrator-authored; everything from Step 3 onward is agent-authored. APPEND-MODE (3.1 dispatch with `APPEND-MODE:` prefix) is also agent-authored end-to-end — the agent re-Writes the full updated file per `agents/mpl-decomposer.md` Rule 9.
+**How this rule applies under autonomous mandates**: a user instruction like "no questions, run autonomously" authorizes the agent to skip *user-facing prompts*, never to skip *agent dispatches*. Phase 0 artifacts (PP, core-scenarios, design-intent, user-contract) remain orchestrator-authored; everything from Step 3 onward is agent-authored. APPEND-MODE/RECOMPOSE-MODE is also agent-authored end-to-end — the agent writes the delta artifact and then re-Writes the full updated file per `agents/mpl-decomposer.md` Rule 9.
 
 ### 3.0: Ambiguity Gate — Delegated to Stage 2 Re-Entry (Issue #51)
 
@@ -105,7 +105,7 @@ Task(subagent_type="mpl-decomposer", model="opus",
      CRITICAL: Do NOT scope down. Every feature, requirement, and component in the user's spec must be covered by at least one phase. If the spec describes 10 features, all 10 must appear in the decomposition. Create as many phases as needed — there is no hard cap on phase count.
 
      Use Phase 0 artifacts to inform decomposition decisions — they contain pre-analyzed API contracts, usage patterns, type policies, and error specifications. Use the Pre-Execution Analysis's Recommended Execution Order (section 7) to guide phase ordering, and its Gap Analysis (sections 1-4) to catch missing requirements. **Write the YAML directly to `.mpl/mpl/decomposition.yaml` using the Write tool**, then return a single confirmation line (e.g., `Wrote .mpl/mpl/decomposition.yaml — 5 phases, 3 tiers.`). Do NOT print the YAML body in your response.
-     Top-level graph metadata is REQUIRED: `graph_version`, `generated_by: mpl-decomposer`, `recompose_count`, `completed_phase_policy`, and `goal_contract_hash` (MUST equal sha256(normalized `.mpl/goal-contract.yaml`)). The write is blocked if graph metadata is missing, the hash is stale, phase `goal_trace` does not cover every Goal Contract AC/AX id, or any `interface_contract.requires[].from_phase` points to an unknown/self phase.
+     Top-level graph metadata is REQUIRED: `graph_version`, `generated_by: mpl-decomposer`, `recompose_count`, `completed_phase_policy`, and `goal_contract_hash` (MUST equal sha256(normalized `.mpl/goal-contract.yaml`)). The write is blocked if graph metadata is missing, the hash is stale, phase `goal_trace` does not cover every Goal Contract AC/AX id, any `interface_contract.requires[].from_phase` points to an unknown/self phase, or an existing graph changes without a matching `.mpl/mpl/decomposition-deltas/recompose-N.yaml`.
      Each phase: id, name, phase_domain (F-28: db|api|ui|algorithm|test|ai|infra|general),
      pp_proximity (pp_core|pp_adjacent|non_pp — see classification rules below),
      phase_subdomain (F-39, optional: tech-stack e.g. react, prisma, langchain),
@@ -398,36 +398,29 @@ if feedback_conditions is empty:
   Report: "[MPL] Step 3-F: No feedback conditions. Proceeding to verification planning."
   -> proceed to Step 3-B
 
-type_a_or_c = feedback_conditions.filter(fc => fc.type in ["A", "C", "E"])
-type_b = feedback_conditions.filter(fc => fc.type == "B")
-type_d = feedback_conditions.filter(fc => fc.type == "D")
+recompose_feedback = feedback_conditions.filter(fc => fc.type in ["A", "B", "C", "D", "E"])
 
-// Type A/C/E: Lightweight fixes — patch decomposition in-place
-for each fc in type_a_or_c:
-  apply_patch(decomposition, fc)
-  // A: change phase_domain from infra/algorithm to ai
-  // C: append to risk_notes
-  // E: add default ai_complexity field
-Save patched decomposition to .mpl/mpl/decomposition.yaml
-
-// Type B: Phase split — patch in-place (no re-invocation)
-for each fc in type_b:
-  split_phase(decomposition, fc.phase_id)
-Save updated decomposition
-
-// Type D: Re-invoke Decomposer (expensive, max 1 time)
-if type_d is not empty AND state.step3f_count == 0:
+// All graph-affecting feedback: Recompose through decomposer (delta-first, no orchestrator patch)
+if recompose_feedback is not empty AND state.step3f_count == 0:
   state.step3f_count = 1
-  Report: "[MPL] Step 3-F: {type_d.length} unmapped requirements. Re-invoking Decomposer."
-  // Re-run Step 3 with additional constraint:
-  //   "The following requirements from Pre-Execution Analysis are NOT covered: {type_d}"
-  -> return to Step 3 with feedback constraints
+  Report: "[MPL] Step 3-F: recomposing graph for {recompose_feedback.length} feedback conditions."
+  Task(subagent_type="mpl-decomposer", prompt=`
+    RECOMPOSE-MODE:
+    Existing decomposition.yaml must remain coherent. Do not Edit/MultiEdit it.
+    First write .mpl/mpl/decomposition-deltas/recompose-{N}.yaml where
+    N = current recompose_count + 1, then Write the full updated
+    .mpl/mpl/decomposition.yaml with recompose_count: N.
 
-elif type_d is not empty AND state.step3f_count >= 1:
-  Report: "[MPL] Step 3-F: Unmapped requirements remain but feedback loop exhausted. Logging as caveats."
+    Apply these Step 3-F feedback conditions:
+    ${JSON.stringify(recompose_feedback, null, 2)}
+  `)
+  -> proceed to Step 3-B after reading the recomposed graph
+
+elif recompose_feedback is not empty AND state.step3f_count >= 1:
+  Report: "[MPL] Step 3-F: recomposition feedback remains after one attempt. Logging as caveats."
   // Log as READY_WITH_CAVEATS
 
-Report: "[MPL] Step 3-F: Applied {feedback_conditions.length} feedback conditions ({type_a_or_c.length} patches, {type_b.length} splits, {type_d.length} re-invocations)."
+Report: "[MPL] Step 3-F: Applied {feedback_conditions.length} feedback conditions via recomposition."
 ```
 
 ---

--- a/commands/references/e2e-recovery.md
+++ b/commands/references/e2e-recovery.md
@@ -75,7 +75,10 @@ while state.e2e_recovery.iter < state.e2e_recovery.max_iter AND failures not emp
     case "A":   # spec gap → decomposer appends phases
       Task(subagent_type="mpl-decomposer", prompt=`
         APPEND-MODE: existing decomposition.yaml remains; append the phases
-        below without modifying existing phase ids. Each appended phase MUST
+        below without modifying existing phase ids. First write
+        .mpl/mpl/decomposition-deltas/recompose-{N}.yaml where N =
+        current recompose_count + 1, then Write the full updated
+        decomposition.yaml with recompose_count: N. Each appended phase MUST
         include covers:[UC-N] per 0.16 Tier B and test_agent_required:true.
 
         Append hints (from mpl_diagnose_e2e_failure):
@@ -164,4 +167,3 @@ Before knowledge extraction, verify all AD (After Decision) markers:
 - Check each AD has: interface definition + minimal implementation
 - Incomplete ADs: report to user (awareness, not blocking)
 - Report: `[MPL] AD Verification: {complete}/{total} ADs verified.`
-

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -196,6 +196,7 @@ the immutable post-Phase-0 snapshot consumed by delta calculation and rollback.
 | `goal_contract_required` | boolean | `true` | Blocks decomposer dispatch until `.mpl/goal-contract.yaml` freezes source goal, project pivot, ontology, variation axes, acceptance criteria, E2E policy, security policy, and completion evidence. | `mpl-ambiguity-gate.mjs` |
 | `goal_trace_required` | boolean | `true` | Blocks `decomposition.yaml` writes unless top-level `goal_contract_hash` matches the frozen Goal Contract and phase `goal_trace` covers every AC/AX id. | `mpl-require-goal-trace.mjs` |
 | `phase_contract_graph_required` | boolean | `true` | Blocks `decomposition.yaml` writes unless graph metadata, per-phase evidence/change policy, and non-dangling phase dependencies are present. | `mpl-require-phase-contract-graph.mjs` |
+| `decomposition_delta_required` | boolean | `true` | Blocks changes to an existing `decomposition.yaml` unless `recompose_count` increments by one and a matching `.mpl/mpl/decomposition-deltas/recompose-N.yaml` exists. | `mpl-require-decomposition-delta.mjs` |
 | `finalize_artifacts_required` | boolean | `true` | Blocks `finalize_done=true` unless the goal contract's required artifacts, RUNBOOK final section, finalize timestamps, security evidence, and optional commit evidence are present. Override file: `.mpl/config/finalize-artifact-override.json`. | `mpl-require-finalize-artifacts.mjs` |
 
 ## Adversarial Reviewer (P0-A, #103)

--- a/docs/schemas/decomposition-delta.md
+++ b/docs/schemas/decomposition-delta.md
@@ -1,0 +1,48 @@
+# Decomposition Delta Schema
+
+File: `.mpl/mpl/decomposition-deltas/recompose-N.yaml`
+
+Existing decomposition graphs are immutable by default. Any change after the
+initial `recompose_count: 0` write must leave a delta artifact before the full
+graph is rewritten.
+
+## Required Fields
+
+```yaml
+delta_version: 1
+generated_by: mpl-decomposer
+base_recompose_count: 0
+target_recompose_count: 1
+reason: "why the decomposition graph must change"
+change_policy: decomposition_delta_then_recompose
+operations:
+  - op: append_phase
+    target_phase: phase-3b
+    rationale: "what this operation preserves or fixes"
+    goal_trace:
+      acceptance_criteria: [AC-1]
+      variation_axes: [AX-1]
+```
+
+Allowed `operations[].op` values:
+
+- `append_phase`
+- `split_phase`
+- `modify_phase`
+- `retire_phase`
+- `reorder_phase`
+- `update_dependency`
+- `update_evidence`
+
+## Runtime Enforcement
+
+- `hooks/mpl-require-decomposition-delta.mjs` blocks partial
+  `Edit`/`MultiEdit` writes to an existing `.mpl/mpl/decomposition.yaml`.
+- Rewriting an existing decomposition requires:
+  - `new.recompose_count == old.recompose_count + 1`
+  - a matching `.mpl/mpl/decomposition-deltas/recompose-N.yaml`
+  - a valid delta whose `base_recompose_count` and `target_recompose_count`
+    match the old and new graph counts
+- Delta writes are also validated against the current graph count.
+- `.mpl/config.json { "decomposition_delta_required": false }` is an explicit
+  migration opt-out.

--- a/docs/schemas/goal-contract.md
+++ b/docs/schemas/goal-contract.md
@@ -82,6 +82,9 @@ overrides: []
 - `hooks/mpl-require-phase-contract-graph.mjs` blocks decomposition writes that
   lack graph metadata, phase evidence/change policy, or valid phase dependency
   references.
+- `hooks/mpl-require-decomposition-delta.mjs` blocks decomposition rewrites
+  without a matching recomposition delta and one-step `recompose_count`
+  increment.
 - `hooks/mpl-require-e2e-authenticity.mjs` reads `e2e_policy` before allowing
   `finalize_done=true`.
 - `hooks/mpl-require-finalize-artifacts.mjs` reads `security_policy` and

--- a/docs/schemas/phase-contract-graph.md
+++ b/docs/schemas/phase-contract-graph.md
@@ -52,9 +52,13 @@ phases:
     unknown phase
 - `.mpl/config.json { "phase_contract_graph_required": false }` is an explicit
   migration opt-out.
+- `hooks/mpl-require-decomposition-delta.mjs` blocks changes to an existing
+  graph unless a valid `decomposition-deltas/recompose-N.yaml` exists and
+  `recompose_count` advances by exactly one.
 
 ## Notes
 
 `contract_hash` is reserved for a later post-processing phase that can compute a
 real hash from canonical phase content. Do not ask the decomposer to fabricate a
-cryptographic value.
+cryptographic value. Use `recompose_count` plus decomposition deltas for graph
+change history until canonical phase hashes exist.

--- a/hooks/__tests__/mpl-decomposition-delta.test.mjs
+++ b/hooks/__tests__/mpl-decomposition-delta.test.mjs
@@ -1,0 +1,198 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { tmpdir } from 'os';
+
+import {
+  parseDecompositionDeltaText,
+  validateDecompositionDelta,
+} from '../lib/mpl-decomposition-delta.mjs';
+import { CURRENT_SCHEMA_VERSION } from '../lib/mpl-state.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const HOOK_PATH = join(dirname(__filename), '..', 'mpl-require-decomposition-delta.mjs');
+
+let tmp;
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'mpl-decomposition-delta-'));
+  mkdirSync(join(tmp, '.mpl', 'mpl', 'decomposition-deltas'), { recursive: true });
+  writeFileSync(join(tmp, '.mpl', 'state.json'), JSON.stringify({
+    schema_version: CURRENT_SCHEMA_VERSION,
+    current_phase: 'mpl-decompose',
+  }));
+});
+afterEach(() => rmSync(tmp, { recursive: true, force: true }));
+
+function graph(count = 0, phaseName = 'Bootstrap', extraPhase = '') {
+  return `
+graph_version: 1
+generated_by: mpl-decomposer
+recompose_count: ${count}
+completed_phase_policy: immutable_by_default
+goal_contract_hash: abc
+phases:
+  - id: phase-1
+    name: ${phaseName}
+    evidence_required: [command, goal_trace]
+    change_policy: append_delta_only
+    interface_contract:
+      requires: []
+      produces:
+        - type: artifact
+          name: bootstrap
+${extraPhase}`;
+}
+
+function appendedPhase() {
+  return `  - id: phase-2
+    name: Followup
+    evidence_required: [command, test_agent]
+    change_policy: append_delta_only
+    interface_contract:
+      requires:
+        - type: artifact
+          name: bootstrap
+          from_phase: phase-1
+      produces: []
+`;
+}
+
+function delta(base = 0, target = 1, op = 'append_phase') {
+  return `
+delta_version: 1
+generated_by: mpl-decomposer
+base_recompose_count: ${base}
+target_recompose_count: ${target}
+reason: "Append missing coverage phase"
+change_policy: decomposition_delta_then_recompose
+operations:
+  - op: ${op}
+    target_phase: phase-2
+    rationale: "cover recovered requirement"
+`;
+}
+
+function writeCurrentGraph(count = 0) {
+  writeFileSync(join(tmp, '.mpl', 'mpl', 'decomposition.yaml'), graph(count));
+}
+
+function writeDeltaFile(base = 0, target = 1) {
+  writeFileSync(
+    join(tmp, '.mpl', 'mpl', 'decomposition-deltas', `recompose-${target}.yaml`),
+    delta(base, target),
+  );
+}
+
+function runHook(toolInput, opts = {}) {
+  if (opts.config) {
+    writeFileSync(join(tmp, '.mpl', 'config.json'), JSON.stringify(opts.config));
+  }
+  const input = {
+    cwd: tmp,
+    tool_name: opts.toolName || 'Write',
+    tool_input: toolInput,
+  };
+  return JSON.parse(execFileSync('node', [HOOK_PATH], {
+    input: JSON.stringify(input),
+    encoding: 'utf-8',
+  }));
+}
+
+describe('decomposition delta parser', () => {
+  it('validates a recomposition delta', () => {
+    const parsed = parseDecompositionDeltaText(delta());
+    assert.equal(parsed.generated_by, 'mpl-decomposer');
+    assert.equal(parsed.base_recompose_count, 0);
+    assert.equal(parsed.target_recompose_count, 1);
+    assert.deepEqual(parsed.operations, ['append_phase']);
+    const verdict = validateDecompositionDelta(parsed, { expectedBase: 0, expectedTarget: 1 });
+    assert.equal(verdict.valid, true, verdict.issues.join(', '));
+  });
+
+  it('rejects non-incremental or unknown delta operations', () => {
+    const verdict = validateDecompositionDelta(parseDecompositionDeltaText(delta(0, 2, 'invent_phase')));
+    assert.equal(verdict.valid, false);
+    assert.ok(verdict.issues.includes('target_recompose_count:not_next:0->2'));
+    assert.ok(verdict.issues.includes('operations:unknown:invent_phase'));
+  });
+});
+
+describe('mpl-require-decomposition-delta hook integration', () => {
+  it('allows initial decomposition write when no graph exists yet', () => {
+    const r = runHook({
+      file_path: '.mpl/mpl/decomposition.yaml',
+      content: graph(0),
+    });
+    assert.equal(r.continue, true);
+  });
+
+  it('blocks rewriting an existing graph without incrementing recompose_count', () => {
+    writeCurrentGraph(0);
+    const r = runHook({
+      file_path: '.mpl/mpl/decomposition.yaml',
+      content: graph(0, 'Changed'),
+    });
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason, /recompose_count:expected:1:actual:0/);
+  });
+
+  it('blocks recompose_count increment when matching delta is missing', () => {
+    writeCurrentGraph(0);
+    const r = runHook({
+      file_path: '.mpl/mpl/decomposition.yaml',
+      content: graph(1, 'Bootstrap', appendedPhase()),
+    });
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason, /decomposition_delta:missing:recompose-1\.yaml/);
+  });
+
+  it('allows full graph recomposition with a matching delta file', () => {
+    writeCurrentGraph(0);
+    writeDeltaFile(0, 1);
+    const r = runHook({
+      file_path: '.mpl/mpl/decomposition.yaml',
+      content: graph(1, 'Bootstrap', appendedPhase()),
+    });
+    assert.equal(r.continue, true);
+  });
+
+  it('blocks partial Edit or MultiEdit changes to an existing graph', () => {
+    writeCurrentGraph(0);
+    const r = runHook({
+      file_path: '.mpl/mpl/decomposition.yaml',
+      edits: [{ old_string: 'Bootstrap', new_string: 'Changed' }],
+    }, { toolName: 'MultiEdit' });
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason, /decomposition:partial_edit_not_allowed/);
+  });
+
+  it('validates delta writes against the current graph count', () => {
+    writeCurrentGraph(0);
+    const r = runHook({
+      file_path: '.mpl/mpl/decomposition-deltas/recompose-1.yaml',
+      content: delta(0, 1),
+    });
+    assert.equal(r.continue, true);
+
+    const bad = runHook({
+      file_path: '.mpl/mpl/decomposition-deltas/recompose-2.yaml',
+      content: delta(0, 1),
+    });
+    assert.equal(bad.decision, 'block');
+    assert.match(bad.reason, /target_recompose_count:expected:1:actual:1|path_target:expected:2:actual:1/);
+  });
+
+  it('allows migration opt-out', () => {
+    writeCurrentGraph(0);
+    const r = runHook({
+      file_path: '.mpl/mpl/decomposition.yaml',
+      content: graph(0, 'Changed'),
+    }, {
+      config: { decomposition_delta_required: false },
+    });
+    assert.equal(r.continue, true);
+  });
+});

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -126,6 +126,16 @@
         "hooks": [
           {
             "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/mpl-require-decomposition-delta.mjs\"",
+            "timeout": 3
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/mpl-baseline-guard.mjs\"",
             "timeout": 3
           }

--- a/hooks/lib/mpl-config.mjs
+++ b/hooks/lib/mpl-config.mjs
@@ -66,6 +66,7 @@ const DEFAULTS = {
   goal_contract_required: true,
   goal_trace_required: true,
   phase_contract_graph_required: true,
+  decomposition_delta_required: true,
   e2e_authenticity_required: true,
   finalize_artifacts_required: true,
   convergence: {

--- a/hooks/lib/mpl-decomposition-delta.mjs
+++ b/hooks/lib/mpl-decomposition-delta.mjs
@@ -1,0 +1,148 @@
+/**
+ * Validation helpers for controlled decomposition recomposition.
+ *
+ * Recomposition is a two-step protocol:
+ * 1. Write `.mpl/mpl/decomposition-deltas/recompose-N.yaml`.
+ * 2. Write the full updated `.mpl/mpl/decomposition.yaml` with
+ *    `recompose_count: N`.
+ */
+
+import { existsSync, readFileSync, readdirSync } from 'fs';
+import { basename, join } from 'path';
+
+export const DELTA_DIR_REL = '.mpl/mpl/decomposition-deltas';
+export const LEGACY_DELTA_REL = '.mpl/mpl/decomposition-delta.yaml';
+
+const ALLOWED_OPS = new Set([
+  'append_phase',
+  'split_phase',
+  'modify_phase',
+  'retire_phase',
+  'reorder_phase',
+  'update_dependency',
+  'update_evidence',
+]);
+
+function normalizeScalar(value) {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (!trimmed || trimmed === 'null') return null;
+  return trimmed.replace(/^["']|["']$/g, '').trim() || null;
+}
+
+function scalar(text, key) {
+  const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const m = String(text || '').match(new RegExp(`^${escaped}\\s*:\\s*(.+?)\\s*$`, 'm'));
+  return m ? normalizeScalar(m[1]) : null;
+}
+
+export function parseRecomposeCount(value) {
+  const normalized = normalizeScalar(String(value ?? ''));
+  if (normalized === null) return null;
+  if (!/^\d+$/.test(normalized)) return null;
+  return Number.parseInt(normalized, 10);
+}
+
+function extractOperations(text) {
+  return [...String(text || '').matchAll(/^\s*-\s+op\s*:\s*["']?([\w-]+)["']?/gm)]
+    .map((m) => m[1]);
+}
+
+export function parseDecompositionDeltaText(text) {
+  return {
+    delta_version: scalar(text, 'delta_version'),
+    generated_by: scalar(text, 'generated_by'),
+    base_recompose_count: parseRecomposeCount(scalar(text, 'base_recompose_count')),
+    target_recompose_count: parseRecomposeCount(scalar(text, 'target_recompose_count')),
+    reason: scalar(text, 'reason'),
+    change_policy: scalar(text, 'change_policy'),
+    operations: extractOperations(text),
+  };
+}
+
+export function targetCountFromDeltaPath(filePath) {
+  const m = basename(String(filePath || '')).match(/^recompose-(\d+)\.ya?ml$/);
+  return m ? Number.parseInt(m[1], 10) : null;
+}
+
+export function validateDecompositionDelta(delta, opts = {}) {
+  const issues = [];
+  if (!delta?.delta_version) issues.push('delta_version:missing');
+  if (delta?.generated_by !== 'mpl-decomposer') {
+    issues.push(`generated_by:${delta?.generated_by || 'missing'}`);
+  }
+  if (!Number.isInteger(delta?.base_recompose_count)) {
+    issues.push('base_recompose_count:missing');
+  }
+  if (!Number.isInteger(delta?.target_recompose_count)) {
+    issues.push('target_recompose_count:missing');
+  }
+  if (Number.isInteger(delta?.base_recompose_count) && Number.isInteger(delta?.target_recompose_count)) {
+    if (delta.target_recompose_count !== delta.base_recompose_count + 1) {
+      issues.push(`target_recompose_count:not_next:${delta.base_recompose_count}->${delta.target_recompose_count}`);
+    }
+  }
+  if (!delta?.reason) issues.push('reason:missing');
+  if (delta?.change_policy !== 'decomposition_delta_then_recompose') {
+    issues.push(`change_policy:${delta?.change_policy || 'missing'}`);
+  }
+  if (!Array.isArray(delta?.operations) || delta.operations.length === 0) {
+    issues.push('operations:missing');
+  } else {
+    for (const op of delta.operations) {
+      if (!ALLOWED_OPS.has(op)) issues.push(`operations:unknown:${op}`);
+    }
+  }
+
+  if (Number.isInteger(opts.expectedBase) && delta?.base_recompose_count !== opts.expectedBase) {
+    issues.push(`base_recompose_count:expected:${opts.expectedBase}:actual:${delta?.base_recompose_count ?? 'missing'}`);
+  }
+  if (Number.isInteger(opts.expectedTarget) && delta?.target_recompose_count !== opts.expectedTarget) {
+    issues.push(`target_recompose_count:expected:${opts.expectedTarget}:actual:${delta?.target_recompose_count ?? 'missing'}`);
+  }
+  if (Number.isInteger(opts.expectedPathTarget) && delta?.target_recompose_count !== opts.expectedPathTarget) {
+    issues.push(`path_target:expected:${opts.expectedPathTarget}:actual:${delta?.target_recompose_count ?? 'missing'}`);
+  }
+
+  return {
+    valid: issues.length === 0,
+    issues,
+  };
+}
+
+function readDeltaCandidate(path, expectedBase, expectedTarget) {
+  if (!existsSync(path)) return null;
+  const text = readFileSync(path, 'utf-8');
+  const expectedPathTarget = targetCountFromDeltaPath(path);
+  const delta = parseDecompositionDeltaText(text);
+  const verdict = validateDecompositionDelta(delta, {
+    expectedBase,
+    expectedTarget,
+    ...(expectedPathTarget === null ? {} : { expectedPathTarget }),
+  });
+  return { path, delta, verdict };
+}
+
+export function findMatchingDecompositionDelta(cwd, expectedBase, expectedTarget) {
+  const candidates = [
+    join(cwd, DELTA_DIR_REL, `recompose-${expectedTarget}.yaml`),
+    join(cwd, DELTA_DIR_REL, `recompose-${expectedTarget}.yml`),
+    join(cwd, LEGACY_DELTA_REL),
+  ];
+
+  for (const path of candidates) {
+    const result = readDeltaCandidate(path, expectedBase, expectedTarget);
+    if (result) return result;
+  }
+
+  const dir = join(cwd, DELTA_DIR_REL);
+  if (existsSync(dir)) {
+    for (const name of readdirSync(dir)) {
+      if (!/\.ya?ml$/.test(name)) continue;
+      const result = readDeltaCandidate(join(dir, name), expectedBase, expectedTarget);
+      if (result?.verdict.valid) return result;
+    }
+  }
+
+  return null;
+}

--- a/hooks/mpl-require-decomposition-delta.mjs
+++ b/hooks/mpl-require-decomposition-delta.mjs
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+/**
+ * MPL Require Decomposition Delta Hook (PreToolUse on Write|Edit|MultiEdit).
+ *
+ * Existing decomposition graphs may only change through a recomposition delta:
+ * write `.mpl/mpl/decomposition-deltas/recompose-N.yaml`, then write the full
+ * updated `.mpl/mpl/decomposition.yaml` with `recompose_count: N`.
+ */
+
+import { existsSync, readFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const isMain = import.meta.url === pathToFileURL(process.argv[1] || '').href;
+
+const { isMplActive } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-state.mjs')).href
+);
+const { loadConfig } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-config.mjs')).href
+);
+const { parsePhaseContractGraphText } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-phase-contract-graph.mjs')).href
+);
+const {
+  findMatchingDecompositionDelta,
+  parseDecompositionDeltaText,
+  parseRecomposeCount,
+  targetCountFromDeltaPath,
+  validateDecompositionDelta,
+} = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-decomposition-delta.mjs')).href
+);
+const { collectFileWrites, isFileWriteTool } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'tool-input.mjs')).href
+);
+const { readStdin } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'stdin.mjs')).href
+);
+
+function ok() {
+  console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+}
+
+function block(reason) {
+  console.log(JSON.stringify({ continue: false, decision: 'block', reason }));
+}
+
+function isFullWriteTool(toolName) {
+  return ['Write', 'write'].includes(String(toolName || ''));
+}
+
+export function targetsDecompositionFile(filePath) {
+  if (!filePath || typeof filePath !== 'string') return false;
+  return /(^|\/)\.mpl\/mpl\/decomposition\.ya?ml$/.test(filePath);
+}
+
+export function targetsDecompositionDeltaFile(filePath) {
+  if (!filePath || typeof filePath !== 'string') return false;
+  return /(^|\/)\.mpl\/mpl\/decomposition-delta\.ya?ml$/.test(filePath) ||
+    /(^|\/)\.mpl\/mpl\/decomposition-deltas\/[^/]+\.ya?ml$/.test(filePath);
+}
+
+function currentDecompositionPath(cwd) {
+  return join(cwd, '.mpl', 'mpl', 'decomposition.yaml');
+}
+
+function recomposeCountFromText(text) {
+  const graph = parsePhaseContractGraphText(text);
+  return parseRecomposeCount(graph.recompose_count);
+}
+
+function validateDeltaWrite(cwd, filePath, text, toolName) {
+  const issues = [];
+  if (!isFullWriteTool(toolName)) {
+    issues.push('delta_write:partial_edit_not_allowed');
+  }
+  if (!text || !String(text).trim()) {
+    issues.push('delta_write:empty');
+    return issues;
+  }
+
+  const existingPath = currentDecompositionPath(cwd);
+  if (!existsSync(existingPath)) {
+    issues.push('decomposition:missing_for_delta');
+    return issues;
+  }
+
+  const baseCount = recomposeCountFromText(readFileSync(existingPath, 'utf-8'));
+  if (!Number.isInteger(baseCount)) {
+    issues.push('decomposition:recompose_count:missing');
+    return issues;
+  }
+
+  const pathTarget = targetCountFromDeltaPath(filePath);
+  const delta = parseDecompositionDeltaText(text);
+  const verdict = validateDecompositionDelta(delta, {
+    expectedBase: baseCount,
+    expectedTarget: baseCount + 1,
+    ...(pathTarget === null ? {} : { expectedPathTarget: pathTarget }),
+  });
+  issues.push(...verdict.issues);
+  return issues;
+}
+
+function validateDecompositionWrite(cwd, text, toolName) {
+  const issues = [];
+  const existingPath = currentDecompositionPath(cwd);
+  if (!existsSync(existingPath)) return issues;
+
+  const oldText = readFileSync(existingPath, 'utf-8');
+  if (text && String(text).trim() === oldText.trim()) return issues;
+
+  if (!isFullWriteTool(toolName)) {
+    issues.push('decomposition:partial_edit_not_allowed');
+    return issues;
+  }
+  if (!text || !String(text).trim()) {
+    issues.push('decomposition:empty_write');
+    return issues;
+  }
+
+  const oldCount = recomposeCountFromText(oldText);
+  const newCount = recomposeCountFromText(text);
+  if (!Number.isInteger(oldCount)) issues.push('decomposition:old_recompose_count:missing');
+  if (!Number.isInteger(newCount)) issues.push('decomposition:new_recompose_count:missing');
+  if (!Number.isInteger(oldCount) || !Number.isInteger(newCount)) return issues;
+
+  if (newCount !== oldCount + 1) {
+    issues.push(`recompose_count:expected:${oldCount + 1}:actual:${newCount}`);
+    return issues;
+  }
+
+  const delta = findMatchingDecompositionDelta(cwd, oldCount, newCount);
+  if (!delta) {
+    issues.push(`decomposition_delta:missing:recompose-${newCount}.yaml`);
+    return issues;
+  }
+  if (!delta.verdict.valid) {
+    issues.push(...delta.verdict.issues.map((issue) => `decomposition_delta:${issue}`));
+  }
+  return issues;
+}
+
+async function main() {
+  const raw = await readStdin();
+  if (!raw.trim()) return ok();
+
+  let data;
+  try { data = JSON.parse(raw); } catch { return ok(); }
+
+  const toolName = data.tool_name || data.toolName || '';
+  if (!isFileWriteTool(toolName)) return ok();
+
+  const cwd = data.cwd || data.directory || process.cwd();
+  if (!isMplActive(cwd)) return ok();
+
+  const cfg = loadConfig(cwd);
+  if (cfg.decomposition_delta_required === false) return ok();
+
+  const toolInput = data.tool_input || data.toolInput || {};
+  const issues = [];
+  for (const entry of collectFileWrites(toolInput)) {
+    if (targetsDecompositionDeltaFile(entry.filePath)) {
+      issues.push(...validateDeltaWrite(cwd, entry.filePath, entry.text, toolName));
+    } else if (targetsDecompositionFile(entry.filePath)) {
+      issues.push(...validateDecompositionWrite(cwd, entry.text, toolName));
+    }
+  }
+
+  if (issues.length > 0) {
+    const shown = issues.slice(0, 12).join(', ');
+    const more = issues.length > 12 ? ` (+${issues.length - 12} more)` : '';
+    block(
+      `[MPL Decomposition Delta] Existing decomposition changes must go through ` +
+        `.mpl/mpl/decomposition-deltas/recompose-N.yaml before the full graph rewrite: ${shown}${more}.`
+    );
+    return;
+  }
+
+  ok();
+}
+
+if (isMain) {
+  await main().catch(() => ok());
+}


### PR DESCRIPTION
## Summary
- add a decomposition delta parser and PreToolUse guard for controlled recomposition
- require existing decomposition rewrites to increment `recompose_count` by one with a matching `.mpl/mpl/decomposition-deltas/recompose-N.yaml`
- block partial Edit/MultiEdit changes to existing decomposition graphs
- document the delta schema and update decomposer/recovery prompts to use delta-first recompose flow

## Verification
- npm test (793 tests / 0 failures)
- git diff --check

## Phase
- Phase 4: decomposition delta / recompose flow