### PR TITLE
Add phase evidence latch guard

### DIFF
--- a/agents/mpl-phase-runner.md
+++ b/agents/mpl-phase-runner.md
@@ -152,6 +152,11 @@ disallowedTools: []
         "pass_rate": 100,
         "total_tests": 0,
         "passed_tests": 0,
+        "evidence_latch": [
+          { "type": "command", "status": "PASS", "evidence": "command + exit_code=0" },
+          { "type": "test_agent", "status": "PASS", "evidence": "state.test_agent_dispatched.phase-N.timestamp" },
+          { "type": "goal_trace", "status": "PASS", "evidence": "AC/AX ids covered by this phase" }
+        ],
         "criteria_results": [
           { "criterion": "str", "pass": true, "evidence": "str" }
         ]
@@ -190,6 +195,7 @@ disallowedTools: []
     - **AP-RUNNER-02 · False verification**: claiming `success_criteria` pass without running commands. Always run the actual command and record real evidence (exit code + output tail) — self-report without execution is the dominant verification-failure shape.
     - **AP-RUNNER-03 · Weak state summary**: omitting required sections. The next phase has no other source of truth about what happened here; missing sections force later phases to re-discover context and drift.
     - **AP-RUNNER-04 · Silent invariant violation (#50)**: committing code that violates a `verification_plan.invariants[]` entry without filing a Discovery. Teleological invariants are verbatim user-confirmed ground truth — rationalizing around them defeats the mechanical enforcement model.
+    - **AP-RUNNER-05 · Unlatched completion**: writing state-summary.md or marking `.mpl/state.json.execution.phase_details[].status="completed"` before `verification.md` has a `## Evidence Latch` row for every phase `evidence_required` token. The hook blocks this because state-summary.md is disk-truth for completed phase count.
   </Failure_Modes_To_Avoid>
 
   <Anti_Patterns_Prohibited>

--- a/commands/mpl-run-execute-context.md
+++ b/commands/mpl-run-execute-context.md
@@ -210,6 +210,10 @@ Phase Runner MUST structure state-summary.md with these sections in order:
 
 ## Verification Results
 {pass/fail details — L2 only}
+
+## Evidence Latch
+{copy the PASS rows from verification.md; each phase `evidence_required` token
+must have a latch row before state-summary.md can be written}
 ```
 
 This structure enables mechanical L0/L1 extraction without LLM re-summarization.
@@ -383,4 +387,3 @@ Reference risk_level from the current Phase info in state.json:
 - Maintain only 1 worktree at a time (no parallel worktrees)
 - Do not copy `.mpl/` directory to worktree (reference original)
 - Phase Runner's Read/Grep scope inside worktree is remapped to the worktree path
-

--- a/commands/mpl-run-execute.md
+++ b/commands/mpl-run-execute.md
@@ -528,19 +528,31 @@ Skip/conditional rules prevent unnecessary invocations, keeping actual additions
 ```
 1. Validate state_summary required sections: ["What was implemented", "Phase Decisions", "Verification results"]
    - Missing -> request supplement (1 attempt). Still missing -> warn, proceed (non-blocking)
-2. Save state_summary to .mpl/mpl/phases/phase-N/state-summary.md
-2.5. Generate and save code diff for N-1 context transfer (v0.7.0):
+2. Build `verification.md` with a mandatory `## Evidence Latch` section. For every
+   token in this phase's `evidence_required`, include a PASS row backed by the
+   machine source used by that token:
+   - `command`: command string + `exit_code=0`
+   - `test_agent`: `state.test_agent_dispatched.{phase_id}.timestamp`
+   - `goal_trace`: covered AC/AX ids from `goal_trace`
+   - any other token: token-specific PASS evidence, command, file, or result
+3. Save verification to .mpl/mpl/phases/phase-N/verification.md
+   - `hooks/mpl-require-phase-evidence.mjs` blocks this write if the latch is
+     missing or stale.
+4. Save state_summary to .mpl/mpl/phases/phase-N/state-summary.md
+   - This happens after verification because state-summary is disk-truth for
+     completed phase count; the hook blocks summary writes until verification
+     latch exists.
+4.5. Generate and save code diff for N-1 context transfer (v0.7.0):
      diff = Bash("git diff HEAD~1 --stat --patch -- {phase_impact_files}", timeout=10000)
      Write(".mpl/mpl/phases/phase-N/changes.diff", diff)
      // If git diff fails (no commits yet, etc.), skip silently — diff is optional context
-3. Save verification to .mpl/mpl/phases/phase-N/verification.md
-4. Update phase-decisions.md with result.new_decisions
-5. Process discoveries (see Discovery Processing section)
-5.5. **Process warnings (HA-04, v0.12.0)**: If result.warnings is non-empty, store warnings for next Seed generation:
+5. Update phase-decisions.md with result.new_decisions
+6. Process discoveries (see Discovery Processing section)
+6.5. **Process warnings (HA-04, v0.12.0)**: If result.warnings is non-empty, store warnings for next Seed generation:
      - Append to `.mpl/mpl/phases/phase-N/warnings.json` (for traceability)
      - When generating the next Phase Seed, include relevant warnings in the `prior_summaries` context
      - Warnings that affect adjacent phases (dependency substitutions, platform constraints) → inject into next Seed's constraints section
-6. **Update execution state (P2-6 — unified `.mpl/state.json.execution`)**:
+7. **Update execution state (P2-6 — unified `.mpl/state.json.execution`)**:
    ```
    mpl_state_write(cwd, {
      execution: {

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -197,6 +197,7 @@ the immutable post-Phase-0 snapshot consumed by delta calculation and rollback.
 | `goal_trace_required` | boolean | `true` | Blocks `decomposition.yaml` writes unless top-level `goal_contract_hash` matches the frozen Goal Contract and phase `goal_trace` covers every AC/AX id. | `mpl-require-goal-trace.mjs` |
 | `phase_contract_graph_required` | boolean | `true` | Blocks `decomposition.yaml` writes unless graph metadata, per-phase evidence/change policy, and non-dangling phase dependencies are present. | `mpl-require-phase-contract-graph.mjs` |
 | `decomposition_delta_required` | boolean | `true` | Blocks changes to an existing `decomposition.yaml` unless `recompose_count` increments by one and a matching `.mpl/mpl/decomposition-deltas/recompose-N.yaml` exists. | `mpl-require-decomposition-delta.mjs` |
+| `phase_evidence_latch_required` | boolean | `true` | Blocks phase `verification.md`, `state-summary.md`, or completion state writes unless the phase's `evidence_required` tokens are latched in `verification.md`. | `mpl-require-phase-evidence.mjs` |
 | `finalize_artifacts_required` | boolean | `true` | Blocks `finalize_done=true` unless the goal contract's required artifacts, RUNBOOK final section, finalize timestamps, security evidence, and optional commit evidence are present. Override file: `.mpl/config/finalize-artifact-override.json`. | `mpl-require-finalize-artifacts.mjs` |
 
 ## Adversarial Reviewer (P0-A, #103)

--- a/docs/schemas/phase-contract-graph.md
+++ b/docs/schemas/phase-contract-graph.md
@@ -55,6 +55,9 @@ phases:
 - `hooks/mpl-require-decomposition-delta.mjs` blocks changes to an existing
   graph unless a valid `decomposition-deltas/recompose-N.yaml` exists and
   `recompose_count` advances by exactly one.
+- `hooks/mpl-require-phase-evidence.mjs` consumes each phase's
+  `evidence_required` list and blocks phase completion artifacts/state until
+  `verification.md` contains a matching Evidence Latch.
 
 ## Notes
 

--- a/docs/schemas/phase-evidence-latch.md
+++ b/docs/schemas/phase-evidence-latch.md
@@ -1,0 +1,44 @@
+# Phase Evidence Latch Schema
+
+Files:
+
+- `.mpl/mpl/phases/phase-N/verification.md`
+- `.mpl/mpl/phases/phase-N/state-summary.md`
+- `.mpl/state.json`
+
+Each phase declares `evidence_required` in `.mpl/mpl/decomposition.yaml`.
+Completion is latched only when `verification.md` proves each required token.
+
+## Verification Format
+
+```markdown
+## Criterion
+phase success criteria
+
+## Evidence Type
+command, test_agent, goal_trace
+
+## Evidence Latch
+- command: PASS command="npm test" exit_code=0
+- test_agent: PASS state.test_agent_dispatched.phase-1.timestamp=...
+- goal_trace: PASS AC-1 AX-1
+```
+
+Generic evidence tokens such as `security`, `e2e`, or `file_exists` must have a
+token-specific row with `PASS`, `result=pass`, or `exit_code=0`.
+
+## Runtime Enforcement
+
+- `hooks/mpl-require-phase-evidence.mjs` blocks `verification.md` writes when:
+  - `## Evidence Latch` is missing
+  - any declared `evidence_required` token has no PASS latch
+  - `command` evidence lacks `exit_code=0`
+  - `test_agent` evidence lacks `state.test_agent_dispatched[phase_id]`
+  - `goal_trace` evidence is not backed by decomposition goal trace
+- The same hook blocks `state-summary.md` writes until a valid
+  `verification.md` exists. This matters because `state-summary.md` is disk
+  truth for completed phase count.
+- The same hook blocks `.mpl/state.json` writes that newly mark a phase
+  `completed` unless that phase already has a valid verification latch.
+- `.mpl/config.json { "phase_evidence_latch_required": false }` is an explicit
+  migration opt-out.

--- a/docs/schemas/state.md
+++ b/docs/schemas/state.md
@@ -41,7 +41,7 @@ strict mode elevates `warn → block`.
 | I1 | `session_status='paused_budget' AND finalize_done=true` is impossible | all | Mutual contradiction. |
 | I2 | `current_phase='completed' AND finalize_done=false` is impossible | all | Completion requires finalize. |
 | I3 | `paused_*` or `verification_hang` AND new Task/Agent dispatch | task-dispatch | Resume the pipeline (`/mpl:mpl-resume`) before dispatching. |
-| I4 | `execution.phases.completed != count(phase-N/state-summary.md)` | all | Disk truth = number of phase directories carrying the `state-summary.md` finalize artifact. Declared count must match. Empty `phase-N/` directories pre-created by `mpl-run-decompose.md` Step 4 do NOT count. |
+| I4 | `execution.phases.completed != count(phase-N/state-summary.md)` | all | Disk truth = number of phase directories carrying the `state-summary.md` finalize artifact. Declared count must match. Empty `phase-N/` directories pre-created by `mpl-run-decompose.md` Step 4 do NOT count. Phase 5 additionally requires a valid `verification.md` Evidence Latch before state-summary or completion state writes. |
 | I5 | `fix_loop_count != sum(fix_loop_history)` | all | G5 (#114) writes history; counter must agree. |
 | I6 | phase3-gate state-write missing structured gate evidence | state-write | P0-1 (#102) requirement. |
 | I7 | `current_phase='phase-N' AND .mpl/mpl/phases/phase-N/` absent | all | Lifecycle marker vs disk drift. |

--- a/hooks/__tests__/mpl-phase-evidence.test.mjs
+++ b/hooks/__tests__/mpl-phase-evidence.test.mjs
@@ -1,0 +1,233 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { tmpdir } from 'os';
+
+import {
+  newlyCompletedPhaseIds,
+  parsePhaseEvidenceText,
+  validatePhaseEvidenceLatch,
+} from '../lib/mpl-phase-evidence.mjs';
+import { CURRENT_SCHEMA_VERSION } from '../lib/mpl-state.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const HOOK_PATH = join(dirname(__filename), '..', 'mpl-require-phase-evidence.mjs');
+
+let tmp;
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'mpl-phase-evidence-'));
+  mkdirSync(join(tmp, '.mpl', 'mpl', 'phases', 'phase-1'), { recursive: true });
+  writeState(baseState());
+  writeFileSync(join(tmp, '.mpl', 'mpl', 'decomposition.yaml'), decomposition());
+});
+afterEach(() => rmSync(tmp, { recursive: true, force: true }));
+
+function baseState(extra = {}) {
+  return {
+    schema_version: CURRENT_SCHEMA_VERSION,
+    current_phase: 'phase2-sprint',
+    test_agent_dispatched: {
+      'phase-1': { timestamp: '2026-05-17T00:00:00Z' },
+    },
+    execution: {
+      phases: { total: 1, completed: 0, current: 'phase-1', failed: 0, circuit_breaks: 0 },
+      phase_details: [{ id: 'phase-1', name: 'One', status: 'in_progress' }],
+    },
+    ...extra,
+  };
+}
+
+function completedState() {
+  return baseState({
+    execution: {
+      phases: { total: 1, completed: 1, current: null, failed: 0, circuit_breaks: 0 },
+      phase_details: [{ id: 'phase-1', name: 'One', status: 'completed' }],
+    },
+  });
+}
+
+function writeState(state) {
+  writeFileSync(join(tmp, '.mpl', 'state.json'), JSON.stringify(state, null, 2));
+}
+
+function decomposition() {
+  return `
+phases:
+  - id: phase-1
+    evidence_required:
+      - command
+      - test_agent
+      - goal_trace
+      - security
+    goal_trace:
+      acceptance_criteria: [AC-1]
+      variation_axes: [AX-1]
+`;
+}
+
+function validVerification() {
+  return `
+## Criterion
+phase complete
+
+## Evidence Type
+command, test_agent, goal_trace, security
+
+## Evidence Latch
+- command: PASS command="npm test" exit_code=0
+- test_agent: PASS state.test_agent_dispatched.phase-1.timestamp=2026-05-17T00:00:00Z
+- goal_trace: PASS AC-1 AX-1
+- security: PASS dependency audit completed
+`;
+}
+
+function summary() {
+  return `
+## Status
+completed
+
+## Files Changed
+- Modified: src/app.ts
+
+## Verification
+See verification.md
+
+## Decisions
+None
+
+## Next Phase Context
+Ready
+`;
+}
+
+function runHook(toolInput, opts = {}) {
+  if (opts.config) {
+    writeFileSync(join(tmp, '.mpl', 'config.json'), JSON.stringify(opts.config));
+  }
+  const input = {
+    cwd: tmp,
+    tool_name: opts.toolName || 'Write',
+    tool_input: toolInput,
+  };
+  return JSON.parse(execFileSync('node', [HOOK_PATH], {
+    input: JSON.stringify(input),
+    encoding: 'utf-8',
+  }));
+}
+
+describe('phase evidence parser', () => {
+  it('extracts evidence_required and newly completed phase ids', () => {
+    const parsed = parsePhaseEvidenceText(decomposition());
+    assert.deepEqual(parsed.phases[0].evidence_required, ['command', 'test_agent', 'goal_trace', 'security']);
+
+    assert.deepEqual(
+      newlyCompletedPhaseIds(baseState(), completedState()),
+      ['phase-1'],
+    );
+  });
+
+  it('validates all required evidence tokens', () => {
+    const phase = parsePhaseEvidenceText(decomposition()).phases[0];
+    const verdict = validatePhaseEvidenceLatch({
+      phase,
+      phaseId: 'phase-1',
+      verificationText: validVerification(),
+      state: baseState(),
+    });
+    assert.equal(verdict.valid, true, verdict.issues.join(', '));
+  });
+});
+
+describe('mpl-require-phase-evidence hook integration', () => {
+  it('allows verification.md with a complete Evidence Latch', () => {
+    const r = runHook({
+      file_path: '.mpl/mpl/phases/phase-1/verification.md',
+      content: validVerification(),
+    });
+    assert.equal(r.continue, true);
+  });
+
+  it('blocks verification.md missing command exit_code evidence', () => {
+    const r = runHook({
+      file_path: '.mpl/mpl/phases/phase-1/verification.md',
+      content: validVerification().replace('exit_code=0', 'exit_code=1'),
+    });
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason, /phase-1:command:missing_exit_code_0/);
+  });
+
+  it('blocks test_agent evidence when dispatch state is missing', () => {
+    writeState(baseState({ test_agent_dispatched: {} }));
+    const r = runHook({
+      file_path: '.mpl/mpl/phases/phase-1/verification.md',
+      content: validVerification(),
+    });
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason, /phase-1:test_agent:missing_dispatch/);
+  });
+
+  it('blocks state-summary completion artifact until verification latch exists', () => {
+    const r = runHook({
+      file_path: '.mpl/mpl/phases/phase-1/state-summary.md',
+      content: summary(),
+    });
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason, /phase-1:verification:missing/);
+  });
+
+  it('allows state-summary after verification latch exists', () => {
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'phases', 'phase-1', 'verification.md'), validVerification());
+    const r = runHook({
+      file_path: '.mpl/mpl/phases/phase-1/state-summary.md',
+      content: summary(),
+    });
+    assert.equal(r.continue, true);
+  });
+
+  it('blocks state completion when verification latch is missing', () => {
+    const r = runHook({
+      file_path: '.mpl/state.json',
+      content: JSON.stringify(completedState(), null, 2),
+    });
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason, /phase-1:verification:missing/);
+  });
+
+  it('allows state completion when verification latch exists', () => {
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'phases', 'phase-1', 'verification.md'), validVerification());
+    const r = runHook({
+      file_path: '.mpl/state.json',
+      content: JSON.stringify(completedState(), null, 2),
+    });
+    assert.equal(r.continue, true);
+  });
+
+  it('blocks completed count increments that omit phase detail evidence', () => {
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'phases', 'phase-1', 'verification.md'), validVerification());
+    const proposed = baseState({
+      execution: {
+        phases: { total: 1, completed: 1, current: null, failed: 0, circuit_breaks: 0 },
+        phase_details: [{ id: 'phase-1', name: 'One', status: 'in_progress' }],
+      },
+    });
+    const r = runHook({
+      file_path: '.mpl/state.json',
+      content: JSON.stringify(proposed, null, 2),
+    });
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason, /state:phase_completion:missing_phase_detail/);
+  });
+
+  it('allows migration opt-out', () => {
+    const r = runHook({
+      file_path: '.mpl/mpl/phases/phase-1/verification.md',
+      content: '## Criterion\nnone\n',
+    }, {
+      config: { phase_evidence_latch_required: false },
+    });
+    assert.equal(r.continue, true);
+  });
+});

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -136,6 +136,16 @@
         "hooks": [
           {
             "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/mpl-require-phase-evidence.mjs\"",
+            "timeout": 3
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/mpl-baseline-guard.mjs\"",
             "timeout": 3
           }

--- a/hooks/lib/mpl-config.mjs
+++ b/hooks/lib/mpl-config.mjs
@@ -67,6 +67,7 @@ const DEFAULTS = {
   goal_trace_required: true,
   phase_contract_graph_required: true,
   decomposition_delta_required: true,
+  phase_evidence_latch_required: true,
   e2e_authenticity_required: true,
   finalize_artifacts_required: true,
   convergence: {

--- a/hooks/lib/mpl-phase-evidence.mjs
+++ b/hooks/lib/mpl-phase-evidence.mjs
@@ -1,0 +1,195 @@
+/**
+ * Phase evidence latch validation.
+ *
+ * The decomposer declares `evidence_required` per phase. A phase may only be
+ * counted complete after `.mpl/mpl/phases/{phase}/verification.md` records an
+ * Evidence Latch satisfying each declared evidence token.
+ */
+
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+
+function normalizeToken(value) {
+  return String(value || '')
+    .trim()
+    .replace(/^["']|["']$/g, '')
+    .toLowerCase()
+    .replace(/[\s-]+/g, '_');
+}
+
+function parseInlineList(value) {
+  const v = String(value || '').trim();
+  if (!v.startsWith('[') || !v.endsWith(']')) return null;
+  return v
+    .slice(1, -1)
+    .split(',')
+    .map((x) => normalizeToken(x))
+    .filter(Boolean);
+}
+
+function phaseBlocks(text) {
+  const blocks = [];
+  let cur = null;
+  const flush = () => {
+    if (cur) blocks.push(cur);
+    cur = null;
+  };
+
+  for (const line of String(text || '').split('\n').map((l) => l.replace(/\r$/, ''))) {
+    const idMatch = line.match(/^\s*-\s+id:\s*["']?(phase-[\w.-]+)["']?/);
+    if (idMatch) {
+      flush();
+      cur = { id: idMatch[1], text: `${line}\n` };
+      continue;
+    }
+    if (cur) cur.text += `${line}\n`;
+  }
+  flush();
+  return blocks;
+}
+
+function extractListField(block, key) {
+  const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const inline = block.match(new RegExp(`^[ \\t]+${escaped}[ \\t]*:[ \\t]*(.+?)[ \\t]*$`, 'm'));
+  if (inline) {
+    const parsed = parseInlineList(inline[1]);
+    if (parsed) return parsed;
+    const scalar = normalizeToken(inline[1]);
+    return scalar ? [scalar] : [];
+  }
+
+  const nested = block.match(new RegExp(`^([ \\t]+)${escaped}[ \\t]*:[ \\t]*\\n((?:\\1[ \\t]+.+\\n?)*)`, 'm'));
+  if (!nested) return [];
+  return nested[2]
+    .split('\n')
+    .map((line) => {
+      const m = line.match(/^\s*-\s+(.+?)\s*$/);
+      return m ? normalizeToken(m[1]) : null;
+    })
+    .filter(Boolean);
+}
+
+function hasGoalTrace(block) {
+  return /^\s+goal_trace\s*:/m.test(block) &&
+    /\b(?:AC|AX)-[\w-]+\b/i.test(block);
+}
+
+export function parsePhaseEvidenceText(text) {
+  const phases = phaseBlocks(text).map((block) => ({
+    id: block.id,
+    evidence_required: extractListField(block.text, 'evidence_required'),
+    has_goal_trace: hasGoalTrace(block.text),
+  }));
+  return { phases };
+}
+
+export function readPhaseEvidence(cwd) {
+  const path = join(cwd, '.mpl', 'mpl', 'decomposition.yaml');
+  if (!existsSync(path)) return null;
+  return parsePhaseEvidenceText(readFileSync(path, 'utf-8'));
+}
+
+export function phaseIdFromArtifactPath(filePath, artifactName) {
+  if (!filePath || typeof filePath !== 'string') return null;
+  const escaped = artifactName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const m = filePath.match(new RegExp(`(^|/)\\.mpl/mpl/phases/(phase-[\\w.-]+)/${escaped}$`));
+  return m ? m[2] : null;
+}
+
+function hasEvidenceLatch(text) {
+  return /^#{2,}\s*Evidence[\s_-]+Latch\b/im.test(String(text || '')) ||
+    /^\s*evidence_latch\s*:/im.test(String(text || ''));
+}
+
+function lineForToken(text, token) {
+  const normalized = normalizeToken(token);
+  const matches = String(text || '')
+    .split('\n')
+    .filter((line) => normalizeToken(line).includes(normalized));
+  return matches.find((line) => lineHasPass(line)) || matches[0];
+}
+
+function lineHasPass(line) {
+  return /\bpass(?:ed)?\b/i.test(line || '') ||
+    /\bexit[_\s-]?code\s*[:=]\s*0\b/i.test(line || '') ||
+    /\bresult\s*[:=]\s*(?:ok|pass|passed)\b/i.test(line || '');
+}
+
+function commandEvidenceOk(text) {
+  return /\bcommand\b/i.test(text || '') &&
+    /\bexit[_\s-]?code\s*[:=]\s*0\b/i.test(text || '');
+}
+
+function goalTraceEvidenceOk(text, phase) {
+  if (!phase?.has_goal_trace) return false;
+  const line = lineForToken(text, 'goal_trace');
+  return Boolean(line && (lineHasPass(line) || /\b(?:AC|AX)-[\w-]+\b/i.test(line)));
+}
+
+export function validatePhaseEvidenceLatch({ phase, phaseId, verificationText, state = {} }) {
+  const issues = [];
+  const required = phase?.evidence_required || [];
+  if (!phase) {
+    issues.push(`${phaseId}:phase:missing`);
+    return { valid: false, issues };
+  }
+  if (required.length === 0) {
+    issues.push(`${phaseId}:evidence_required:missing`);
+    return { valid: false, issues };
+  }
+  if (!hasEvidenceLatch(verificationText)) {
+    issues.push(`${phaseId}:evidence_latch:missing`);
+  }
+
+  for (const token of required) {
+    if (token === 'command') {
+      if (!commandEvidenceOk(verificationText)) issues.push(`${phaseId}:command:missing_exit_code_0`);
+      continue;
+    }
+    if (token === 'test_agent') {
+      if (!state?.test_agent_dispatched?.[phaseId]) issues.push(`${phaseId}:test_agent:missing_dispatch`);
+      continue;
+    }
+    if (token === 'goal_trace') {
+      if (!goalTraceEvidenceOk(verificationText, phase)) issues.push(`${phaseId}:goal_trace:missing_latch`);
+      continue;
+    }
+
+    const line = lineForToken(verificationText, token);
+    if (!line || !lineHasPass(line)) issues.push(`${phaseId}:${token}:missing_pass_latch`);
+  }
+
+  return {
+    valid: issues.length === 0,
+    issues,
+  };
+}
+
+export function validatePhaseEvidenceFile(cwd, phaseId, state = {}) {
+  const parsed = readPhaseEvidence(cwd);
+  const phase = parsed?.phases?.find((p) => p.id === phaseId);
+  const path = join(cwd, '.mpl', 'mpl', 'phases', phaseId, 'verification.md');
+  if (!existsSync(path)) {
+    return { valid: false, issues: [`${phaseId}:verification:missing`] };
+  }
+  return validatePhaseEvidenceLatch({
+    phase,
+    phaseId,
+    verificationText: readFileSync(path, 'utf-8'),
+    state,
+  });
+}
+
+export function newlyCompletedPhaseIds(previousState = {}, proposedState = {}) {
+  const previous = new Map(
+    (previousState?.execution?.phase_details || []).map((p) => [p.id, p.status])
+  );
+  const out = [];
+  for (const detail of proposedState?.execution?.phase_details || []) {
+    if (!detail?.id) continue;
+    if (detail.status === 'completed' && previous.get(detail.id) !== 'completed') {
+      out.push(detail.id);
+    }
+  }
+  return out;
+}

--- a/hooks/mpl-require-phase-evidence.mjs
+++ b/hooks/mpl-require-phase-evidence.mjs
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+/**
+ * MPL Require Phase Evidence Hook (PreToolUse on Write|Edit|MultiEdit).
+ *
+ * Blocks phase completion artifacts and state transitions unless the phase's
+ * declared `evidence_required` tokens are latched in verification.md.
+ */
+
+import { existsSync, readFileSync } from 'fs';
+import { dirname, join, resolve, sep } from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const isMain = import.meta.url === pathToFileURL(process.argv[1] || '').href;
+
+const { isMplActive, readState } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-state.mjs')).href
+);
+const { loadConfig } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-config.mjs')).href
+);
+const {
+  newlyCompletedPhaseIds,
+  phaseIdFromArtifactPath,
+  readPhaseEvidence,
+  validatePhaseEvidenceFile,
+  validatePhaseEvidenceLatch,
+} = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-phase-evidence.mjs')).href
+);
+const { collectFileWrites, isFileWriteTool } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'tool-input.mjs')).href
+);
+const { readStdin } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'stdin.mjs')).href
+);
+
+function ok() {
+  console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+}
+
+function block(reason) {
+  console.log(JSON.stringify({ continue: false, decision: 'block', reason }));
+}
+
+function isStatePath(filePath, cwd) {
+  if (!filePath || typeof filePath !== 'string') return false;
+  const abs = resolve(cwd, filePath);
+  return abs.endsWith(`.mpl${sep}state.json`) || abs.endsWith('.mpl/state.json');
+}
+
+function simulateWrittenState(toolName, toolInput, cwd) {
+  const t = String(toolName || '').toLowerCase();
+  const fp = toolInput?.file_path || toolInput?.filePath;
+  const abs = fp ? resolve(cwd, fp) : null;
+
+  if (t === 'write') {
+    if (typeof toolInput.content !== 'string') return null;
+    try { return JSON.parse(toolInput.content); } catch { return null; }
+  }
+
+  if (t === 'edit' || t === 'multiedit') {
+    if (!abs || !existsSync(abs)) return null;
+    let content;
+    try { content = readFileSync(abs, 'utf-8'); } catch { return null; }
+
+    const apply = (oldStr, newStr, replaceAll) => {
+      if (typeof oldStr !== 'string' || typeof newStr !== 'string') return null;
+      if (replaceAll === true) return content.split(oldStr).join(newStr);
+      const idx = content.indexOf(oldStr);
+      if (idx === -1) return null;
+      return content.slice(0, idx) + newStr + content.slice(idx + oldStr.length);
+    };
+
+    if (t === 'edit') {
+      const next = apply(toolInput.old_string, toolInput.new_string, toolInput.replace_all);
+      if (next === null) return null;
+      content = next;
+    } else {
+      if (!Array.isArray(toolInput.edits)) return null;
+      for (const edit of toolInput.edits) {
+        const next = apply(edit?.old_string, edit?.new_string, edit?.replace_all);
+        if (next === null) return null;
+        content = next;
+      }
+    }
+    try { return JSON.parse(content); } catch { return null; }
+  }
+
+  return null;
+}
+
+function validateVerificationWrite(cwd, phaseId, text, state) {
+  const parsed = readPhaseEvidence(cwd);
+  const phase = parsed?.phases?.find((p) => p.id === phaseId);
+  return validatePhaseEvidenceLatch({
+    phase,
+    phaseId,
+    verificationText: text,
+    state,
+  }).issues;
+}
+
+function validateStateSummaryWrite(cwd, phaseId, state) {
+  return validatePhaseEvidenceFile(cwd, phaseId, state).issues;
+}
+
+async function main() {
+  const raw = await readStdin();
+  if (!raw.trim()) return ok();
+
+  let data;
+  try { data = JSON.parse(raw); } catch { return ok(); }
+
+  const toolName = data.tool_name || data.toolName || '';
+  if (!isFileWriteTool(toolName)) return ok();
+
+  const cwd = data.cwd || data.directory || process.cwd();
+  if (!isMplActive(cwd)) return ok();
+
+  const cfg = loadConfig(cwd);
+  if (cfg.phase_evidence_latch_required === false) return ok();
+
+  const state = readState(cwd) || {};
+  const toolInput = data.tool_input || data.toolInput || {};
+  const issues = [];
+
+  for (const entry of collectFileWrites(toolInput)) {
+    const verificationPhase = phaseIdFromArtifactPath(entry.filePath, 'verification.md');
+    if (verificationPhase) {
+      issues.push(...validateVerificationWrite(cwd, verificationPhase, entry.text, state));
+      continue;
+    }
+
+    const summaryPhase = phaseIdFromArtifactPath(entry.filePath, 'state-summary.md');
+    if (summaryPhase) {
+      issues.push(...validateStateSummaryWrite(cwd, summaryPhase, state));
+      continue;
+    }
+
+    if (isStatePath(entry.filePath, cwd)) {
+      const proposed = simulateWrittenState(toolName, toolInput, cwd);
+      if (!proposed || typeof proposed !== 'object') continue;
+      const completed = newlyCompletedPhaseIds(state, proposed);
+      const priorCount = state?.execution?.phases?.completed ?? 0;
+      const nextCount = proposed?.execution?.phases?.completed ?? priorCount;
+      if (nextCount > priorCount && completed.length === 0) {
+        issues.push(`state:phase_completion:missing_phase_detail`);
+      }
+      for (const phaseId of completed) {
+        issues.push(...validatePhaseEvidenceFile(cwd, phaseId, proposed).issues);
+      }
+    }
+  }
+
+  if (issues.length > 0) {
+    const shown = issues.slice(0, 12).join(', ');
+    const more = issues.length > 12 ? ` (+${issues.length - 12} more)` : '';
+    block(
+      `[MPL Phase Evidence] Phase completion requires verification.md Evidence Latch ` +
+        `for every phase evidence_required token: ${shown}${more}.`
+    );
+    return;
+  }
+
+  ok();
+}
+
+if (isMain) {
+  await main().catch(() => ok());
+}


### PR DESCRIPTION
## Summary
- add phase evidence parser and PreToolUse guard for phase completion evidence latching
- require `verification.md` to include `## Evidence Latch` rows for every phase `evidence_required` token
- block `state-summary.md` and completion state writes until the verification latch exists
- update phase-runner and execute protocol to write verification before state-summary

## Verification
- npm test (804 tests / 0 failures)
- git diff --check

## Phase
- Phase 5: phase evidence latch