### PR TITLE
v0.18.5: Make execution tiers the phase scheduler contract

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "mpl",
       "description": "Decomposes tasks into micro-phases with independent plan-execute-verify mini-loops. Orchestrator-Worker separation enforced via hooks.",
-      "version": "0.18.3",
+      "version": "0.18.5",
       "author": {
         "name": "KyubumShin"
       },
@@ -25,5 +25,5 @@
       ]
     }
   ],
-  "version": "0.18.3"
+  "version": "0.18.5"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mpl",
-  "version": "0.18.3",
+  "version": "0.18.5",
   "description": "Micro-Phase Loop - Coherence-first autonomous coding pipeline with decomposition, phase execution, and verification",
   "author": {
     "name": "KyubumShin"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mpl",
-  "version": "0.18.3",
+  "version": "0.18.5",
   "description": "Micro-Phase Loop - coherence-first autonomous coding pipeline for goal-fixed, phase-scoped implementation and verification.",
   "author": {
     "name": "KyubumShin",

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# MPL (Micro-Phase Loop) v0.18.3
+# MPL (Micro-Phase Loop) v0.18.5
 
 **Prevention over cure. Specification over debugging.**
 

--- a/README_ko.md
+++ b/README_ko.md
@@ -1,4 +1,4 @@
-# MPL (Micro-Phase Loop) v0.18.3
+# MPL (Micro-Phase Loop) v0.18.5
 
 **예방이 치료보다 낫다. 명세가 디버깅보다 낫다.**
 

--- a/agents/mpl-decomposer.md
+++ b/agents/mpl-decomposer.md
@@ -37,6 +37,8 @@ disallowedTools: Bash,Task,WebFetch,WebSearch,NotebookEdit
     8. **Vertical slice for multi-layer projects**: If 2+ layers detected (frontend/backend/DB/IPC), decompose by feature, not by layer. Each phase implements ONE feature across ALL layers. Scaffold/infrastructure phases remain horizontal.
 
     9. **RECOMPOSE-MODE / APPEND-MODE (controlled recomposition)**: When the dispatch prompt begins with `RECOMPOSE-MODE:` or `APPEND-MODE:`, never patch `.mpl/mpl/decomposition.yaml` in place. First read the existing graph, keep every completed phase block byte-for-byte intact, and write `.mpl/mpl/decomposition-deltas/recompose-{N}.yaml` where `N = existing recompose_count + 1`. Then write the FULL updated `.mpl/mpl/decomposition.yaml` with `recompose_count: N`. APPEND-MODE is a restricted RECOMPOSE-MODE that may only append 1-3 phases from `append_phases` hints. New phase ids must not collide — use `{anchor}b`, `{anchor}c`, etc. (e.g., `phase-3b` after `phase-3`); each appended phase MUST include `covers:[UC-N]` and `test_agent_required:true`; preserve `execution_tiers` by inserting new ids immediately after the anchor.
+
+    10. **Execution tiers are a scheduler contract (v0.18.5)**: Top-level `execution_tiers` is REQUIRED and consumed by the executor. It is not a hint. Only set `parallel: true` when phases have no file overlap, no dependency edge between them, and no shared `resource_locks`. Do NOT emit `parallel_with`; executor ignores it.
   </Rules>
 
   <Reasoning_Steps>
@@ -363,6 +365,12 @@ disallowedTools: Bash,Task,WebFetch,WebSearch,NotebookEdit
             - path: string
               reason: string
 
+        resource_locks:             # REQUIRED (v0.18.5). Empty [] allowed.
+          - string                  # package_manager | dev_server | db_migration
+          # Use when the phase changes dependency manifests/lockfiles, starts or
+          # reconfigures a dev server, or runs DB migrations/schema writes. Phases
+          # with the same lock cannot share a parallel execution wave.
+
         interface_contract:
           requires:
             - type: string
@@ -482,6 +490,11 @@ disallowedTools: Bash,Task,WebFetch,WebSearch,NotebookEdit
           # the test-agent dispatch (e.g., "focus on boundary invariants of X").
 
     execution_tiers:
+      # REQUIRED scheduler contract (v0.18.5). Executor consumes this directly.
+      # Sort by tier ascending. Every phase id must appear exactly once.
+      # `parallel: true` means the executor must try a conflict-free parallel wave
+      # under `parallelism.max_phase_workers`; do not use it for merely "could be
+      # parallel later" ideas.
       - tier: number
         phases: [string]
         parallel: boolean

--- a/commands/mpl-run-execute-parallel.md
+++ b/commands/mpl-run-execute-parallel.md
@@ -8,6 +8,11 @@ This file contains the Task-based TODO protocol, Background Execution for indepe
 and Orchestrator Context Cleanup.
 Load this when parallel TODOs are detected during phase execution.
 
+Phase-level parallelism is scheduled only by `commands/mpl-run-execute.md`
+Step 4.0 from top-level `execution_tiers`. This file does not consume
+`execution_tiers` or phase-level `resource_locks`; it is limited to TODO
+parallelism inside a single phase.
+
 See also: `mpl-run-execute.md` (core loop), `mpl-run-execute-context.md` (context assembly), `mpl-run-execute-gates.md` (3 Hard Gate system).
 
 ---

--- a/commands/mpl-run-execute.md
+++ b/commands/mpl-run-execute.md
@@ -15,45 +15,91 @@ Load this when `current_phase` is `phase2-sprint`.
 
 ### 4.0: Phase Execution Dispatch
 
-For each phase in decomposition order:
+`execution_tiers` in `.mpl/mpl/decomposition.yaml` is the scheduler contract.
+Do not consume `parallel_with`; that legacy field is ignored even when present.
 
-If phase has `parallel_with` field AND parallel phases have no file overlap:
-  ```
-  // Parallel execution for independent phases
-  announce: "[MPL] Executing {parallel_phases.length} phases in parallel"
+Before executing phases:
 
-  results = parallel_map(parallel_phases, fn(phase_id):
+```
+decomposition = Read(".mpl/mpl/decomposition.yaml")
+config = loadConfig(".mpl/config.json")
+max_phase_workers = min(config.parallelism?.max_phase_workers ?? 2, 3)
+phase_map = index_by_id(decomposition.phases)
+tiers = decomposition.execution_tiers
+
+if tiers is missing or empty:
+  // Legacy fallback only. Prefer fixing decomposition output.
+  tiers = decomposition.phases.map((phase, index) => ({
+    tier: index + 1,
+    phases: [phase.id],
+    parallel: false
+  }))
+```
+
+For each tier in ascending `tier` order:
+
+```
+phase_ids = tier.phases.filter(id => !is_completed(id))
+
+if phase_ids.length == 0:
+  continue
+
+if tier.parallel != true or phase_ids.length == 1:
+  for each phase_id in phase_ids:
+    execute_single_phase(phase_id)  // normal flow: 4.0.5 → 4.1 → 4.2 → 4.3 → 4.8
+  continue
+
+waves = split_into_conflict_free_waves(phase_ids, rules:
+  - no overlapping impact.create/impact.modify/impact.affected_tests paths
+  - no shared resource_locks entries among ["package_manager", "dev_server", "db_migration"]
+  - every interface_contract.requires[].from_phase is already completed or in an earlier tier
+)
+
+for each wave in waves:
+  announce: "[MPL] Tier {tier.tier}: executing {wave.length} phase(s) with max {max_phase_workers} workers"
+
+  ready_but_blocked = phase_ids - wave when blocked by file overlap, resource lock, or dependency frontier
+  record ready_but_blocked_reason for each blocked phase in the tier reconciliation artifact
+
+  // Multi-worktree pool. Reuse up to max_phase_workers isolated slots after
+  // verifying each worktree has the current base branch commit reachable.
+  worktree_pool = ensure_worktree_pool(size: min(max_phase_workers, wave.length))
+
+  results = parallel_map(wave, fn(phase_id, slot):
     seed = generate_phase_seed(phase_id, all_prior_summaries)
     context = assemble_context(phase_id, seed)
-    return execute_phase(context, isolation: "worktree")
-  , max_concurrent: 3)
+    return execute_phase(context, isolation: worktree_pool[slot])
+  , max_concurrent: min(max_phase_workers, wave.length))
 
-  // Merge worktree results sequentially
-  for each result in results:
+  // Merge worktree results sequentially in decomposition order.
+  for each result in sort_by_decomposition_order(results):
     merge_worktree(result)
     save_state_summary(result)
 
-  // Post-Join Semantic Boundary Verification — L2 (CB-08)
-  // Mechanical key extraction for boundary conflicts
-  if parallel_phases.length > 1:
-    all_contracts = collect_contract_files(parallel_phases)
-    if all_contracts.length > 0:
-      reconciliation_issues = verify_boundary_keys(all_contracts)
-      if reconciliation_issues.length > 0:
-        announce: "[MPL] CB-08 L2: {reconciliation_issues.length} boundary conflicts after parallel join"
-        → Dispatch targeted boundary fix
-      else:
-        announce: "[MPL] CB-08 L2: Post-join verification clean."
+// Required after every tier whose original `parallel` flag is true.
+write_join_reconciliation_artifact(
+  path: ".mpl/mpl/phases/tier-{tier.tier}-join-reconciliation.md",
+  fields: {
+    changed_files_by_phase,
+    contract_files_by_phase,
+    exported_symbols_by_phase,
+    test_agent_findings_by_phase,
+    resource_locks_and_blocked_reasons,
+    verdict: "PASS" | "FAIL",
+    targeted_fix_instructions
+  }
+)
 
-  // Cumulative test run
-  run_cumulative_tests(parallel_phases)
-
+if join_reconciliation.verdict == "FAIL":
+  announce: "[MPL] Tier {tier.tier}: post-join reconciliation failed"
+  dispatch targeted boundary/resource fix instructions before the next tier
 else:
-  // Sequential execution (default)
-  // Normal flow: 4.0.5 → 4.1 → 4.2 → 4.3 → 4.8
-  ```
+  announce: "[MPL] Tier {tier.tier}: post-join reconciliation PASS"
 
-For each phase in order:
+run_cumulative_tests(phase_ids)
+```
+
+For each single phase execution:
 
 ### 4.0.5: Phase Seed Generation
 

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -2,8 +2,8 @@
 
 All fields for `.mpl/config.json`. Single source of truth for configuration.
 
-> **Version**: v0.18.3 (runtime verification closure: real-runtime E2E zero-scenario block, Tauri capabilities check, and decomposition test-agent field validation)
-> **Last updated**: 2026-05-18
+> **Version**: v0.18.5 (execution_tiers scheduler contract and phase worker cap)
+> **Last updated**: 2026-05-19
 
 ---
 
@@ -21,6 +21,16 @@ All fields for `.mpl/config.json`. Single source of truth for configuration.
 | Field | Type | Default | Description | Source |
 |-------|------|---------|-------------|--------|
 | `context_cleanup_window` | number | `3` | Sliding window size — number of recent phases to retain detailed data (v0.7.0) | `mpl-run-execute-parallel.md` |
+
+## Phase Parallelism
+
+`execution_tiers` in `.mpl/mpl/decomposition.yaml` is the phase scheduler
+contract. This config only caps worker fan-out after the executor has selected a
+conflict-free parallel tier/wave.
+
+| Field | Type | Default | Description | Source |
+|-------|------|---------|-------------|--------|
+| `parallelism.max_phase_workers` | integer `1..3` | `2` | Maximum concurrent phase workers for `execution_tiers[].parallel: true`; values above `3` are clamped to `3`. | `commands/mpl-run-execute.md` |
 
 ## Convergence Detection
 
@@ -268,6 +278,9 @@ Per-project override for the global `~/.mpl/cache/sessions.json` TTL. The cache 
 {
   "max_fix_loops": 10,
   "context_cleanup_window": 3,
+  "parallelism": {
+    "max_phase_workers": 2
+  },
   "hat": {
     "default_level": "auto",
     "pp_weight": 0.40,

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,4 +1,4 @@
-# MPL (Micro-Phase Loop) v0.18.3 Design Document
+# MPL (Micro-Phase Loop) v0.18.5 Design Document
 
 ## 1. Overview
 
@@ -475,6 +475,7 @@ The following options are supported in `.mpl/config.json`:
 |------|--------|------|
 | `max_fix_loops` | `10` | Maximum Fix Loop iterations |
 | `context_cleanup_window` | `3` | Sliding window size — number of recent phases to retain detailed data (v0.7.0) |
+| `parallelism.max_phase_workers` | `2` | Maximum concurrent phase workers for `execution_tiers[].parallel: true`; runtime clamps to max 3 |
 | `gate1_strategy` | `"auto"` | Gate 1 test strategy (auto/docker/native/skip) |
 | `hitl_timeout_seconds` | `30` | HITL response wait time |
 | `convergence.stagnation_window` | `3` | Fix attempts to evaluate for stagnation (see `config-schema.md`) |
@@ -485,6 +486,19 @@ The following options are supported in `.mpl/config.json`:
 ---
 
 ## 9. Version History
+
+### v0.18.5 — Execution Tier Scheduler Contract (2026-05-19)
+
+v0.18.5 makes phase-level parallelism reachable by treating decomposer
+`execution_tiers` as the executor scheduler contract instead of relying on the
+legacy `parallel_with` field.
+
+| Change | Before | After | Type | Rationale |
+|--------|--------|-------|------|-----------|
+| Phase scheduling input | Executor looked for legacy `parallel_with`, while decomposer emitted top-level `execution_tiers` | Executor Step 4.0 consumes sorted `execution_tiers` directly and ignores `parallel_with` | Prompt contract | Fixes the branch reachability bug that made phase-level parallel worktree execution mostly unreachable |
+| Phase worker cap | Parallel phase fan-out was hard-coded at 3 | `.mpl/config.json:parallelism.max_phase_workers` defaults to 2 and clamps to max 3 | Config + tests | Lets dogfood runs start conservatively without exceeding UI stability limits |
+| Resource locks | Decomposition could not declare package manager, dev server, or DB migration conflicts | Each phase must include `resource_locks`; graph validation blocks omission | Hook + schema | Prevents scheduler waves from parallelizing mutually exclusive resources |
+| Join reconciliation | Parallel branch only performed ad hoc boundary verification | Every parallel tier writes a join reconciliation artifact with changed files, contracts, exported symbols, test-agent findings, PASS/FAIL, and targeted fixes | Prompt contract | Makes parallel joins auditable before the next tier starts |
 
 ### v0.18.3 — Runtime Verification Closure (2026-05-18)
 

--- a/docs/roadmap/pending-features.md
+++ b/docs/roadmap/pending-features.md
@@ -5,7 +5,7 @@
 > **⚠ v0.17 (#55) 반영**: Triage / `interview_depth` / `pp_proximity` / Hat model / F-22 routing-pattern recall 모두 삭제됨. 본 문서 내 위 개념을 가정한 설계(특히 `interview_depth` 분기를 활용하는 PM 설계, F-20→F-22 라우터 의존 항목)는 **재기준선화 필요**. 측정 대기 항목(F-25/F-28/F-39)은 `docs/roadmap/0.16-exp12-plan.md` exp12 데이터로 결정 보류 중.
 
 > **Status**: Pending implementation (for review)
-> **Last updated**: 2026-04-26
+> **Last updated**: 2026-05-19
 > **Purpose**: Consolidated list of all features not yet implemented. Completed items have been moved to `overview.md`.
 
 ### Recently Completed (Post-v0.16 — 2026-04-21 ~ 2026-04-26)
@@ -423,11 +423,13 @@ gstack `/benchmark` — Core Web Vitals baseline + bundle size regression detect
 
 | ID | Feature | Status | Priority | Version Target |
 |----|---------|--------|----------|----------------|
-| PAR-02 | execution_tiers Scheduler Contract | ❌ Not implemented | 🔴 High | v0.18.5 |
+| PAR-02 | execution_tiers Scheduler Contract | ✅ Implemented | 🔴 High | v0.18.5 |
 
 **현재**: Decomposer가 `execution_tiers`를 생성하지만 Phase Runner가 무시 (`mpl-decomposer.md:156`).
 
 **exp20 이후 수정**: Executor가 `parallel_with`가 아니라 `execution_tiers`를 스케줄러 입력으로 소비해야 한다. `parallel: true` tier는 max worker/resource lock/reconciliation 규칙을 거쳐 실제 병렬 branch에 도달해야 하며, 무시 가능한 soft hint가 아니다.
+
+**v0.18.5 구현**: executor Step 4.0은 top-level `execution_tiers`를 직접 소비하고, phase graph hook은 `execution_tiers`/`resource_locks` 존재를 decomposition write 단계에서 검증한다. `parallelism.max_phase_workers` 기본값은 2, 상한은 3이다.
 
 ### PAR-03: Decomposer depends_on 정확도 강화
 
@@ -443,7 +445,7 @@ gstack `/benchmark` — Core Web Vitals baseline + bundle size regression detect
 
 | ID | Feature | Status | Priority | Version Target |
 |----|---------|--------|----------|----------------|
-| PAR-04 | Phase별 실행 메트릭/무결성 수집 | 🟡 In progress | 🔴 Blocker | v0.18.4 |
+| PAR-04 | Phase별 실행 메트릭/무결성 수집 | ✅ Implemented | 🔴 Blocker | v0.18.4 |
 
 **수집 항목**: Phase별 실행 시간, Gate 통과율, TODO 유휴 시간 비율, API 비용, completion freshness, `run-summary.json`, telemetry error channel.
 

--- a/docs/schemas/phase-contract-graph.md
+++ b/docs/schemas/phase-contract-graph.md
@@ -14,6 +14,10 @@ generated_by: mpl-decomposer
 recompose_count: 0
 completed_phase_policy: immutable_by_default
 goal_contract_hash: "<sha256 .mpl/goal-contract.yaml>"
+execution_tiers:
+  - tier: 1
+    phases: [phase-1]
+    parallel: false
 ```
 
 ## Required Per-Phase Surface
@@ -26,6 +30,7 @@ phases:
       - test_agent
       - goal_trace
     change_policy: append_delta_only
+    resource_locks: [] # package_manager | dev_server | db_migration
     goal_trace:
       acceptance_criteria: [AC-1]
       variation_axes: [AX-1]
@@ -46,8 +51,12 @@ phases:
   `decomposition.yaml` writes when:
   - top-level graph metadata is missing
   - `generated_by` is not `mpl-decomposer`
+  - top-level `execution_tiers` is missing or empty
+  - `execution_tiers` references an unknown phase, duplicates a phase id, or
+    omits any declared phase
   - any phase lacks non-empty `evidence_required`
   - any phase lacks non-empty `change_policy`
+  - any phase omits `resource_locks` (empty `[]` is valid)
   - `interface_contract.requires[].from_phase` points to the same phase or an
     unknown phase
 - `.mpl/config.json { "phase_contract_graph_required": false }` is an explicit

--- a/hooks/__tests__/mpl-config.test.mjs
+++ b/hooks/__tests__/mpl-config.test.mjs
@@ -1,0 +1,44 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+import { loadConfig } from '../lib/mpl-config.mjs';
+
+let tmp;
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'mpl-config-'));
+  mkdirSync(join(tmp, '.mpl'), { recursive: true });
+});
+afterEach(() => rmSync(tmp, { recursive: true, force: true }));
+
+function writeUserConfig(obj) {
+  writeFileSync(join(tmp, '.mpl', 'config.json'), JSON.stringify(obj));
+}
+
+describe('loadConfig parallelism', () => {
+  it('defaults phase workers to 2', () => {
+    assert.strictEqual(loadConfig(tmp).parallelism.max_phase_workers, 2);
+  });
+
+  it('honors configured phase workers up to 3', () => {
+    writeUserConfig({ parallelism: { max_phase_workers: 3 } });
+    assert.strictEqual(loadConfig(tmp).parallelism.max_phase_workers, 3);
+  });
+
+  it('clamps excessive phase workers to 3', () => {
+    writeUserConfig({ parallelism: { max_phase_workers: 9 } });
+    assert.strictEqual(loadConfig(tmp).parallelism.max_phase_workers, 3);
+  });
+
+  it('clamps phase workers below 1 to 1', () => {
+    writeUserConfig({ parallelism: { max_phase_workers: 0 } });
+    assert.strictEqual(loadConfig(tmp).parallelism.max_phase_workers, 1);
+  });
+
+  it('falls back to default for non-integer phase workers', () => {
+    writeUserConfig({ parallelism: { max_phase_workers: '3' } });
+    assert.strictEqual(loadConfig(tmp).parallelism.max_phase_workers, 2);
+  });
+});

--- a/hooks/__tests__/mpl-phase-contract-graph.test.mjs
+++ b/hooks/__tests__/mpl-phase-contract-graph.test.mjs
@@ -39,6 +39,7 @@ phases:
       - command
       - goal_trace
     change_policy: append_delta_only
+    resource_locks: []
     interface_contract:
       requires: []
       produces:
@@ -47,12 +48,20 @@ phases:
   - id: phase-2
     evidence_required: [command, test_agent]
     change_policy: append_delta_only
+    resource_locks: [dev_server]
     interface_contract:
       requires:
         - type: artifact
           name: bootstrap
           from_phase: phase-1
       produces: []
+execution_tiers:
+  - tier: 1
+    phases: [phase-1]
+    parallel: false
+  - tier: 2
+    phases: [phase-2]
+    parallel: false
 `;
 }
 
@@ -81,7 +90,10 @@ describe('phase contract graph parser', () => {
     assert.equal(graph.generated_by, 'mpl-decomposer');
     assert.equal(graph.recompose_count, '0');
     assert.equal(graph.completed_phase_policy, 'immutable_by_default');
+    assert.equal(graph.has_execution_tiers, true);
+    assert.deepEqual(graph.execution_tier_phase_refs, ['phase-1', 'phase-2']);
     assert.equal(graph.phases.length, 2);
+    assert.equal(graph.phases[0].has_resource_locks, true);
     assert.deepEqual(graph.phases[1].requires_from_phases, ['phase-1']);
   });
 
@@ -103,9 +115,27 @@ phases:
     assert.equal(verdict.valid, false);
     assert.ok(verdict.issues.includes('graph_version:missing'));
     assert.ok(verdict.issues.includes('generated_by:orchestrator'));
+    assert.ok(verdict.issues.includes('execution_tiers:missing'));
     assert.ok(verdict.issues.includes('phase-1:evidence_required:missing'));
     assert.ok(verdict.issues.includes('phase-1:change_policy:missing'));
+    assert.ok(verdict.issues.includes('phase-1:resource_locks:missing'));
     assert.ok(verdict.issues.includes('phase-1:requires:unknown:phase-99'));
+  });
+
+  it('reports execution_tiers unknown, duplicate, and missing phase refs', () => {
+    const graph = parsePhaseContractGraphText(validGraph().replace(
+      `  - tier: 2
+    phases: [phase-2]
+    parallel: false`,
+      `  - tier: 2
+    phases: [phase-1, phase-404]
+    parallel: true`,
+    ));
+    const verdict = validatePhaseContractGraph(graph);
+    assert.equal(verdict.valid, false);
+    assert.ok(verdict.issues.includes('execution_tiers:duplicate:phase-1'));
+    assert.ok(verdict.issues.includes('execution_tiers:unknown:phase-404'));
+    assert.ok(verdict.issues.includes('phase-2:execution_tiers:missing'));
   });
 });
 

--- a/hooks/lib/mpl-config.mjs
+++ b/hooks/lib/mpl-config.mjs
@@ -59,6 +59,12 @@ const ENFORCEMENT_DEFAULTS = {
   audit_residual: 'warn',
 };
 
+const PARALLELISM_DEFAULTS = {
+  max_phase_workers: 2,
+};
+
+const MAX_PHASE_WORKERS_LIMIT = 3;
+
 const DEFAULTS = {
   max_fix_loops: 10,
   gate1_strategy: 'auto',  // 'docker', 'native', 'skip'
@@ -77,9 +83,34 @@ const DEFAULTS = {
     min_improvement: 0.05,
     regression_threshold: -0.1
   },
+  parallelism: PARALLELISM_DEFAULTS,
   enforcement: ENFORCEMENT_DEFAULTS,
   overrides: [],
 };
+
+function normalizeMaxPhaseWorkers(value) {
+  if (!Number.isInteger(value)) return PARALLELISM_DEFAULTS.max_phase_workers;
+  return Math.min(MAX_PHASE_WORKERS_LIMIT, Math.max(1, value));
+}
+
+function normalizeConfig(config) {
+  const parallelism = (
+    config?.parallelism &&
+    typeof config.parallelism === 'object' &&
+    !Array.isArray(config.parallelism)
+  )
+    ? config.parallelism
+    : {};
+
+  return {
+    ...config,
+    parallelism: {
+      ...PARALLELISM_DEFAULTS,
+      ...parallelism,
+      max_phase_workers: normalizeMaxPhaseWorkers(parallelism.max_phase_workers),
+    },
+  };
+}
 
 /**
  * Load MPL config from .mpl/config.json, falling back to defaults.
@@ -88,11 +119,11 @@ const DEFAULTS = {
  */
 export function loadConfig(cwd) {
   const configPath = join(cwd, '.mpl', 'config.json');
-  if (!existsSync(configPath)) return { ...DEFAULTS };
+  if (!existsSync(configPath)) return normalizeConfig(DEFAULTS);
   try {
     const userConfig = JSON.parse(readFileSync(configPath, 'utf-8'));
-    return deepMergeConfig(DEFAULTS, userConfig);
+    return normalizeConfig(deepMergeConfig(DEFAULTS, userConfig));
   } catch {
-    return { ...DEFAULTS };
+    return normalizeConfig(DEFAULTS);
   }
 }

--- a/hooks/lib/mpl-phase-contract-graph.mjs
+++ b/hooks/lib/mpl-phase-contract-graph.mjs
@@ -19,6 +19,29 @@ function topScalar(text, key) {
   return m ? normalizeScalar(m[1]) : null;
 }
 
+function topLevelBlock(text, key) {
+  const lines = String(text || '').split('\n').map((l) => l.replace(/\r$/, ''));
+  const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const startRe = new RegExp(`^${escaped}\\s*:\\s*(.*)$`);
+  const start = lines.findIndex((line) => startRe.test(line));
+  if (start === -1) return null;
+
+  const first = lines[start].match(startRe)?.[1]?.trim() || '';
+  const out = [first];
+  for (const line of lines.slice(start + 1)) {
+    if (/^\S/.test(line)) break;
+    out.push(line);
+  }
+  return out.join('\n').trim();
+}
+
+function hasTopLevelNonEmptyField(text, key) {
+  const block = topLevelBlock(text, key);
+  if (block === null) return false;
+  if (!block || block === '[]' || block === '{}' || block === 'null') return false;
+  return block.split('\n').some((line) => line.trim() && line.trim() !== '[]' && line.trim() !== '{}');
+}
+
 function phaseBlocks(text) {
   const blocks = [];
   let cur = null;
@@ -39,6 +62,12 @@ function phaseBlocks(text) {
   }
   flush();
   return blocks;
+}
+
+function hasField(block, key) {
+  const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const inline = block.match(new RegExp(`^\\s+${escaped}\\s*:`, 'm'));
+  return Boolean(inline);
 }
 
 function hasNonEmptyField(block, key) {
@@ -62,11 +91,20 @@ function extractRequiresFromPhases(block) {
   return out;
 }
 
+function extractPhaseRefs(text) {
+  const out = [];
+  const refs = String(text || '').matchAll(/\bphase-[\w-]+\b/g);
+  for (const ref of refs) out.push(ref[0]);
+  return out;
+}
+
 export function parsePhaseContractGraphText(text) {
+  const executionTiersBlock = topLevelBlock(text, 'execution_tiers');
   const phases = phaseBlocks(text).map((block) => ({
     id: block.id,
     has_evidence_required: hasNonEmptyField(block.text, 'evidence_required'),
     has_change_policy: hasNonEmptyField(block.text, 'change_policy'),
+    has_resource_locks: hasField(block.text, 'resource_locks'),
     requires_from_phases: extractRequiresFromPhases(block.text),
   }));
 
@@ -75,6 +113,8 @@ export function parsePhaseContractGraphText(text) {
     generated_by: topScalar(text, 'generated_by'),
     recompose_count: topScalar(text, 'recompose_count'),
     completed_phase_policy: topScalar(text, 'completed_phase_policy'),
+    has_execution_tiers: hasTopLevelNonEmptyField(text, 'execution_tiers'),
+    execution_tier_phase_refs: extractPhaseRefs(executionTiersBlock),
     phases,
   };
 }
@@ -89,12 +129,27 @@ export function validatePhaseContractGraph(graph) {
     issues.push('recompose_count:missing');
   }
   if (!graph?.completed_phase_policy) issues.push('completed_phase_policy:missing');
+  if (!graph?.has_execution_tiers) issues.push('execution_tiers:missing');
   if (!Array.isArray(graph?.phases) || graph.phases.length === 0) issues.push('phases:missing');
 
   const knownPhases = new Set((graph?.phases || []).map((p) => p.id));
+  const tierPhaseRefs = graph?.execution_tier_phase_refs || [];
+  const tierPhaseRefCounts = new Map();
+  for (const phaseRef of tierPhaseRefs) {
+    tierPhaseRefCounts.set(phaseRef, (tierPhaseRefCounts.get(phaseRef) || 0) + 1);
+    if (!knownPhases.has(phaseRef)) issues.push(`execution_tiers:unknown:${phaseRef}`);
+  }
+  for (const [phaseRef, count] of tierPhaseRefCounts) {
+    if (count > 1) issues.push(`execution_tiers:duplicate:${phaseRef}`);
+  }
+
   for (const phase of graph?.phases || []) {
     if (!phase.has_evidence_required) issues.push(`${phase.id}:evidence_required:missing`);
     if (!phase.has_change_policy) issues.push(`${phase.id}:change_policy:missing`);
+    if (!phase.has_resource_locks) issues.push(`${phase.id}:resource_locks:missing`);
+    if (graph?.has_execution_tiers && !tierPhaseRefCounts.has(phase.id)) {
+      issues.push(`${phase.id}:execution_tiers:missing`);
+    }
     for (const fromPhase of phase.requires_from_phases || []) {
       if (fromPhase === phase.id) issues.push(`${phase.id}:requires:self:${fromPhase}`);
       else if (!knownPhases.has(fromPhase)) issues.push(`${phase.id}:requires:unknown:${fromPhase}`);

--- a/hooks/mpl-require-phase-contract-graph.mjs
+++ b/hooks/mpl-require-phase-contract-graph.mjs
@@ -81,7 +81,7 @@ async function main() {
     const more = issues.length > 12 ? ` (+${issues.length - 12} more)` : '';
     block(
       `[MPL Phase Contract Graph] decomposition.yaml is not a valid phase contract graph: ${shown}${more}. ` +
-        `Add graph metadata, per-phase evidence_required/change_policy, and valid interface requires.from_phase refs.`
+        `Add graph metadata, execution_tiers, per-phase evidence_required/change_policy/resource_locks, and valid interface requires.from_phase refs.`
     );
     return;
   }

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mpl-mcp-server",
-  "version": "0.18.3",
+  "version": "0.18.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mpl-mcp-server",
-      "version": "0.18.3",
+      "version": "0.18.5",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.81",
         "@modelcontextprotocol/sdk": "^1.0.0"

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mpl-mcp-server",
-  "version": "0.18.3",
+  "version": "0.18.5",
   "description": "MPL MCP Server — deterministic scoring + active state access",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Replace executor phase scheduling from legacy `parallel_with` to top-level `execution_tiers`.
- Add `parallelism.max_phase_workers` default 2 / max 3 with config coverage.
- Require `execution_tiers` phase coverage and per-phase `resource_locks` in phase contract graph validation.
- Add the parallel tier post-join reconciliation artifact contract and align plugin/README/MCP metadata to 0.18.5.

## Tests
- `npm test` (852 tests / 0 failures)
- `npm --prefix mcp-server test` (77 tests / 0 failures)
- `git diff --check`