### PR TITLE
fix: explain legacy test-agent scalar count blocks

### DIFF
--- a/hooks/__tests__/mpl-require-test-agent.test.mjs
+++ b/hooks/__tests__/mpl-require-test-agent.test.mjs
@@ -233,6 +233,11 @@ phases:
       assert.equal(r.continue, false);
       assert.equal(r.decision, 'block');
       assert.match(r.reason, /recorded mpl-test-agent evidence is verdict=PASS/);
+      assert.match(r.reason, /missing scalar count fields/);
+      assert.match(r.reason, /pre-v0\.18\.7 legacy record/);
+      assert.match(r.reason, /Re-run mpl-test-agent for phase-1/);
+      const state = JSON.parse(readFileSync(join(tmp, '.mpl', 'state.json'), 'utf-8'));
+      assert.match(state.block_reason, /missing scalar count fields/);
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }

--- a/hooks/mpl-require-test-agent.mjs
+++ b/hooks/mpl-require-test-agent.mjs
@@ -94,6 +94,53 @@ function clearBlockedHook(cwd, phaseId) {
   }
 }
 
+function finiteNumber(value) {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function missingScalarCountFields(evidence) {
+  const fields = [
+    'test_files_created_count',
+    'command_exit_codes_count',
+    'command_exit_codes_nonzero_count',
+  ];
+  return fields.filter((field) => !finiteNumber(evidence?.[field]));
+}
+
+function isLegacyArrayOnlyPassEvidence(evidence) {
+  if (!evidence) return false;
+  const missingFields = missingScalarCountFields(evidence);
+  return Boolean(
+    missingFields.length > 0 &&
+    evidence.valid_json === true &&
+    evidence.verdict === 'PASS' &&
+    (evidence.invalid_reason === null || evidence.invalid_reason === undefined) &&
+    finiteNumber(evidence.tests_total) &&
+    evidence.tests_total > 0 &&
+    finiteNumber(evidence.tests_failed) &&
+    evidence.tests_failed === 0 &&
+    finiteNumber(evidence.tests_skipped) &&
+    evidence.tests_skipped === 0 &&
+    Array.isArray(evidence.test_files_created) &&
+    evidence.test_files_created.length > 0 &&
+    Array.isArray(evidence.command_exit_codes) &&
+    evidence.command_exit_codes.length > 0 &&
+    evidence.command_exit_codes.every((code) => code === 0) &&
+    evidence.bugs_found_count === 0
+  );
+}
+
+function describePriorEvidence(prior, phaseId) {
+  if (!prior) return 'but mpl-test-agent was not dispatched';
+  const summary = `but the recorded mpl-test-agent evidence is verdict=${prior.verdict || 'UNKNOWN'} ` +
+    `(valid_json=${prior.valid_json === true}, reason=${prior.invalid_reason || 'none'})`;
+  if (!isLegacyArrayOnlyPassEvidence(prior)) return summary;
+
+  return `${summary}; missing scalar count fields (${missingScalarCountFields(prior).join(', ')}) ` +
+    `in a pre-v0.18.7 legacy record. Re-run mpl-test-agent for ${phaseId} so MPL records ` +
+    `lossless scalar counts`;
+}
+
 /**
  * Extract phase id from the phase-runner prompt. Looks for "phase-N" / "phase N".
  * Returns null if no match — the hook conservatively allows such dispatches (the
@@ -251,10 +298,7 @@ try {
 
   // Not overridden, required, not dispatched → BLOCK
   const prior = dispatched[phaseId];
-  const missingOrBad = prior
-    ? `but the recorded mpl-test-agent evidence is verdict=${prior.verdict || 'UNKNOWN'} ` +
-      `(valid_json=${prior.valid_json === true}, reason=${prior.invalid_reason || 'none'})`
-    : 'but mpl-test-agent was not dispatched';
+  const missingOrBad = describePriorEvidence(prior, phaseId);
   const rationale = phase.test_agent_rationale
     ? ` (rationale: ${phase.test_agent_rationale})`
     : '';


### PR DESCRIPTION
## What
- Adds a specific legacy array-only PASS evidence description for `mpl-require-test-agent` blocks.
- Tells the operator that scalar count fields are missing in a pre-v0.18.7 record and to re-run `mpl-test-agent`.
- Extends the array-only legacy evidence integration test to assert the emitted reason and stored block reason.

## Why
Closes #161. PR #160 made scalar counts the only trusted gate inputs, but the existing block message could still say `verdict=PASS` without explaining why MPL was blocking.

## Design
N/A - small follow-up from #160 review.

## Tests
- `node --test hooks/__tests__/mpl-require-test-agent.test.mjs`
- `npm test`

## Agent Review Status

This PR is gated on **2 unique agent reviews** using footer markers.

- [ ] from claude
- [ ] from codex

---
_Awaiting reviews. Merge once the gate is satisfied._
