### PR TITLE
fix: require scalar test-agent evidence counts

### DIFF
--- a/docs/schemas/migration-policy.md
+++ b/docs/schemas/migration-policy.md
@@ -33,6 +33,7 @@ of change to the state shape:
 | Rename an existing field | **Breaking** | Bump + migration must read the old name and write the new one. Drop the old name only after one stable release. | `current_phase` rename across exp16. |
 | Change the meaning of an existing field (units, enum) | **Breaking** | Bump + migration translates each prior value to the new domain. Hand-write the mapping — no implicit identity. | `session_status` enum widening (#109 G4 added `verification_hang`). |
 | Remove a field | **Breaking** | Bump + migration drops the key cleanly. Document the removal in this file. | (none yet). |
+| Retire a compatibility reader path without changing stored fields | **Consumer breaking** | Document the removal version and recovery path. Do not backfill if the old representation cannot prove the new lossless semantics. | v0.18.7 (#157): `test_agent_dispatched.*.test_files_created[]` and `command_exit_codes[]` no longer satisfy PASS without scalar counts. |
 
 ### What this means in practice
 
@@ -45,6 +46,19 @@ of change to the state shape:
   removal without a translation. Without a registered migration, a writer
   bumping `CURRENT_SCHEMA_VERSION` will trip its own G3 I8 on the next
   read.
+
+### Consumer-only compatibility retirements
+
+Some changes leave stored fields in place but change which fields a hook trusts.
+These are consumer-breaking, even when `CURRENT_SCHEMA_VERSION` does not change.
+Document the removal version and recovery path in the schema doc that owns the
+field.
+
+For v0.18.7 (#157), array-only `test_agent_dispatched[phase_id]` records are not
+migrated into scalar counts. Pre-count records must be refreshed by re-running
+`mpl-test-agent` for the phase. The arrays are retained only as bounded previews,
+and there is no durable marker that proves an array is a complete historical
+record rather than a truncated preview.
 
 ## Migration registry
 

--- a/docs/schemas/state.md
+++ b/docs/schemas/state.md
@@ -61,19 +61,24 @@ a dispatch timestamp. PASS evidence requires:
 - `tests_total > 0`
 - `tests_failed == 0`
 - `tests_skipped == 0`
-- `test_files_created_count > 0` (or legacy `test_files_created[]` length > 0)
+- `test_files_created_count > 0`
 - `command_exit_codes_count > 0` and `command_exit_codes_nonzero_count == 0`
-  (or legacy `command_exit_codes[]` length > 0, all `0`)
 - `bugs_found_count == 0`
 
 `test_files_created[]` and `command_exit_codes[]` are bounded previews to keep
 `.mpl/state.json` small. The scalar count fields are the lossless gate inputs:
 large responses retain total counts and nonzero command-exit counts even when
-the preview is truncated.
+the preview is truncated. Preview arrays are not gate inputs and do not satisfy
+PASS evidence on their own.
 
 Legacy timestamp-only records are treated as non-PASS and cannot satisfy Hard 2
 or a phase `evidence_required: [test_agent]` latch. Records missing an explicit
 `verdict` are `INVALID`; a PASS-shaped partial state object is not enough.
+
+Legacy pre-count records that contain only `test_files_created[]` and
+`command_exit_codes[]` are also non-PASS as of v0.18.7 (#157). Re-dispatch
+`mpl-test-agent` for that phase to record scalar count fields; MPL does not
+infer lossless counts from arrays because post-v0.18.6 arrays are previews.
 
 ## Trigger registration
 

--- a/hooks/__tests__/mpl-gate-recorder.test.mjs
+++ b/hooks/__tests__/mpl-gate-recorder.test.mjs
@@ -235,4 +235,18 @@ describe('mpl-gate-recorder test-agent evidence', () => {
       command_exit_codes: [0],
     }), false);
   });
+
+  it('rejects legacy array-only PASS evidence without scalar counts', () => {
+    assert.equal(isPassingTestAgentEvidence({
+      valid_json: true,
+      verdict: 'PASS',
+      invalid_reason: null,
+      tests_total: 1,
+      tests_failed: 0,
+      tests_skipped: 0,
+      test_files_created: ['tests/phase-1.test.ts'],
+      command_exit_codes: [0],
+      bugs_found_count: 0,
+    }), false);
+  });
 });

--- a/hooks/__tests__/mpl-phase-evidence.test.mjs
+++ b/hooks/__tests__/mpl-phase-evidence.test.mjs
@@ -51,7 +51,10 @@ function passingEvidence() {
     tests_failed: 0,
     tests_skipped: 0,
     test_files_created: ['tests/phase-1.test.ts'],
+    test_files_created_count: 1,
     bugs_found_count: 0,
+    command_exit_codes_count: 1,
+    command_exit_codes_nonzero_count: 0,
   };
 }
 

--- a/hooks/__tests__/mpl-require-test-agent.test.mjs
+++ b/hooks/__tests__/mpl-require-test-agent.test.mjs
@@ -21,7 +21,10 @@ function passingEvidence() {
     tests_failed: 0,
     tests_skipped: 0,
     test_files_created: ['tests/phase-1.test.ts'],
+    test_files_created_count: 1,
     bugs_found_count: 0,
+    command_exit_codes_count: 1,
+    command_exit_codes_nonzero_count: 0,
   };
 }
 
@@ -159,6 +162,53 @@ phases:
             valid_json: true,
             verdict: 'PASS',
             command_exit_codes: [0],
+          },
+        },
+      }));
+      writeFileSync(join(tmp, '.mpl', 'mpl', 'decomposition.yaml'), `
+phases:
+  - id: phase-1
+    test_agent_required: true
+`);
+
+      const input = {
+        cwd: tmp,
+        tool_name: 'Task',
+        tool_input: {
+          subagent_type: 'mpl-phase-runner',
+          prompt: 'Run phase-1 and report completion.',
+        },
+      };
+      const r = JSON.parse(execFileSync('node', [HOOK_PATH], {
+        input: JSON.stringify(input),
+        encoding: 'utf-8',
+      }));
+      assert.equal(r.continue, false);
+      assert.equal(r.decision, 'block');
+      assert.match(r.reason, /recorded mpl-test-agent evidence is verdict=PASS/);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('blocks legacy array-only PASS evidence without scalar counts', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'mpl-test-agent-array-only-'));
+    try {
+      mkdirSync(join(tmp, '.mpl', 'mpl'), { recursive: true });
+      writeFileSync(join(tmp, '.mpl', 'state.json'), JSON.stringify({
+        schema_version: CURRENT_SCHEMA_VERSION,
+        current_phase: 'phase2-sprint',
+        test_agent_dispatched: {
+          'phase-1': {
+            valid_json: true,
+            verdict: 'PASS',
+            invalid_reason: null,
+            tests_total: 1,
+            tests_failed: 0,
+            tests_skipped: 0,
+            test_files_created: ['tests/phase-1.test.ts'],
+            command_exit_codes: [0],
+            bugs_found_count: 0,
           },
         },
       }));

--- a/hooks/lib/mpl-test-agent-evidence.mjs
+++ b/hooks/lib/mpl-test-agent-evidence.mjs
@@ -159,24 +159,14 @@ export function parseTestAgentEvidence({
   return evidence;
 }
 
-function evidenceCount(evidence, countKey, arrayKey) {
-  const counted = numeric(evidence?.[countKey], null);
-  if (counted !== null) return counted;
-  return Array.isArray(evidence?.[arrayKey]) ? evidence[arrayKey].length : 0;
-}
-
 function commandExitCodesPass(evidence) {
   const counted = numeric(evidence?.command_exit_codes_count, null);
   const nonzeroCount = numeric(evidence?.command_exit_codes_nonzero_count, null);
-  if (counted !== null || nonzeroCount !== null) {
-    return counted > 0 && nonzeroCount === 0;
-  }
-  return Array.isArray(evidence?.command_exit_codes) &&
-    evidence.command_exit_codes.length > 0 &&
-    evidence.command_exit_codes.every((code) => code === 0);
+  return counted > 0 && nonzeroCount === 0;
 }
 
 export function isPassingTestAgentEvidence(evidence) {
+  const testFilesCreatedCount = numeric(evidence?.test_files_created_count, null);
   return Boolean(
     evidence &&
     evidence.valid_json === true &&
@@ -188,7 +178,7 @@ export function isPassingTestAgentEvidence(evidence) {
     evidence.tests_failed === 0 &&
     typeof evidence.tests_skipped === 'number' &&
     evidence.tests_skipped === 0 &&
-    evidenceCount(evidence, 'test_files_created_count', 'test_files_created') > 0 &&
+    testFilesCreatedCount > 0 &&
     commandExitCodesPass(evidence) &&
     evidence.bugs_found_count === 0
   );


### PR DESCRIPTION
## What
- Remove legacy array-only PASS fallback from `isPassingTestAgentEvidence()`.
- Require scalar `test_files_created_count`, `command_exit_codes_count`, and `command_exit_codes_nonzero_count` for PASS consumption.
- Add regression tests for array-only PASS-shaped evidence in direct helper and hook paths.
- Document v0.18.7 consumer-breaking retirement and recovery path for pre-count records.

## Why
Closes #157. The bounded arrays are previews after #156, so they should not remain gate inputs. PASS evidence now depends only on the lossless scalar count fields.

## Design
- `hooks/lib/mpl-test-agent-evidence.mjs`
- `docs/schemas/state.md`
- `docs/schemas/migration-policy.md`

## Tests
- `node --test hooks/__tests__/mpl-gate-recorder.test.mjs`
- `node --test hooks/__tests__/mpl-require-test-agent.test.mjs`
- `node --test hooks/__tests__/mpl-phase-evidence.test.mjs`
- `npm test`

## Agent Review Status

This PR is gated on **2 unique agent reviews** using footer markers.

- [ ] from claude
- [ ] from codex

---
_Awaiting reviews. Merge once the gate is satisfied._
