### PR TITLE
Close exp19 runtime verification gaps

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "mpl",
       "description": "Decomposes tasks into micro-phases with independent plan-execute-verify mini-loops. Orchestrator-Worker separation enforced via hooks.",
-      "version": "0.18.2",
+      "version": "0.18.3",
       "author": {
         "name": "KyubumShin"
       },
@@ -25,5 +25,5 @@
       ]
     }
   ],
-  "version": "0.18.2"
+  "version": "0.18.3"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mpl",
-  "version": "0.18.2",
+  "version": "0.18.3",
   "description": "Micro-Phase Loop - Coherence-first autonomous coding pipeline with decomposition, phase execution, and verification",
   "author": {
     "name": "KyubumShin"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mpl",
-  "version": "0.18.2",
+  "version": "0.18.3",
   "description": "Micro-Phase Loop - coherence-first autonomous coding pipeline for goal-fixed, phase-scoped implementation and verification.",
   "author": {
     "name": "KyubumShin",

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# MPL (Micro-Phase Loop) v0.18.2
+# MPL (Micro-Phase Loop) v0.18.3
 
 **Prevention over cure. Specification over debugging.**
 

--- a/README_ko.md
+++ b/README_ko.md
@@ -1,4 +1,4 @@
-# MPL (Micro-Phase Loop) v0.18.2
+# MPL (Micro-Phase Loop) v0.18.3
 
 **예방이 치료보다 낫다. 명세가 디버깅보다 낫다.**
 

--- a/agents/mpl-doctor.md
+++ b/agents/mpl-doctor.md
@@ -45,7 +45,7 @@ disallowedTools: Write, Edit, Task
     - List all .md files in `MPL/agents/`
     - For each: verify YAML frontmatter has `name`, `description`, `model`
     - Verify `model` is one of: haiku, sonnet, opus
-    - Expected agents (11 total, v0.18.2):
+    - Expected agents (11 total, v0.18.3):
       mpl-adversarial-reviewer, mpl-codebase-analyzer, mpl-codex-auditor,
       mpl-decomposer, mpl-doctor, mpl-git-master, mpl-interviewer,
       mpl-phase-runner, mpl-phase0-analyzer, mpl-seed-generator, mpl-test-agent

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -2,8 +2,8 @@
 
 All fields for `.mpl/config.json`. Single source of truth for configuration.
 
-> **Version**: v0.18.2 (dual-runtime install metadata: Claude Code + Codex CLI manifests share one version, skills, commands, and MCP server)
-> **Last updated**: 2026-05-17
+> **Version**: v0.18.3 (runtime verification closure: real-runtime E2E zero-scenario block, Tauri capabilities check, and decomposition test-agent field validation)
+> **Last updated**: 2026-05-18
 
 ---
 
@@ -187,7 +187,7 @@ the immutable post-Phase-0 snapshot consumed by delta calculation and rollback.
 | Field | Type | Default | Description | Source |
 |-------|------|---------|-------------|--------|
 | `e2e_timeout` | number | `60000` | Timeout per E2E scenario in milliseconds | `mpl-run-finalize.md` Step 5.0 |
-| `e2e_authenticity_required` | boolean | `true` | Blocks `finalize_done=true` when required E2E scenarios are mock/unit/placeholder evidence instead of the real runtime evidence declared by `.mpl/goal-contract.yaml`. Override file: `.mpl/config/e2e-authenticity-override.json`. | `mpl-require-e2e-authenticity.mjs` |
+| `e2e_authenticity_required` | boolean | `true` | Blocks `finalize_done=true` when real-runtime policy has zero executable E2E scenarios, when required scenarios are mock/unit/placeholder evidence instead of the real runtime evidence declared by `.mpl/goal-contract.yaml`, or when a Tauri IPC project lacks `src-tauri/capabilities/*.json`. Override file: `.mpl/config/e2e-authenticity-override.json`. | `mpl-require-e2e-authenticity.mjs` |
 
 ## Goal Contract & Finalize Evidence
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,4 +1,4 @@
-# MPL (Micro-Phase Loop) v0.18.2 Design Document
+# MPL (Micro-Phase Loop) v0.18.3 Design Document
 
 ## 1. Overview
 
@@ -484,6 +484,24 @@ The following options are supported in `.mpl/config.json`:
 ---
 
 ## 9. Version History
+
+### v0.18.3 — Runtime Verification Closure (2026-05-18)
+
+exp19 showed a false-completion class where a Tauri app could pass build/unit gates while missing the runtime boundary that makes the app usable. v0.18.3 closes the immediate gaps without adding a new agent: existing artifact, E2E, and authenticity hooks now fail earlier and on machine evidence.
+
+| Change | Before | After | Type | Rationale |
+|--------|--------|-------|------|-----------|
+| Decomposition test-agent schema | Missing `test_agent_required` was discovered late by `mpl-require-test-agent`, after sprint execution had already advanced | `decomposition.yaml` artifact validation flags every phase missing `test_agent_required`, and requires `test_agent_rationale` when a phase opts out | Hook + schema | Prevents exp19's fast-path decomposer omission from turning into a silent mid-sprint block |
+| Zero E2E scenario finalize | `mpl-require-e2e` allowed `finalize_done=true` when no required E2E scenario existed | Real-runtime Goal Contracts and included UCs now block finalize when there is no executable E2E scenario | Hook | `real_runtime_required=true` must mean at least one runnable runtime scenario exists and records evidence |
+| E2E authenticity | Existing scenarios were checked for mock/placeholder evidence, but absence of scenarios was not itself an authenticity failure | `mpl-require-e2e-authenticity` reports `required_e2e_scenario_missing` under real-runtime policy | Hook | Avoids "nothing to verify" passing as authentic verification |
+| Tauri v2 runtime prerequisite | No mechanical check for `src-tauri/capabilities/*.json` | Tauri projects with `invoke()`/`#[tauri::command]` surfaces block finalize when no capabilities JSON exists | Hook | Catches exp19's app-brick failure where frontend IPC would be rejected at runtime |
+| Visible hook block state | AD-0007 blocks were returned only as hook output, so harness/UI could see a long silence with `pause_reason:null` | `mpl-require-test-agent` now records `session_status: blocked_hook` plus hook id, phase, reason, resume instruction, and clears it when evidence/override appears | Hook + state enum | Prevents quality guard blocks from presenting as silent deadlocks |
+
+**Affected files:** `hooks/lib/mpl-artifact-schema.mjs`, `hooks/mpl-require-e2e.mjs`, `hooks/mpl-require-e2e-authenticity.mjs`, `hooks/mpl-require-test-agent.mjs`, `hooks/lib/mpl-state.mjs`, `hooks/lib/mpl-state-invariant.mjs`, `hooks/__tests__/mpl-artifact-schema.test.mjs`, `hooks/__tests__/mpl-require-e2e.test.mjs`, `hooks/__tests__/mpl-require-e2e-authenticity.test.mjs`, `hooks/__tests__/mpl-require-test-agent.test.mjs`, `hooks/__tests__/mpl-state-invariant.test.mjs`, version metadata and docs.
+
+**Breaking changes:** Existing projects that set `e2e_policy.real_runtime_required: true` can no longer finalize with zero executable E2E scenarios. Tauri v2 projects using IPC need a capabilities JSON before finalize.
+
+**Tests:** Adds exp19 regression coverage for missing `test_agent_required`, zero E2E scenarios, missing `test_command`, included UC with no executable E2E, missing Tauri capabilities, valid Tauri capabilities, and visible AD-0007 block state.
 
 ### v0.18.2 — Dual Runtime Install Metadata (2026-05-17)
 

--- a/docs/roadmap/overview.md
+++ b/docs/roadmap/overview.md
@@ -2,7 +2,7 @@
 
 > **Version notation (v0.9.4)**: This file uses legacy major-version notation (v1.0, v3.0, v4.0) from the original roadmap. Actual release versions follow the `v0.x.y` semver series. Mapping: v1.0 = initial design, v3.x ≈ v0.3.x, v4.x ≈ v0.4.x. See `design.md` for the canonical version reference.
 >
-> **Currency note (2026-05-17)**: Plugin version is `0.18.2`. v0.18.0/v0.18.1 closed the v3.10 P0 enforcement track; v0.18.2 adds dual-runtime install metadata so the same MPL plugin can be installed by Claude Code and Codex CLI while sharing one skills/commands/MCP implementation. Per-version detail in `docs/design.md` §9.
+> **Currency note (2026-05-18)**: Plugin version is `0.18.3`. v0.18.0/v0.18.1 closed the v3.10 P0 enforcement track; v0.18.2 added dual-runtime install metadata; v0.18.3 closes exp19 runtime-verification false completion gaps. Per-version detail in `docs/design.md` §9.
 
 ## Vision: "Phase 0 Enhanced + Phase 5 Minimized"
 

--- a/docs/schemas/state.md
+++ b/docs/schemas/state.md
@@ -25,7 +25,7 @@
 | `completed_at` / `finalized_at` | per-pipeline | Finalize timestamps required by Goal Contract completion evidence when `require_finalize_timestamps: true`. |
 | `goal_contract_set` / `goal_contract_path` / `goal_contract_hash` | per-pipeline | Goal Contract readiness mirror for `.mpl/goal-contract.yaml`; disk artifact remains the source of truth. |
 | `security_results.*` | per-pipeline | Structured security gate evidence consumed by `mpl-require-finalize-artifacts.mjs`. |
-| `session_status` | per-session | `null \| active \| paused_budget \| paused_checkpoint \| verification_hang \| cancelled`. Single-valued — pause / hang / cancel states are mutually exclusive (G3 I9). |
+| `session_status` | per-session | `null \| active \| paused_budget \| paused_checkpoint \| verification_hang \| blocked_hook \| cancelled`. Single-valued — pause / hang / explicit hook block / cancel states are mutually exclusive (G3 I9). |
 | `last_tool_at` | per-session | ISO-8601 stamp from `mpl-tool-tracker.mjs`. Powers G4 (#109). |
 | `enforcement.*` | per-pipeline override | P0-2 (#110) per-rule policy. Top of the precedence chain. |
 
@@ -40,7 +40,7 @@ strict mode elevates `warn → block`.
 |---|---|---|---|
 | I1 | `session_status='paused_budget' AND finalize_done=true` is impossible | all | Mutual contradiction. |
 | I2 | `current_phase='completed' AND finalize_done=false` is impossible | all | Completion requires finalize. |
-| I3 | `paused_*` or `verification_hang` AND new Task/Agent dispatch | task-dispatch | Resume the pipeline (`/mpl:mpl-resume`) before dispatching. |
+| I3 | `paused_*` or `verification_hang` AND new Task/Agent dispatch | task-dispatch | Resume the pipeline (`/mpl:mpl-resume`) before dispatching. `blocked_hook` is visible state but does not block dispatch globally; the originating hook remains responsible for the specific blocked action. |
 | I4 | `execution.phases.completed != count(phase-N/state-summary.md)` | all | Disk truth = number of phase directories carrying the `state-summary.md` finalize artifact. Declared count must match. Empty `phase-N/` directories pre-created by `mpl-run-decompose.md` Step 4 do NOT count. Phase 5 additionally requires a valid `verification.md` Evidence Latch before state-summary or completion state writes. |
 | I5 | `fix_loop_count != sum(fix_loop_history)` | all | G5 (#114) writes history; counter must agree. |
 | I6 | phase3-gate state-write missing structured gate evidence | state-write | P0-1 (#102) requirement. |

--- a/hooks/__tests__/mpl-artifact-schema.test.mjs
+++ b/hooks/__tests__/mpl-artifact-schema.test.mjs
@@ -176,6 +176,7 @@ phases:
       requires: []
       produces: []
       contract_files: []
+    test_agent_required: true
     success_criteria:
       - type: test
         command: npm test
@@ -199,6 +200,37 @@ phases:
     const r = validateArtifactFile('.mpl/mpl/decomposition.yaml', content);
     assert.equal(r.valid, false);
     assert.ok(r.missing.includes('interface_contract'));
+  });
+
+  it('exp19 regression: rejects decomposition phases missing test_agent_required', () => {
+    const content =
+`phases:
+  - id: "phase-1"
+    scope: "Add editor"
+    covers: [UC-01]
+    impact: { create: [], modify: [], affected_tests: [] }
+    interface_contract: { requires: [], produces: [], contract_files: [] }
+    success_criteria: []
+`;
+    const r = validateArtifactFile('.mpl/mpl/decomposition.yaml', content);
+    assert.equal(r.valid, false);
+    assert.ok(r.missing.includes('phase-1.test_agent_required'));
+  });
+
+  it('requires rationale when a phase opts out of test-agent dispatch', () => {
+    const content =
+`phases:
+  - id: "phase-docs"
+    scope: "Document install"
+    covers: [UC-01]
+    impact: { create: [], modify: [], affected_tests: [] }
+    interface_contract: { requires: [], produces: [], contract_files: [] }
+    test_agent_required: false
+    success_criteria: []
+`;
+    const r = validateArtifactFile('.mpl/mpl/decomposition.yaml', content);
+    assert.equal(r.valid, false);
+    assert.ok(r.missing.includes('phase-docs.test_agent_rationale'));
   });
 });
 

--- a/hooks/__tests__/mpl-require-e2e-authenticity.test.mjs
+++ b/hooks/__tests__/mpl-require-e2e-authenticity.test.mjs
@@ -98,6 +98,12 @@ e2e_scenarios:
 });
 
 describe('mpl-require-e2e-authenticity hook', () => {
+  it('exp19 regression: blocks real-runtime finalize when no E2E scenarios exist', () => {
+    const r = runHook();
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason, /required_e2e_scenario_missing/);
+  });
+
   it('allows real runtime scenarios with assertion evidence', () => {
     writeScenarios(`
 e2e_scenarios:
@@ -183,5 +189,48 @@ e2e_scenarios:
     const r = runHook();
     assert.equal(r.decision, 'block');
     assert.match(r.reason, /placeholder_assertion/);
+  });
+
+  it('blocks Tauri v2 IPC projects without capabilities JSON', () => {
+    mkdirSync(join(tmp, 'src'), { recursive: true });
+    mkdirSync(join(tmp, 'src-tauri', 'src'), { recursive: true });
+    writeFileSync(join(tmp, 'src-tauri', 'tauri.conf.json'), '{"productName":"app"}\n');
+    writeFileSync(join(tmp, 'src', 'App.tsx'), 'import { invoke } from "@tauri-apps/api/core";\ninvoke("project_new");\n');
+    writeFileSync(join(tmp, 'src-tauri', 'src', 'lib.rs'), '#[tauri::command]\nfn project_new() {}\n');
+    writeScenarios(`
+e2e_scenarios:
+  - id: E2E-1
+    required: true
+    test_command: "npm run e2e"
+    runtime_class: real_desktop
+    mock_allowed: false
+    launcher_evidence: "tauri app launch"
+    assertion_evidence: "project_new IPC succeeds from UI"
+`);
+    const r = runHook();
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason, /tauri_capabilities_missing/);
+  });
+
+  it('allows Tauri IPC projects when a capabilities JSON exists', () => {
+    mkdirSync(join(tmp, 'src'), { recursive: true });
+    mkdirSync(join(tmp, 'src-tauri', 'src'), { recursive: true });
+    mkdirSync(join(tmp, 'src-tauri', 'capabilities'), { recursive: true });
+    writeFileSync(join(tmp, 'src-tauri', 'tauri.conf.json'), '{"productName":"app"}\n');
+    writeFileSync(join(tmp, 'src', 'App.tsx'), 'import { invoke } from "@tauri-apps/api/core";\ninvoke("project_new");\n');
+    writeFileSync(join(tmp, 'src-tauri', 'src', 'lib.rs'), '#[tauri::command]\nfn project_new() {}\n');
+    writeFileSync(join(tmp, 'src-tauri', 'capabilities', 'default.json'), '{"identifier":"default","permissions":["core:default"]}\n');
+    writeScenarios(`
+e2e_scenarios:
+  - id: E2E-1
+    required: true
+    test_command: "npm run e2e"
+    runtime_class: real_desktop
+    mock_allowed: false
+    launcher_evidence: "tauri app launch"
+    assertion_evidence: "project_new IPC succeeds from UI"
+`);
+    const r = runHook();
+    assert.equal(r.continue, true);
   });
 });

--- a/hooks/__tests__/mpl-require-e2e.test.mjs
+++ b/hooks/__tests__/mpl-require-e2e.test.mjs
@@ -14,6 +14,55 @@ import { CURRENT_SCHEMA_VERSION } from '../lib/mpl-state.mjs';
 const __filename = fileURLToPath(import.meta.url);
 const HOOK_PATH = join(dirname(__filename), '..', 'mpl-require-e2e.mjs');
 
+function goalContract({ realRuntimeRequired = true } = {}) {
+  return `
+source:
+  user_request: "Build app"
+  user_request_hash: "req"
+mission:
+  goal: "Build app"
+  project_pivot: "real runtime"
+  must_ship_outcomes:
+    - "usable app"
+ontology:
+  entities:
+    - app
+variation_axes:
+  - id: AX-1
+acceptance_criteria:
+  - id: AC-1
+e2e_policy:
+  real_runtime_required: ${realRuntimeRequired ? 'true' : 'false'}
+  mock_allowed: false
+  placeholder_assertions_allowed: false
+security_policy:
+  required: false
+completion_evidence:
+  required_artifacts:
+    - .mpl/mpl/RUNBOOK.md
+  require_commit: false
+  require_finalize_timestamps: true
+`;
+}
+
+function finalizeWriteInput(tmp, toolInput = null) {
+  return {
+    cwd: tmp,
+    tool_name: 'Write',
+    tool_input: toolInput || {
+      file_path: '.mpl/state.json',
+      content: JSON.stringify({ current_phase: 'phase5-finalize', finalize_done: true }),
+    },
+  };
+}
+
+function runHook(tmp, input = null) {
+  return JSON.parse(execFileSync('node', [HOOK_PATH], {
+    input: JSON.stringify(input || finalizeWriteInput(tmp)),
+    encoding: 'utf-8',
+  }));
+}
+
 describe('parseUserContractText', () => {
   it('extracts included UC ids with explicit status', () => {
     const text = `
@@ -161,6 +210,69 @@ describe('computeUncoveredUcs', () => {
 });
 
 describe('mpl-require-e2e hook integration', () => {
+  it('exp19 regression: blocks finalize when real-runtime goal has zero E2E scenarios', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'mpl-require-e2e-zero-'));
+    try {
+      mkdirSync(join(tmp, '.mpl', 'mpl'), { recursive: true });
+      writeFileSync(join(tmp, '.mpl', 'state.json'), JSON.stringify({
+        schema_version: CURRENT_SCHEMA_VERSION,
+        current_phase: 'phase5-finalize',
+        e2e_results: {},
+      }));
+      writeFileSync(join(tmp, '.mpl', 'goal-contract.yaml'), goalContract());
+      const r = runHook(tmp);
+      assert.equal(r.decision, 'block');
+      assert.match(r.reason, /requires real runtime E2E/);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('blocks required E2E scenarios missing executable test_command', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'mpl-require-e2e-command-'));
+    try {
+      mkdirSync(join(tmp, '.mpl', 'mpl'), { recursive: true });
+      writeFileSync(join(tmp, '.mpl', 'state.json'), JSON.stringify({
+        schema_version: CURRENT_SCHEMA_VERSION,
+        current_phase: 'phase5-finalize',
+        e2e_results: {},
+      }));
+      writeFileSync(join(tmp, '.mpl', 'mpl', 'e2e-scenarios.yaml'), `
+e2e_scenarios:
+  - id: E2E-1
+    required: true
+`);
+      const r = runHook(tmp);
+      assert.equal(r.decision, 'block');
+      assert.match(r.reason, /missing executable test_command: E2E-1/);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('blocks included UCs when no executable E2E scenario exists', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'mpl-require-e2e-uc-'));
+    try {
+      mkdirSync(join(tmp, '.mpl', 'requirements'), { recursive: true });
+      writeFileSync(join(tmp, '.mpl', 'state.json'), JSON.stringify({
+        schema_version: CURRENT_SCHEMA_VERSION,
+        current_phase: 'phase5-finalize',
+        e2e_results: {},
+      }));
+      writeFileSync(join(tmp, '.mpl', 'requirements', 'user-contract.md'), `
+user_cases:
+  - id: UC-01
+    status: included
+scenarios: []
+`);
+      const r = runHook(tmp);
+      assert.equal(r.decision, 'block');
+      assert.match(r.reason, /included UC/);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it('blocks MultiEdit finalize writes when a required scenario never ran', () => {
     const tmp = mkdtempSync(join(tmpdir(), 'mpl-require-e2e-'));
     try {
@@ -187,10 +299,7 @@ e2e_scenarios:
           }],
         },
       };
-      const r = JSON.parse(execFileSync('node', [HOOK_PATH], {
-        input: JSON.stringify(input),
-        encoding: 'utf-8',
-      }));
+      const r = runHook(tmp, input);
       assert.equal(r.decision, 'block');
       assert.match(r.reason, /E2E-1/);
     } finally {

--- a/hooks/__tests__/mpl-require-test-agent.test.mjs
+++ b/hooks/__tests__/mpl-require-test-agent.test.mjs
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'fs';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { tmpdir } from 'os';
@@ -43,6 +43,52 @@ phases:
       assert.equal(r.continue, false);
       assert.equal(r.decision, 'block');
       assert.match(r.reason, /mpl-test-agent was not dispatched/);
+      const state = JSON.parse(readFileSync(join(tmp, '.mpl', 'state.json'), 'utf-8'));
+      assert.equal(state.session_status, 'blocked_hook');
+      assert.equal(state.blocked_by_hook, 'mpl-require-test-agent');
+      assert.equal(state.blocked_phase, 'phase-1');
+      assert.match(state.resume_instruction, /Dispatch mpl-test-agent for phase-1/);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('clears its visible blocked state once test-agent evidence exists', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'mpl-test-agent-clear-'));
+    try {
+      mkdirSync(join(tmp, '.mpl', 'mpl'), { recursive: true });
+      writeFileSync(join(tmp, '.mpl', 'state.json'), JSON.stringify({
+        schema_version: CURRENT_SCHEMA_VERSION,
+        current_phase: 'phase2-sprint',
+        session_status: 'blocked_hook',
+        blocked_by_hook: 'mpl-require-test-agent',
+        blocked_phase: 'phase-1',
+        block_reason: 'old block',
+        test_agent_dispatched: { 'phase-1': { ts: '2026-05-18T00:00:00Z' } },
+      }));
+      writeFileSync(join(tmp, '.mpl', 'mpl', 'decomposition.yaml'), `
+phases:
+  - id: phase-1
+    test_agent_required: true
+`);
+
+      const input = {
+        cwd: tmp,
+        tool_name: 'Task',
+        tool_input: {
+          subagent_type: 'mpl-phase-runner',
+          prompt: 'Run phase-1 and report completion.',
+        },
+      };
+      const r = JSON.parse(execFileSync('node', [HOOK_PATH], {
+        input: JSON.stringify(input),
+        encoding: 'utf-8',
+      }));
+      assert.equal(r.continue, true);
+      const state = JSON.parse(readFileSync(join(tmp, '.mpl', 'state.json'), 'utf-8'));
+      assert.equal(state.session_status, 'active');
+      assert.equal(state.blocked_by_hook, null);
+      assert.equal(state.blocked_phase, null);
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }

--- a/hooks/__tests__/mpl-state-invariant.test.mjs
+++ b/hooks/__tests__/mpl-state-invariant.test.mjs
@@ -269,7 +269,7 @@ describe('I9 session_status enum', () => {
     const r = checkInvariants({ session_status: 'mystery_state' }, { cwd: tmp });
     assert.ok(r.violations.some((v) => v.id === VIOLATION_IDS.SESSION_STATUS_INVALID));
   });
-  for (const valid of [null, 'active', 'paused_budget', 'paused_checkpoint', 'verification_hang', 'cancelled']) {
+  for (const valid of [null, 'active', 'paused_budget', 'paused_checkpoint', 'verification_hang', 'blocked_hook', 'cancelled']) {
     it(`accepts ${valid === null ? 'null' : valid}`, () => {
       const r = checkInvariants({ session_status: valid }, { cwd: tmp });
       assert.ok(!r.violations.some((v) => v.id === VIOLATION_IDS.SESSION_STATUS_INVALID));

--- a/hooks/lib/mpl-artifact-schema.mjs
+++ b/hooks/lib/mpl-artifact-schema.mjs
@@ -57,6 +57,7 @@ const ARTIFACTS = [
     // `covers`, `interface_contract`, `success_criteria`. The earlier
     // schema rejected every valid decomposition.yaml.
     required: ['id', 'scope', 'impact', 'covers', 'interface_contract', 'success_criteria'],
+    customValidate: validateDecompositionContract,
   },
   {
     artifact: 'state-summary',
@@ -177,11 +178,64 @@ export function validateAgainstSchema(content, schema) {
       missingAnyOf.push(group);
     }
   }
+  if (typeof schema.customValidate === 'function') {
+    const custom = schema.customValidate(content);
+    missing.push(...(custom.missing ?? []));
+    missingAnyOf.push(...(custom.missingAnyOf ?? []));
+  }
   return {
     valid: missing.length === 0 && missingAnyOf.length === 0,
     missing,
     missingAnyOf,
   };
+}
+
+function parseDecompositionPhases(content) {
+  const phases = [];
+  let cur = null;
+
+  for (const rawLine of String(content || '').split('\n')) {
+    const line = rawLine.replace(/\r$/, '');
+    const idMatch = line.match(/^\s*-\s+id:\s*["']?([^"'\s#]+)["']?/);
+    if (idMatch) {
+      if (cur) phases.push(cur);
+      cur = {
+        id: idMatch[1],
+        hasTestAgentRequired: false,
+        hasTestAgentRationale: false,
+        testAgentRequired: null,
+      };
+      continue;
+    }
+    if (!cur) continue;
+
+    const reqMatch = line.match(/^\s+test_agent_required\s*:\s*(true|false)\b/i);
+    if (reqMatch) {
+      cur.hasTestAgentRequired = true;
+      cur.testAgentRequired = reqMatch[1].toLowerCase() === 'true';
+      continue;
+    }
+
+    if (/^\s+test_agent_rationale\s*:/.test(line)) {
+      cur.hasTestAgentRationale = true;
+    }
+  }
+
+  if (cur) phases.push(cur);
+  return phases;
+}
+
+function validateDecompositionContract(content) {
+  const missing = [];
+  for (const phase of parseDecompositionPhases(content)) {
+    if (!phase.hasTestAgentRequired) {
+      missing.push(`${phase.id}.test_agent_required`);
+    }
+    if (phase.testAgentRequired === false && !phase.hasTestAgentRationale) {
+      missing.push(`${phase.id}.test_agent_rationale`);
+    }
+  }
+  return { missing, missingAnyOf: [] };
 }
 
 /**

--- a/hooks/lib/mpl-state-invariant.mjs
+++ b/hooks/lib/mpl-state-invariant.mjs
@@ -267,10 +267,10 @@ function checkI9(state) {
   // this check guards the value itself. Future writers introducing new
   // statuses MUST add them to the H1 allowlist (`docs/schemas/state.md`)
   // before they can be emitted — otherwise unknown values surface as I9.
-  const allowed = new Set([null, 'active', 'paused_budget', 'paused_checkpoint', 'verification_hang', 'cancelled']);
+  const allowed = new Set([null, 'active', 'paused_budget', 'paused_checkpoint', 'verification_hang', 'blocked_hook', 'cancelled']);
   if (!allowed.has(state.session_status ?? null)) {
     return v(VIOLATION_IDS.SESSION_STATUS_INVALID,
-      `session_status='${state.session_status}' is not in the allowed enum (null|active|paused_budget|paused_checkpoint|verification_hang|cancelled).`,
+      `session_status='${state.session_status}' is not in the allowed enum (null|active|paused_budget|paused_checkpoint|verification_hang|blocked_hook|cancelled).`,
       { session_status: state.session_status });
   }
   return null;

--- a/hooks/lib/mpl-state.mjs
+++ b/hooks/lib/mpl-state.mjs
@@ -209,7 +209,8 @@ const DEFAULT_STATE = {
   // #35 (v0.14.1): "paused_checkpoint" added for orchestrator verbal pause (self-pause on checkpoint report)
   // #109 G4 (v0.18.0): "verification_hang" added — Stop hook detects when last_tool_at is older
   // than the hang threshold (default 15min) and marks the session for resume / user intervention.
-  session_status: null,          // null | "active" | "paused_budget" | "paused_checkpoint" | "verification_hang"
+  // v0.18.3: "blocked_hook" makes explicit hook blocks visible to harnesses.
+  session_status: null,          // null | "active" | "paused_budget" | "paused_checkpoint" | "verification_hang" | "blocked_hook"
   pause_reason: null,            // human-readable pause reason
   resume_from_phase: null,       // phase ID to resume from
   pause_timestamp: null,         // ISO timestamp of pause

--- a/hooks/mpl-require-e2e-authenticity.mjs
+++ b/hooks/mpl-require-e2e-authenticity.mjs
@@ -10,7 +10,7 @@
 
 import { dirname, join } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
-import { existsSync, readFileSync } from 'fs';
+import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -39,6 +39,7 @@ const REAL_RUNTIME_CLASSES = new Set([
 
 const MOCK_PATTERN = /\b(mock|stub|fake|msw|mockIPC|VITE_E2E_MOCK|__mocks__)\b/i;
 const PLACEHOLDER_PATTERN = /\b(expect\s*\(\s*true\s*\)|assert\s*\(\s*true\s*\)|\.toBe\s*\(\s*true\s*\)|test\.skip\s*\(|it\.skip\s*\(|describe\.skip\s*\()/;
+const FAKE_RUNTIME_E2E_PATTERN = /\bWITHOUT\s+a\s+running\s+Tauri\s+runtime\b|\bwithout\s+a\s+running\s+Tauri\s+runtime\b|\brepo\/db layer directly\b|\brepo layer directly\b|\bbypass(?:es|ing)?\s+Tauri\s+runtime\b/i;
 
 function ok() {
   console.log(JSON.stringify({ continue: true, suppressOutput: true }));
@@ -200,6 +201,12 @@ function scanTestFiles(cwd, scenario) {
     let text;
     try { text = readFileSync(abs, 'utf-8'); } catch { continue; }
     if (PLACEHOLDER_PATTERN.test(text)) hits.push(`${scenario.id}:placeholder_assertion:${rel}`);
+    if (
+      scenario.runtime_class === 'real_desktop' &&
+      FAKE_RUNTIME_E2E_PATTERN.test(text)
+    ) {
+      hits.push(`${scenario.id}:fake_runtime_e2e:${rel}`);
+    }
     for (const pattern of scenario.forbidden_patterns || []) {
       if (pattern && text.includes(pattern)) hits.push(`${scenario.id}:forbidden_pattern:${pattern}:${rel}`);
     }
@@ -207,9 +214,67 @@ function scanTestFiles(cwd, scenario) {
   return hits;
 }
 
+function walkFiles(root, opts = {}) {
+  const limit = opts.limit ?? 1000;
+  const out = [];
+  const stack = [root];
+  while (stack.length > 0 && out.length < limit) {
+    const dir = stack.pop();
+    let entries = [];
+    try { entries = readdirSync(dir); } catch { continue; }
+    for (const entry of entries) {
+      if (entry === 'node_modules' || entry === 'target' || entry === '.git') continue;
+      const abs = join(dir, entry);
+      let st;
+      try { st = statSync(abs); } catch { continue; }
+      if (st.isDirectory()) {
+        stack.push(abs);
+        continue;
+      }
+      if (st.isFile()) out.push(abs);
+      if (out.length >= limit) break;
+    }
+  }
+  return out;
+}
+
+function anyFileMatches(root, pattern) {
+  if (!existsSync(root)) return false;
+  for (const file of walkFiles(root)) {
+    let text;
+    try { text = readFileSync(file, 'utf-8'); } catch { continue; }
+    if (pattern.test(text)) return true;
+  }
+  return false;
+}
+
+function hasCapabilityJson(cwd) {
+  const dir = join(cwd, 'src-tauri', 'capabilities');
+  if (!existsSync(dir)) return false;
+  return walkFiles(dir, { limit: 100 }).some((file) => /\.json$/i.test(file));
+}
+
+function detectTauriCapabilityIssues(cwd) {
+  const conf = join(cwd, 'src-tauri', 'tauri.conf.json');
+  if (!existsSync(conf)) return [];
+
+  const frontendInvokes = anyFileMatches(join(cwd, 'src'), /\binvoke\s*\(|@tauri-apps\/api\/core/);
+  const rustCommands = anyFileMatches(join(cwd, 'src-tauri', 'src'), /#\s*\[\s*tauri::command\s*\]/);
+  if (!frontendInvokes && !rustCommands) return [];
+
+  if (!hasCapabilityJson(cwd)) return ['tauri_capabilities_missing'];
+  return [];
+}
+
 function evaluateScenarioAuthenticity(cwd, scenarios, policy) {
   const issues = [];
   const required = scenarios.filter((s) => s.required !== false && s.test_command);
+  if (policy.real_runtime_required !== false && required.length === 0) {
+    issues.push('required_e2e_scenario_missing');
+  }
+  if (policy.real_runtime_required !== false) {
+    issues.push(...detectTauriCapabilityIssues(cwd));
+  }
 
   for (const scenario of required) {
     if (policy.real_runtime_required !== false && !REAL_RUNTIME_CLASSES.has(scenario.runtime_class)) {

--- a/hooks/mpl-require-e2e.mjs
+++ b/hooks/mpl-require-e2e.mjs
@@ -39,6 +39,9 @@ const isMain = import.meta.url === pathToFileURL(process.argv[1] || '').href;
 const { readState, isMplActive } = await import(
   pathToFileURL(join(__dirname, 'lib', 'mpl-state.mjs')).href
 );
+const { readGoalContract } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-goal-contract.mjs')).href
+);
 const { readStdin } = isMain
   ? await import(pathToFileURL(join(__dirname, 'lib', 'stdin.mjs')).href)
   : { readStdin: async () => '' };
@@ -288,6 +291,11 @@ export function computeUncoveredUcs(includedUcIds, scenarios) {
   return includedUcIds.filter((id) => !covered.has(id));
 }
 
+function realRuntimeE2ERequired(cwd) {
+  const goal = readGoalContract(cwd);
+  return goal.valid && goal.contract.e2e_policy.real_runtime_required === true;
+}
+
 /**
  * Detect whether the incoming tool input writes `finalize_done: true` to
  * `.mpl/state.json`. Handles Edit (old_string/new_string) and Write (content).
@@ -353,9 +361,44 @@ async function runHook() {
 
   // A finalize_done: true write is imminent. Validate E2E coverage.
   const scenarios = parseScenarios(cwd);
-  const required = scenarios.filter((s) => s.required && s.test_command);
+  const declaredRequired = scenarios.filter((s) => s.required !== false);
+  const missingCommand = declaredRequired.filter((s) => !s.test_command).map((s) => s.id);
+  if (missingCommand.length > 0) {
+    block(
+      `[MPL AD-0008] Cannot set finalize_done=true — required E2E scenario(s) missing executable test_command: ${missingCommand.join(', ')}. ` +
+        `Re-run decomposition Step 3-H and emit executable commands, or mark the scenario required:false with a rationale.`
+    );
+    return;
+  }
+
+  const required = declaredRequired.filter((s) => s.test_command);
+  const contract = parseUserContract(cwd);
+
   if (required.length === 0) {
-    // No declared E2E scenarios — nothing to enforce. Allow.
+    const reasons = [];
+    if (realRuntimeE2ERequired(cwd)) {
+      reasons.push('goal contract requires real runtime E2E');
+    }
+    if (contract.included_uc_ids.length > 0) {
+      reasons.push(`${contract.included_uc_ids.length} included UC(s) have no executable E2E scenario`);
+    }
+
+    if (reasons.length > 0) {
+      const message =
+        `[MPL AD-0008] Cannot set finalize_done=true — ${reasons.join('; ')}. ` +
+        `Emit .mpl/mpl/e2e-scenarios.yaml with at least one required scenario and executable test_command, run it, and let gate-recorder populate state.e2e_results.`;
+      if (realRuntimeE2ERequired(cwd) || isE2EContractStrict(cwd)) {
+        block(message);
+        return;
+      }
+      console.log(JSON.stringify({
+        continue: true,
+        suppressOutput: false,
+        systemMessage: `[MPL AD-0008 WARN] ${message}`,
+      }));
+      return;
+    }
+
     ok();
     return;
   }
@@ -405,7 +448,6 @@ async function runHook() {
   }
 
   // 0.16 Tier C: UC coverage gate.
-  const contract = parseUserContract(cwd);
   if (contract.included_uc_ids.length > 0) {
     const uncovered = computeUncoveredUcs(contract.included_uc_ids, contract.scenarios);
     if (uncovered.length > 0) {

--- a/hooks/mpl-require-test-agent.mjs
+++ b/hooks/mpl-require-test-agent.mjs
@@ -35,7 +35,7 @@ import { existsSync, readFileSync } from 'fs';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-const { readState, isMplActive } = await import(
+const { readState, writeState, isMplActive } = await import(
   pathToFileURL(join(__dirname, 'lib', 'mpl-state.mjs')).href
 );
 const { readStdin } = await import(
@@ -48,6 +48,46 @@ function ok() {
 
 function block(reason) {
   console.log(JSON.stringify({ continue: false, decision: 'block', reason }));
+}
+
+const HOOK_ID = 'mpl-require-test-agent';
+
+function recordBlockedHook(cwd, phaseId, reason) {
+  try {
+    writeState(cwd, {
+      session_status: 'blocked_hook',
+      blocked_by_hook: HOOK_ID,
+      blocked_phase: phaseId,
+      block_reason: reason,
+      resume_instruction:
+        `Dispatch mpl-test-agent for ${phaseId}, or record a user-approved ${phaseId} override in .mpl/config/test-agent-override.json, then retry the blocked phase transition.`,
+      blocked_at: new Date().toISOString(),
+    });
+  } catch {
+    // Visibility is best-effort; the hook block itself remains authoritative.
+  }
+}
+
+function clearBlockedHook(cwd, phaseId) {
+  try {
+    const state = readState(cwd) || {};
+    if (
+      state.session_status === 'blocked_hook' &&
+      state.blocked_by_hook === HOOK_ID &&
+      state.blocked_phase === phaseId
+    ) {
+      writeState(cwd, {
+        session_status: 'active',
+        blocked_by_hook: null,
+        blocked_phase: null,
+        block_reason: null,
+        resume_instruction: null,
+        blocked_at: null,
+      });
+    }
+  } catch {
+    // Best-effort cleanup only.
+  }
 }
 
 /**
@@ -191,6 +231,7 @@ try {
   const override = loadOverride(cwd);
   if (override[phaseId] || override['*']) {
     // Override accepted — the reason is logged but we do not block.
+    clearBlockedHook(cwd, phaseId);
     ok();
     process.exit(0);
   }
@@ -199,6 +240,7 @@ try {
   const state = readState(cwd) || {};
   const dispatched = state.test_agent_dispatched || {};
   if (dispatched[phaseId]) {
+    clearBlockedHook(cwd, phaseId);
     ok();
     process.exit(0);
   }
@@ -207,14 +249,15 @@ try {
   const rationale = phase.test_agent_rationale
     ? ` (rationale: ${phase.test_agent_rationale})`
     : '';
-  block(
+  const reason =
     `[MPL AD-0007] Phase ${phaseId} is marked test_agent_required=true${rationale} ` +
       `but mpl-test-agent was not dispatched. You MUST run Task(subagent_type="mpl-test-agent", ` +
       `model="sonnet", prompt=...) with the phase's interface_contract + impact files ` +
       `BEFORE proceeding to the next phase. code_author == test_author is a tautology, ` +
       `not a verification (AD-0004). To bypass with user consent, add ${phaseId} to ` +
-      `.mpl/config/test-agent-override.json with a reason.`
-  );
+      `.mpl/config/test-agent-override.json with a reason.`;
+  recordBlockedHook(cwd, phaseId, reason);
+  block(reason);
 } catch {
   // Hook must never wedge the pipeline.
   ok();

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mpl-mcp-server",
-  "version": "0.18.2",
+  "version": "0.18.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mpl-mcp-server",
-      "version": "0.18.2",
+      "version": "0.18.3",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.81",
         "@modelcontextprotocol/sdk": "^1.0.0"

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mpl-mcp-server",
-  "version": "0.18.2",
+  "version": "0.18.3",
   "description": "MPL MCP Server — deterministic scoring + active state access",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- block finalize when real-runtime goals or included UCs have zero executable E2E scenarios
- extend E2E authenticity checks for missing scenarios, fake runtime E2E hints, and missing Tauri v2 capabilities JSON
- validate per-phase test_agent_required in decomposition.yaml and record visible blocked_hook state for AD-0007 blocks
- bump plugin/MCP/docs to v0.18.3 and document the exp19 runtime verification closure

## Tests
- npm test
- npm test (mcp-server)
- node --test hooks/__tests__/mpl-install-metadata.test.mjs
- git diff --check