### PR TITLE
fix: bound test-agent evidence previews

### DIFF
--- a/docs/schemas/state.md
+++ b/docs/schemas/state.md
@@ -61,9 +61,15 @@ a dispatch timestamp. PASS evidence requires:
 - `tests_total > 0`
 - `tests_failed == 0`
 - `tests_skipped == 0`
-- at least one `test_files_created[]`
-- at least one `command_exit_codes[]`, all `0`
+- `test_files_created_count > 0` (or legacy `test_files_created[]` length > 0)
+- `command_exit_codes_count > 0` and `command_exit_codes_nonzero_count == 0`
+  (or legacy `command_exit_codes[]` length > 0, all `0`)
 - `bugs_found_count == 0`
+
+`test_files_created[]` and `command_exit_codes[]` are bounded previews to keep
+`.mpl/state.json` small. The scalar count fields are the lossless gate inputs:
+large responses retain total counts and nonzero command-exit counts even when
+the preview is truncated.
 
 Legacy timestamp-only records are treated as non-PASS and cannot satisfy Hard 2
 or a phase `evidence_required: [test_agent]` latch. Records missing an explicit

--- a/hooks/__tests__/mpl-gate-recorder.test.mjs
+++ b/hooks/__tests__/mpl-gate-recorder.test.mjs
@@ -9,6 +9,7 @@ import { CURRENT_SCHEMA_VERSION } from '../lib/mpl-state.mjs';
 import {
   isPassingTestAgentEvidence,
   parseTestAgentEvidence,
+  TEST_AGENT_EVIDENCE_PREVIEW_LIMIT,
 } from '../lib/mpl-test-agent-evidence.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -47,7 +48,7 @@ function runHook(dir, toolResponse, prompt = 'Verify phase-1 from the contract.'
 function responsePayload(overrides = {}) {
   const payload = {
     phase_id: 'phase-1',
-    test_files_created: ['tests/phase-1.test.ts'],
+    test_files_created: overrides.test_files_created || ['tests/phase-1.test.ts'],
     test_results: {
       total: 2,
       passed: 2,
@@ -55,7 +56,7 @@ function responsePayload(overrides = {}) {
       skipped: overrides.skipped ?? 0,
       pass_rate: 100,
     },
-    commands_run: [{
+    commands_run: overrides.commands_run || [{
       command: 'npm test -- tests/phase-1.test.ts',
       exit_code: overrides.exit_code ?? 0,
     }],
@@ -88,6 +89,58 @@ describe('mpl-gate-recorder test-agent evidence', () => {
       assert.deepEqual(ev.command_exit_codes, [0]);
       assert.equal(ev.tests_total, 2);
       assert.equal(ev.bugs_found_count, 0);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('bounds oversized test-agent arrays while preserving PASS semantics', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'mpl-gate-recorder-bounded-'));
+    try {
+      seedState(tmp);
+      const testFiles = Array.from(
+        { length: TEST_AGENT_EVIDENCE_PREVIEW_LIMIT + 5 },
+        (_, i) => `tests/generated-${i}.test.ts`
+      );
+      const commandsRun = Array.from(
+        { length: TEST_AGENT_EVIDENCE_PREVIEW_LIMIT + 7 },
+        (_, i) => ({ command: `npm test -- shard=${i}`, exit_code: 0 })
+      );
+
+      runHook(tmp, responseJson({ test_files_created: testFiles, commands_run: commandsRun }));
+      const ev = readState(tmp).test_agent_dispatched['phase-1'];
+
+      assert.equal(ev.test_files_created.length, TEST_AGENT_EVIDENCE_PREVIEW_LIMIT);
+      assert.equal(ev.test_files_created_count, testFiles.length);
+      assert.equal(ev.test_files_created_truncated, true);
+      assert.equal(ev.command_exit_codes.length, TEST_AGENT_EVIDENCE_PREVIEW_LIMIT);
+      assert.equal(ev.command_exit_codes_count, commandsRun.length);
+      assert.equal(ev.command_exit_codes_nonzero_count, 0);
+      assert.equal(ev.command_exit_codes_truncated, true);
+      assert.equal(isPassingTestAgentEvidence(ev), true);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('does not hide nonzero command exits outside the stored preview', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'mpl-gate-recorder-bounded-fail-'));
+    try {
+      seedState(tmp);
+      const commandsRun = Array.from(
+        { length: TEST_AGENT_EVIDENCE_PREVIEW_LIMIT + 1 },
+        (_, i) => ({ command: `npm test -- shard=${i}`, exit_code: i < TEST_AGENT_EVIDENCE_PREVIEW_LIMIT ? 0 : 1 })
+      );
+
+      runHook(tmp, responseJson({ commands_run: commandsRun }));
+      const ev = readState(tmp).test_agent_dispatched['phase-1'];
+
+      assert.deepEqual(ev.command_exit_codes, Array(TEST_AGENT_EVIDENCE_PREVIEW_LIMIT).fill(0));
+      assert.equal(ev.command_exit_codes_count, commandsRun.length);
+      assert.equal(ev.command_exit_codes_nonzero_count, 1);
+      assert.equal(ev.verdict, 'FAIL');
+      assert.match(ev.invalid_reason, /nonzero_command_exit_code/);
+      assert.equal(isPassingTestAgentEvidence(ev), false);
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }

--- a/hooks/lib/mpl-test-agent-evidence.mjs
+++ b/hooks/lib/mpl-test-agent-evidence.mjs
@@ -11,6 +11,8 @@ function normalizeStatus(value) {
   return String(value || '').trim().toUpperCase();
 }
 
+export const TEST_AGENT_EVIDENCE_PREVIEW_LIMIT = 20;
+
 function firstJsonCandidate(text) {
   if (typeof text !== 'string') return null;
   const fenced = text.match(/```json\s*([\s\S]*?)```/i);
@@ -50,6 +52,15 @@ function commandExitCodes(body) {
     .filter((n) => n !== null);
 }
 
+function boundedPreview(values, limit = TEST_AGENT_EVIDENCE_PREVIEW_LIMIT) {
+  const items = Array.isArray(values) ? values : [];
+  return {
+    preview: items.slice(0, limit),
+    count: items.length,
+    truncated: items.length > limit,
+  };
+}
+
 function coverageStatuses(rows) {
   if (!Array.isArray(rows)) return [];
   return rows.map((r) => normalizeStatus(r?.status)).filter(Boolean);
@@ -76,7 +87,12 @@ export function parseTestAgentEvidence({
     tests_skipped: null,
     pass_rate: null,
     test_files_created: [],
+    test_files_created_count: 0,
+    test_files_created_truncated: false,
     command_exit_codes: [],
+    command_exit_codes_count: 0,
+    command_exit_codes_nonzero_count: 0,
+    command_exit_codes_truncated: false,
     bugs_found_count: null,
     invalid_reason: parsed.reason || null,
   };
@@ -90,6 +106,9 @@ export function parseTestAgentEvidence({
   const bugs = Array.isArray(body.bugs_found) ? body.bugs_found : [];
   const aStatuses = coverageStatuses(body.a_item_coverage);
   const sStatuses = coverageStatuses(body.s_item_coverage);
+  const testFilePreview = boundedPreview(testFiles);
+  const commandExitPreview = boundedPreview(commands);
+  const commandNonzeroCount = commands.filter((code) => code !== 0).length;
 
   const evidence = {
     ...base,
@@ -99,8 +118,13 @@ export function parseTestAgentEvidence({
     tests_failed: numeric(results.failed, 0),
     tests_skipped: numeric(results.skipped, 0),
     pass_rate: numeric(results.pass_rate, null),
-    test_files_created: testFiles,
-    command_exit_codes: commands,
+    test_files_created: testFilePreview.preview,
+    test_files_created_count: testFilePreview.count,
+    test_files_created_truncated: testFilePreview.truncated,
+    command_exit_codes: commandExitPreview.preview,
+    command_exit_codes_count: commandExitPreview.count,
+    command_exit_codes_nonzero_count: commandNonzeroCount,
+    command_exit_codes_truncated: commandExitPreview.truncated,
     bugs_found_count: bugs.length,
     invalid_reason: null,
   };
@@ -133,6 +157,23 @@ export function parseTestAgentEvidence({
   return evidence;
 }
 
+function evidenceCount(evidence, countKey, arrayKey) {
+  const counted = numeric(evidence?.[countKey], null);
+  if (counted !== null) return counted;
+  return Array.isArray(evidence?.[arrayKey]) ? evidence[arrayKey].length : 0;
+}
+
+function commandExitCodesPass(evidence) {
+  const counted = numeric(evidence?.command_exit_codes_count, null);
+  const nonzeroCount = numeric(evidence?.command_exit_codes_nonzero_count, null);
+  if (counted !== null || nonzeroCount !== null) {
+    return counted > 0 && nonzeroCount === 0;
+  }
+  return Array.isArray(evidence?.command_exit_codes) &&
+    evidence.command_exit_codes.length > 0 &&
+    evidence.command_exit_codes.every((code) => code === 0);
+}
+
 export function isPassingTestAgentEvidence(evidence) {
   return Boolean(
     evidence &&
@@ -145,11 +186,8 @@ export function isPassingTestAgentEvidence(evidence) {
     evidence.tests_failed === 0 &&
     typeof evidence.tests_skipped === 'number' &&
     evidence.tests_skipped === 0 &&
-    Array.isArray(evidence.test_files_created) &&
-    evidence.test_files_created.length > 0 &&
-    Array.isArray(evidence.command_exit_codes) &&
-    evidence.command_exit_codes.length > 0 &&
-    evidence.command_exit_codes.every((code) => code === 0) &&
+    evidenceCount(evidence, 'test_files_created_count', 'test_files_created') > 0 &&
+    commandExitCodesPass(evidence) &&
     evidence.bugs_found_count === 0
   );
 }

--- a/hooks/lib/mpl-test-agent-evidence.mjs
+++ b/hooks/lib/mpl-test-agent-evidence.mjs
@@ -11,6 +11,8 @@ function normalizeStatus(value) {
   return String(value || '').trim().toUpperCase();
 }
 
+// Keep enough context for debugging while preventing large sharded verifier
+// responses from bloating .mpl/state.json.
 export const TEST_AGENT_EVIDENCE_PREVIEW_LIMIT = 20;
 
 function firstJsonCandidate(text) {


### PR DESCRIPTION
## What
- Bound stored `mpl-test-agent` evidence arrays to small previews before writing `state.test_agent_dispatched`.
- Preserve lossless gate inputs with scalar counts: test file total, command exit total, and nonzero command-exit count.
- Keep legacy PASS evidence compatibility while making new evidence robust against hidden nonzero exits beyond the preview.
- Document the bounded-preview evidence shape.

## Why
Closes #154. A malformed or overly verbose `mpl-test-agent` response could otherwise bloat `.mpl/state.json`; gates still need full PASS/FAIL semantics without storing unbounded arrays.

## Design
- `hooks/lib/mpl-test-agent-evidence.mjs`
- `docs/schemas/state.md`

## Tests
- `node --test hooks/__tests__/mpl-gate-recorder.test.mjs`
- `node --test hooks/__tests__/mpl-require-test-agent.test.mjs`
- `node --test hooks/__tests__/mpl-phase-evidence.test.mjs`
- `npm test`

## Agent Review Status

This PR is gated on **2 unique agent reviews** using footer markers.

- [ ] from claude
- [ ] from codex

---
_Awaiting reviews. Merge once the gate is satisfied._
