### PR TITLE
Guard keyword detector from task notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ mcp-server/dist/
 node_modules/
 .omc/
 .resume/
+.pr-review-state/

--- a/docs/design.md
+++ b/docs/design.md
@@ -463,7 +463,7 @@ MPL maintains pipeline integrity with 8 hooks:
 | `mpl-permit-learner` | PostToolUse | Learn permission allow patterns (F-34) |
 | `mpl-phase-controller` | Stop | Manages phase transitions based on state |
 | `mpl-session-init` | SessionStart | Initialize Context Rotation at session start (F-38) |
-| `mpl-keyword-detector` | UserPromptSubmit | Detects "mpl" keyword in user input and initializes pipeline state |
+| `mpl-keyword-detector` | UserPromptSubmit | Detects "mpl" keyword in user input and initializes pipeline state; ignores `<task-notification>` completion XML |
 
 ---
 

--- a/hooks/__tests__/mpl-keyword-detector.test.mjs
+++ b/hooks/__tests__/mpl-keyword-detector.test.mjs
@@ -1,7 +1,12 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { extractPrompt, sanitize, extractFeatureName } from '../mpl-keyword-detector.mjs';
+import {
+  extractPrompt,
+  isTaskNotificationPrompt,
+  sanitize,
+  extractFeatureName,
+} from '../mpl-keyword-detector.mjs';
 
 describe('extractFeatureName', () => {
   it('should extract English feature name', () => {
@@ -106,5 +111,24 @@ describe('extractPrompt', () => {
 
   it('should return empty string for empty object', () => {
     assert.strictEqual(extractPrompt('{}'), '');
+  });
+});
+
+describe('isTaskNotificationPrompt', () => {
+  it('detects Claude Code task-notification XML', () => {
+    const prompt = `
+<task-notification>
+<status>completed</status>
+<summary>mpl-phase-runner completed</summary>
+</task-notification>`;
+    assert.equal(isTaskNotificationPrompt(prompt), true);
+  });
+
+  it('does not treat ordinary MPL prompts as task notifications', () => {
+    assert.equal(isTaskNotificationPrompt('mpl fix task notification handling'), false);
+  });
+
+  it('does not match mentions of the XML tag outside the leading position', () => {
+    assert.equal(isTaskNotificationPrompt('please inspect <task-notification> output in mpl'), false);
   });
 });

--- a/hooks/__tests__/mpl-user-intervention.test.mjs
+++ b/hooks/__tests__/mpl-user-intervention.test.mjs
@@ -33,6 +33,8 @@ function runHook(promptText) {
   runHookPayload({ prompt: promptText });
 }
 
+// Keep payload-level entry available for notification-shaped regression tests
+// that need to exercise hook input fields beyond plain prompt text.
 function runHookPayload(payload) {
   const stdin = JSON.stringify({
     cwd: tmp,

--- a/hooks/__tests__/mpl-user-intervention.test.mjs
+++ b/hooks/__tests__/mpl-user-intervention.test.mjs
@@ -1,7 +1,7 @@
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync } from 'fs';
+import { existsSync, mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { tmpdir } from 'os';
@@ -30,10 +30,14 @@ function seedState(state) {
 }
 
 function runHook(promptText) {
+  runHookPayload({ prompt: promptText });
+}
+
+function runHookPayload(payload) {
   const stdin = JSON.stringify({
     cwd: tmp,
     hook_event_name: 'UserPromptSubmit',
-    prompt: promptText,
+    ...payload,
   });
   execFileSync('node', [HOOK_PATH], { input: stdin, encoding: 'utf-8' });
 }
@@ -111,5 +115,42 @@ describe('G6 (#114) user_intervention_count', () => {
     runHook('/mpl:mpl-resume');
     runHook('/mpl:mpl-cancel reason');
     assert.equal(readPersistedState().user_intervention_count, 3);
+  });
+});
+
+describe('#43 task-notification guard', () => {
+  const notificationPrompt = `<task-notification>
+<task-id>agent-123</task-id>
+<status>completed</status>
+<summary>mpl-phase-runner completed</summary>
+<result>MPL implementation finished.</result>
+</task-notification>`;
+
+  it('does NOT initialize a fresh pipeline from a Task completion notification', () => {
+    runHook(notificationPrompt);
+    assert.equal(existsSync(join(tmp, '.mpl', 'state.json')), false);
+  });
+
+  it('does NOT reset a completed pipeline snapshot', () => {
+    seedState({
+      pipeline_id: 'mpl-20260415-yggdrasil-novel-writing-app',
+      feature_name: 'yggdrasil-novel-writing-app',
+      current_phase: 'completed',
+      session_status: 'completed',
+      user_intervention_count: 4,
+    });
+    const before = readPersistedState();
+
+    runHook(notificationPrompt);
+
+    assert.deepEqual(readPersistedState(), before);
+  });
+
+  it('does NOT count Task completion notifications as user interventions', () => {
+    seedState({});
+
+    runHook(notificationPrompt);
+
+    assert.equal(readPersistedState().user_intervention_count, 0);
   });
 });

--- a/hooks/mpl-keyword-detector.mjs
+++ b/hooks/mpl-keyword-detector.mjs
@@ -77,6 +77,15 @@ function extractPrompt(input) {
 }
 
 /**
+ * Claude Code delivers background Task/Agent completions as user-role
+ * `<task-notification>` XML. They can contain "mpl" in agent names/results,
+ * but they are not human prompts and must never initialize/reset MPL state.
+ */
+function isTaskNotificationPrompt(prompt) {
+  return /^<task-notification(?:\s|>)/i.test(String(prompt || '').trimStart());
+}
+
+/**
  * Sanitize text for keyword detection (strip code blocks, URLs, paths)
  */
 function sanitize(text) {
@@ -120,6 +129,14 @@ async function main() {
 
     const prompt = extractPrompt(input);
     if (!prompt) {
+      console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+      return;
+    }
+
+    // #43: Background Task/Agent completion notifications are routed through
+    // UserPromptSubmit as user-role XML. Skip before telemetry and keyword
+    // activation so harness/coordinator notifications cannot reset state.
+    if (isTaskNotificationPrompt(prompt)) {
       console.log(JSON.stringify({ continue: true, suppressOutput: true }));
       return;
     }
@@ -272,4 +289,4 @@ IMPORTANT: Load the MPL orchestration protocol via /mpl:mpl-run command, then be
 
 main();
 
-export { extractPrompt, sanitize, extractFeatureName };
+export { extractPrompt, isTaskNotificationPrompt, sanitize, extractFeatureName };


### PR DESCRIPTION
## Summary

- ignore Claude Code `<task-notification>` XML before MPL keyword activation
- prevent Task/Agent completion notifications from resetting completed `.mpl/state.json`
- exclude task notifications from `user_intervention_count` telemetry

## Tests

- `node --test hooks/__tests__/mpl-keyword-detector.test.mjs hooks/__tests__/mpl-user-intervention.test.mjs`
- `npm test`

## Agent Review Status

- [ ] claude
- [ ] codex

Closes #43
