### PR TITLE
feat: flag exp21 domain fallback literals

### DIFF
--- a/commands/references/anti-patterns.md
+++ b/commands/references/anti-patterns.md
@@ -85,8 +85,9 @@ codex auditor agent (#117).
 
 ## Ground-truth → registry mapping
 
-exp15 §11 reported 8 distinct anti-patterns. Some are split into multiple regex IDs in this registry for tighter
-metric attribution and divergent permitted-when semantics:
+exp15 §11 reported 8 distinct anti-patterns; exp21 later added one regression-specific fallback rule. Some exp15
+findings are split into multiple regex IDs in this registry for tighter metric attribution and divergent
+permitted-when semantics:
 
 | GT # | finding | Registry IDs | Reason for split |
 |------|-------------------|--------------|------------------|
@@ -360,8 +361,8 @@ sets CSP.
 - **category**: `fallback-poison`
 - **severity**: `block`
 - **escalation**: `strict_block`
-- **rationale**: A hardcoded runtime/domain fallback like `web_novel` can mask absent request or project classification
-  evidence. exp21 showed this can survive while gate self-report still claims Hard 1/2/3 PASS.
+- **rationale**: The exp21 `web_novel` hardcoded runtime/domain fallback can mask absent request or project
+  classification evidence while gate self-report still claims Hard 1/2/3 PASS.
 - **ground-truth source**: `exp21 dispatch.ts web_novel fallback`
 
 ```regex

--- a/commands/references/anti-patterns.md
+++ b/commands/references/anti-patterns.md
@@ -6,8 +6,9 @@ description: Anti-pattern enumeration consumed by phase-runner self-check + mpl-
 
 **Loaded by**: `agents/mpl-phase-runner.md` `<Anti_Patterns_Prohibited>` (human-readable summary) and
 `hooks/mpl-fallback-grep.mjs` (#105 F3, machine consumer).
-**Source of truth**: yggdrasil-exp15 §11 retrofit audit (8 distinct ground-truth anti-patterns; expanded into 10 regex
-IDs here for finer addressability). See §"Ground-truth → registry mapping" for the explicit 8 → 10 expansion.
+**Source of truth**: yggdrasil-exp15 §11 retrofit audit (8 distinct ground-truth anti-patterns) plus exp21
+regression findings; expanded into 11 regex IDs here for finer addressability. See §"Ground-truth → registry
+mapping" for the explicit expansion.
 **Issue**: #104 (F2). Companion: #105 (F3 grep hook), #106 (F4 doctor meta-self), #112 (F5 property check),
 #117 (F6 codex auditor).
 
@@ -87,7 +88,7 @@ codex auditor agent (#117).
 exp15 §11 reported 8 distinct anti-patterns. Some are split into multiple regex IDs in this registry for tighter
 metric attribution and divergent permitted-when semantics:
 
-| GT # | exp15 §11 finding | Registry IDs | Reason for split |
+| GT # | finding | Registry IDs | Reason for split |
 |------|-------------------|--------------|------------------|
 | 1 | Tautological test assertion | `TC1` | 1:1 |
 | 2 | Conditional assertion | `TC2` | 1:1 |
@@ -98,10 +99,11 @@ metric attribution and divergent permitted-when semantics:
 | 7 | Unconditional default-coalesce + synthetic-ID literal | `D1.a`, `D1.b` | exp15 conflated; this registry splits coalesce poisoning vs synthetic-id masking — different `permitted-when` semantics, different metric |
 | 8 | Swallowed promise rejection | `D2` | 1:1 |
 | add | Missing CSP meta tag (renderer hardening) | `CSP` | added beyond exp15 §11; not part of 8 GT — explicitly labeled `(unmeasured)` |
+| exp21 | Hardcoded domain/runtime fallback literal | `D1.c` | exp21 `dispatch.ts`-style `web_novel` fallback masked missing runtime/domain evidence while gate self-report still claimed PASS |
 
-**Catch rate accounting**: "Tier 4 catch 8/8" refers to the **8 ground truths**, not the 10 registry IDs. CSP is
+**Catch rate accounting**: "Tier 4 catch 8/8" refers to the **8 ground truths**, not the 11 registry IDs. CSP is
 added as a defensive item (no exp15 measurement); D1.a + D1.b together count as catching GT #7. Future expansions
-must update this table to keep the 8/8 vs 10-ID accounting transparent.
+must update this table to keep the 8/8 vs 11-ID accounting transparent.
 
 ## F3 / F4 parsing contract
 
@@ -350,6 +352,27 @@ sets CSP.
 ```permitted-when
 - the synthesized literal is explicitly tagged with a `synthetic_origin` field on the same object literal AND
   downstream consumers branch on that field (e.g. `if (id.startsWith('no-git-')) ...`)
+```
+
+### D1.c · Exp21 domain fallback literal
+
+- **id**: `D1.c`
+- **category**: `fallback-poison`
+- **severity**: `block`
+- **escalation**: `strict_block`
+- **rationale**: A hardcoded runtime/domain fallback like `web_novel` can mask absent request or project classification
+  evidence. exp21 showed this can survive while gate self-report still claims Hard 1/2/3 PASS.
+- **ground-truth source**: `exp21 dispatch.ts web_novel fallback`
+
+```regex
+\b(?:domain|project(?:Type|_type)?|content(?:Type|_type)?|genre|kind|type)\b[\s\S]{0,120}(?:\?\?|\|\|)\s*['"]web[-_]novel['"]
+```
+
+```permitted-when
+- the literal is an explicit user-configured default declared in a schema/config file and the code validates that
+  source before applying it
+- tests and fixtures are already excluded from Tier 1 source scanning; if a source file intentionally embeds a demo
+  fallback, document the product default next to the fallback and keep it out of verification-result paths
 ```
 
 ### D2 · Swallowed promise rejection

--- a/hooks/__tests__/mpl-fallback-grep.test.mjs
+++ b/hooks/__tests__/mpl-fallback-grep.test.mjs
@@ -76,12 +76,12 @@ assert\\s*\\(\\s*true\\s*\\)
     assert.match(p.permittedWhen, /environment precondition/);
   });
 
-  it('parses real registry into 10 patterns', () => {
+  it('parses real registry into 11 patterns', () => {
     const md = readFileSync(REGISTRY_PATH, 'utf-8');
     const { patterns, scope } = parseRegistry(md);
-    assert.strictEqual(patterns.length, 10);
+    assert.strictEqual(patterns.length, 11);
     const ids = patterns.map(p => p.id).sort();
-    assert.deepStrictEqual(ids, ['C2', 'C3', 'CSP', 'D1.a', 'D1.b', 'D2', 'M1', 'TC1', 'TC2', 'TC3']);
+    assert.deepStrictEqual(ids, ['C2', 'C3', 'CSP', 'D1.a', 'D1.b', 'D1.c', 'D2', 'M1', 'TC1', 'TC2', 'TC3']);
     assert.ok(scope.allowed.has('.mjs'));
     assert.ok(scope.allowed.has('.ts'));
     assert.ok(scope.excluded.has('.md'));
@@ -129,6 +129,7 @@ foo
       'M1':  ['tier_3_block_in:production'],
       'CSP': ['tier_3_only'],
       'D1.a': ['tier_3_block_in:verification-result-LHS'],
+      'D1.c': ['strict_block'],
     };
     for (const [id, exp] of Object.entries(expected)) {
       const p = reg.patterns.find(x => x.id === id);
@@ -240,13 +241,19 @@ test('foo', () => {
     assert.ok(hits.filter(h => h.id === 'D1.b').length >= 1);
   });
 
+  it('D1.c exp21 domain fallback literal → match', () => {
+    const src = `const domain = request.domain ?? 'web_novel';`;
+    const hits = scanContent(src, registry.patterns);
+    assert.ok(hits.filter(h => h.id === 'D1.c').length >= 1);
+  });
+
   it('clean source → no hits in block-severity patterns', () => {
     const src = `
 function add(a, b) { return a + b; }
 export { add };
 `;
     const hits = scanContent(src, registry.patterns);
-    const blockIds = ['TC1', 'TC2', 'TC3', 'C3', 'D1.b', 'D2'];
+    const blockIds = ['TC1', 'TC2', 'TC3', 'C3', 'D1.b', 'D1.c', 'D2'];
     const blockHits = hits.filter(h => blockIds.includes(h.id));
     assert.strictEqual(blockHits.length, 0);
   });


### PR DESCRIPTION
## What
- Adds anti-pattern registry ID `D1.c` for exp21-style hardcoded domain/runtime fallback literals such as `request.domain ?? 'web_novel'`.
- Updates registry accounting from 10 to 11 IDs while preserving the exp15 8/8 catch-rate accounting.
- Adds fallback-grep parser/scanner tests for the new pattern.

## Why
Closes #163. exp21 showed that production fallback literals can mask missing runtime/domain evidence while gate self-report still claims PASS.

## Design
- Uses the existing anti-pattern registry / `mpl-fallback-grep` path instead of adding a new hook.
- Default policy remains warn; strict/per-rule enforcement can block because `D1.c` is a block-severity pattern with `strict_block`.
- The regex is deliberately narrow around domain/project/content/kind/type identifiers and the exp21 `web_novel` literal.

## Tests
- `node --test hooks/__tests__/mpl-fallback-grep.test.mjs`
- `npm test`

## Agent Review Status

This PR is gated on **2 unique agent reviews** using footer markers.

- [ ] from claude
- [ ] from codex

---
_Awaiting reviews. Merge once the gate is satisfied._
