### PR TITLE
feat: surface Tauri Rust resource risk

### DIFF
--- a/agents/mpl-doctor.md
+++ b/agents/mpl-doctor.md
@@ -189,7 +189,7 @@ disallowedTools: Write, Edit, Task
     - WARN if missing (functional but undocumented)
 
     ### Category 12: Measurement Integrity Audit (AD-0006, v0.15.0)
-    - **Scope**: `.mpl/state.json`, `.mpl/goal-contract.yaml`, `.mpl/mpl/baseline.yaml`, `.mpl/mpl/phases/**`, `.mpl/config/test-agent-override.json`, `.mpl/config/e2e-scenario-override.json`
+    - **Scope**: `.mpl/state.json`, `.mpl/goal-contract.yaml`, `.mpl/mpl/baseline.yaml`, `.mpl/mpl/phases/**`, `.mpl/config/test-agent-override.json`, `.mpl/config/e2e-scenario-override.json`, `src-tauri/target/**`
     This category runs only when invoked as `mpl-doctor audit` (not default). Validates that a **completed** pipeline produced machine-evidence gate records and that Anti-rationalization guardrails held. Run against `.mpl/state.json` and `.mpl/mpl/` of a finalized run.
 
     **Preconditions**: `.mpl/state.json.current_phase == "completed"` AND `.mpl/state.json.finalize_done == true`. Otherwise report "NOT APPLICABLE (pipeline not finalized)" and skip.
@@ -251,6 +251,15 @@ disallowedTools: Write, Edit, Task
       - WARN if any phase has `test_agent_required: false` without a `test_agent_rationale` (schema violation; gate-recorder allowed it through but doctor flags it)
       - FAIL if `required > 0 AND dispatched == 0` (AD-0004 empirical gap — the original exp11 pattern)
 
+    - **[j] Tauri/Rust resource risk (exp21)** — surface build artifact growth before long verification loops:
+      - Invoke the resource-risk CLI:
+        `node ${CLAUDE_PLUGIN_ROOT}/hooks/mpl-resource-risk.mjs ${CWD}`
+      - Parse JSON fields: `status`, `measurements[]`, `warnings[]`.
+      - NOT APPLICABLE if the workspace has no `src-tauri/Cargo.toml` and no `src-tauri/target`.
+      - PASS when Tauri/Rust is present but no warning thresholds are exceeded.
+      - WARN when `warnings[]` is non-empty. Include measured size, threshold, and recommendation for each warning.
+      - This is advisory in v0.18.x; do not fail a pipeline solely on resource size until thresholds are calibrated.
+
     **Output format for Category 13**:
     ```
     ### Measurement Integrity Audit
@@ -263,7 +272,8 @@ disallowedTools: Write, Edit, Task
     [g] test_agent coverage:        ✓ N건     or ✗ 0건 despite {M} mandatory-domain phases
     [h] E2E scenario coverage:      ✓ N건     or ✗ missing/failing E2E-N
     [i] goal_contract integrity:    ✓ hash ok or ✗ missing fields: mission.goal
-    Result: PASS (9/9) / FAIL (X/9) / WARN (Y/9)
+    [j] Tauri/Rust resource risk:   ✓ clean   or ⚠️ src-tauri/target=16.0 GiB over 8.0 GiB
+    Result: PASS (10/10) / FAIL (X/10) / WARN (Y/10)
     ```
 
     ### Category 15: Property Check (F5, #112)

--- a/hooks/__tests__/mpl-resource-risk.test.mjs
+++ b/hooks/__tests__/mpl-resource-risk.test.mjs
@@ -1,0 +1,93 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { tmpdir } from 'os';
+import { fileURLToPath } from 'url';
+
+import {
+  detectTauriRustResourceRisk,
+  formatBytes,
+  parseByteSize,
+} from '../lib/mpl-resource-risk.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const HOOK_PATH = join(dirname(__filename), '..', 'mpl-resource-risk.mjs');
+
+function writeSizedFile(path, bytes) {
+  writeFileSync(path, Buffer.alloc(bytes, 1));
+}
+
+describe('resource risk byte parsing', () => {
+  it('parses human-readable byte sizes', () => {
+    assert.equal(parseByteSize('16GB'), 16 * 1024 ** 3);
+    assert.equal(parseByteSize('13.5 GiB'), Math.round(13.5 * 1024 ** 3));
+    assert.equal(parseByteSize('705MB'), 705 * 1024 ** 2);
+    assert.equal(parseByteSize(42), 42);
+    assert.equal(parseByteSize('not-a-size'), null);
+  });
+
+  it('formats byte sizes for warnings', () => {
+    assert.equal(formatBytes(16 * 1024 ** 3), '16.0 GiB');
+    assert.equal(formatBytes(705 * 1024 ** 2), '705.0 MiB');
+    assert.equal(formatBytes(512), '512 B');
+  });
+});
+
+describe('detectTauriRustResourceRisk', () => {
+  it('returns not_applicable for non-Tauri/Rust workspaces', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'mpl-resource-risk-na-'));
+    try {
+      const r = detectTauriRustResourceRisk(tmp);
+      assert.equal(r.status, 'not_applicable');
+      assert.deepEqual(r.warnings, []);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('warns with measured sizes and recovery recommendations over thresholds', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'mpl-resource-risk-warn-'));
+    try {
+      mkdirSync(join(tmp, 'src-tauri', 'target', 'debug', 'deps'), { recursive: true });
+      writeFileSync(join(tmp, 'src-tauri', 'Cargo.toml'), '[package]\nname = "app"\n');
+      writeSizedFile(join(tmp, 'src-tauri', 'target', 'debug', 'deps', 'libdep.rlib'), 80);
+      writeSizedFile(join(tmp, 'src-tauri', 'target', 'debug', 'libapp.a'), 70);
+      writeSizedFile(join(tmp, 'src-tauri', 'target', 'debug', 'other.o'), 10);
+
+      const r = detectTauriRustResourceRisk(tmp, {
+        targetWarnBytes: 100,
+        depsWarnBytes: 50,
+        staticLibWarnBytes: 60,
+      });
+      assert.equal(r.status, 'warn');
+      assert.deepEqual(r.warnings.map((w) => w.id).sort(), [
+        'tauri_deps_size_warn',
+        'tauri_static_lib_size_warn',
+        'tauri_target_size_warn',
+      ]);
+      assert.ok(r.measurements.find((m) => m.id === 'src_tauri_target' && m.bytes === 160));
+      assert.ok(r.measurements.find((m) => m.id === 'src_tauri_target_deps' && m.bytes === 80));
+      assert.match(r.warnings.find((w) => w.id === 'tauri_target_size_warn').recommendation, /cargo clean/);
+      assert.match(r.warnings.find((w) => w.id === 'tauri_static_lib_size_warn').recommendation, /multi-crate/);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('CLI emits deterministic JSON', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'mpl-resource-risk-cli-'));
+    try {
+      mkdirSync(join(tmp, 'src-tauri'), { recursive: true });
+      writeFileSync(join(tmp, 'src-tauri', 'Cargo.toml'), '[package]\nname = "app"\n');
+      const out = execFileSync('node', [HOOK_PATH, tmp], { encoding: 'utf-8' });
+      const r = JSON.parse(out);
+      assert.equal(r.kind, 'tauri_rust_resource_risk');
+      assert.equal(r.status, 'pass');
+      assert.deepEqual(r.warnings, []);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/hooks/lib/mpl-resource-risk.mjs
+++ b/hooks/lib/mpl-resource-risk.mjs
@@ -1,0 +1,191 @@
+import { existsSync, lstatSync, readdirSync } from 'fs';
+import { extname, join, relative, sep } from 'path';
+
+const KIB = 1024;
+const MIB = KIB * 1024;
+const GIB = MIB * 1024;
+
+export const DEFAULT_TAURI_RUST_RESOURCE_THRESHOLDS = {
+  targetWarnBytes: 8 * GIB,
+  depsWarnBytes: 8 * GIB,
+  staticLibWarnBytes: 512 * MIB,
+};
+
+export function parseByteSize(value) {
+  if (typeof value === 'number' && Number.isFinite(value) && value >= 0) {
+    return Math.round(value);
+  }
+  if (typeof value !== 'string') return null;
+  const m = value.trim().match(/^(\d+(?:\.\d+)?)\s*(b|bytes?|kb|kib|mb|mib|gb|gib|tb|tib)?$/i);
+  if (!m) return null;
+  const amount = Number(m[1]);
+  if (!Number.isFinite(amount) || amount < 0) return null;
+  const unit = (m[2] || 'b').toLowerCase();
+  const mult = {
+    b: 1,
+    byte: 1,
+    bytes: 1,
+    kb: KIB,
+    kib: KIB,
+    mb: MIB,
+    mib: MIB,
+    gb: GIB,
+    gib: GIB,
+    tb: GIB * 1024,
+    tib: GIB * 1024,
+  }[unit];
+  return Math.round(amount * mult);
+}
+
+export function formatBytes(bytes) {
+  const n = typeof bytes === 'number' && Number.isFinite(bytes) ? bytes : 0;
+  if (n >= GIB) return `${(n / GIB).toFixed(1)} GiB`;
+  if (n >= MIB) return `${(n / MIB).toFixed(1)} MiB`;
+  if (n >= KIB) return `${(n / KIB).toFixed(1)} KiB`;
+  return `${n} B`;
+}
+
+function posixRel(cwd, filePath) {
+  return relative(cwd, filePath).split(sep).join('/');
+}
+
+function isDepsPath(filePath) {
+  return filePath.split(sep).includes('deps');
+}
+
+function scanTargetTree(targetDir, cwd) {
+  const result = {
+    targetBytes: 0,
+    depsBytes: 0,
+    largestStaticLib: null,
+  };
+
+  function walk(filePath) {
+    let st;
+    try {
+      st = lstatSync(filePath);
+    } catch {
+      return;
+    }
+    if (st.isSymbolicLink()) return;
+    if (st.isDirectory()) {
+      let entries = [];
+      try {
+        entries = readdirSync(filePath);
+      } catch {
+        return;
+      }
+      for (const entry of entries) walk(join(filePath, entry));
+      return;
+    }
+    if (!st.isFile()) return;
+
+    result.targetBytes += st.size;
+    if (isDepsPath(filePath)) result.depsBytes += st.size;
+    if (extname(filePath) === '.a') {
+      const candidate = {
+        path: posixRel(cwd, filePath),
+        bytes: st.size,
+        human: formatBytes(st.size),
+      };
+      if (!result.largestStaticLib || candidate.bytes > result.largestStaticLib.bytes) {
+        result.largestStaticLib = candidate;
+      }
+    }
+  }
+
+  if (existsSync(targetDir)) walk(targetDir);
+  return result;
+}
+
+function warning({ id, measurement, path, bytes, thresholdBytes, recommendation }) {
+  return {
+    id,
+    severity: 'warn',
+    measurement,
+    path,
+    bytes,
+    human: formatBytes(bytes),
+    threshold_bytes: thresholdBytes,
+    threshold_human: formatBytes(thresholdBytes),
+    recommendation,
+  };
+}
+
+export function detectTauriRustResourceRisk(cwd, thresholds = DEFAULT_TAURI_RUST_RESOURCE_THRESHOLDS) {
+  const root = cwd || process.cwd();
+  const tauriRoot = join(root, 'src-tauri');
+  const targetDir = join(tauriRoot, 'target');
+  const isTauriRust = existsSync(join(tauriRoot, 'Cargo.toml')) || existsSync(targetDir);
+  if (!isTauriRust) {
+    return {
+      kind: 'tauri_rust_resource_risk',
+      status: 'not_applicable',
+      measurements: [],
+      warnings: [],
+    };
+  }
+
+  const scan = scanTargetTree(targetDir, root);
+  const measurements = [];
+  const warnings = [];
+
+  if (existsSync(targetDir)) {
+    measurements.push({
+      id: 'src_tauri_target',
+      path: posixRel(root, targetDir),
+      bytes: scan.targetBytes,
+      human: formatBytes(scan.targetBytes),
+    });
+    measurements.push({
+      id: 'src_tauri_target_deps',
+      path: 'src-tauri/target/**/deps',
+      bytes: scan.depsBytes,
+      human: formatBytes(scan.depsBytes),
+    });
+  }
+  if (scan.largestStaticLib) {
+    measurements.push({
+      id: 'largest_static_lib',
+      ...scan.largestStaticLib,
+    });
+  }
+
+  if (scan.targetBytes >= thresholds.targetWarnBytes) {
+    warnings.push(warning({
+      id: 'tauri_target_size_warn',
+      measurement: 'src_tauri_target',
+      path: 'src-tauri/target',
+      bytes: scan.targetBytes,
+      thresholdBytes: thresholds.targetWarnBytes,
+      recommendation: 'Run cargo clean when safe, lower build/test concurrency, or split large Rust/Tauri work into smaller crates/phases.',
+    }));
+  }
+  if (scan.depsBytes >= thresholds.depsWarnBytes) {
+    warnings.push(warning({
+      id: 'tauri_deps_size_warn',
+      measurement: 'src_tauri_target_deps',
+      path: 'src-tauri/target/**/deps',
+      bytes: scan.depsBytes,
+      thresholdBytes: thresholds.depsWarnBytes,
+      recommendation: 'Reduce duplicate dependency builds, prefer workspace-level crate boundaries, and clean stale target deps before long verification loops.',
+    }));
+  }
+  if (scan.largestStaticLib && scan.largestStaticLib.bytes >= thresholds.staticLibWarnBytes) {
+    warnings.push(warning({
+      id: 'tauri_static_lib_size_warn',
+      measurement: 'largest_static_lib',
+      path: scan.largestStaticLib.path,
+      bytes: scan.largestStaticLib.bytes,
+      thresholdBytes: thresholds.staticLibWarnBytes,
+      recommendation: 'Consider multi-crate decomposition or smaller Rust module boundaries before continuing long Tauri verification runs.',
+    }));
+  }
+
+  return {
+    kind: 'tauri_rust_resource_risk',
+    status: warnings.length > 0 ? 'warn' : 'pass',
+    measurements,
+    warnings,
+  };
+}

--- a/hooks/mpl-resource-risk.mjs
+++ b/hooks/mpl-resource-risk.mjs
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+/**
+ * Machine-readable Tauri/Rust resource-risk probe for doctor audit.
+ *
+ * Emits JSON and never blocks by itself; policy consumers decide whether WARN
+ * should remain advisory or become an enforcement signal.
+ */
+
+import { existsSync } from 'fs';
+import { dirname, join, resolve } from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const { detectTauriRustResourceRisk } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-resource-risk.mjs')).href
+);
+
+const cwd = resolve(process.argv[2] || process.cwd());
+if (!existsSync(cwd)) {
+  console.error(JSON.stringify({ error: `workspace not found: ${cwd}` }));
+  process.exit(2);
+}
+
+process.stdout.write(JSON.stringify(detectTauriRustResourceRisk(cwd), null, 2) + '\n');


### PR DESCRIPTION
## What
- Adds `hooks/mpl-resource-risk.mjs`, a machine-readable JSON probe for Tauri/Rust build artifact resource risk.
- Measures `src-tauri/target`, `target/**/deps`, and the largest `.a` static library, then emits advisory WARN records with size, threshold, and recovery recommendation.
- Wires the probe into `mpl-doctor audit` Category 12 as `[j] Tauri/Rust resource risk`.
- Adds unit/CLI tests using tiny fixtures plus low thresholds instead of real large artifacts.

## Why
Closes #164. exp21 hit a large Tauri/Rust resource failure mode (`src-tauri/target` around 16GB, large deps/static lib) that was not surfaced before long verification loops.

## Design
- Advisory-only in v0.18.x: the probe emits JSON warnings but does not block by itself.
- Default thresholds: target/deps 8 GiB, largest static library 512 MiB.
- The detector is deterministic and local filesystem based; no shell `du` dependency.

## Tests
- `node --test hooks/__tests__/mpl-resource-risk.test.mjs`
- `node --check hooks/mpl-resource-risk.mjs`
- `npm test`

## Agent Review Status

This PR is gated on **2 unique agent reviews** using footer markers.

- [ ] from claude
- [ ] from codex

---
_Awaiting reviews. Merge once the gate is satisfied._
