### PR TITLE
Add whole goal closure guard

### DIFF
--- a/commands/mpl-run-finalize.md
+++ b/commands/mpl-run-finalize.md
@@ -763,6 +763,10 @@ goal_contract = Read(".mpl/goal-contract.yaml")
 require exists(".mpl/mpl/audit-report.json")        # Step 5.1.7 Codex audit
 require exists(".mpl/mpl/profile/run-summary.json") # Step 5.4 profile
 require ".mpl/mpl/RUNBOOK.md" contains "## Pipeline Complete"
+require every decomposition phase has:
+  - state-summary.md
+  - verification.md with valid Evidence Latch
+require completed phases' goal_trace union covers every Goal Contract AC/AX id
 
 if goal_contract.security_policy.required:
   for check in goal_contract.security_policy.checks:
@@ -793,7 +797,7 @@ Completion Report.
 Pipeline `current_phase = "completed"`, MPL `status = "completed"`,
 `completed_at = timestamp`, `finalized_at = timestamp`, `finalize_done = true`.
 The write is blocked unless AD-0008 E2E coverage, E2E authenticity, and
-completion-evidence hooks all pass.
+whole-goal closure / completion-evidence hooks all pass.
 
 ---
 

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -199,6 +199,7 @@ the immutable post-Phase-0 snapshot consumed by delta calculation and rollback.
 | `decomposition_delta_required` | boolean | `true` | Blocks changes to an existing `decomposition.yaml` unless `recompose_count` increments by one and a matching `.mpl/mpl/decomposition-deltas/recompose-N.yaml` exists. | `mpl-require-decomposition-delta.mjs` |
 | `phase_evidence_latch_required` | boolean | `true` | Blocks phase `verification.md`, `state-summary.md`, or completion state writes unless the phase's `evidence_required` tokens are latched in `verification.md`. | `mpl-require-phase-evidence.mjs` |
 | `completed_phase_immutability_required` | boolean | `true` | Blocks recomposition writes that modify or remove phase blocks already completed by state or state-summary evidence. | `mpl-require-completed-phase-immutability.mjs` |
+| `whole_goal_closure_required` | boolean | `true` | Blocks `finalize_done=true` unless every decomposition phase is completed and completed phase goal_trace/evidence latches cover every Goal Contract AC/AX id. | `mpl-require-whole-goal-closure.mjs` |
 | `finalize_artifacts_required` | boolean | `true` | Blocks `finalize_done=true` unless the goal contract's required artifacts, RUNBOOK final section, finalize timestamps, security evidence, and optional commit evidence are present. Override file: `.mpl/config/finalize-artifact-override.json`. | `mpl-require-finalize-artifacts.mjs` |
 
 ## Adversarial Reviewer (P0-A, #103)

--- a/docs/schemas/goal-contract.md
+++ b/docs/schemas/goal-contract.md
@@ -87,6 +87,9 @@ overrides: []
   increment.
 - `hooks/mpl-require-e2e-authenticity.mjs` reads `e2e_policy` before allowing
   `finalize_done=true`.
+- `hooks/mpl-require-whole-goal-closure.mjs` blocks `finalize_done=true`
+  until completed phases' evidence latches and goal_trace union cover every
+  Goal Contract AC/AX id.
 - `hooks/mpl-require-finalize-artifacts.mjs` reads `security_policy` and
   `completion_evidence` before allowing `finalize_done=true`; it also blocks
   finalization when the current goal contract hash differs from the Phase 0

--- a/docs/schemas/phase-evidence-latch.md
+++ b/docs/schemas/phase-evidence-latch.md
@@ -40,5 +40,8 @@ token-specific row with `PASS`, `result=pass`, or `exit_code=0`.
   truth for completed phase count.
 - The same hook blocks `.mpl/state.json` writes that newly mark a phase
   `completed` unless that phase already has a valid verification latch.
+- `hooks/mpl-require-whole-goal-closure.mjs` re-checks every completed phase
+  latch at finalize time and requires completed phase goal_trace coverage to
+  close the Goal Contract.
 - `.mpl/config.json { "phase_evidence_latch_required": false }` is an explicit
   migration opt-out.

--- a/docs/schemas/whole-goal-closure.md
+++ b/docs/schemas/whole-goal-closure.md
@@ -1,0 +1,29 @@
+# Whole Goal Closure
+
+File: `.mpl/state.json` (`finalize_done: true` write)
+
+Finalization must prove that completed phase evidence closes the frozen Goal
+Contract. Artifact existence alone is not enough.
+
+## Closure Rules
+
+Before `finalize_done=true` is accepted:
+
+- `.mpl/mpl/decomposition.yaml` must exist and contain phases.
+- Every phase in the decomposition must be completed.
+- `state.execution.phases.completed` must equal the decomposition phase count
+  when the count is present.
+- Every completed phase must have a valid `verification.md` Evidence Latch.
+- Completed phases' `goal_trace.acceptance_criteria` union must cover every
+  `acceptance_criteria[].id` in `.mpl/goal-contract.yaml`.
+- Completed phases' `goal_trace.variation_axes` union must cover every
+  `variation_axes[].id` in `.mpl/goal-contract.yaml`.
+
+## Runtime Enforcement
+
+- `hooks/mpl-require-whole-goal-closure.mjs` blocks `finalize_done=true`
+  writes when any closure rule is missing.
+- It reuses `hooks/lib/mpl-phase-evidence.mjs` to validate each phase's
+  `verification.md` latch.
+- `.mpl/config.json { "whole_goal_closure_required": false }` is an explicit
+  migration opt-out.

--- a/hooks/__tests__/mpl-whole-goal-closure.test.mjs
+++ b/hooks/__tests__/mpl-whole-goal-closure.test.mjs
@@ -1,0 +1,213 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { tmpdir } from 'os';
+
+import { validateWholeGoalClosure } from '../lib/mpl-whole-goal-closure.mjs';
+import { readGoalContract } from '../lib/mpl-goal-contract.mjs';
+import { CURRENT_SCHEMA_VERSION } from '../lib/mpl-state.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const HOOK_PATH = join(dirname(__filename), '..', 'mpl-require-whole-goal-closure.mjs');
+
+let tmp;
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'mpl-whole-goal-closure-'));
+  mkdirSync(join(tmp, '.mpl', 'mpl', 'phases', 'phase-1'), { recursive: true });
+  mkdirSync(join(tmp, '.mpl', 'mpl', 'phases', 'phase-2'), { recursive: true });
+  writeFileSync(join(tmp, '.mpl', 'goal-contract.yaml'), goalContract());
+  writeFileSync(join(tmp, '.mpl', 'mpl', 'decomposition.yaml'), decomposition());
+  writeFileSync(join(tmp, '.mpl', 'state.json'), JSON.stringify(state(), null, 2));
+  writeFileSync(join(tmp, '.mpl', 'mpl', 'phases', 'phase-1', 'state-summary.md'), '# done');
+  writeFileSync(join(tmp, '.mpl', 'mpl', 'phases', 'phase-2', 'state-summary.md'), '# done');
+  writeFileSync(join(tmp, '.mpl', 'mpl', 'phases', 'phase-1', 'verification.md'), verification('AC-1', 'AX-1'));
+  writeFileSync(join(tmp, '.mpl', 'mpl', 'phases', 'phase-2', 'verification.md'), verification('AC-2', 'AX-2'));
+});
+afterEach(() => rmSync(tmp, { recursive: true, force: true }));
+
+function goalContract() {
+  return `
+source:
+  user_request: "Build app"
+  user_request_hash: "req"
+mission:
+  goal: "Ship the full app"
+  project_pivot: "No false completion"
+  must_ship_outcomes:
+    - "all phases complete"
+ontology:
+  entities:
+    - runtime
+variation_axes:
+  - id: AX-1
+    name: runtime
+  - id: AX-2
+    name: security
+acceptance_criteria:
+  - id: AC-1
+    statement: first
+  - id: AC-2
+    statement: second
+e2e_policy:
+  real_runtime_required: true
+  mock_allowed: false
+  placeholder_assertions_allowed: false
+security_policy:
+  required: false
+completion_evidence:
+  required_artifacts:
+    - .mpl/mpl/audit-report.json
+    - .mpl/mpl/profile/run-summary.json
+    - .mpl/mpl/RUNBOOK.md
+  require_commit: false
+  require_finalize_timestamps: true
+`;
+}
+
+function decomposition(phase2Trace = 'AC-2', phase2Axis = 'AX-2') {
+  return `
+goal_contract_hash: abc
+phases:
+  - id: phase-1
+    evidence_required: [command, goal_trace]
+    goal_trace:
+      acceptance_criteria: [AC-1]
+      variation_axes: [AX-1]
+  - id: phase-2
+    evidence_required: [command, goal_trace]
+    goal_trace:
+      acceptance_criteria: [${phase2Trace}]
+      variation_axes: [${phase2Axis}]
+`;
+}
+
+function verification(ac, ax) {
+  return `
+## Criterion
+done
+
+## Evidence Type
+command, goal_trace
+
+## Evidence Latch
+- command: PASS command="npm test" exit_code=0
+- goal_trace: PASS ${ac} ${ax}
+`;
+}
+
+function state(overrides = {}) {
+  return {
+    schema_version: CURRENT_SCHEMA_VERSION,
+    current_phase: 'phase5-finalize',
+    finalize_done: false,
+    execution: {
+      phases: { total: 2, completed: 2, current: null, failed: 0, circuit_breaks: 0 },
+      phase_details: [
+        { id: 'phase-1', status: 'completed' },
+        { id: 'phase-2', status: 'completed' },
+      ],
+    },
+    ...overrides,
+  };
+}
+
+function finalizeState() {
+  return JSON.stringify({
+    ...state(),
+    current_phase: 'completed',
+    finalize_done: true,
+    completed_at: '2026-05-17T00:00:00Z',
+    finalized_at: '2026-05-17T00:00:01Z',
+  }, null, 2);
+}
+
+function runHook(content = finalizeState(), opts = {}) {
+  if (opts.config) {
+    writeFileSync(join(tmp, '.mpl', 'config.json'), JSON.stringify(opts.config));
+  }
+  const input = {
+    cwd: tmp,
+    tool_name: 'Write',
+    tool_input: {
+      file_path: '.mpl/state.json',
+      content,
+    },
+  };
+  return JSON.parse(execFileSync('node', [HOOK_PATH], {
+    input: JSON.stringify(input),
+    encoding: 'utf-8',
+  }));
+}
+
+describe('whole goal closure validator', () => {
+  it('passes when every phase is complete and AC/AX coverage is closed', () => {
+    const goal = readGoalContract(tmp);
+    const verdict = validateWholeGoalClosure({ cwd: tmp, state: state(), contract: goal.contract });
+    assert.equal(verdict.valid, true, verdict.issues.join(', '));
+  });
+
+  it('reports AC/AX coverage missing from completed phases', () => {
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'decomposition.yaml'), decomposition('AC-1', 'AX-1'));
+    const goal = readGoalContract(tmp);
+    const verdict = validateWholeGoalClosure({ cwd: tmp, state: state(), contract: goal.contract });
+    assert.equal(verdict.valid, false);
+    assert.ok(verdict.issues.includes('acceptance_criteria:not_completed:AC-2'));
+    assert.ok(verdict.issues.includes('variation_axes:not_completed:AX-2'));
+  });
+});
+
+describe('mpl-require-whole-goal-closure hook integration', () => {
+  it('allows finalize_done when the whole goal is closed', () => {
+    const r = runHook();
+    assert.equal(r.continue, true);
+  });
+
+  it('blocks finalize_done when a phase is not completed', () => {
+    rmSync(join(tmp, '.mpl', 'mpl', 'phases', 'phase-2', 'state-summary.md'));
+    writeFileSync(join(tmp, '.mpl', 'state.json'), JSON.stringify(state({
+      execution: {
+        phases: { total: 2, completed: 1, current: 'phase-2', failed: 0, circuit_breaks: 0 },
+        phase_details: [
+          { id: 'phase-1', status: 'completed' },
+          { id: 'phase-2', status: 'in_progress' },
+        ],
+      },
+    }), null, 2));
+    const r = runHook();
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason, /phase-2:not_completed/);
+  });
+
+  it('blocks finalize_done when completed phase verification is missing', () => {
+    rmSync(join(tmp, '.mpl', 'mpl', 'phases', 'phase-2', 'verification.md'));
+    const r = runHook();
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason, /phase-2:verification:missing/);
+  });
+
+  it('blocks finalize_done when execution completed count does not match graph', () => {
+    writeFileSync(join(tmp, '.mpl', 'state.json'), JSON.stringify(state({
+      execution: {
+        phases: { total: 2, completed: 1, current: null, failed: 0, circuit_breaks: 0 },
+        phase_details: [
+          { id: 'phase-1', status: 'completed' },
+          { id: 'phase-2', status: 'completed' },
+        ],
+      },
+    }), null, 2));
+    const r = runHook();
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason, /execution\.phases\.completed:expected:2:actual:1/);
+  });
+
+  it('allows migration opt-out', () => {
+    rmSync(join(tmp, '.mpl', 'mpl', 'phases', 'phase-2', 'verification.md'));
+    const r = runHook(finalizeState(), {
+      config: { whole_goal_closure_required: false },
+    });
+    assert.equal(r.continue, true);
+  });
+});

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -86,6 +86,16 @@
         "hooks": [
           {
             "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/mpl-require-whole-goal-closure.mjs\"",
+            "timeout": 3
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/mpl-validate-pp-schema.mjs\"",
             "timeout": 3
           }

--- a/hooks/lib/mpl-config.mjs
+++ b/hooks/lib/mpl-config.mjs
@@ -69,6 +69,7 @@ const DEFAULTS = {
   decomposition_delta_required: true,
   phase_evidence_latch_required: true,
   completed_phase_immutability_required: true,
+  whole_goal_closure_required: true,
   e2e_authenticity_required: true,
   finalize_artifacts_required: true,
   convergence: {

--- a/hooks/lib/mpl-whole-goal-closure.mjs
+++ b/hooks/lib/mpl-whole-goal-closure.mjs
@@ -1,0 +1,67 @@
+/**
+ * Whole-goal closure validation.
+ *
+ * Finalization must prove that completed phase evidence covers the frozen Goal
+ * Contract, not merely that some artifacts exist.
+ */
+
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+
+import { completedPhaseIds } from './mpl-completed-phase-immutability.mjs';
+import { parseDecompositionGoalTraceText } from './mpl-goal-trace.mjs';
+import { validatePhaseEvidenceFile } from './mpl-phase-evidence.mjs';
+
+function difference(required, actual) {
+  const actualSet = new Set(actual);
+  return required.filter((id) => !actualSet.has(id));
+}
+
+export function readDecompositionGoalTrace(cwd) {
+  const path = join(cwd, '.mpl', 'mpl', 'decomposition.yaml');
+  if (!existsSync(path)) return null;
+  return parseDecompositionGoalTraceText(readFileSync(path, 'utf-8'));
+}
+
+export function validateWholeGoalClosure({ cwd, state = {}, contract = null }) {
+  const issues = [];
+  const decomposition = readDecompositionGoalTrace(cwd);
+  if (!decomposition || !Array.isArray(decomposition.phases) || decomposition.phases.length === 0) {
+    return { valid: false, issues: ['decomposition:missing'] };
+  }
+
+  const completed = new Set(completedPhaseIds(cwd, state));
+  const phaseIds = decomposition.phases.map((phase) => phase.id);
+  const completedAc = [];
+  const completedAx = [];
+
+  const declaredCompleted = state?.execution?.phases?.completed;
+  if (Number.isInteger(declaredCompleted) && declaredCompleted !== phaseIds.length) {
+    issues.push(`execution.phases.completed:expected:${phaseIds.length}:actual:${declaredCompleted}`);
+  }
+
+  for (const phase of decomposition.phases) {
+    if (!completed.has(phase.id)) {
+      issues.push(`${phase.id}:not_completed`);
+      continue;
+    }
+    const evidence = validatePhaseEvidenceFile(cwd, phase.id, state);
+    issues.push(...evidence.issues);
+    completedAc.push(...(phase.acceptance_criteria || []));
+    completedAx.push(...(phase.variation_axes || []));
+  }
+
+  if (contract) {
+    for (const id of difference(contract.acceptance_criteria || [], completedAc)) {
+      issues.push(`acceptance_criteria:not_completed:${id}`);
+    }
+    for (const id of difference(contract.variation_axes || [], completedAx)) {
+      issues.push(`variation_axes:not_completed:${id}`);
+    }
+  }
+
+  return {
+    valid: issues.length === 0,
+    issues,
+  };
+}

--- a/hooks/mpl-require-whole-goal-closure.mjs
+++ b/hooks/mpl-require-whole-goal-closure.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+/**
+ * MPL Require Whole Goal Closure Hook (PreToolUse Write|Edit|MultiEdit).
+ *
+ * Blocks `finalize_done=true` unless every decomposition phase is completed and
+ * completed phase evidence covers every Goal Contract AC/AX id.
+ */
+
+import { dirname, join } from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const isMain = import.meta.url === pathToFileURL(process.argv[1] || '').href;
+
+const { isMplActive, readState } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-state.mjs')).href
+);
+const { loadConfig } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-config.mjs')).href
+);
+const { readGoalContract } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-goal-contract.mjs')).href
+);
+const { validateWholeGoalClosure } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-whole-goal-closure.mjs')).href
+);
+const { collectFileWrites, isFileWriteTool } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'tool-input.mjs')).href
+);
+const { readStdin } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'stdin.mjs')).href
+);
+
+function ok() {
+  console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+}
+
+function block(reason) {
+  console.log(JSON.stringify({ continue: false, decision: 'block', reason }));
+}
+
+function isFinalizeDoneStateWrite(toolInput) {
+  const writes = collectFileWrites(toolInput);
+  return writes.some((entry) =>
+    /(^|\/)\.mpl\/state\.json$/.test(entry.filePath || '') &&
+    /"finalize_done"\s*:\s*true/.test(entry.text || '')
+  );
+}
+
+async function main() {
+  const raw = await readStdin();
+  if (!raw.trim()) return ok();
+
+  let data;
+  try { data = JSON.parse(raw); } catch { return ok(); }
+
+  const toolName = data.tool_name || data.toolName || '';
+  if (!isFileWriteTool(toolName)) return ok();
+
+  const toolInput = data.tool_input || data.toolInput || {};
+  if (!isFinalizeDoneStateWrite(toolInput)) return ok();
+
+  const cwd = data.cwd || data.directory || process.cwd();
+  if (!isMplActive(cwd)) return ok();
+
+  const cfg = loadConfig(cwd);
+  if (cfg.whole_goal_closure_required === false) return ok();
+
+  const goal = readGoalContract(cwd);
+  if (cfg.goal_contract_required !== false && (!goal.exists || !goal.valid)) {
+    block(`[MPL Whole Goal Closure] Cannot set finalize_done=true — goal contract missing or invalid: ${goal.missing.join(', ')}.`);
+    return;
+  }
+
+  const state = readState(cwd) || {};
+  const verdict = validateWholeGoalClosure({
+    cwd,
+    state,
+    contract: goal.valid ? goal.contract : null,
+  });
+
+  if (!verdict.valid) {
+    const shown = verdict.issues.slice(0, 12).join(', ');
+    const more = verdict.issues.length > 12 ? ` (+${verdict.issues.length - 12} more)` : '';
+    block(
+      `[MPL Whole Goal Closure] Cannot set finalize_done=true — completed phase evidence does not close the Goal Contract: ` +
+        `${shown}${more}. Complete every decomposition phase and ensure verification.md Evidence Latch covers all AC/AX ids.`
+    );
+    return;
+  }
+
+  ok();
+}
+
+if (isMain) {
+  await main().catch(() => ok());
+}


### PR DESCRIPTION
## Summary
- add whole-goal closure validator and PreToolUse finalize guard
- block `finalize_done=true` unless every decomposition phase is completed with valid phase evidence latch
- require completed phase `goal_trace` coverage to close every Goal Contract AC/AX id
- document whole-goal closure in finalize protocol and schemas

## Verification
- npm test (819 tests / 0 failures)
- git diff --check

## Phase
- Phase 7: finalize whole-goal closure