### PR TITLE
Start v0.18.4 measurement integrity recovery

### DIFF
--- a/commands/mpl-run.md
+++ b/commands/mpl-run.md
@@ -100,6 +100,7 @@ layout.
 |------|---------|
 | `phases.jsonl` | Per-phase token/timing profile (append-only, JSONL) |
 | `run-summary.json` | Complete run profile (generated at finalize) |
+| `telemetry-errors.jsonl` | Non-blocking health log for profile/RUNBOOK telemetry write/read failures |
 
 ### Routing Memory: `.mpl/memory/`
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -417,7 +417,8 @@ Convergence settings are adjusted in the `convergence` section of `.mpl/config.j
     ├── RUNBOOK.md                # Integrated execution log — current state, milestones, decisions, issues, resume info (F-10)
     ├── profile/                  # Token profiling
     │   ├── phases.jsonl          # Per-phase token/time (append-only)
-    │   └── run-summary.json     # Full execution profile
+    │   ├── run-summary.json      # Full execution profile
+    │   └── telemetry-errors.jsonl # Non-blocking telemetry health channel
     ├── metrics.json              # Final metrics
     └── ../memory/                # Routing memory (F-22) — (v0.17 REMOVED: routing-patterns.jsonl no longer recorded or recalled; learnings.md still in use via F-11)
         ├── routing-patterns.jsonl # (v0.17 REMOVED) Past execution patterns — Triage gone; no consumer

--- a/docs/roadmap/parallelism-exp20-research.md
+++ b/docs/roadmap/parallelism-exp20-research.md
@@ -1,0 +1,172 @@
+# MPL Parallelism Research After exp20
+
+Date: 2026-05-19
+Status: research record
+
+## Context
+
+This note records the follow-up research after reviewing MPL's current parallel execution flow and the Yggdrasil exp20 final report.
+
+Inputs:
+
+- MPL flow review: `commands/mpl-run-execute.md`, `commands/mpl-run-execute-parallel.md`, `commands/mpl-run-execute-context.md`, `agents/mpl-decomposer.md`
+- exp20 report: `/Users/kbshin/project/harness_lab/yggdrasil/runs/exp20-final-report.md`
+- exp20 artifacts: `/Users/kbshin/playground/ygg-exp20/.mpl/**`
+
+## Current Finding
+
+MPL already describes two levels of parallelism, but the active execution path is still mostly sequential.
+
+The main contract mismatch is:
+
+- Decomposer emits `execution_tiers`.
+- Executor's phase-parallel branch looks for `parallel_with`.
+
+This means decomposer output already contains useful scheduling intent, but executor does not consume it as the runtime scheduling contract.
+
+Other blockers:
+
+- TODO parallelism is batch-then-wait with max 3 workers, so worker slots can sit idle.
+- The executor already has a worktree-isolated branch for parallel phases, but that branch is guarded by `parallel_with`; exp20-style decompositions emit `execution_tiers` instead, so the worktree branch is effectively unreachable.
+- `chain_seed.enabled` defaults to false, so chain-scoped seed batching is not active in normal runs.
+- Test Agent and reviewer verification are treated mostly as blocking joins instead of pipelinable stages guarded by dependency frontiers.
+
+## exp20 Evidence
+
+exp20 was a quality success and a throughput warning.
+
+Quality recovered:
+
+- 21/21 phases completed.
+- Tauri capability setup recovered.
+- Fake E2E was replaced by WebdriverIO + tauri-driver scenario tests.
+- Measured tests increased from exp19's 27 to exp20's 293.
+- `test_agent_required` was emitted for 21/21 phases.
+
+Cost increased:
+
+- Wall time was about 11h 5m.
+- The report estimates 1.5M+ tokens, but exact token accounting is unreliable because state/profile writing stalled.
+- The non-MPL comparator finished in about 42m, with much shallower backend depth.
+
+The decomposer already identified parallelizable waves in exp20:
+
+```yaml
+execution_tiers:
+  - { tier: 4, phases: ["phase-04", "phase-05"], parallel: true }
+  - { tier: 6, phases: ["phase-07", "phase-08", "phase-09"], parallel: true }
+  - { tier: 7, phases: ["phase-10", "phase-11"], parallel: true }
+  - { tier: 13, phases: ["phase-18", "phase-19", "phase-20"], parallel: true }
+```
+
+The 21-phase run therefore had a 14-wave phase critical path if those tiers were actually consumed by a scheduler. This is a theoretical 33% reduction in phase wave count, not a wall-time estimate. exp20's wall time also includes Test Agent, E2E, gate, research, and retry/network overhead, so this should not be read as "11h becomes 7h" without measurement.
+
+## Measurement Blocker
+
+Parallelism work must start with telemetry recovery. exp20 cannot cleanly prove where time was spent because state/profile integrity regressed:
+
+- `current_phase` reached `completed`, but `execution.phases.total/completed/current` stayed zero/null.
+- structured gate evidence existed, but legacy `hardN_passed` booleans remained null, creating public summary drift.
+- `session_status` remained `blocked_hook` after `block_reason` and `resume_instruction` were cleared.
+- `last_tool_at` stopped far before completion.
+- `profile/phases.jsonl` ended early.
+- `profile/run-summary.json` was absent.
+
+Without fixing this, exp21 cannot prove whether scheduler changes improve throughput.
+
+## Recommended Priority
+
+### v0.18.4: Restore Measurement Integrity
+
+Do this before aggressive parallelism.
+
+Required changes:
+
+- Add a state freshness invariant at completion.
+- Require `profile/run-summary.json` before `finalize_done=true`.
+- Add a non-blocking telemetry health channel such as `.mpl/mpl/profile/telemetry-errors.jsonl`.
+- Fix blocked hook cleanup so `session_status`, `blocked_by_hook`, `blocked_phase`, `block_reason`, `resume_instruction`, and `blocked_at` clear atomically.
+- Resolve structured gate evidence vs legacy boolean drift:
+  - either derive compatibility booleans from structured evidence,
+  - or remove boolean-based displays and use structured evidence everywhere.
+- Record test count manifests with exact feature flags and commands, so feature-gated test deltas are explainable.
+
+Product-quality guardrails observed in exp20 should be tracked separately from measurement integrity:
+
+- Add UI placeholder detection for visible fake counters such as `0 / 0 words`.
+- Strengthen production TODO enforcement for user-facing error handling and workflow code.
+
+### v0.18.5: Make Phase Parallelism Real
+
+Required changes:
+
+- Replace `parallel_with` consumption with `execution_tiers` scheduling.
+- Treat `execution_tiers` as scheduler input, not a soft hint.
+- Once the scheduler actually reaches the parallel branch, add `parallelism.max_phase_workers`, default 2, max 3.
+- Add multi-worktree pool support after the scheduler reachability bug is fixed; the primary defect is currently not the worktree mechanism itself, but that the phase-parallel worktree branch is not called for `execution_tiers`.
+- Add resource locks such as `package_manager`, `dev_server`, and `db_migration`.
+- Require a post-join reconciliation artifact after every parallel tier:
+  - changed files
+  - contract files
+  - exported symbols
+  - test-agent findings
+  - PASS/FAIL and targeted fix instructions
+
+### v0.18.6: Add Pipeline Pipelining
+
+Required changes:
+
+- Enable Test Agent background pipelining for phases whose consumers do not depend on unverified behavior.
+- Join before any dependent phase, gate entry, or finalize.
+- Add reviewer pipelining behind the same dependency frontier.
+- Replace TODO batch-then-wait with slot streaming:
+  - keep max 3 active TODO slots,
+  - when one finishes, immediately dispatch the next ready TODO.
+- Require Seed TODOs to include `depends_on`, `files_to_modify`, and `resource_locks`.
+
+## exp21 Measurement Design
+
+exp21 should fail if telemetry is not trustworthy.
+
+Measurement recovery gates:
+
+- fail if `execution.phases.completed` is zero at completion,
+- fail if `profile/run-summary.json` is absent,
+- fail if gate public status and structured evidence disagree,
+- fail if `session_status` remains `blocked_hook` with no active `block_reason`.
+
+Parallelism metrics:
+
+- `phase_waves_planned`
+- `phase_waves_executed`
+- `parallel_slots_available_ms`
+- `parallel_slots_used_ms`
+- `ready_but_blocked_reason`
+- `critical_path_ms`
+- `join_reconciliation_ms`
+
+Success criteria:
+
+- State/profile integrity is 100%.
+- At least one decomposer parallel tier actually executes with concurrency greater than 1.
+- Wall time improves against exp20 or the run explains why quality gates consumed the saved time.
+- Quality does not regress: real E2E stays real, Test Agent dispatch coverage stays complete, and exp20's UI placeholder/TODO bugs are caught.
+
+## Relationship To Existing Roadmap
+
+This research updates the priority of the existing parallelism backlog in `docs/roadmap/pending-features.md`.
+
+Prior backlog items still apply:
+
+- PAR-01: intra-phase streaming dispatch
+- PAR-02: `execution_tiers` activation
+- PAR-03: dependency graph accuracy
+- PAR-04: phase execution metrics
+- PAR-05: conditional cross-phase pipelining
+
+Change from this research:
+
+- PAR-04 becomes a blocker, not a medium-priority follow-up.
+- PAR-02 should become a hard executor contract, not only a soft hint.
+- Multi-worktree pool support is required before phase-level parallelism can be real.
+- Verification pipelining should be dependency-frontier based, not phase-order based.

--- a/docs/roadmap/pending-features.md
+++ b/docs/roadmap/pending-features.md
@@ -401,6 +401,7 @@ gstack `/benchmark` — Core Web Vitals baseline + bundle size regression detect
 > **Source**: 3건의 구조화 토론 (Pro/Con/Mutant 3자)
 > **Decision records**: `~/project/decision/2026-04-06-mpl-*.md` (3건)
 > **Status**: ❌ Not implemented — 합의 완료, 구현 대기
+> **Update 2026-05-19**: `docs/roadmap/parallelism-exp20-research.md` reprioritizes this backlog. Measurement integrity (`PAR-04`) is now the v0.18.4 blocker before aggressive parallelism; `PAR-02` must become an executor contract over `execution_tiers`, not a soft hint.
 
 ### PAR-01: Intra-Phase Streaming Dispatch
 
@@ -422,11 +423,11 @@ gstack `/benchmark` — Core Web Vitals baseline + bundle size regression detect
 
 | ID | Feature | Status | Priority | Version Target |
 |----|---------|--------|----------|----------------|
-| PAR-02 | execution_tiers Soft Hint 활용 | ❌ Not implemented | 🟠 Medium | v1.1.0+ |
+| PAR-02 | execution_tiers Scheduler Contract | ❌ Not implemented | 🔴 High | v0.18.5 |
 
 **현재**: Decomposer가 `execution_tiers`를 생성하지만 Phase Runner가 무시 (`mpl-decomposer.md:156`).
 
-**합의안**: Phase Runner가 tier를 soft 힌트로 참조하여 TODO dispatch 순서에 반영. 강제 아님 — 무시해도 동작에 영향 없음. 실패 시 기존 Phase 단위 fix cycle 유지 (부분 재시작 없음).
+**exp20 이후 수정**: Executor가 `parallel_with`가 아니라 `execution_tiers`를 스케줄러 입력으로 소비해야 한다. `parallel: true` tier는 max worker/resource lock/reconciliation 규칙을 거쳐 실제 병렬 branch에 도달해야 하며, 무시 가능한 soft hint가 아니다.
 
 ### PAR-03: Decomposer depends_on 정확도 강화
 
@@ -442,11 +443,11 @@ gstack `/benchmark` — Core Web Vitals baseline + bundle size regression detect
 
 | ID | Feature | Status | Priority | Version Target |
 |----|---------|--------|----------|----------------|
-| PAR-04 | Phase별 실행 메트릭 수집 | ❌ Not implemented | 🟠 Medium | v1.1.0+ |
+| PAR-04 | Phase별 실행 메트릭/무결성 수집 | 🟡 In progress | 🔴 Blocker | v0.18.4 |
 
-**수집 항목**: Phase별 실행 시간, Gate 통과율, TODO 유휴 시간 비율, API 비용. 로그 기반 수동 집계로 시작.
+**수집 항목**: Phase별 실행 시간, Gate 통과율, TODO 유휴 시간 비율, API 비용, completion freshness, `run-summary.json`, telemetry error channel.
 
-**근거**: PAR-05 (cross-phase) 진입 조건이 메트릭 기반. 메트릭 없으면 Stage 2가 영원히 사장됨 (Mutant 유보).
+**근거**: exp20에서 `execution.phases.*`, `last_tool_at`, `profile/phases.jsonl`, `profile/run-summary.json`, `blocked_hook` cleanup drift가 관측되었다. PAR-05뿐 아니라 PAR-02 효과도 이 무결성이 없으면 측정할 수 없다.
 
 ### PAR-05: 조건부 Cross-Phase Pipelining (Stage 2)
 
@@ -521,9 +522,9 @@ interface_contract:
 | 2 | CTX-01 | Pull 기반 컨텍스트 전달 | cross-boundary 결함의 근본 해결 |
 | 3 | CTX-02 | Contract verbatim 보존 | CTX-01과 함께 즉시 적용 가능 |
 | 4 | CTX-03 | boundary_checks | 검증 Gate 활성화 |
-| 5 | PAR-01 | Streaming Dispatch | PAR-03 이후 경량 변경 |
-| 6 | PAR-02 | execution_tiers 활용 | PAR-01과 병행 가능 |
-| 7 | PAR-04 | 메트릭 수집 | PAR-05 진입 조건 |
+| 5 | PAR-04 | 메트릭/상태 무결성 수집 | exp21 측정 신뢰성의 선행 조건 |
+| 6 | PAR-01 | Streaming Dispatch | PAR-03 이후 경량 변경 |
+| 7 | PAR-02 | execution_tiers scheduler contract | 실제 phase 병렬 branch reachability |
 | 8 | PAR-05 | Cross-Phase Pipelining | 메트릭 확보 + 3중 조건 충족 시 |
 
 ---

--- a/docs/schemas/state.md
+++ b/docs/schemas/state.md
@@ -26,6 +26,7 @@
 | `goal_contract_set` / `goal_contract_path` / `goal_contract_hash` | per-pipeline | Goal Contract readiness mirror for `.mpl/goal-contract.yaml`; disk artifact remains the source of truth. |
 | `security_results.*` | per-pipeline | Structured security gate evidence consumed by `mpl-require-finalize-artifacts.mjs`. |
 | `session_status` | per-session | `null \| active \| paused_budget \| paused_checkpoint \| verification_hang \| blocked_hook \| cancelled`. Single-valued — pause / hang / explicit hook block / cancel states are mutually exclusive (G3 I9). |
+| `blocked_by_hook` / `blocked_phase` / `block_reason` / `resume_instruction` / `blocked_at` | per-session | Required companion fields while `session_status='blocked_hook'`. `writeState` clears all five when the blocked status clears so stale half-blocked state cannot survive. |
 | `last_tool_at` | per-session | ISO-8601 stamp from `mpl-tool-tracker.mjs`. Powers G4 (#109). |
 | `enforcement.*` | per-pipeline override | P0-2 (#110) per-rule policy. Top of the precedence chain. |
 
@@ -47,6 +48,8 @@ strict mode elevates `warn → block`.
 | I7 | `current_phase='phase-N' AND .mpl/mpl/phases/phase-N/` absent | all | Lifecycle marker vs disk drift. |
 | I8 | `schema_version > CURRENT_SCHEMA_VERSION` | all | Hook is older than writer; upgrade plugin. |
 | I9 | `session_status` outside the allowed enum | all | Forward-compat with G4 / #109 future fields. |
+| I10 | completion/finalize state with stale `execution.phases` accounting | all | At `finalize_done=true` or `current_phase='completed'`, `execution.status` must be completed, `total/completed` must be positive, `completed <= total`, and `current` must be null. |
+| I11 | `session_status='blocked_hook'` without all companion fields | all | A visible hook block must keep hook id, phase, reason, resume instruction, and timestamp together. |
 
 ## Trigger registration
 

--- a/hooks/__tests__/mpl-profile.test.mjs
+++ b/hooks/__tests__/mpl-profile.test.mjs
@@ -1,11 +1,18 @@
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdirSync, writeFileSync, rmSync } from 'fs';
+import { existsSync, mkdirSync, readFileSync, writeFileSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { randomUUID } from 'crypto';
 
-import { parseJsonl, analyzeProfile, detectAnomalies, readRunSummary, formatReport } from '../lib/mpl-profile.mjs';
+import {
+  parseJsonl,
+  analyzeProfile,
+  detectAnomalies,
+  readRunSummary,
+  formatReport,
+  recordTelemetryError,
+} from '../lib/mpl-profile.mjs';
 
 function createTempDir() {
   const dir = join(tmpdir(), `mpl-profile-test-${randomUUID()}`);
@@ -150,6 +157,44 @@ describe('readRunSummary', () => {
     const result = readRunSummary(tempDir);
     assert.equal(result.run_id, 'mpl-123');
     assert.equal(result.complexity.grade, 'Complex');
+  });
+
+  it('records a telemetry error when summary JSON is malformed', () => {
+    const profileDir = join(tempDir, '.mpl', 'mpl', 'profile');
+    mkdirSync(profileDir, { recursive: true });
+    writeFileSync(join(profileDir, 'run-summary.json'), 'not json');
+    assert.equal(readRunSummary(tempDir), null);
+    const telemetry = parseJsonl(join(profileDir, 'telemetry-errors.jsonl'));
+    assert.equal(telemetry.length, 1);
+    assert.equal(telemetry[0].source, 'mpl-profile:readRunSummary');
+    assert.match(telemetry[0].message, /JSON/);
+  });
+});
+
+describe('recordTelemetryError', () => {
+  let tempDir;
+  beforeEach(() => { tempDir = createTempDir(); });
+  afterEach(() => { rmSync(tempDir, { recursive: true, force: true }); });
+
+  it('appends non-blocking telemetry health records', () => {
+    recordTelemetryError(tempDir, 'unit-test', new Error('profile write failed'), {
+      phase: 'phase-1',
+    });
+    const path = join(tempDir, '.mpl', 'mpl', 'profile', 'telemetry-errors.jsonl');
+    assert.ok(existsSync(path));
+    const entries = parseJsonl(path);
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].source, 'unit-test');
+    assert.equal(entries[0].message, 'profile write failed');
+    assert.deepEqual(entries[0].details, { phase: 'phase-1' });
+  });
+
+  it('does not throw when details are not serializable', () => {
+    const details = {};
+    details.self = details;
+    assert.doesNotThrow(() => recordTelemetryError(tempDir, 'unit-test', 'boom', details));
+    const raw = readFileSync(join(tempDir, '.mpl', 'mpl', 'profile', 'telemetry-errors.jsonl'), 'utf-8');
+    assert.match(raw, /unserializable/);
   });
 });
 

--- a/hooks/__tests__/mpl-require-test-agent.test.mjs
+++ b/hooks/__tests__/mpl-require-test-agent.test.mjs
@@ -86,9 +86,12 @@ phases:
       }));
       assert.equal(r.continue, true);
       const state = JSON.parse(readFileSync(join(tmp, '.mpl', 'state.json'), 'utf-8'));
-      assert.equal(state.session_status, 'active');
+      assert.equal(state.session_status, null);
       assert.equal(state.blocked_by_hook, null);
       assert.equal(state.blocked_phase, null);
+      assert.equal(state.block_reason, null);
+      assert.equal(state.resume_instruction, null);
+      assert.equal(state.blocked_at, null);
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }

--- a/hooks/__tests__/mpl-runbook.test.mjs
+++ b/hooks/__tests__/mpl-runbook.test.mjs
@@ -120,6 +120,18 @@ describe('summarizeGates', () => {
     assert.equal(s, 'H1✓ H2✗ H3?');
   });
 
+  it('does not mix legacy PASS values into partial structured summaries', () => {
+    const ent = (e) => ({ command: 'x', exit_code: e, stdout_tail: '', timestamp: 'now' });
+    const s = summarizeGates({
+      gate_results: {
+        hard1_baseline: ent(0),
+        hard2_passed: true,
+        hard3_passed: true,
+      },
+    });
+    assert.equal(s, 'H1✓ H2? H3?');
+  });
+
   it('handles missing gate_results', () => {
     assert.equal(summarizeGates({}), '');
     assert.equal(summarizeGates(null), '');

--- a/hooks/__tests__/mpl-state-invariant.test.mjs
+++ b/hooks/__tests__/mpl-state-invariant.test.mjs
@@ -277,6 +277,78 @@ describe('I9 session_status enum', () => {
   }
 });
 
+describe('I10 completion execution freshness', () => {
+  it('flags completed pipelines whose execution accounting stayed at defaults', () => {
+    const r = checkInvariants({
+      current_phase: 'completed',
+      finalize_done: true,
+      execution: {
+        status: null,
+        phases: { total: 0, completed: 0, current: null },
+      },
+    }, { cwd: tmp });
+    const v = r.violations.find((x) => x.id === VIOLATION_IDS.COMPLETION_EXECUTION_STALE);
+    assert.ok(v);
+    assert.ok(v.issues.includes('execution.phases.total<=0_or_missing'));
+    assert.ok(v.issues.includes('execution.phases.completed<=0_or_missing'));
+    assert.ok(v.issues.includes('execution.status_not_completed'));
+  });
+
+  it('flags finalize_done writes that still point at an active phase id', () => {
+    const r = checkInvariants({
+      current_phase: 'phase5-finalize',
+      finalize_done: true,
+      execution: {
+        status: 'completed',
+        phases: { total: 2, completed: 2, current: 'phase-2' },
+      },
+    }, { cwd: tmp });
+    const v = r.violations.find((x) => x.id === VIOLATION_IDS.COMPLETION_EXECUTION_STALE);
+    assert.ok(v);
+    assert.ok(v.issues.includes('execution.phases.current_not_null_at_completion'));
+  });
+
+  it('accepts fresh completion accounting', () => {
+    const r = checkInvariants({
+      current_phase: 'completed',
+      finalize_done: true,
+      execution: {
+        status: 'completed',
+        phases: { total: 2, completed: 2, current: null },
+      },
+    }, { cwd: tmp });
+    assert.ok(!r.violations.some((v) => v.id === VIOLATION_IDS.COMPLETION_EXECUTION_STALE));
+  });
+});
+
+describe('I11 blocked_hook companion fields', () => {
+  it('flags blocked_hook with no active reason/instruction', () => {
+    const r = checkInvariants({
+      session_status: 'blocked_hook',
+      blocked_by_hook: 'mpl-require-test-agent',
+      blocked_phase: 'phase-1',
+      block_reason: null,
+      resume_instruction: '',
+      blocked_at: '2026-05-19T00:00:00Z',
+    }, { cwd: tmp });
+    const v = r.violations.find((x) => x.id === VIOLATION_IDS.BLOCKED_HOOK_STALE);
+    assert.ok(v);
+    assert.deepStrictEqual(v.missing.sort(), ['block_reason', 'resume_instruction']);
+  });
+
+  it('accepts a fully actionable blocked_hook state', () => {
+    const r = checkInvariants({
+      session_status: 'blocked_hook',
+      blocked_by_hook: 'mpl-require-test-agent',
+      blocked_phase: 'phase-1',
+      block_reason: 'missing test-agent dispatch',
+      resume_instruction: 'dispatch mpl-test-agent for phase-1',
+      blocked_at: '2026-05-19T00:00:00Z',
+    }, { cwd: tmp });
+    assert.ok(!r.violations.some((v) => v.id === VIOLATION_IDS.BLOCKED_HOOK_STALE));
+  });
+});
+
 describe('Multi-violation aggregation (exp15 4-way desync)', () => {
   it('surfaces 4 simultaneous violations', () => {
     // Realistic desync — I1 (paused+finalize), I4 (folder mismatch), I5

--- a/hooks/__tests__/mpl-state.test.mjs
+++ b/hooks/__tests__/mpl-state.test.mjs
@@ -101,6 +101,59 @@ describe('readState / writeState', () => {
     assert.strictEqual(state.fix_loop_count, 5);
   });
 
+  it('derives legacy gate booleans from structured machine evidence', () => {
+    const ent = (exit_code) => ({ command: 'npm test', exit_code, stdout_tail: '', timestamp: 'now' });
+    writeState(tmpDir, {
+      current_phase: 'phase3-gate',
+      gate_results: {
+        hard1_baseline: ent(0),
+        hard2_coverage: ent(1),
+        hard3_resilience: ent(0),
+        hard2_passed: true,
+      },
+    });
+    const state = readState(tmpDir);
+    assert.strictEqual(state.gate_results.hard1_passed, true);
+    assert.strictEqual(state.gate_results.hard2_passed, false);
+    assert.strictEqual(state.gate_results.hard3_passed, true);
+  });
+
+  it('does not mix legacy PASS values into partial structured gate evidence', () => {
+    const ent = (exit_code) => ({ command: 'npm test', exit_code, stdout_tail: '', timestamp: 'now' });
+    writeState(tmpDir, {
+      current_phase: 'phase3-gate',
+      gate_results: {
+        hard1_baseline: ent(0),
+        hard2_passed: true,
+        hard3_passed: true,
+      },
+    });
+    const state = readState(tmpDir);
+    assert.strictEqual(state.gate_results.hard1_passed, true);
+    assert.strictEqual(state.gate_results.hard2_passed, null);
+    assert.strictEqual(state.gate_results.hard3_passed, null);
+  });
+
+  it('clears hook-block companion fields when blocked_hook status clears', () => {
+    writeState(tmpDir, {
+      current_phase: 'phase2-sprint',
+      session_status: 'blocked_hook',
+      blocked_by_hook: 'mpl-require-test-agent',
+      blocked_phase: 'phase-1',
+      block_reason: 'missing test agent',
+      resume_instruction: 'dispatch test agent',
+      blocked_at: '2026-05-19T00:00:00Z',
+    });
+    writeState(tmpDir, { session_status: null });
+    const state = readState(tmpDir);
+    assert.strictEqual(state.session_status, null);
+    assert.strictEqual(state.blocked_by_hook, null);
+    assert.strictEqual(state.blocked_phase, null);
+    assert.strictEqual(state.block_reason, null);
+    assert.strictEqual(state.resume_instruction, null);
+    assert.strictEqual(state.blocked_at, null);
+  });
+
   it('should create .mpl directory if missing', () => {
     writeState(tmpDir, { current_phase: 'phase1-plan' });
     assert.ok(existsSync(join(tmpDir, '.mpl')));

--- a/hooks/lib/mpl-profile.mjs
+++ b/hooks/lib/mpl-profile.mjs
@@ -2,17 +2,59 @@
  * MPL Token Profile Analyzer
  *
  * Parses phases.jsonl and run-summary.json to produce aggregate statistics,
- * anomaly detection, and text-based reports.
+ * anomaly detection, and text-based reports. Also exposes a best-effort
+ * telemetry-errors.jsonl health channel for profile/RUNBOOK telemetry failures.
  *
  * Profile directory: .mpl/mpl/profile/
  */
 
-import { existsSync, readFileSync } from 'fs';
+import { appendFileSync, existsSync, mkdirSync, readFileSync } from 'fs';
 import { join } from 'path';
 
 const PROFILE_DIR = '.mpl/mpl/profile';
 const PHASES_FILE = 'phases.jsonl';
 const SUMMARY_FILE = 'run-summary.json';
+const TELEMETRY_ERRORS_FILE = 'telemetry-errors.jsonl';
+
+/**
+ * Append a non-blocking telemetry health record.
+ *
+ * This channel is intentionally best-effort and independent from state.json:
+ * telemetry failures should be visible during post-run analysis, but they must
+ * not wedge the pipeline while trying to report themselves.
+ *
+ * @param {string} cwd - Project root directory
+ * @param {string} source - Component/function that observed the failure
+ * @param {unknown} error - Error object or message
+ * @param {object} [details] - Small serializable context object
+ */
+export function recordTelemetryError(cwd, source, error, details = {}) {
+  try {
+    const profileDir = join(cwd, PROFILE_DIR);
+    if (!existsSync(profileDir)) mkdirSync(profileDir, { recursive: true });
+    const message = error instanceof Error
+      ? error.message
+      : String(error || 'unknown telemetry error');
+    const entry = {
+      timestamp: new Date().toISOString(),
+      source: source || 'unknown',
+      message: message.slice(0, 1000),
+      details: safeDetails(details),
+    };
+    appendFileSync(join(profileDir, TELEMETRY_ERRORS_FILE), JSON.stringify(entry) + '\n');
+  } catch {
+    // Never throw from the telemetry health channel.
+  }
+}
+
+function safeDetails(details) {
+  if (!details || typeof details !== 'object') return {};
+  try {
+    return JSON.parse(JSON.stringify(details));
+  } catch {
+    return { unserializable: true };
+  }
+}
 
 /**
  * Parse a JSONL file into an array of objects.
@@ -139,7 +181,8 @@ export function readRunSummary(cwd) {
   if (!existsSync(summaryPath)) return null;
   try {
     return JSON.parse(readFileSync(summaryPath, 'utf-8'));
-  } catch {
+  } catch (err) {
+    recordTelemetryError(cwd, 'mpl-profile:readRunSummary', err, { path: summaryPath });
     return null;
   }
 }

--- a/hooks/lib/mpl-runbook.mjs
+++ b/hooks/lib/mpl-runbook.mjs
@@ -193,11 +193,15 @@ export function appendRunbookRow(cwd, row) {
 export function summarizeGates(state) {
   const gr = state?.gate_results;
   if (!gr || typeof gr !== 'object') return '';
+  const hasStructuredSignal = ['hard1_baseline', 'hard2_coverage', 'hard3_resilience']
+    .some((k) => gr[k] !== null && gr[k] !== undefined);
   const cells = [];
   for (const [k, label] of [['hard1_baseline', 'H1'], ['hard2_coverage', 'H2'], ['hard3_resilience', 'H3']]) {
     const ent = gr[k];
     if (ent && typeof ent === 'object' && typeof ent.exit_code === 'number') {
       cells.push(`${label}${ent.exit_code === 0 ? '✓' : '✗'}`);
+    } else if (hasStructuredSignal) {
+      cells.push(`${label}?`);
     } else {
       const legacy = gr[`${label.toLowerCase().replace('h', 'hard')}_passed`];
       if (legacy === true) cells.push(`${label}✓`);

--- a/hooks/lib/mpl-state-invariant.mjs
+++ b/hooks/lib/mpl-state-invariant.mjs
@@ -54,6 +54,8 @@ export const VIOLATION_IDS = Object.freeze({
   // checkI9 before this hook can vouch for them; otherwise unknown values
   // surface here.
   SESSION_STATUS_INVALID: 'I9',
+  COMPLETION_EXECUTION_STALE: 'I10',
+  BLOCKED_HOOK_STALE: 'I11',
 });
 
 const ACTIVE_PHASES = new Set([
@@ -276,6 +278,60 @@ function checkI9(state) {
   return null;
 }
 
+function checkI10(state) {
+  // Completion freshness: exp20 reached current_phase='completed' while
+  // execution.phases stayed at its zero/null defaults. At completion/finalize
+  // time, the execution subtree must show that real phase accounting survived.
+  if (state.current_phase !== 'completed' && state.finalize_done !== true) return null;
+
+  const phases = state?.execution?.phases || {};
+  const issues = [];
+  const total = phases.total;
+  const completed = phases.completed;
+  const current = phases.current;
+
+  if (typeof total !== 'number' || !Number.isFinite(total) || total <= 0) {
+    issues.push('execution.phases.total<=0_or_missing');
+  }
+  if (typeof completed !== 'number' || !Number.isFinite(completed) || completed <= 0) {
+    issues.push('execution.phases.completed<=0_or_missing');
+  }
+  if (
+    typeof total === 'number' && Number.isFinite(total) &&
+    typeof completed === 'number' && Number.isFinite(completed) &&
+    completed > total
+  ) {
+    issues.push('execution.phases.completed>total');
+  }
+  if (current !== null && current !== undefined) {
+    issues.push('execution.phases.current_not_null_at_completion');
+  }
+  if (state?.execution?.status !== 'completed') {
+    issues.push('execution.status_not_completed');
+  }
+
+  if (issues.length === 0) return null;
+  return v(VIOLATION_IDS.COMPLETION_EXECUTION_STALE,
+    `completion state is stale: ${issues.join(', ')}. Final completion requires fresh execution.phases accounting.`,
+    { issues });
+}
+
+function checkI11(state) {
+  // A visible hook block is actionable only when all companion fields remain
+  // present. Missing reason/instruction was the exp20 blocked_hook cleanup
+  // failure mode.
+  if (state.session_status !== 'blocked_hook') return null;
+  const required = ['blocked_by_hook', 'blocked_phase', 'block_reason', 'resume_instruction', 'blocked_at'];
+  const missing = required.filter((key) => {
+    const value = state[key];
+    return typeof value !== 'string' || value.trim() === '';
+  });
+  if (missing.length === 0) return null;
+  return v(VIOLATION_IDS.BLOCKED_HOOK_STALE,
+    `session_status='blocked_hook' but companion field(s) are missing: ${missing.join(', ')}. Hook block cleanup/recording must be atomic.`,
+    { missing });
+}
+
 /* ────────────────────────── aggregator ──────────────────────────────────── */
 
 /**
@@ -303,6 +359,8 @@ export function checkInvariants(state, opts = {}) {
     () => checkI7(state, cwd),
     () => checkI8(state),
     () => checkI9(state),
+    () => checkI10(state),
+    () => checkI11(state),
   ];
 
   const violations = [];

--- a/hooks/lib/mpl-state.mjs
+++ b/hooks/lib/mpl-state.mjs
@@ -13,6 +13,7 @@ import { deepMerge } from './mpl-state-merge.mjs';
 import { runMigrations } from './migrations/index.mjs';
 import { LEGACY_EXECUTION_STATE_PATH as V1_TO_V2_LEGACY_PATH } from './migrations/v1-to-v2.mjs';
 import { appendRunbookRow, parseRunbookRows, summarizeGates, wallMinutes } from './mpl-runbook.mjs';
+import { recordTelemetryError } from './mpl-profile.mjs';
 
 export { deepMerge };
 
@@ -210,7 +211,12 @@ const DEFAULT_STATE = {
   // #109 G4 (v0.18.0): "verification_hang" added — Stop hook detects when last_tool_at is older
   // than the hang threshold (default 15min) and marks the session for resume / user intervention.
   // v0.18.3: "blocked_hook" makes explicit hook blocks visible to harnesses.
-  session_status: null,          // null | "active" | "paused_budget" | "paused_checkpoint" | "verification_hang" | "blocked_hook"
+  session_status: null,          // null | "active" | "paused_budget" | "paused_checkpoint" | "verification_hang" | "blocked_hook" | "cancelled"
+  blocked_by_hook: null,          // hook id that set session_status="blocked_hook"
+  blocked_phase: null,            // phase id associated with the active hook block
+  block_reason: null,             // user-visible block reason
+  resume_instruction: null,       // concrete instruction for clearing the block
+  blocked_at: null,               // ISO timestamp when hook block was recorded
   pause_reason: null,            // human-readable pause reason
   resume_from_phase: null,       // phase ID to resume from
   pause_timestamp: null,         // ISO timestamp of pause
@@ -469,6 +475,8 @@ export function writeState(cwd, patch) {
   // Catches both phase-controller writers and orchestrator mpl_state_write
   // calls without each caller having to remember the bookkeeping.
   recordFixLoopHistory(current, merged);
+  deriveLegacyGateBooleans(merged);
+  normalizeBlockedHookState(merged);
 
   // C2: Atomic write via temp file + rename
   const tmpPath = join(stateDir, `.state-${randomBytes(4).toString('hex')}.tmp`);
@@ -545,10 +553,61 @@ function recordRunbookTransition(cwd, prev, merged) {
     // result — those stay quiet.
     if (result && !result.appended && result.reason && result.reason !== 'duplicate') {
       process.stderr.write(`[mpl-runbook] append refused for ${prevPhase}: ${result.reason}\n`);
+      recordTelemetryError(cwd, 'mpl-state:recordRunbookTransition', result.reason, {
+        phase: prevPhase,
+        next_phase: newPhase,
+      });
     }
-  } catch {
+  } catch (err) {
+    recordTelemetryError(cwd, 'mpl-state:recordRunbookTransition', err, {
+      phase: prevPhase,
+      next_phase: newPhase,
+    });
     // Non-fatal: RUNBOOK is observability, must not block writes.
   }
+}
+
+/**
+ * Structured gate evidence is the source of truth, but legacy display fields
+ * remain in the public state shape for compatibility. Derive those booleans
+ * from structured exit codes on every write so HUD/status displays cannot drift
+ * to null or contradict the machine evidence. Once any structured gate signal
+ * exists, legacy values for missing/malformed structured gates are cleared
+ * instead of mixing self-report with machine evidence.
+ */
+function deriveLegacyGateBooleans(state) {
+  const gr = state?.gate_results;
+  if (!gr || typeof gr !== 'object') return;
+  const pairs = [
+    ['hard1_baseline', 'hard1_passed'],
+    ['hard2_coverage', 'hard2_passed'],
+    ['hard3_resilience', 'hard3_passed'],
+  ];
+  const hasStructuredSignal = pairs.some(([structuredKey]) => gr[structuredKey] !== null && gr[structuredKey] !== undefined);
+  if (!hasStructuredSignal) return;
+  for (const [structuredKey, legacyKey] of pairs) {
+    const entry = gr[structuredKey];
+    if (entry && typeof entry === 'object'
+        && typeof entry.exit_code === 'number' && Number.isFinite(entry.exit_code)) {
+      gr[legacyKey] = entry.exit_code === 0;
+    } else {
+      gr[legacyKey] = null;
+    }
+  }
+}
+
+/**
+ * Keep hook-block metadata atomic. Once session_status is no longer
+ * "blocked_hook", the companion fields must clear in the same write; otherwise
+ * later telemetry can look blocked while the actionable reason has vanished.
+ */
+function normalizeBlockedHookState(state) {
+  if (!state || state.session_status === 'blocked_hook') return;
+  state.blocked_by_hook = null;
+  state.blocked_phase = null;
+  state.block_reason = null;
+  state.resume_instruction = null;
+  state.blocked_at = null;
 }
 
 /**

--- a/hooks/mpl-hud.mjs
+++ b/hooks/mpl-hud.mjs
@@ -222,6 +222,21 @@ function formatGate(hard1, hard2, hard3) {
   return `${g(hard1)}${g(hard2)}${g(hard3)}`;
 }
 
+function hasStructuredGateSignal(gr) {
+  return ['hard1_baseline', 'hard2_coverage', 'hard3_resilience']
+    .some((key) => gr?.[key] !== null && gr?.[key] !== undefined);
+}
+
+function gateBool(gr, structuredKey, legacyKey, structuredMode = false) {
+  const entry = gr?.[structuredKey];
+  if (entry && typeof entry === 'object'
+      && typeof entry.exit_code === 'number' && Number.isFinite(entry.exit_code)) {
+    return entry.exit_code === 0;
+  }
+  if (structuredMode) return null;
+  return gr?.[legacyKey];
+}
+
 function formatContext(contextPercent) {
   if (contextPercent == null) return null;
   const pct = Math.round(contextPercent);
@@ -355,8 +370,14 @@ async function main() {
 
     // Gates (Hard gates)
     const gr = state.gate_results;
-    if (gr && (gr.hard1_passed != null || gr.hard2_passed != null || gr.hard3_passed != null)) {
-      parts2.push(`${c.blue}Gate:${c.reset}${formatGate(gr.hard1_passed, gr.hard2_passed, gr.hard3_passed)}`);
+    if (gr) {
+      const structuredMode = hasStructuredGateSignal(gr);
+      const hard1 = gateBool(gr, 'hard1_baseline', 'hard1_passed', structuredMode);
+      const hard2 = gateBool(gr, 'hard2_coverage', 'hard2_passed', structuredMode);
+      const hard3 = gateBool(gr, 'hard3_resilience', 'hard3_passed', structuredMode);
+      if (hard1 != null || hard2 != null || hard3 != null) {
+        parts2.push(`${c.blue}Gate:${c.reset}${formatGate(hard1, hard2, hard3)}`);
+      }
     }
 
     // Fix loop

--- a/hooks/mpl-require-test-agent.mjs
+++ b/hooks/mpl-require-test-agent.mjs
@@ -77,7 +77,7 @@ function clearBlockedHook(cwd, phaseId) {
       state.blocked_phase === phaseId
     ) {
       writeState(cwd, {
-        session_status: 'active',
+        session_status: null,
         blocked_by_hook: null,
         blocked_phase: null,
         block_reason: null,

--- a/hooks/mpl-validate-output.mjs
+++ b/hooks/mpl-validate-output.mjs
@@ -22,6 +22,10 @@ const { isMplActive, readState, writeState } = await import(
   pathToFileURL(join(__dirname, 'lib', 'mpl-state.mjs')).href
 );
 
+const { recordTelemetryError } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-profile.mjs')).href
+);
+
 // Import shared stdin reader
 const { readStdin } = await import(
   pathToFileURL(join(__dirname, 'lib', 'stdin.mjs')).href
@@ -151,7 +155,11 @@ function logPhaseProfile(cwd, state, agentType, estimatedTokens) {
       timestamp: new Date().toISOString(),
     };
     appendFileSync(join(profileDir, 'phases.jsonl'), JSON.stringify(phaseRecord) + '\n');
-  } catch {
+  } catch (err) {
+    recordTelemetryError(cwd, 'mpl-validate-output:logPhaseProfile', err, {
+      agent_type: agentType || null,
+      phase: state?.current_phase || null,
+    });
     // Profile logging is best-effort
   }
 }
@@ -180,13 +188,20 @@ function trackTokenUsage(cwd, agentType, responseText) {
             timestamp: new Date().toISOString(),
             tokens: estimatedTokens,
           }) + '\n');
-        } catch { /* best-effort */ }
+        } catch (err) {
+          recordTelemetryError(cwd, 'mpl-validate-output:weeklyUsage', err, {
+            agent_type: agentType || null,
+          });
+        }
 
         // Experiment: append compaction_count to phases.jsonl for correlation analysis
         logPhaseProfile(cwd, currentState, agentType, estimatedTokens);
       }
     }
-  } catch {
+  } catch (err) {
+    recordTelemetryError(cwd, 'mpl-validate-output:trackTokenUsage', err, {
+      agent_type: agentType || null,
+    });
     // Token tracking is best-effort; do not block on failure
   }
 }


### PR DESCRIPTION
## Summary
- add exp20 parallelism research record and reprioritize PAR-04/PAR-02 roadmap items
- add completion freshness and blocked_hook invariants for v0.18.4 measurement integrity
- add telemetry-errors.jsonl health channel and prevent structured gate evidence from drifting into legacy displays

## Tests
- npm test (846 tests, 0 failures)
- git diff --check