### PR TITLE
fix: refine Tauri resource-risk probe

### DIFF
--- a/agents/mpl-doctor.md
+++ b/agents/mpl-doctor.md
@@ -254,10 +254,13 @@ disallowedTools: Write, Edit, Task
     - **[j] Tauri/Rust resource risk (exp21)** — surface build artifact growth before long verification loops:
       - Invoke the resource-risk CLI:
         `node ${CLAUDE_PLUGIN_ROOT}/hooks/mpl-resource-risk.mjs ${CWD}`
-      - Parse JSON fields: `status`, `measurements[]`, `warnings[]`.
+      - This CLI is manually invoked by doctor and is not a registered Claude hook event.
+      - Parse JSON fields: `status`, `measurements[]`, `warnings[]`, `scan_errors[]`, `scan_error_count`.
       - NOT APPLICABLE if the workspace has no `src-tauri/Cargo.toml` and no `src-tauri/target`.
       - PASS when Tauri/Rust is present but no warning thresholds are exceeded.
-      - WARN when `warnings[]` is non-empty. Include measured size, threshold, and recommendation for each warning.
+      - WARN when `warnings[]` is non-empty. Include measured size, threshold, and recommendation for size warnings.
+      - If `scan_error_count > 0`, report partial scan as WARN with representative `scan_errors[]` paths before treating the resource measurement as clean.
+      - When deps dominate the target tree, prefer the deps warning over a redundant whole-target warning so the output points at the likely root cause.
       - This is advisory in v0.18.x; do not fail a pipeline solely on resource size until thresholds are calibrated.
 
     **Output format for Category 13**:

--- a/hooks/__tests__/mpl-resource-risk.test.mjs
+++ b/hooks/__tests__/mpl-resource-risk.test.mjs
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { existsSync, lstatSync, mkdtempSync, mkdirSync, readdirSync, rmSync, writeFileSync } from 'fs';
 import { join, dirname } from 'path';
 import { tmpdir } from 'os';
 import { fileURLToPath } from 'url';
@@ -71,6 +71,53 @@ describe('detectTauriRustResourceRisk', () => {
       assert.ok(r.measurements.find((m) => m.id === 'src_tauri_target_deps' && m.bytes === 80));
       assert.match(r.warnings.find((w) => w.id === 'tauri_target_size_warn').recommendation, /cargo clean/);
       assert.match(r.warnings.find((w) => w.id === 'tauri_static_lib_size_warn').recommendation, /multi-crate/);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('surfaces partial scan errors without treating the scan as clean', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'mpl-resource-risk-partial-'));
+    try {
+      const blocked = join(tmp, 'src-tauri', 'target', 'blocked');
+      mkdirSync(blocked, { recursive: true });
+      writeFileSync(join(tmp, 'src-tauri', 'Cargo.toml'), '[package]\nname = "app"\n');
+      const denied = Object.assign(new Error('permission denied'), { code: 'EACCES' });
+      const fsImpl = {
+        existsSync,
+        lstatSync,
+        readdirSync(path) {
+          if (path === blocked) throw denied;
+          return readdirSync(path);
+        },
+      };
+
+      const r = detectTauriRustResourceRisk(tmp, {}, { fs: fsImpl });
+      assert.equal(r.status, 'warn');
+      assert.equal(r.scan_error_count, 1);
+      assert.equal(r.scan_errors[0].path, 'src-tauri/target/blocked');
+      assert.equal(r.scan_errors[0].code, 'EACCES');
+      assert.ok(r.warnings.find((w) => w.id === 'tauri_scan_partial_warn'));
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('deduplicates target warning when deps dominate the target size', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'mpl-resource-risk-dedup-'));
+    try {
+      mkdirSync(join(tmp, 'src-tauri', 'target', 'debug', 'deps'), { recursive: true });
+      writeFileSync(join(tmp, 'src-tauri', 'Cargo.toml'), '[package]\nname = "app"\n');
+      writeSizedFile(join(tmp, 'src-tauri', 'target', 'debug', 'deps', 'libdep.rlib'), 95);
+      writeSizedFile(join(tmp, 'src-tauri', 'target', 'debug', 'other.o'), 5);
+
+      const r = detectTauriRustResourceRisk(tmp, {
+        targetWarnBytes: '90 B',
+        depsWarnBytes: '50 B',
+        staticLibWarnBytes: '1 KiB',
+      });
+      const warningIds = r.warnings.map((w) => w.id);
+      assert.deepEqual(warningIds, ['tauri_deps_size_warn']);
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }

--- a/hooks/lib/mpl-resource-risk.mjs
+++ b/hooks/lib/mpl-resource-risk.mjs
@@ -4,6 +4,8 @@ import { extname, join, relative, sep } from 'path';
 const KIB = 1024;
 const MIB = KIB * 1024;
 const GIB = MIB * 1024;
+const DEFAULT_DEPS_DOMINANCE_RATIO = 0.9;
+const MAX_SCAN_ERRORS = 25;
 
 export const DEFAULT_TAURI_RUST_RESOURCE_THRESHOLDS = {
   targetWarnBytes: 8 * GIB,
@@ -11,6 +13,7 @@ export const DEFAULT_TAURI_RUST_RESOURCE_THRESHOLDS = {
   staticLibWarnBytes: 512 * MIB,
 };
 
+// Keep threshold config human-readable once config/env wiring is added.
 export function parseByteSize(value) {
   if (typeof value === 'number' && Number.isFinite(value) && value >= 0) {
     return Math.round(value);
@@ -53,32 +56,69 @@ function isDepsPath(filePath) {
   return filePath.split(sep).includes('deps');
 }
 
-function scanTargetTree(targetDir, cwd) {
+function normalizeThresholds(thresholds = DEFAULT_TAURI_RUST_RESOURCE_THRESHOLDS) {
+  const overrides = thresholds && typeof thresholds === 'object' ? thresholds : {};
+  const t = { ...DEFAULT_TAURI_RUST_RESOURCE_THRESHOLDS, ...overrides };
+  const ratio = Number(t.depsDominanceRatio);
+  return {
+    targetWarnBytes: parseByteSize(t.targetWarnBytes) ?? DEFAULT_TAURI_RUST_RESOURCE_THRESHOLDS.targetWarnBytes,
+    depsWarnBytes: parseByteSize(t.depsWarnBytes) ?? DEFAULT_TAURI_RUST_RESOURCE_THRESHOLDS.depsWarnBytes,
+    staticLibWarnBytes: parseByteSize(t.staticLibWarnBytes) ?? DEFAULT_TAURI_RUST_RESOURCE_THRESHOLDS.staticLibWarnBytes,
+    depsDominanceRatio: Number.isFinite(ratio) && ratio > 0 && ratio <= 1
+      ? ratio
+      : DEFAULT_DEPS_DOMINANCE_RATIO,
+  };
+}
+
+function scanError(cwd, filePath, err) {
+  return {
+    path: posixRel(cwd, filePath),
+    code: err?.code || err?.name || 'SCAN_ERROR',
+    message: err?.message || String(err),
+  };
+}
+
+function scanTargetTree(targetDir, cwd, fsImpl = { existsSync, lstatSync, readdirSync }) {
   const result = {
     targetBytes: 0,
     depsBytes: 0,
     largestStaticLib: null,
+    scanErrorCount: 0,
+    scanErrors: [],
   };
 
-  function walk(filePath) {
+  function recordScanError(filePath, err) {
+    result.scanErrorCount += 1;
+    if (result.scanErrors.length < MAX_SCAN_ERRORS) {
+      result.scanErrors.push(scanError(cwd, filePath, err));
+    }
+  }
+
+  if (!fsImpl.existsSync(targetDir)) return result;
+
+  const stack = [targetDir];
+  while (stack.length > 0) {
+    const filePath = stack.pop();
     let st;
     try {
-      st = lstatSync(filePath);
-    } catch {
-      return;
+      st = fsImpl.lstatSync(filePath);
+    } catch (err) {
+      recordScanError(filePath, err);
+      continue;
     }
-    if (st.isSymbolicLink()) return;
+    if (st.isSymbolicLink()) continue;
     if (st.isDirectory()) {
       let entries = [];
       try {
-        entries = readdirSync(filePath);
-      } catch {
-        return;
+        entries = fsImpl.readdirSync(filePath);
+      } catch (err) {
+        recordScanError(filePath, err);
+        continue;
       }
-      for (const entry of entries) walk(join(filePath, entry));
-      return;
+      for (const entry of entries) stack.push(join(filePath, entry));
+      continue;
     }
-    if (!st.isFile()) return;
+    if (!st.isFile()) continue;
 
     result.targetBytes += st.size;
     if (isDepsPath(filePath)) result.depsBytes += st.size;
@@ -94,7 +134,6 @@ function scanTargetTree(targetDir, cwd) {
     }
   }
 
-  if (existsSync(targetDir)) walk(targetDir);
   return result;
 }
 
@@ -112,25 +151,29 @@ function warning({ id, measurement, path, bytes, thresholdBytes, recommendation 
   };
 }
 
-export function detectTauriRustResourceRisk(cwd, thresholds = DEFAULT_TAURI_RUST_RESOURCE_THRESHOLDS) {
+export function detectTauriRustResourceRisk(cwd, thresholds = DEFAULT_TAURI_RUST_RESOURCE_THRESHOLDS, options = {}) {
+  const fsImpl = options.fs || { existsSync, lstatSync, readdirSync };
+  const effectiveThresholds = normalizeThresholds(thresholds);
   const root = cwd || process.cwd();
   const tauriRoot = join(root, 'src-tauri');
   const targetDir = join(tauriRoot, 'target');
-  const isTauriRust = existsSync(join(tauriRoot, 'Cargo.toml')) || existsSync(targetDir);
+  const isTauriRust = fsImpl.existsSync(join(tauriRoot, 'Cargo.toml')) || fsImpl.existsSync(targetDir);
   if (!isTauriRust) {
     return {
       kind: 'tauri_rust_resource_risk',
       status: 'not_applicable',
       measurements: [],
       warnings: [],
+      scan_errors: [],
+      scan_error_count: 0,
     };
   }
 
-  const scan = scanTargetTree(targetDir, root);
+  const scan = scanTargetTree(targetDir, root, fsImpl);
   const measurements = [];
   const warnings = [];
 
-  if (existsSync(targetDir)) {
+  if (fsImpl.existsSync(targetDir)) {
     measurements.push({
       id: 'src_tauri_target',
       path: posixRel(root, targetDir),
@@ -151,33 +194,48 @@ export function detectTauriRustResourceRisk(cwd, thresholds = DEFAULT_TAURI_RUST
     });
   }
 
-  if (scan.targetBytes >= thresholds.targetWarnBytes) {
+  const depsDominatesTarget = scan.targetBytes > 0
+    && scan.depsBytes >= effectiveThresholds.depsWarnBytes
+    && scan.depsBytes / scan.targetBytes >= effectiveThresholds.depsDominanceRatio;
+
+  if (scan.scanErrorCount > 0) {
+    warnings.push({
+      id: 'tauri_scan_partial_warn',
+      severity: 'warn',
+      measurement: 'scan_errors',
+      path: 'src-tauri/target',
+      count: scan.scanErrorCount,
+      shown: scan.scanErrors.length,
+      recommendation: 'Inspect unreadable target paths and rerun the doctor audit so resource-risk measurements are not treated as clean when the scan was partial.',
+    });
+  }
+  if (scan.targetBytes >= effectiveThresholds.targetWarnBytes && !depsDominatesTarget) {
     warnings.push(warning({
       id: 'tauri_target_size_warn',
       measurement: 'src_tauri_target',
       path: 'src-tauri/target',
       bytes: scan.targetBytes,
-      thresholdBytes: thresholds.targetWarnBytes,
+      thresholdBytes: effectiveThresholds.targetWarnBytes,
       recommendation: 'Run cargo clean when safe, lower build/test concurrency, or split large Rust/Tauri work into smaller crates/phases.',
     }));
   }
-  if (scan.depsBytes >= thresholds.depsWarnBytes) {
+  if (scan.depsBytes >= effectiveThresholds.depsWarnBytes) {
     warnings.push(warning({
       id: 'tauri_deps_size_warn',
       measurement: 'src_tauri_target_deps',
       path: 'src-tauri/target/**/deps',
       bytes: scan.depsBytes,
-      thresholdBytes: thresholds.depsWarnBytes,
+      thresholdBytes: effectiveThresholds.depsWarnBytes,
       recommendation: 'Reduce duplicate dependency builds, prefer workspace-level crate boundaries, and clean stale target deps before long verification loops.',
     }));
   }
-  if (scan.largestStaticLib && scan.largestStaticLib.bytes >= thresholds.staticLibWarnBytes) {
+  if (scan.largestStaticLib && scan.largestStaticLib.bytes >= effectiveThresholds.staticLibWarnBytes) {
     warnings.push(warning({
       id: 'tauri_static_lib_size_warn',
       measurement: 'largest_static_lib',
       path: scan.largestStaticLib.path,
       bytes: scan.largestStaticLib.bytes,
-      thresholdBytes: thresholds.staticLibWarnBytes,
+      thresholdBytes: effectiveThresholds.staticLibWarnBytes,
       recommendation: 'Consider multi-crate decomposition or smaller Rust module boundaries before continuing long Tauri verification runs.',
     }));
   }
@@ -187,5 +245,7 @@ export function detectTauriRustResourceRisk(cwd, thresholds = DEFAULT_TAURI_RUST
     status: warnings.length > 0 ? 'warn' : 'pass',
     measurements,
     warnings,
+    scan_errors: scan.scanErrors,
+    scan_error_count: scan.scanErrorCount,
   };
 }

--- a/hooks/mpl-resource-risk.mjs
+++ b/hooks/mpl-resource-risk.mjs
@@ -2,6 +2,9 @@
 /**
  * Machine-readable Tauri/Rust resource-risk probe for doctor audit.
  *
+ * This is a manually invoked diagnostic CLI under hooks/ for plugin packaging
+ * compatibility. It is not registered as a Claude hook event.
+ *
  * Emits JSON and never blocks by itself; policy consumers decide whether WARN
  * should remain advisory or become an enforcement signal.
  */


### PR DESCRIPTION
## What
- Replace the Tauri/Rust resource-risk target scan with iterative traversal.
- Surface partial scan errors through `scan_errors[]`, `scan_error_count`, and an advisory warning.
- Deduplicate target/deps warnings when deps dominate the target tree.
- Document that the resource-risk CLI is a manually invoked doctor diagnostic, not a registered hook event.
- Add regression tests for partial scan visibility and warning dedup.

## Why
Follow-up from #166 review: keep the exp21 resource-risk signal useful under large or partially unreadable `src-tauri/target` trees without turning advisory measurements into false-clean results.

## Design
- Issue: #167
- Preceding PR: #166

## Tests
- `node --test hooks/__tests__/mpl-resource-risk.test.mjs`
- `node --check hooks/mpl-resource-risk.mjs`
- `node --check hooks/lib/mpl-resource-risk.mjs`
- `npm test`

## Agent Review Status

This PR is gated on **2 unique agent reviews** using footer markers.

- [ ] from claude
- [ ] from codex

Closes #167

---
_Awaiting reviews. Merge once the gate is satisfied._
