### PR TITLE
v0.18.6: Add pipeline pipelining contracts

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "mpl",
       "description": "Decomposes tasks into micro-phases with independent plan-execute-verify mini-loops. Orchestrator-Worker separation enforced via hooks.",
-      "version": "0.18.5",
+      "version": "0.18.6",
       "author": {
         "name": "KyubumShin"
       },
@@ -25,5 +25,5 @@
       ]
     }
   ],
-  "version": "0.18.5"
+  "version": "0.18.6"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mpl",
-  "version": "0.18.5",
+  "version": "0.18.6",
   "description": "Micro-Phase Loop - Coherence-first autonomous coding pipeline with decomposition, phase execution, and verification",
   "author": {
     "name": "KyubumShin"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mpl",
-  "version": "0.18.5",
+  "version": "0.18.6",
   "description": "Micro-Phase Loop - coherence-first autonomous coding pipeline for goal-fixed, phase-scoped implementation and verification.",
   "author": {
     "name": "KyubumShin",

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# MPL (Micro-Phase Loop) v0.18.5
+# MPL (Micro-Phase Loop) v0.18.6
 
 **Prevention over cure. Specification over debugging.**
 

--- a/README_ko.md
+++ b/README_ko.md
@@ -1,4 +1,4 @@
-# MPL (Micro-Phase Loop) v0.18.5
+# MPL (Micro-Phase Loop) v0.18.6
 
 **예방이 치료보다 낫다. 명세가 디버깅보다 낫다.**
 

--- a/agents/mpl-phase-runner.md
+++ b/agents/mpl-phase-runner.md
@@ -14,7 +14,7 @@ disallowedTools: []
 
   <Constraints>
     - **Scope discipline**: ONLY work within this phase's scope and impact files. Do not implement features from other phases.
-    - **Concurrent limit**: max 3 TODOs in parallel. Batch if more.
+    - **Concurrent limit**: max 3 TODOs in parallel. Use slot streaming: when one TODO worker finishes, immediately dispatch the next ready TODO.
     - **Max 3 retries** on verification failure. After 3 failures → circuit_break.
     - **No state.json modification** — orchestrator manages pipeline state.
     - **PD Override**: never silently change a prior phase's decision. Create an explicit override request.
@@ -46,19 +46,21 @@ disallowedTools: []
     Use `mini_plan_seed.todo_structure` as the canonical mini-plan:
     - TODOs are pre-determined — do NOT generate new ones
     - `depends_on` graph defines execution order
+    - `files_to_modify` defines TODO-level write conflicts
+    - `resource_locks` defines TODO-level mutexes (`package_manager`, `dev_server`, `db_migration`)
     - `acceptance_link` maps each TODO to success criteria
-    - Build parallel execution tiers from `mini_plan_seed.execution_tiers`
+    - Build a ready queue from `depends_on`, then stream independent TODOs into up to 3 active slots
     - Use `exit_conditions` as formal completion criteria
 
     **If no Seed (legacy):**
     Create 1-7 TODOs scoped to this phase. Check against PP constraints and Phase Decisions.
-    For parallel TODOs, verify no file overlap (force sequential if conflict detected).
+    For parallel TODOs, declare `depends_on`, `files_to_modify`, and `resource_locks`; verify no active file/resource overlap before dispatch.
 
     **Working Memory**: Write initial TODO list to `.mpl/memory/working.md`.
 
     ### Step 3: Direct Implementation (Build-Test-Fix Cycles)
 
-    For each TODO (in dependency order):
+    For each ready TODO (streamed by dependency order and conflict-free active slots):
 
     **3a. Build** — Read target files, implement using Edit/Write. Reference Phase 0 artifacts and seed's `acceptance_link`.
 

--- a/agents/mpl-seed-generator.md
+++ b/agents/mpl-seed-generator.md
@@ -49,6 +49,8 @@ disallowedTools: Write,Edit,Bash,Task,WebFetch,WebSearch,NotebookEdit
     7. **No invention**: If a required piece of information is not in inputs (design-intent, Decomposer edges, PP, phase0 artifacts), mark `ambiguity_notes` rather than guess.
 
     8. **Discovery-mode regeneration**: When invoked with a discovery-patch, ONLY regenerate the phases listed in `affected_phases`. Preserve unchanged phases exactly. Add `regenerated_at`, `regenerated_phases`, `regeneration_trigger` fields.
+
+    9. **TODO scheduling contract (v0.18.6)**: Every `todo_structure[]` item MUST include `depends_on`, `files_to_modify`, and `resource_locks`. Empty arrays are valid. These fields are consumed by the Phase Runner slot scheduler; omission makes the seed invalid.
   </Rules>
 
   <Inputs>
@@ -98,6 +100,7 @@ disallowedTools: Write,Edit,Bash,Task,WebFetch,WebSearch,NotebookEdit
     Step 5: Derive todo_structure per phase
       - Break phase work into 1-7 TODOs (MPL phase size rule)
       - Order topologically within phase (no intra-phase cycles)
+      - Populate each TODO's `depends_on`, `files_to_modify`, and `resource_locks`
       - Include exit_conditions references
 
     Step 6: Resolve ambiguities
@@ -137,6 +140,8 @@ disallowedTools: Write,Edit,Bash,Task,WebFetch,WebSearch,NotebookEdit
           - id: string
             description: string
             depends_on: [string]
+            files_to_modify: [string]   # exact paths this TODO may edit; [] only for read-only verification
+            resource_locks: [string]    # package_manager | dev_server | db_migration; [] when none
         exit_conditions:
           - type: "command" | "test" | "file_exists" | "grep"
             # type-specific fields

--- a/commands/mpl-run-execute-parallel.md
+++ b/commands/mpl-run-execute-parallel.md
@@ -46,52 +46,68 @@ Benefits over mini-plan.md:
 Backward compatibility: mini-plan.md is still written as a human-readable artifact,
 but Task tool is the SSOT for TODO state during execution.
 
-### 4.2.4: Background Execution for Independent TODOs (F-13)
+### 4.2.4: Slot Streaming for Independent TODOs (F-13, v0.18.6)
 
-When Phase Runner identifies independent TODOs (no file overlap), implement them in parallel batches:
+When Phase Runner identifies independent TODOs, implement them with a streaming
+slot scheduler. Do not batch-then-wait. As soon as one active worker completes,
+fill the freed slot with the next ready TODO.
 
 ```
-// File conflict detection (v3.1):
-for each pair of pending TODOs:
-  files_a = todo_a.impact_files
-  files_b = todo_b.impact_files
-  if intersection(files_a, files_b) is EMPTY:
-    -> mark as independent, eligible for parallel dispatch
+// Ready queue eligibility (v0.18.6):
+for each pending TODO:
+  ready = all todo.depends_on ids are completed
+  no_file_conflict = todo.files_to_modify does not overlap any active worker
+  no_resource_conflict = todo.resource_locks does not overlap any active worker
+  if ready && no_file_conflict && no_resource_conflict:
+    -> eligible for streaming dispatch
 
-// Parallel dispatch with HARD LIMIT (F-36):
+// Streaming dispatch with HARD LIMIT (F-36):
 MAX_CONCURRENT_TODOS = 3  // Hard limit for UI stability
 
-independent_todos = todos.filter(independent)
-batches = chunk(independent_todos, MAX_CONCURRENT_WORKERS)  // batches of 3
+active = new Map()
+pending = todos in dependency order
+completed = new Set()
+failed = new Set()
 
-for each batch in batches:
-  // Parallel dispatch workers within the batch
-  for each todo in batch:
+while pending.length > 0 || active.size > 0:
+  while active.size < MAX_CONCURRENT_TODOS:
+    todo = next_ready_todo(pending, completed, active,
+      conflict_keys: ["files_to_modify", "resource_locks"])
+    if no todo:
+      break
     worker_model = (todo.retry_count >= 3 || todo.tags.includes("architecture")) ? "opus" : "sonnet"
-    Task(subagent_type="mpl-phase-runner", model=worker_model,
-         prompt="...", run_in_background=true)
+    handle = Task(subagent_type="mpl-phase-runner", model=worker_model,
+                  prompt="...", run_in_background=true)
+    active.set(handle.id, { todo, handle })
+    pending.remove(todo)
+    TaskUpdate(id=todo.task_id, status="in_progress")
 
-  // Wait for all workers in current batch to complete
-  // Next batch only starts after current batch completes
-  for each background task in batch:
-    result = await task completion
-    TaskUpdate(id=task_id, status=result.status)
+  if active.size == 0:
+    // Deadlock: remaining TODOs depend on failed/missing predecessors.
+    fail remaining pending TODOs with ready_blocked reason
+    break
 
-// Sequential fallback (TODOs with file conflicts):
-for each TODO with file conflicts:
-  worker_model = (todo.retry_count >= 3 || todo.tags.includes("architecture")) ? "opus" : "sonnet"
-  Task(subagent_type="mpl-phase-runner", model=worker_model,
-       prompt="...", run_in_background=false)
+  result = wait_any_completion(active)
+  active.delete(result.handle_id)
+  if result.status == "completed":
+    completed.add(result.todo.id)
+    TaskUpdate(id=result.todo.task_id, status="completed")
+  else:
+    failed.add(result.todo.id)
+    TaskUpdate(id=result.todo.task_id, status="failed")
+    // Dependent TODOs remain pending but not ready; fix cycle consumes failed graph.
 ```
 
 Constraints:
 - **HARD LIMIT: max 3 concurrent background workers** — excess queued for later
   (Claude Code UI stability restriction. Not adjustable via config)
-- Batch execution: 3 complete → next 3 start (concurrent count never exceeds 3)
-- File conflict detection uses v3.1's existing overlap logic
+- Slot streaming: one completion immediately opens a slot for the next ready TODO
+- File conflict detection uses `files_to_modify`; resource conflict detection uses `resource_locks`
 - If any parallel worker fails, remaining workers continue
 - Failed worker results feed into fix cycle (existing behavior)
-- Phase Runner must wait for ALL workers in current batch before starting next batch
+- Phase Runner must join all active TODO workers before phase verification/final summary
+- Seed TODOs MUST include `depends_on`, `files_to_modify`, and `resource_locks`.
+  Missing fields invalidate the seed via `mpl-validate-seed.mjs`.
 
 
 ### 4.3.7: Orchestrator Context Cleanup (Sliding Window)

--- a/commands/mpl-run-execute.md
+++ b/commands/mpl-run-execute.md
@@ -486,7 +486,7 @@ If you are about to skip this step for ANY reason (complexity, time, proximity),
 The skip is the bug. AD-0003 restored mpl-test-agent specifically because this dispatch
 was broken. AD-0004 Option A baseline depends on F-40 running on every mandatory-domain phase.
 
-After Phase Runner completes with status `"complete"`, the Test Agent is dispatched as a **mandatory gate** based on phase_domain rules.
+After Phase Runner completes with status `"complete"`, the Test Agent is dispatched as a **mandatory gate** based on phase_domain rules. In v0.18.6, the dispatch may run in the background only when the dependency frontier proves no next phase can consume unverified behavior.
 
 #### Domain-Based Invocation Rules
 
@@ -521,8 +521,15 @@ if is_conditional:
     Report: "[MPL] Phase {phase_id}: {domain} domain — no source changes, Test Agent skipped."
     -> proceed to 4.2.3
 
+// Dependency-frontier pipelining decision (v0.18.6)
+can_pipeline_verification =
+  config.test_wait?.pipelining_enabled == true
+  AND no not-yet-started phase has interface_contract.requires[].from_phase == phase_id
+  AND next scheduler tier does not read phase_id contract_files
+  AND phase_id is not immediately entering phase3-gate or phase5-finalize
+
 // Dispatch Test Agent (mandatory or conditional-triggered)
-test_result = Task(subagent_type="mpl-test-agent", model="sonnet",
+test_handle_or_result = Task(subagent_type="mpl-test-agent", model="sonnet",
      prompt="""
      ## Phase: {phase_id} - {phase_name}
      ## Phase Domain: {domain}
@@ -537,7 +544,32 @@ test_result = Task(subagent_type="mpl-test-agent", model="sonnet",
 
      Write and run tests for this phase's implementation.
      ALL S-items MUST have corresponding executable tests.
-     """)
+     """,
+     run_in_background=can_pipeline_verification)
+
+if can_pipeline_verification:
+  record_pending_verification(
+    phase_id,
+    kind: "test_agent",
+    handle: test_handle_or_result.handle,
+    join_before: ["dependent_phase", "phase3-gate", "phase5-finalize"]
+  )
+  Report: "[MPL] Phase {phase_id}: Test Agent pipelined behind dependency frontier."
+else:
+  test_result = test_handle_or_result
+```
+
+#### Verification Join Boundary
+
+Before starting any phase that depends on `{phase_id}`, before entering Gate
+execution, and before finalize, join every pending Test Agent result for the
+frontier:
+
+```
+for each pending verification where join_before condition is met:
+  test_result = await pending.handle
+  merge_test_agent_result(test_result)
+  apply Zero-Test Enforcement Gate and Result Merging below
 ```
 
 #### Zero-Test Enforcement Gate
@@ -677,9 +709,12 @@ Skip/conditional rules prevent unnecessary invocations, keeping actual additions
     ```
 
 12. **Adversarial Review (P0-A redesign, #103)** — dispatch the reviewer
-    BEFORE advancing to the next phase:
+    before the dependency frontier can consume this phase. In v0.18.6, this may
+    run in the background under the same `can_pipeline_verification` predicate
+    used for Test Agent; it MUST join before a dependent phase, Gate entry, or
+    finalize:
     ```
-    Task({
+    reviewer_handle_or_result = Task({
       subagent_type: "mpl-adversarial-reviewer",
       prompt: `Audit phase ${phase.id}.
         - phase_definition: ${JSON.stringify(phase_definition)}
@@ -689,8 +724,19 @@ Skip/conditional rules prevent unnecessary invocations, keeping actual additions
         - prior_history: ${JSON.stringify(state.quality_score_history)}
 
         Write the score JSON to .mpl/signals/quality-score.json per
-        agents/mpl-adversarial-reviewer.md spec. Return a one-paragraph summary.`
+        agents/mpl-adversarial-reviewer.md spec. Return a one-paragraph summary.`,
+      run_in_background: can_pipeline_verification
     })
+
+    if can_pipeline_verification:
+      record_pending_verification(
+        phase.id,
+        kind: "adversarial_reviewer",
+        handle: reviewer_handle_or_result.handle,
+        join_before: ["dependent_phase", "phase3-gate", "phase5-finalize"]
+      )
+    else:
+      wait reviewer_handle_or_result now
     ```
 
     `hooks/mpl-quality-gate.mjs` (PostToolUse Task) reads the JSON, mutates

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -2,7 +2,7 @@
 
 All fields for `.mpl/config.json`. Single source of truth for configuration.
 
-> **Version**: v0.18.5 (execution_tiers scheduler contract and phase worker cap)
+> **Version**: v0.18.6 (dependency-frontier verification pipelining and TODO slot streaming)
 > **Last updated**: 2026-05-19
 
 ---
@@ -76,7 +76,7 @@ Runner waits for Test Agent result vs terminates based on cache TTL.
 | `test_wait.cache_mode` | `"default"` \| `"extended"` | `"default"` | Prompt cache TTL mode (default=5min, extended=1h) | `commands/mpl-run-execute.md` |
 | `test_wait.threshold_default_sec` | number | `270` | Runner waits if test_duration < this (default cache, 4.5min safety margin) | `commands/mpl-run-execute.md` |
 | `test_wait.threshold_extended_sec` | number | `3300` | Runner waits if test_duration < this (extended cache, 55min margin) | `commands/mpl-run-execute.md` |
-| `test_wait.pipelining_enabled` | boolean | `false` | Allow Runner to proceed to next phase while Test Agent verifies prev (non_pp opt-in) | `commands/mpl-run-execute.md` |
+| `test_wait.pipelining_enabled` | boolean | `true` | Allow Test Agent and adversarial reviewer verification to run in the background only until a dependency frontier, Gate entry, or finalize join boundary. Set `false` to force immediate joins after every phase. | `commands/mpl-run-execute.md` |
 
 ## Discovery Pipeline (#34, Stage 2)
 
@@ -280,6 +280,9 @@ Per-project override for the global `~/.mpl/cache/sessions.json` TTL. The cache 
   "context_cleanup_window": 3,
   "parallelism": {
     "max_phase_workers": 2
+  },
+  "test_wait": {
+    "pipelining_enabled": true
   },
   "hat": {
     "default_level": "auto",

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,4 +1,4 @@
-# MPL (Micro-Phase Loop) v0.18.5 Design Document
+# MPL (Micro-Phase Loop) v0.18.6 Design Document
 
 ## 1. Overview
 
@@ -476,6 +476,7 @@ The following options are supported in `.mpl/config.json`:
 | `max_fix_loops` | `10` | Maximum Fix Loop iterations |
 | `context_cleanup_window` | `3` | Sliding window size — number of recent phases to retain detailed data (v0.7.0) |
 | `parallelism.max_phase_workers` | `2` | Maximum concurrent phase workers for `execution_tiers[].parallel: true`; runtime clamps to max 3 |
+| `test_wait.pipelining_enabled` | `true` | Allow Test Agent/reviewer background verification until a dependency frontier, Gate, or finalize join boundary |
 | `gate1_strategy` | `"auto"` | Gate 1 test strategy (auto/docker/native/skip) |
 | `hitl_timeout_seconds` | `30` | HITL response wait time |
 | `convergence.stagnation_window` | `3` | Fix attempts to evaluate for stagnation (see `config-schema.md`) |
@@ -486,6 +487,20 @@ The following options are supported in `.mpl/config.json`:
 ---
 
 ## 9. Version History
+
+### v0.18.6 — Pipeline Pipelining (2026-05-19)
+
+v0.18.6 removes the remaining batch wait points after phase-level scheduler
+reachability: TODO workers now stream through bounded slots, and independent
+verification can run behind a dependency frontier with mandatory joins before
+any consumer, Gate, or finalize step.
+
+| Change | Before | After | Type | Rationale |
+|--------|--------|-------|------|-----------|
+| TODO parallelism | Independent TODOs ran in fixed batches; the next batch waited for all active workers | Phase Runner uses slot streaming: a completed worker immediately opens a slot for the next ready TODO, capped at 3 active workers | Prompt contract | Reduces idle worker slots without raising the UI stability limit |
+| Seed TODO scheduling metadata | Seed TODOs only required `depends_on`, leaving file/resource conflicts implicit | `mpl-validate-seed` requires every TODO to declare `depends_on`, `files_to_modify`, and `resource_locks` | Hook + schema | Gives the ready queue machine-checkable dependency, file conflict, and resource mutex inputs |
+| Seed path validation | Seed validation watched legacy `.mpl/seeds/*.yaml` paths but missed actual phase/chain seed paths | The hook now validates `.mpl/mpl/phases/{phase}/phase-seed.yaml` and `.mpl/mpl/chains/{chain}/chain-seed.yaml` | Hook | Makes SEED-03 enforcement cover the paths the executor actually writes |
+| Verification pipelining | Test Agent and adversarial reviewer were blocking joins after every phase | Verification may run in background when `test_wait.pipelining_enabled` and no dependency frontier consumes the phase; joins are required before dependent phases, Gate, or finalize | Prompt contract + config | Preserves quality gates while overlapping independent verification latency |
 
 ### v0.18.5 — Execution Tier Scheduler Contract (2026-05-19)
 

--- a/docs/roadmap/pending-features.md
+++ b/docs/roadmap/pending-features.md
@@ -407,11 +407,13 @@ gstack `/benchmark` — Core Web Vitals baseline + bundle size regression detect
 
 | ID | Feature | Status | Priority | Version Target |
 |----|---------|--------|----------|----------------|
-| PAR-01 | Phase 내 Streaming Dispatch | ❌ Not implemented | 🟠 Medium | v1.1.0+ |
+| PAR-01 | Phase 내 Streaming Dispatch | ✅ Implemented | 🟠 Medium | v0.18.6 |
 
 **현재**: batch-then-wait (3개 TODO 배치 완료 대기 후 다음 배치). `mpl-run-execute-parallel.md:57` MAX_CONCURRENT_TODOS=3 하드코딩.
 
 **합의안**: 슬롯 기반 streaming — 완료된 슬롯에 즉시 다음 ready TODO 투입. `while (remaining > 0) { wait_any_completion(); dispatch_next_ready(); }`. MAX=3 유지 (플랫폼 제약).
+
+**v0.18.6 구현**: Phase Runner prompt가 batch-then-wait 대신 slot streaming을 사용한다. Seed TODO는 `depends_on`, `files_to_modify`, `resource_locks`를 필수로 가져야 하며 hook이 누락을 차단한다.
 
 **전제조건**: PAR-03 (Decomposer depends_on 정확도) 선행 필수
 
@@ -435,11 +437,13 @@ gstack `/benchmark` — Core Web Vitals baseline + bundle size regression detect
 
 | ID | Feature | Status | Priority | Version Target |
 |----|---------|--------|----------|----------------|
-| PAR-03 | depends_on 그래프 정확도 강화 | ❌ Not implemented | 🔴 High | v1.0.0+ |
+| PAR-03 | depends_on 그래프 정확도 강화 | 🟡 In progress | 🔴 High | v0.18.6+ |
 
 **근거**: "더 똑똑한 스케줄러보다 더 좋은 TODO 분해가 먼저다." depends_on이 부정확하면 streaming dispatch의 ready queue도 무의미.
 
 **범위**: Decomposer 프롬프트에서 TODO 간 의존성 선언의 정밀도 개선. 파일 수준 충돌 감지는 유지 (심볼 수준 도입하지 않음).
+
+**v0.18.6 진행**: Seed Generator가 TODO별 `depends_on`, `files_to_modify`, `resource_locks`를 반드시 emit하고, `mpl-validate-seed`가 실제 phase/chain seed 경로에서 이를 검증한다. Decomposer-level graph precision은 후속 측정 대상으로 유지.
 
 ### PAR-04: Phase 실행 메트릭 수집
 
@@ -455,14 +459,16 @@ gstack `/benchmark` — Core Web Vitals baseline + bundle size regression detect
 
 | ID | Feature | Status | Priority | Version Target |
 |----|---------|--------|----------|----------------|
-| PAR-05 | 조건부 Cross-Phase Pipelining | ❌ Not implemented | 🟡 Low | v1.2.0+ |
+| PAR-05 | 조건부 Cross-Phase Pipelining | 🟡 In progress | 🟡 Low | v0.18.6+ |
 
 **활성화 3중 조건** (하나라도 미충족 시 비활성):
 1. Gate 통과율 ≥ 80% (최소 10회 연속 실행 기준)
 2. 선행 Phase의 완료된 TODO에만 의존 (read-only 의존성)
-3. 명시적 opt-in 설정
+3. `test_wait.pipelining_enabled`가 true (v0.18.6 기본값 true, workspace opt-out 가능)
 
 **안전장치**: CORE Phase 순차 유지, impact_files 충돌 시 순차 fallback (킬 스위치), Gate 실패 시 해당 TODO만 cancel.
+
+**v0.18.6 진행**: Test Agent와 adversarial reviewer는 `test_wait.pipelining_enabled`가 켜져 있고 dependency frontier가 비어 있을 때만 background verification으로 보낼 수 있다. dependent phase, Gate, finalize 진입 전에는 반드시 join한다.
 
 **아키텍처**: 하이브리드 2계층 — Phase DAG(스케줄링/롤백 단위) + impact_files 교차 그래프(검증 단위)
 

--- a/docs/schemas/chain-seed.md
+++ b/docs/schemas/chain-seed.md
@@ -26,7 +26,11 @@ phases:
     goal: string                   # 이 phase의 구체 목표
     acceptance_criteria: [string]  # 검증 기준
     todo_structure:                # Phase Runner가 따를 TODO
-      - { id, description, depends_on: [ids] }
+      - id: string
+        description: string
+        depends_on: [ids]          # 선행 TODO ids, [] 허용
+        files_to_modify: [path]    # 이 TODO가 수정할 파일, read-only면 []
+        resource_locks: [string]   # package_manager | dev_server | db_migration, 없으면 []
     exit_conditions: [object]      # 완료 판정 (command/test/file_exists/grep 등)
     contract_snippet:              # 해당 phase의 contract 상세
       edges:
@@ -58,6 +62,9 @@ phases:
 2. **Phase 순서 인식**: 후행 phase가 선행 phase의 결과물(`depends_on_prev`)을 명시적 참조
 3. **Discovery 예비**: probing_hints는 adversarial edge case용 (Test Agent가 소비)
 4. **Runner 자가완결성**: Runner는 chain-seed + handoff만 있으면 Seed 재호출 없이 모든 phase 실행 가능
+5. **Slot scheduler metadata**: 모든 TODO는 `depends_on`, `files_to_modify`,
+   `resource_locks`를 명시한다. Phase Runner는 이 세 필드로 ready queue,
+   file conflict, resource mutex를 판단한다. 필드 누락은 seed validation 실패다.
 
 ## 부분 재생성 (Discovery-Triggered)
 
@@ -82,3 +89,4 @@ regeneration_trigger: "discovery-patch-001"
 - contract_snippet의 edges가 decomposition.yaml에 존재
 - depends_on_prev가 실제 prev phase의 produces와 매칭
 - 필수 필드 존재 (goal, acceptance_criteria, todo_structure, exit_conditions)
+- 모든 todo_structure 항목에 depends_on/files_to_modify/resource_locks 존재

--- a/hooks/__tests__/mpl-config.test.mjs
+++ b/hooks/__tests__/mpl-config.test.mjs
@@ -42,3 +42,18 @@ describe('loadConfig parallelism', () => {
     assert.strictEqual(loadConfig(tmp).parallelism.max_phase_workers, 2);
   });
 });
+
+describe('loadConfig test_wait', () => {
+  it('defaults dependency-frontier verification pipelining on', () => {
+    const cfg = loadConfig(tmp);
+    assert.strictEqual(cfg.test_wait.cache_mode, 'default');
+    assert.strictEqual(cfg.test_wait.threshold_default_sec, 270);
+    assert.strictEqual(cfg.test_wait.threshold_extended_sec, 3300);
+    assert.strictEqual(cfg.test_wait.pipelining_enabled, true);
+  });
+
+  it('allows workspace opt-out of verification pipelining', () => {
+    writeUserConfig({ test_wait: { pipelining_enabled: false } });
+    assert.strictEqual(loadConfig(tmp).test_wait.pipelining_enabled, false);
+  });
+});

--- a/hooks/__tests__/mpl-validate-seed-hook.test.mjs
+++ b/hooks/__tests__/mpl-validate-seed-hook.test.mjs
@@ -5,10 +5,65 @@ import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { tmpdir } from 'os';
+import {
+  validateSeed,
+  validateTodoSchedulingFields,
+} from '../mpl-validate-seed.mjs';
 import { CURRENT_SCHEMA_VERSION } from '../lib/mpl-state.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const HOOK_PATH = join(dirname(__filename), '..', 'mpl-validate-seed.mjs');
+
+function validSeedYaml() {
+  return `phase_seed:
+  goal: "ship"
+  acceptance_criteria:
+    - "AC-1"
+  mini_plan_seed:
+    todo_structure:
+      - id: todo-1
+        description: "Implement feature"
+        depends_on: []
+        files_to_modify:
+          - src/app.ts
+        resource_locks: []
+  exit_conditions:
+    - type: command
+      command: "npm test"
+`;
+}
+
+describe('seed TODO scheduling validation', () => {
+  it('requires depends_on, files_to_modify, and resource_locks on every TODO', () => {
+    const missing = validateTodoSchedulingFields(`phase_seed:
+  goal: "ship"
+  acceptance_criteria:
+    - "AC-1"
+  mini_plan_seed:
+    todo_structure:
+      - id: todo-1
+        description: "Implement feature"
+        depends_on: []
+      - id: todo-2
+        description: "Add tests"
+        files_to_modify: []
+        resource_locks: []
+  exit_conditions:
+    - type: command
+      command: "npm test"
+`);
+    assert.deepEqual(missing, [
+      'phase_seed.mini_plan_seed.todo_structure[todo-1].files_to_modify',
+      'phase_seed.mini_plan_seed.todo_structure[todo-1].resource_locks',
+      'phase_seed.mini_plan_seed.todo_structure[todo-2].depends_on',
+    ]);
+  });
+
+  it('accepts empty dependency and resource arrays when the fields are explicit', () => {
+    assert.deepEqual(validateTodoSchedulingFields(validSeedYaml()), []);
+    assert.equal(validateSeed(validSeedYaml()).valid, true);
+  });
+});
 
 describe('mpl-validate-seed hook integration', () => {
   it('validates MultiEdit writes to seed YAML files', () => {
@@ -38,6 +93,39 @@ describe('mpl-validate-seed hook integration', () => {
       assert.equal(r.continue, true);
       assert.match(r.hookSpecificOutput?.additionalContext || '', /SEED VALIDATION FAILED/);
       assert.match(r.hookSpecificOutput?.additionalContext || '', /acceptance_criteria/);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('validates actual phase-seed and chain-seed write paths', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'mpl-seed-hook-'));
+    try {
+      mkdirSync(join(tmp, '.mpl'), { recursive: true });
+      writeFileSync(join(tmp, '.mpl', 'state.json'), JSON.stringify({
+        schema_version: CURRENT_SCHEMA_VERSION,
+        current_phase: 'phase2-sprint',
+      }));
+
+      for (const file_path of [
+        '.mpl/mpl/phases/phase-1/phase-seed.yaml',
+        '.mpl/mpl/chains/chain-1/chain-seed.yaml',
+      ]) {
+        const input = {
+          cwd: tmp,
+          tool_name: 'Write',
+          tool_input: {
+            file_path,
+            content: validSeedYaml().replace('        resource_locks: []\n', ''),
+          },
+        };
+        const r = JSON.parse(execFileSync('node', [HOOK_PATH], {
+          input: JSON.stringify(input),
+          encoding: 'utf-8',
+        }));
+        assert.equal(r.continue, true);
+        assert.match(r.hookSpecificOutput?.additionalContext || '', /resource_locks/);
+      }
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }

--- a/hooks/lib/mpl-config.mjs
+++ b/hooks/lib/mpl-config.mjs
@@ -65,6 +65,13 @@ const PARALLELISM_DEFAULTS = {
 
 const MAX_PHASE_WORKERS_LIMIT = 3;
 
+const TEST_WAIT_DEFAULTS = {
+  cache_mode: 'default',
+  threshold_default_sec: 270,
+  threshold_extended_sec: 3300,
+  pipelining_enabled: true,
+};
+
 const DEFAULTS = {
   max_fix_loops: 10,
   gate1_strategy: 'auto',  // 'docker', 'native', 'skip'
@@ -84,6 +91,7 @@ const DEFAULTS = {
     regression_threshold: -0.1
   },
   parallelism: PARALLELISM_DEFAULTS,
+  test_wait: TEST_WAIT_DEFAULTS,
   enforcement: ENFORCEMENT_DEFAULTS,
   overrides: [],
 };

--- a/hooks/mpl-validate-seed.mjs
+++ b/hooks/mpl-validate-seed.mjs
@@ -20,6 +20,7 @@ import { fileURLToPath, pathToFileURL } from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
+const isMain = import.meta.url === pathToFileURL(process.argv[1] || '').href;
 
 // Import shared MPL state utility
 const { isMplActive } = await import(
@@ -165,6 +166,82 @@ export function validateMappingValues(yaml, parentKey) {
   return { valid: invalidKeys.length === 0, invalidKeys };
 }
 
+function countIndent(line) {
+  return (line.match(/^[ \t]*/) || [''])[0].length;
+}
+
+function extractTodoStructureBlocks(yaml) {
+  const blocks = [];
+  const lines = String(yaml || '').split('\n').map((line) => line.replace(/\r$/, ''));
+
+  for (let i = 0; i < lines.length; i++) {
+    const match = lines[i].match(/^([ \t]*)todo_structure\s*:\s*(.*)$/);
+    if (!match) continue;
+
+    const baseIndent = match[1].length;
+    const inline = match[2].trim();
+    const blockLines = [];
+    if (inline) blockLines.push(inline);
+
+    for (let j = i + 1; j < lines.length; j++) {
+      const line = lines[j];
+      if (line.trim() && countIndent(line) <= baseIndent) break;
+      blockLines.push(line);
+    }
+
+    blocks.push(blockLines.join('\n'));
+  }
+
+  return blocks;
+}
+
+function splitTodoItems(block) {
+  const items = [];
+  let current = null;
+
+  for (const line of String(block || '').split('\n')) {
+    if (/^[ \t]*-\s+(?:id\s*:|\{)/.test(line)) {
+      if (current) items.push(current.join('\n'));
+      current = [line];
+      continue;
+    }
+    if (current) current.push(line);
+  }
+  if (current) items.push(current.join('\n'));
+
+  return items;
+}
+
+function hasTodoField(item, key) {
+  const escaped = escapeRegex(key);
+  return new RegExp(`(^|[\\s,{])${escaped}\\s*:`, 'm').test(String(item || ''));
+}
+
+function extractTodoId(item, index) {
+  const match = String(item || '').match(/(^|[\s,{])id\s*:\s*["']?([^"',}\]\s]+)/m);
+  return match ? match[2] : `#${index + 1}`;
+}
+
+export function validateTodoSchedulingFields(yamlText) {
+  const missing = [];
+  const blocks = extractTodoStructureBlocks(yamlText);
+
+  for (const block of blocks) {
+    const items = splitTodoItems(block);
+    for (let index = 0; index < items.length; index++) {
+      const item = items[index];
+      const todoId = extractTodoId(item, index);
+      for (const field of ['depends_on', 'files_to_modify', 'resource_locks']) {
+        if (!hasTodoField(item, field)) {
+          missing.push(`phase_seed.mini_plan_seed.todo_structure[${todoId}].${field}`);
+        }
+      }
+    }
+  }
+
+  return missing;
+}
+
 function escapeRegex(str) {
   return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
@@ -200,6 +277,8 @@ export function validateSeed(yamlText, options = {}) {
   if (!hasNonEmptyArray(yamlText, 'todo_structure')) {
     missing.push('phase_seed.mini_plan_seed.todo_structure');
   }
+
+  missing.push(...validateTodoSchedulingFields(yamlText));
 
   // 4. phase_seed.exit_conditions — non-empty array
   if (!hasNonEmptyArray(yamlText, 'exit_conditions')) {
@@ -262,8 +341,13 @@ export function hasContractFilesContext(promptText) {
 // Seed file path detection
 // ---------------------------------------------------------------------------
 
-/** Seed file path pattern: .mpl/seeds/*.yaml or .mpl/seeds/*.yml */
-const SEED_PATH_RE = /\.mpl\/seeds\/[^/]+\.ya?ml$/;
+/**
+ * Seed file path patterns:
+ * - Legacy: .mpl/seeds/*.yaml
+ * - Inline phase seed: .mpl/mpl/phases/{phase_id}/phase-seed.yaml
+ * - Chain seed: .mpl/mpl/chains/{chain_id}/chain-seed.yaml
+ */
+const SEED_PATH_RE = /(?:^|\/)\.mpl\/(?:seeds\/[^/]+|mpl\/phases\/[^/]+\/phase-seed|mpl\/chains\/[^/]+\/chain-seed)\.ya?ml$/;
 
 /**
  * Check whether a tool invocation is related to seed generation/writing.
@@ -410,7 +494,9 @@ Do NOT proceed to Phase Runner until all required Seed fields are present and va
   }));
 }
 
-main().catch(() => {
-  // On error: allow (fail-open for safety)
-  console.log(JSON.stringify({ continue: true, suppressOutput: true }));
-});
+if (isMain) {
+  main().catch(() => {
+    // On error: allow (fail-open for safety)
+    console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+  });
+}

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mpl-mcp-server",
-  "version": "0.18.5",
+  "version": "0.18.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mpl-mcp-server",
-      "version": "0.18.5",
+      "version": "0.18.6",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.81",
         "@modelcontextprotocol/sdk": "^1.0.0"

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mpl-mcp-server",
-  "version": "0.18.5",
+  "version": "0.18.6",
   "description": "MPL MCP Server — deterministic scoring + active state access",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Replace intra-phase TODO batch-then-wait with slot streaming capped at 3 active workers.
- Require Seed TODO scheduling metadata: `depends_on`, `files_to_modify`, and `resource_locks`.
- Extend `mpl-validate-seed` to validate actual phase/chain seed paths and the new TODO scheduling fields.
- Add dependency-frontier Test Agent/adversarial reviewer pipelining with mandatory joins before dependent phases, Gate, or finalize.
- Align plugin/README/MCP metadata to 0.18.6.

## Tests
- `npm test` (857 tests / 0 failures)
- `npm --prefix mcp-server test` (77 tests / 0 failures)
- `git diff --check`