### PR TITLE
fix: group resource-risk defaults

### DIFF
--- a/hooks/__tests__/mpl-resource-risk.test.mjs
+++ b/hooks/__tests__/mpl-resource-risk.test.mjs
@@ -7,6 +7,7 @@ import { tmpdir } from 'os';
 import { fileURLToPath } from 'url';
 
 import {
+  DEFAULT_TAURI_RUST_RESOURCE_THRESHOLDS,
   detectTauriRustResourceRisk,
   formatBytes,
   parseByteSize,
@@ -32,6 +33,13 @@ describe('resource risk byte parsing', () => {
     assert.equal(formatBytes(16 * 1024 ** 3), '16.0 GiB');
     assert.equal(formatBytes(705 * 1024 ** 2), '705.0 MiB');
     assert.equal(formatBytes(512), '512 B');
+  });
+
+  it('exposes size thresholds and dominance heuristic in one default surface', () => {
+    assert.equal(DEFAULT_TAURI_RUST_RESOURCE_THRESHOLDS.targetWarnBytes, 8 * 1024 ** 3);
+    assert.equal(DEFAULT_TAURI_RUST_RESOURCE_THRESHOLDS.depsWarnBytes, 8 * 1024 ** 3);
+    assert.equal(DEFAULT_TAURI_RUST_RESOURCE_THRESHOLDS.staticLibWarnBytes, 512 * 1024 ** 2);
+    assert.equal(DEFAULT_TAURI_RUST_RESOURCE_THRESHOLDS.depsDominanceRatio, 0.9);
   });
 });
 

--- a/hooks/lib/mpl-resource-risk.mjs
+++ b/hooks/lib/mpl-resource-risk.mjs
@@ -4,13 +4,13 @@ import { extname, join, relative, sep } from 'path';
 const KIB = 1024;
 const MIB = KIB * 1024;
 const GIB = MIB * 1024;
-const DEFAULT_DEPS_DOMINANCE_RATIO = 0.9;
 const MAX_SCAN_ERRORS = 25;
 
 export const DEFAULT_TAURI_RUST_RESOURCE_THRESHOLDS = {
   targetWarnBytes: 8 * GIB,
   depsWarnBytes: 8 * GIB,
   staticLibWarnBytes: 512 * MIB,
+  depsDominanceRatio: 0.9,
 };
 
 // Keep threshold config human-readable once config/env wiring is added.
@@ -66,7 +66,7 @@ function normalizeThresholds(thresholds = DEFAULT_TAURI_RUST_RESOURCE_THRESHOLDS
     staticLibWarnBytes: parseByteSize(t.staticLibWarnBytes) ?? DEFAULT_TAURI_RUST_RESOURCE_THRESHOLDS.staticLibWarnBytes,
     depsDominanceRatio: Number.isFinite(ratio) && ratio > 0 && ratio <= 1
       ? ratio
-      : DEFAULT_DEPS_DOMINANCE_RATIO,
+      : DEFAULT_TAURI_RUST_RESOURCE_THRESHOLDS.depsDominanceRatio,
   };
 }
 


### PR DESCRIPTION
## What
- Move `depsDominanceRatio` into `DEFAULT_TAURI_RUST_RESOURCE_THRESHOLDS`.
- Keep the existing fallback behavior while making size thresholds and the dominance heuristic discoverable from one exported default object.
- Add a regression test for the unified default surface.

## Why
Follow-up from #168 review: external consumers should not need to inspect separate module-level constants to discover the default resource-risk settings.

## Design
- Issue: #169
- Preceding PR: #168

## Tests
- `node --test hooks/__tests__/mpl-resource-risk.test.mjs`
- `node --check hooks/lib/mpl-resource-risk.mjs`
- `npm test`

## Agent Review Status

This PR is gated on **2 unique agent reviews** using footer markers.

- [ ] from claude
- [ ] from codex

Closes #169

---
_Awaiting reviews. Merge once the gate is satisfied._
