### PR TITLE
refactor: move framework prompt rules to profiles

### DIFF
--- a/agents/mpl-decomposer.md
+++ b/agents/mpl-decomposer.md
@@ -70,18 +70,21 @@ disallowedTools: Bash,Task,WebFetch,WebSearch,NotebookEdit
     Step 5.5: Per-phase Type Policy Synthesis (v0.17, #57)
       Read raw-scan.md sections: `Type Hints (Path A brownfield)` and `Boundary Pairs`.
       Read PP `tech_stack` and architectural_layers info.
+      Read `commands/references/framework-profiles.md` and apply matching
+      `framework_convention_profiles`/`boundary_profiles`; do not inline new
+      framework-specific convention tables in this prompt.
 
       For each phase, synthesize `type_policy`:
         - Phase layer (backend/frontend/sidecar/shared) from `phase_domain`
-        - Naming convention: snake_case (Rust/Python) / camelCase (TS) / per framework rules at boundaries
-        - Null handling: Option<T> (Rust), T | null (TS), None (Python) — per layer
+        - Naming convention: language defaults plus profile rules at boundaries
+        - Null handling: language defaults plus profile rules per layer
         - Enum constraints: from raw-scan type hints OR PP schema (greenfield)
-        - Prohibited patterns per layer (e.g., no `any` in TS, no `unwrap()` beyond N count in Rust)
+        - Prohibited patterns per layer from raw audit counts and matching profiles
         - Conversion points: at contract_files boundaries where types transform
 
       **Greenfield fallback** (no raw-scan type hints): derive from PP tech stack
-      using well-known framework conventions (Tauri v2 → serde + camelCase auto-convert,
-      Next.js → camelCase, FastAPI → snake_case + pydantic, etc.).
+      using matching `framework_convention_profiles` rather than hardcoded
+      framework knowledge.
 
       **Empty case**: pure doc/infra phases with no type surface emit
       `type_policy: { applies: false }`. Do NOT omit the field — explicit false
@@ -172,8 +175,8 @@ disallowedTools: Bash,Task,WebFetch,WebSearch,NotebookEdit
           touches ≥2 phase impact files (complex-enough single-feature
           integration test)
         - required: true when composed_from contains any core with must_work=true
-        - test_command MUST be executable (e.g., "pnpm playwright test e2e/
-          scenario-1.spec.ts"), NEVER a placeholder like "TODO(integration-ci)"
+        - test_command MUST be executable using the matched `e2e_runner_profile`,
+          NEVER a placeholder like "TODO(integration-ci)"
           or "manual verification"
         - If goal_contract.e2e_policy.real_runtime_required is true, emit:
           runtime_class: one of real_desktop|real_web|real_browser|real_mobile|real_api
@@ -185,8 +188,8 @@ disallowedTools: Bash,Task,WebFetch,WebSearch,NotebookEdit
           style tests are not admissible.
 
       Infrastructure detection:
-        - Scan provided-specs + decomposition for existing E2E stack:
-          playwright in package.json, cypress, wdio, existing e2e/ directory
+        - Scan provided-specs + decomposition for an existing `e2e_runner_profile`
+          match from `commands/references/framework-profiles.md`.
         - If NONE found, insert a new phase at tier-1:
           id: "phase-e2e-infra"
           name: "E2E Infrastructure Setup"
@@ -195,9 +198,9 @@ disallowedTools: Bash,Task,WebFetch,WebSearch,NotebookEdit
           test_agent_required: false
           test_agent_rationale: "Tooling setup — no code path to verify"
           success_criteria:
-            - "playwright config 존재, smoke run 성공"
-            - "e2e/ 디렉토리 구조 준비"
-          impact: ["playwright.config.ts", "e2e/smoke.spec.ts", "package.json"]
+            - "configured e2e runner profile present"
+            - "e2e scenario directory or equivalent project convention prepared"
+          impact: ["profile-specific config file", "profile-specific smoke spec", "project manifest"]
         - This guarantees scenario test_command fields are executable at finalize.
 
       After composition, emit `e2e_scenarios[]` in the top-level output; the
@@ -231,13 +234,13 @@ disallowedTools: Bash,Task,WebFetch,WebSearch,NotebookEdit
           | infra       | "리소스 해제 누락(고아 연산) 테스트" |
           | general     | At least one relevant probing hint based on phase scope |
 
-      (2) Platform constraint hints (from Phase 0 `target_platform` detection):
+      (2) Platform constraint hints (from Phase 0 `Platform API Hits` and
+      `platform_constraint_profiles`):
 
-          | Platform Config | Auto-Generated Hint |
-          |----------------|---------------------|
-          | `tauri.conf.json` exists | "Tauri WebView에서 window.prompt/confirm/alert 차단 — 커스텀 다이얼로그 확인" |
-          | `electron-builder.json` exists | "Renderer 프로세스에서 Node.js native API 직접 호출 여부" |
-          | `next.config.js` exists | "SSR 컴포넌트에서 window/document 직접 접근 여부" |
+          Load `commands/references/framework-profiles.md`, select matching
+          `platform_constraint_profiles`, and copy their `hint` values into
+          phase `probing_hints` when the phase touches the relevant runtime
+          files or boundary.
 
       Fallback rule: if no relevant hints can be determined, omit the field (not an error).
 
@@ -445,9 +448,9 @@ disallowedTools: Bash,Task,WebFetch,WebSearch,NotebookEdit
           strict_mode_advisories: [string]  # advisories emitted when raw audit thresholds exceeded
           # Raw audit counts that triggered advisories (from raw-scan) — for traceability
           raw_audit_counts:
-            unwrap_count: number       # Rust .unwrap() count in src/
-            strict_null_enabled: boolean  # TS tsconfig flag
-            ignored_error_count: number   # Go _ = patterns
+            unwrap_count: number       # language panic/unwrap-style count when measured
+            strict_null_enabled: boolean  # strict-null equivalent flag when measured
+            ignored_error_count: number   # ignored-error count when measured
 
         estimated_complexity: "S" | "M" | "L"
         estimated_todos: number
@@ -518,7 +521,7 @@ disallowedTools: Bash,Task,WebFetch,WebSearch,NotebookEdit
         acceptance_criteria: string     # observable exit-0 criterion
         runtime_class: string           # real_desktop|real_web|real_browser|real_mobile|real_api|mock|unit
         mock_allowed: boolean           # must match goal_contract.e2e_policy
-        launcher_evidence: string       # e.g., "electron.launch", "tauri-driver", "playwright chromium"
+        launcher_evidence: string       # real launcher evidence from matching e2e_runner_profile
         assertion_evidence: string      # real assertion being made, not "expect(true)"
         test_files: [string]            # optional file paths scanned by authenticity hook
         required: boolean               # default true when composed_from includes must_work core
@@ -527,8 +530,8 @@ disallowedTools: Bash,Task,WebFetch,WebSearch,NotebookEdit
     #   - Each e2e_scenario must compose ≥2 core scenarios spanning ≥2 phases
     #   - Exception: a single core may become a 1:1 E2E when flow has ≥3 steps
     #     AND touches ≥2 phase impact files (complex-enough integration)
-    #   - Infrastructure detection: if project lacks e2e runner (no playwright/
-    #     cypress in package.json, no e2e/ directory), INSERT a
+    #   - Infrastructure detection: if project lacks an e2e runner profile match,
+    #     INSERT a
     #     "phase-e2e-infra" phase at tier-1 BEFORE first scenario-exercising phase
 
     risk_assessment:

--- a/agents/mpl-doctor.md
+++ b/agents/mpl-doctor.md
@@ -189,7 +189,7 @@ disallowedTools: Write, Edit, Task
     - WARN if missing (functional but undocumented)
 
     ### Category 12: Measurement Integrity Audit (AD-0006, v0.15.0)
-    - **Scope**: `.mpl/state.json`, `.mpl/goal-contract.yaml`, `.mpl/mpl/baseline.yaml`, `.mpl/mpl/phases/**`, `.mpl/config/test-agent-override.json`, `.mpl/config/e2e-scenario-override.json`, `src-tauri/target/**`
+    - **Scope**: `.mpl/state.json`, `.mpl/goal-contract.yaml`, `.mpl/mpl/baseline.yaml`, `.mpl/mpl/phases/**`, `.mpl/config/test-agent-override.json`, `.mpl/config/e2e-scenario-override.json`, plus paths declared by matching `resource_risk_profiles`
     This category runs only when invoked as `mpl-doctor audit` (not default). Validates that a **completed** pipeline produced machine-evidence gate records and that Anti-rationalization guardrails held. Run against `.mpl/state.json` and `.mpl/mpl/` of a finalized run.
 
     **Preconditions**: `.mpl/state.json.current_phase == "completed"` AND `.mpl/state.json.finalize_done == true`. Otherwise report "NOT APPLICABLE (pipeline not finalized)" and skip.
@@ -225,7 +225,7 @@ disallowedTools: Write, Edit, Task
       - `override = Read(".mpl/config/e2e-scenario-override.json") or {}`
       - WARN if core_scenarios is empty but PPs have CONFIRMED entries with non-invariant flows (orphaned PP coverage)
       - FAIL if any e2e_scenario.test_command matches `/TODO|FIXME|manual verification/i` (Decomposer emitted placeholder — Step 3-H validation missed it)
-      - FAIL if any required e2e_scenario.test_command references a file path that doesn't exist on disk (for playwright/cypress specs: `e2e/*.spec.ts` etc.)
+      - FAIL if any required e2e_scenario.test_command references a file path that doesn't exist on disk (use matched `e2e_runner_profiles` for runner-specific spec globs)
       - FAIL if `required - (passed via results.exit_code==0) - overridden > 0` (AD-0008 enforcement gap)
       - WARN if `"*"` blanket override present (anti-pattern)
       - WARN if any override `recorded_at` is >30 days old (stale environment assumption per AD-0008 R-2)
@@ -251,16 +251,17 @@ disallowedTools: Write, Edit, Task
       - WARN if any phase has `test_agent_required: false` without a `test_agent_rationale` (schema violation; gate-recorder allowed it through but doctor flags it)
       - FAIL if `required > 0 AND dispatched == 0` (AD-0004 empirical gap — the original exp11 pattern)
 
-    - **[j] Tauri/Rust resource risk (exp21)** — surface build artifact growth before long verification loops:
+    - **[j] Build artifact resource risk (exp21)** — surface generated/build artifact growth before long verification loops:
+      - Load matching `resource_risk_profiles` from `commands/references/framework-profiles.md`.
       - Invoke the resource-risk CLI:
         `node ${CLAUDE_PLUGIN_ROOT}/hooks/mpl-resource-risk.mjs ${CWD}`
       - This CLI is manually invoked by doctor and is not a registered Claude hook event.
       - Parse JSON fields: `status`, `measurements[]`, `warnings[]`, `scan_errors[]`, `scan_error_count`.
-      - NOT APPLICABLE if the workspace has no `src-tauri/Cargo.toml` and no `src-tauri/target`.
-      - PASS when Tauri/Rust is present but no warning thresholds are exceeded.
+      - NOT APPLICABLE if no resource-risk profile matches the workspace.
+      - PASS when a resource-risk profile is present but no warning thresholds are exceeded.
       - WARN when `warnings[]` is non-empty. Include measured size, threshold, and recommendation for size warnings.
       - If `scan_error_count > 0`, report partial scan as WARN with representative `scan_errors[]` paths before treating the resource measurement as clean.
-      - When deps dominate the target tree, prefer the deps warning over a redundant whole-target warning so the output points at the likely root cause.
+      - When a profile emits overlapping measurements, prefer the profile's root-cause warning over redundant aggregate warnings.
       - This is advisory in v0.18.x; do not fail a pipeline solely on resource size until thresholds are calibrated.
 
     **Output format for Category 13**:
@@ -275,7 +276,7 @@ disallowedTools: Write, Edit, Task
     [g] test_agent coverage:        ✓ N건     or ✗ 0건 despite {M} mandatory-domain phases
     [h] E2E scenario coverage:      ✓ N건     or ✗ missing/failing E2E-N
     [i] goal_contract integrity:    ✓ hash ok or ✗ missing fields: mission.goal
-    [j] Tauri/Rust resource risk:   ✓ clean   or ⚠️ src-tauri/target=16.0 GiB over 8.0 GiB
+    [j] Build artifact resource risk: ✓ clean or ⚠️ profile path over threshold
     Result: PASS (10/10) / FAIL (X/10) / WARN (Y/10)
     ```
 

--- a/agents/mpl-phase-runner.md
+++ b/agents/mpl-phase-runner.md
@@ -20,10 +20,10 @@ disallowedTools: []
     - **PD Override**: never silently change a prior phase's decision. Create an explicit override request.
     - Edit/Write are allowed: Phase Runner uses them for working.md, state updates, and direct code implementation.
     - **Bash timeout (G1, #107)** — verification commands MUST set `tool_input.timeout` (ms) within the category bounds enforced by `mpl-bash-timeout.mjs`:
-      - vitest / jest / npm test: 60_000–300_000 ms (recommend 300_000)
-      - playwright / npx playwright test: 60_000–600_000 ms (recommend 600_000)
-      - tsc / vite build / cargo build / gradle / mvn: 30_000–180_000 ms
-      - tsc --noEmit / eslint / biome / ruff / flake8 / pyright / mypy / py_compile / cargo check / npm run typecheck|lint: 10_000–120_000 ms
+      - unit/integration test profile: 60_000–300_000 ms (recommend 300_000)
+      - E2E runner profile: 60_000–600_000 ms (recommend 600_000)
+      - build profile: 30_000–180_000 ms
+      - typecheck/lint profile: 10_000–120_000 ms
       Strict mode (`state.enforcement.strict === true`) hard-blocks under-spec'd or over-spec'd timeouts; non-strict warns. Untimed verification accumulates 5h fix-loop walls (exp15 phase-10).
   </Constraints>
 
@@ -84,7 +84,7 @@ disallowedTools: []
     1. **Build verification**: e.g., `npm run build` exits 0
     2. **Phase success_criteria**: execute each criterion by type (command, test, file_exists, grep, description)
     3. **Cumulative regression**: run full test suite across all completed phases
-       - Auto-detect framework (vitest, jest, pytest, cargo test, go test) and use parallel flags
+       - Auto-detect the existing test framework/tool profile and use supported parallel flags
        - Record `pass_rate = passed_tests / total_tests`
     4. **PP violation check**: confirm no CONFIRMED PP is violated
     5. **A/S/H-items**: A-items execute directly; S-items verify BDD scenarios; H-items flag for human verification
@@ -121,7 +121,7 @@ disallowedTools: []
     - **## Notes for Next Phase**: env vars, import paths, deferred discoveries (L2)
     - **## Warnings** (v0.12.0 HA-04): unexpected findings during implementation that may affect subsequent phases. Examples:
       - Dependency substitutions (e.g., "bcrypt unavailable, used argon2 — verify compatibility in next phase")
-      - Platform constraint discoveries (e.g., "Tauri WebView blocks window.prompt — custom dialog needed")
+      - Platform constraint discoveries from `commands/references/framework-profiles.md`
       - Performance concerns (e.g., "FTS5 index on 500K rows may need optimization")
       - Missing infrastructure (e.g., "Redis connection may be required for rate-limiter in Phase 5")
       This section is OPTIONAL — only include if unexpected findings occurred. Orchestrator uses these warnings when generating the next Phase Seed.

--- a/agents/mpl-phase0-analyzer.md
+++ b/agents/mpl-phase0-analyzer.md
@@ -16,6 +16,7 @@ disallowedTools: Edit, Task
     - You CAN use Write to save a single `raw-scan.md` artifact to `{output_dir}`. No other file modifications.
     - You CANNOT spawn other agents.
     - Respect `tool_mode`: if LSP/ast_grep unavailable, fall back to Grep/Glob per `docs/standalone.md`.
+    - Load framework/tool details from `commands/references/framework-profiles.md`. Do not duplicate framework-specific policy tables in this prompt.
     - **Do not synthesize**: no complexity grading, no type policy rules, no error handling decisions. Your output is raw findings; the decomposer interprets them.
     - **No Step gating**: run all scan passes (boundary / API / tests / types / errors / platform / e2e) unconditionally — mechanical extraction is cheap.
   </Constraints>
@@ -54,21 +55,24 @@ disallowedTools: Edit, Task
 
     #### 2.1 — Boundary Pair Scan (CB-01)
 
-    Detect cross-language boundary pairs. Brownfield: grep actual code. Greenfield: infer from PP tech stack.
+    Detect cross-language boundary pairs. Brownfield: grep actual code using `boundary_profiles` from `commands/references/framework-profiles.md`. Greenfield: project boundary pairs from PP tech stack using the same profiles.
 
     ```
     boundary_pairs = []
 
-    // Brownfield: Tauri invoke pairs
-    callers = Grep("invoke[(<].*['\"]([a-z_]+)['\"]", "src/", glob="*.{ts,tsx}")
-    callees = Grep("#\\[tauri::command\\]", "src-tauri/", glob="*.rs")
-    for each caller:
-      match = callees.find(c => c.name == caller.name)
-      if match: boundary_pairs.push({
-        id: "BP-{n}", status: "confirmed",
-        caller, callee: match, protocol: "tauri-invoke",
-        framework_rules: ["camelCase params (Tauri v2 auto-convert)", "snake_case struct fields (serde default)"]
-      })
+    profiles = load("commands/references/framework-profiles.md").boundary_profiles
+
+    // Brownfield: apply each matching boundary profile mechanically
+    for each profile in profiles where profile.applies_when matches project:
+      callers = Grep(profile.caller_patterns, profile.caller_paths)
+      callees = Grep(profile.callee_patterns, profile.callee_paths)
+      for each caller:
+        match = match_boundary_pair(caller, callees, profile)
+        if match: boundary_pairs.push({
+          id: "BP-{n}", status: "confirmed",
+          caller, callee: match, protocol: profile.protocol,
+          framework_rules: profile.framework_rules
+        })
 
     // Brownfield: REST API pairs
     callers = Grep("(fetch|axios)\\.(get|post|put|delete)\\(['\"]([^'\"]+)", "src/")
@@ -81,9 +85,10 @@ disallowedTools: Edit, Task
 
     // Greenfield: infer from PP tech stack keywords
     if no boundary_pairs AND field == "greenfield":
-      if tech_stack contains "tauri":     add projected tauri-invoke pairs
-      if tech_stack contains "next|express": add projected rest-api pairs
-      if tech_stack contains "sidecar|json-rpc": add projected json-rpc pairs
+      for each matching profile in profiles:
+        add projected boundary pairs using profile.protocol and profile.framework_rules
+      add projected generic REST/API pairs when PP declares an HTTP/API layer
+      add projected JSON-RPC pairs when PP declares sidecar/RPC layers
     ```
 
     Emit as a YAML block inside `raw-scan.md`:
@@ -94,11 +99,10 @@ disallowedTools: Edit, Task
       - id: "BP-1"
         status: "confirmed"    # confirmed (brownfield) | projected (greenfield)
         caller: { lang: "ts", file: "src/stores/characterStore.ts", symbol: "invoke('save_character')" }
-        callee: { lang: "rust", file: "src-tauri/src/commands/character.rs", symbol: "fn save_character()" }
-        protocol: "tauri-invoke"
+        callee: { lang: "backend", file: "path/from/profile", symbol: "handler symbol" }
+        protocol: "profile protocol"
         framework_rules:
-          - "top-level params: camelCase (Tauri v2 default)"
-          - "struct fields: snake_case (serde default)"
+          - "rules loaded from commands/references/framework-profiles.md"
     ```
 
     #### 2.2 — API Signature Extraction
@@ -187,15 +191,13 @@ disallowedTools: Edit, Task
     #### 2.6 — Platform API Detection
 
     ```
-    1. Identify target platform from codebase_analysis.tech_stack (Tauri/Electron/RN/Node/etc.)
-    2. Grep for platform-blocked APIs present in source:
-       - Tauri v2 WebView:    window.prompt|window.confirm|window.alert|navigator.clipboard|File\.path
-       - Electron renderer:   require\(['"]fs['"]\)
-       - React Native:        document\.|window\.(?!navigator)
-    3. Record hits with file:line:pattern.
+    1. Load `platform_constraint_profiles` from `commands/references/framework-profiles.md`.
+    2. Identify matching profiles from codebase_analysis.tech_stack, config files, dependencies, and directories.
+    3. Grep each profile's `blocked_or_risky_patterns` in source.
+    4. Record hits with file:line:pattern.
     ```
 
-    Emit `## Platform API Hits` in `raw-scan.md` — raw grep hits per platform. Decomposer decides which are violations given the project's actual runtime.
+    Emit `## Platform API Hits` in `raw-scan.md` — raw grep hits per matched profile. Decomposer decides which are violations given the project's actual runtime.
 
     **Note**: F-48 Frontend Build Constraints synthesis (CSS strategy / bundle budget / code splitting) removed — decomposer derives these from PP directly.
 
@@ -206,28 +208,14 @@ disallowedTools: Edit, Task
     ```
     e2e_infra = { detected: false, tool: null, config_file: null, run_command: null }
 
-    // First match wins
-    if exists("playwright.config.ts") or exists("playwright.config.js"):
-      e2e_infra = { detected: true, tool: "playwright",
-                    config_file: "playwright.config.*",
-                    run_command: "npx playwright test" }
-    elif exists("cypress.config.ts") or exists("cypress.config.js") or exists("cypress/"):
-      e2e_infra = { detected: true, tool: "cypress",
-                    config_file: "cypress.config.*",
-                    run_command: "npx cypress run" }
-    elif exists("e2e/") or exists("tests/e2e/") or exists("test/e2e/"):
-      e2e_infra = { detected: true, tool: "custom",
-                    config_file: "e2e/", run_command: null }
-    elif Grep("puppeteer", "package.json"):
-      e2e_infra = { detected: true, tool: "puppeteer",
-                    config_file: "package.json", run_command: null }
-    elif Grep("selenium", "package.json") or Grep("selenium", "requirements.txt"):
-      e2e_infra = { detected: true, tool: "selenium",
-                    config_file: null, run_command: null }
-    elif Grep("pytest.*e2e|e2e.*pytest", "pyproject.toml"):
-      e2e_infra = { detected: true, tool: "pytest-e2e",
-                    config_file: "pyproject.toml",
-                    run_command: "pytest tests/e2e/" }
+    // First matching e2e_runner_profile wins unless project config declares priority.
+    profiles = load("commands/references/framework-profiles.md").e2e_runner_profiles
+    for each profile in profiles:
+      if profile.applies_when matches project:
+        e2e_infra = { detected: true, tool: profile.id,
+                      config_file: matched_profile_file_or_dir,
+                      run_command: profile.run_command }
+        break
     ```
 
     Emit `## E2E Infrastructure` YAML block in `raw-scan.md`.

--- a/commands/mpl-run-decompose.md
+++ b/commands/mpl-run-decompose.md
@@ -127,7 +127,7 @@ Task(subagent_type="mpl-decomposer", model="opus",
      ```
      This ensures Step 5.0 E2E Test has a concrete S-item to execute.
 
-     **AD-0006 (v0.15.0) — Launch smoke deterministic detection**: if any phase touches a runtime entry point detected mechanically from the project manifest, include a `launch_smoke` S-item on that phase. Detection triggers (pure file existence, no model judgment): `package.json` has `scripts.start`, `scripts.dev`, or `scripts.serve` · `Cargo.toml` has `[[bin]]` OR `[package].default-run` · `pyproject.toml` has `[project.scripts]` · project root has a `Dockerfile` ENTRYPOINT. Emit the matching smoke: `tauri dev --no-open` + liveness for Tauri, `<bin> --help` exit 0 for CLI, startup + `curl /health` for servers, `docker run --rm <image> --help` for containers. This closes the exp9 `cargo test` pass → `cargo run` abort class of failures (MPL#38).
+     **AD-0006 (v0.15.0) — Launch smoke deterministic detection**: if any phase touches a runtime entry point detected mechanically from the project manifest or a matching `launch_smoke_profile` in `commands/references/framework-profiles.md`, include a `launch_smoke` S-item on that phase. Detection uses file existence/config evidence only, with no model judgment. Emit the matching profile smoke shape and liveness evidence. This closes the exp9 "tests pass but runtime launch aborts" class of failures (MPL#38) without hardcoding framework launch commands in the core prompt.
 
      ## PP-Proximity Classification Rules
      Assign `pp_proximity` to each phase:
@@ -428,23 +428,21 @@ Report: "[MPL] Step 3-F: Applied {feedback_conditions.length} feedback condition
 
 ## Step 3-B: Verification Planning
 
-### GUI App Mandatory Check (F-E2E-1c, v0.8.3)
+### Runtime App Mandatory Check (F-E2E-1c, v0.8.3)
 
-Before deciding whether to run Step 3-B, check for GUI app indicators:
+Before deciding whether to run Step 3-B, check for runtime app indicators from `launch_smoke_profiles` and `e2e_runner_profiles`:
 
 ```
 decomposition = Read(".mpl/mpl/decomposition.yaml")
 tech_stack = decomposition.architecture_anchor.tech_stack
 dir_pattern = decomposition.architecture_anchor.directory_pattern
+profiles = load("commands/references/framework-profiles.md")
 
-gui_app_detected = any of:
-  - "src-tauri/" in dir_pattern or directory exists
-  - "electron/" or "src-electron/" in dir_pattern or directory exists
-  - "Tauri" in tech_stack
-  - "Electron" in tech_stack
+runtime_app_detected = any profile in profiles.launch_smoke_profiles or profiles.e2e_runner_profiles
+  whose applies_when matches dir_pattern, project files, dependencies, or tech_stack
 
-if gui_app_detected:
-  announce: "[MPL] GUI app detected. Step 3-B (Verification Planning) is mandatory."
+if runtime_app_detected:
+  announce: "[MPL] Runtime app profile detected. Step 3-B (Verification Planning) is mandatory."
   → MUST execute Step 3-B. Do NOT skip.
 ```
 

--- a/commands/mpl-run-execute-gates.md
+++ b/commands/mpl-run-execute-gates.md
@@ -113,32 +113,16 @@ if diagnostics.errors > 0:
 Report: "[MPL] Hard 1: Type check clean."
 ```
 
-**Step 3: Multi-Stack Build Verification**
+**Step 3: Profile-Backed Build Verification**
 
 ```
 build_commands = []
+profiles = load("commands/references/framework-profiles.md").build_tool_profiles
 
-// Auto-detect build tools
-if exists("package.json"):
-  scripts = parse("package.json").scripts
-  if scripts.build:     build_commands.push({ cmd: "npm run build", name: "Frontend build" })
-  if scripts.typecheck:  build_commands.push({ cmd: "npm run typecheck", name: "TypeScript check" })
-
-if exists("Cargo.toml") or exists("src-tauri/Cargo.toml"):
-  cargo_dir = exists("src-tauri") ? "src-tauri" : "."
-  build_commands.push({ cmd: "cd {cargo_dir} && cargo check", name: "Rust check" })
-
-if exists("pyproject.toml") or exists("setup.py"):
-  build_commands.push({ cmd: "python -m py_compile $(find . -name '*.py' -not -path './node_modules/*')", name: "Python check" })
-
-if exists("go.mod"):
-  build_commands.push({ cmd: "go build ./...", name: "Go build" })
-
-if exists("build.gradle") or exists("build.gradle.kts"):
-  build_commands.push({ cmd: "./gradlew compileJava", name: "Gradle compile" })
-
-if exists("pom.xml"):
-  build_commands.push({ cmd: "mvn compile -q", name: "Maven compile" })
+// Auto-detect build tools from matching build_tool_profiles
+for each profile in profiles:
+  if profile.applies_when matches project files/dependencies:
+    build_commands.push(...materialize(profile.commands, profile.cwd_rule))
 
 // Run all detected build commands
 for each { cmd, name } in build_commands:
@@ -155,7 +139,7 @@ for each { cmd, name } in build_commands:
 // Same principle as AD-02 for Hard 3 — missing precondition ≠ free pass.
 total_checks = lint_commands.length + build_commands.length + (diagnostics ? 1 : 0)
 if total_checks == 0:
-  announce: "[MPL] Hard 1 FAIL: No lint, type check, or build tool detected. At minimum, the project must have one of: package.json with build script, tsconfig.json, Cargo.toml, pyproject.toml, go.mod. Cannot verify code quality with zero tools."
+  announce: "[MPL] Hard 1 FAIL: No lint, type check, or build tool profile detected. Cannot verify code quality with zero tools."
   → enter fix loop (target: add build/lint configuration)
 
 Hard 1 passes when: all lint tools + type check + all build tools succeed AND at least one check ran.

--- a/commands/mpl-run-finalize.md
+++ b/commands/mpl-run-finalize.md
@@ -78,29 +78,30 @@ remain failing without override will be blocked.
 
 - MED/LOW H-items are NOT re-asked here — they are aggregated in Step 5.1.8 (T-10, v3.9)
 
-### 5.0.3: Playwright Trace Collection (0.16 S3-6)
+### 5.0.3: E2E Trace Collection (0.16 S3-6)
 
 When an E2E scenario fails, the diagnostician (Step 5.0.4) needs a trace
-excerpt to classify accurately. This step wires up Playwright trace output
-so the orchestrator can pass meaningful context to `mpl_diagnose_e2e_failure`.
+excerpt to classify accurately. This step wires up runner-specific trace output
+from `e2e_runner_profiles` in `commands/references/framework-profiles.md` so
+the orchestrator can pass meaningful context to `mpl_diagnose_e2e_failure`.
 
 **Auto-wrap policy** (applied inside Step 5.0 loop before `Bash(test_command)`):
 
 ```
-if test_command matches /playwright/ AND test_command does not contain "--trace":
-  # Inject trace flags — non-intrusive; Playwright writes zip files
+profiles = load("commands/references/framework-profiles.md").e2e_runner_profiles
+profile = find_matching_e2e_runner_profile(test_command, project_files, profiles)
+
+if profile.trace_policy supports automatic trace AND test_command lacks profile trace flags:
+  # Inject profile trace flags — non-intrusive; runner writes trace artifacts
   traceDir = ".mpl/e2e-traces"
   Bash("mkdir -p " + traceDir)
-  wrapped = test_command + " --trace on --trace-dir " + traceDir + "/" + s.id
+  wrapped = apply_trace_policy(test_command, profile.trace_policy, traceDir + "/" + s.id)
   Bash(wrapped, timeout=config.e2e_timeout or 60000)
 
-elif test_command matches /pytest/ OR /jest/:
-  # Other frameworks: no automatic trace injection. Diagnostician will
-  # fall back to stderr_tail. Projects can configure project-level
-  # trace via .mpl/config.json { "e2e_trace_cmd_prefix": "..." }.
-  Bash(test_command)
-
 else:
+  # No automatic trace profile. Diagnostician falls back to stderr_tail.
+  # Projects can configure project-level trace via
+  # .mpl/config.json { "e2e_trace_cmd_prefix": "..." }.
   Bash(test_command)
 ```
 

--- a/commands/mpl-run-phase0-analysis.md
+++ b/commands/mpl-run-phase0-analysis.md
@@ -93,7 +93,7 @@ if codebase_analysis.has_database:
 if codebase_analysis.layers.length >= 2:
   decisions_needed.push({
     pattern: "multi-layer IPC",
-    question: "What IPC protocol between {layer_A} and {layer_B}? (Tauri invoke / REST / gRPC / WebSocket)",
+    question: "What boundary protocol connects {layer_A} and {layer_B}? (choose from project/framework profiles or describe the custom protocol)",
     default: "Detect from project config"
   })
 
@@ -114,7 +114,7 @@ if codebase_analysis.has_file_io:
 if codebase_analysis.layers.length >= 2:
   decisions_needed.push({
     pattern: "cross-layer contracts (B-03)",
-    question: "How are types shared between layers?\n  A) Contract-First: one layer generates types for the other (e.g., specta/ts-rs for Tauri, OpenAPI for REST)\n  B) Shared schema: single schema generates both sides (protobuf, JSON Schema)\n  C) Manual sync: both sides define types independently (NOT recommended — drift risk)",
+    question: "How are types shared between layers?\n  A) Contract-First: one layer generates types for the other using the stack's profile-supported tooling\n  B) Shared schema: single schema generates both sides\n  C) Manual sync: both sides define types independently (NOT recommended — drift risk)",
     recommendation: "A or B — auto-generation eliminates structural mismatch",
     default: "A (Contract-First) if tooling exists for the stack"
   })
@@ -162,7 +162,7 @@ Decomposer is your own guess.
 > Output: single `raw-scan.md` artifact. No more `complexity-report.json`,
 > `type-policy.md`, or `error-spec.md` (decomposer generates these inline per-phase).
 
-The raw scan collects boundary pairs, API signatures, test patterns, type hints (brownfield only), error locations, platform API hits, and E2E infra — all via grep/ast_grep with no inference. Decomposer interprets the raw facts during phase decomposition.
+The raw scan collects boundary pairs, API signatures, test patterns, type hints (brownfield only), error locations, platform API hits, and E2E infra — all via grep/ast_grep with no inference. Framework/tool details come from `commands/references/framework-profiles.md`; Decomposer interprets the raw facts during phase decomposition.
 
 ### Subagent Delegation
 
@@ -189,11 +189,12 @@ Task(subagent_type="mpl-phase0-analyzer", model="haiku",
      {loaded_memory}
 
      ## Task
-     1. Check cache (full hit → skip, partial → rerun affected passes only)
-     2. Run all scan passes unconditionally: boundary, API, tests, types (Path A only), errors, platform, e2e
-     3. Assemble single raw-scan.md artifact
-     4. Save cache with per-pass hashes for future partial invalidation
-     5. Return ~200-token summary
+     1. Read `commands/references/framework-profiles.md`
+     2. Check cache (full hit → skip, partial → rerun affected passes only)
+     3. Run all scan passes unconditionally: boundary, API, tests, types (Path A only), errors, platform, e2e
+     4. Assemble single raw-scan.md artifact
+     5. Save cache with per-pass hashes for future partial invalidation
+     6. Return ~200-token summary
 
      Save only raw-scan.md + manifest.json. Do NOT synthesize type policy or error spec.
      Return only the summary. Do NOT return full artifact content.
@@ -265,8 +266,8 @@ Task(subagent_type="mpl-phase0-analyzer", model="haiku",
      })
 
    # Path B (Fallback): heuristic matching by gate-recorder
-   # gate-recorder classifies common tool commands (pnpm lint/test/build,
-   # cargo test/clippy, playwright, etc.) automatically. No orchestrator action
+   # gate-recorder classifies common tool commands from the tool profiles
+   # automatically. No orchestrator action
    # needed for stacks covered by the heuristic.
 
    # Path C (Best-effort): Phase 0 interview for explicit commands
@@ -277,7 +278,7 @@ Task(subagent_type="mpl-phase0-analyzer", model="haiku",
        header: "검증 명령어 수집",
        options: [
          { label: "기본 heuristic 사용",
-           description: "pnpm lint/test/build, cargo test/clippy 등 자동 매칭 — 대부분 프로젝트에 충분" },
+           description: "프로젝트 tool profile 기반 자동 매칭 — 대부분 프로젝트에 충분" },
          { label: "명령어 직접 지정",
            description: "lint/test/build/e2e 명령을 각각 입력" },
          { label: ".mpl/verify.sh 작성 예정",
@@ -308,5 +309,4 @@ Task(subagent_type="mpl-phase0-analyzer", model="haiku",
 > **Fallback**: If `mpl-phase0-analyzer` agent fails, the orchestrator may perform the scan directly using the protocol embedded in `agents/mpl-phase0-analyzer.md`. That doubles orchestrator context load and increases compaction risk; prefer retrying the agent.
 
 > **v0.17 change (#56)**: Prior sections 2.5.0-2.5.9 (complexity detection, API contracts, examples, type policy, error spec, validation per artifact, token profiling per step) are removed. That protocol was duplicated between the orchestrator doc and the agent prompt; the agent is now the single source of truth. Synthesis (complexity grade, type policy, error spec) moved to decomposer (#57).
-
 

--- a/commands/mpl-run-phase0.md
+++ b/commands/mpl-run-phase0.md
@@ -428,13 +428,13 @@ else:
 **Scope (reduced per #56)**: Pure mechanical extraction only. Synthesis (complexity grade, type policy, error spec) moved to decomposer (#57).
 
 Produces raw scan artifacts:
-- Boundary pair scan (CB-01 — tauri-invoke / REST / JSON-RPC)
+- Boundary pair scan (CB-01 — profile-backed boundary protocols + generic API/RPC)
 - API signatures (ast_grep + LSP fallback)
 - Test pattern scan
 - Type hints (Path A brownfield grep only)
 - Error pattern locations
 
-On greenfield (Step 2 skipped), still produces boundary pair **projections** from PP tech stack.
+On greenfield (Step 2 skipped), still produces boundary pair **projections** from PP tech stack using `commands/references/framework-profiles.md`.
 
 ---
 

--- a/commands/references/framework-profiles.md
+++ b/commands/references/framework-profiles.md
@@ -1,0 +1,246 @@
+---
+description: Framework/tool profile registry for boundary scans, platform constraints, launch smoke, resource risk, and E2E runner behavior.
+---
+
+# Framework And Tool Profiles
+
+**Loaded by**: Phase 0 raw scan, decomposer, execute gates, finalize, and doctor when they need framework/tool-specific behavior.
+
+**Purpose**: keep core MPL prompts framework-neutral. Core prompts should ask for profile categories and consume profile outputs; they should not duplicate framework-specific policy tables.
+
+## Profile Contract
+
+Profiles are advisory prompt data. They do not replace hooks or machine checks.
+
+### `boundary_profiles`
+
+- `id`: stable profile id
+- `applies_when`: files, dependencies, or tech-stack markers
+- `caller_paths`: source paths/globs to search
+- `callee_paths`: target paths/globs to search
+- `caller_patterns`: mechanical patterns for caller-side extraction
+- `callee_patterns`: mechanical patterns for callee-side extraction
+- `protocol`: boundary protocol name to record in `raw-scan.md`
+- `framework_rules`: naming/serialization rules to attach to `contract_files`
+
+### `platform_constraint_profiles`
+
+- `id`
+- `applies_when`
+- `blocked_or_risky_patterns`: source grep patterns
+- `hint`: probing hint for decomposer/test-agent
+
+### `framework_convention_profiles`
+
+- `id`
+- `applies_when`
+- `type_policy_rules`
+- `error_policy_rules`
+
+### `launch_smoke_profiles`
+
+- `id`
+- `applies_when`
+- `smoke_shape`: generic launch command shape, not a hard requirement
+- `liveness_evidence`: expected observable signal
+
+### `build_tool_profiles`
+
+- `id`
+- `applies_when`
+- `commands`: build/typecheck/lint command templates
+- `cwd_rule`: how to choose command working directory
+
+### `resource_risk_profiles`
+
+- `id`
+- `applies_when`
+- `paths`
+- `measurements`
+- `warning_policy`
+
+### `e2e_runner_profiles`
+
+- `id`
+- `applies_when`
+- `run_command`
+- `trace_policy`
+- `spec_path_patterns`
+- `launcher_evidence`
+
+## Profiles
+
+### Tauri / Rust Desktop
+
+`boundary_profiles`
+- `id`: `tauri-rust-invoke`
+- `applies_when`: `src-tauri/`, `tauri.conf.json`, `src-tauri/Cargo.toml`, or tech stack contains Tauri.
+- `caller_paths`: frontend source directories.
+- `callee_paths`: Rust source under the Tauri project root.
+- `caller_patterns`: `invoke(...)` call sites in frontend source.
+- `callee_patterns`: Rust functions annotated with `#[tauri::command]`.
+- `protocol`: `tauri-invoke`.
+- `framework_rules`: top-level invoke params use Tauri v2 camelCase conversion; Rust struct fields usually follow Serde defaults.
+
+`platform_constraint_profiles`
+- `id`: `tauri-webview-api`
+- `blocked_or_risky_patterns`: browser-native modal/file APIs that are unavailable or constrained inside the WebView runtime.
+- `hint`: verify runtime-safe dialog/file APIs instead of assuming browser APIs work.
+
+`framework_convention_profiles`
+- `id`: `tauri-rust-serde`
+- `type_policy_rules`: keep frontend/Rust boundary keys explicit; account for Serde naming conversion.
+- `error_policy_rules`: avoid unchecked Rust panic paths on command boundaries; surface command failures as typed frontend errors.
+
+`launch_smoke_profiles`
+- `id`: `tauri-desktop-launch`
+- `smoke_shape`: run the configured Tauri development or app launch command with no UI automation assumption.
+- `liveness_evidence`: process starts, runtime bridge initializes, and no immediate command/runtime rejection occurs.
+
+`build_tool_profiles`
+- `id`: `tauri-rust-build`
+- `applies_when`: `src-tauri/Cargo.toml`.
+- `commands`: Rust compile/typecheck command from the Rust manifest directory.
+- `cwd_rule`: use `src-tauri` when the manifest is under `src-tauri/`, otherwise use the project root.
+
+`resource_risk_profiles`
+- `id`: `tauri-rust-target`
+- `paths`: `src-tauri/target/**`.
+- `measurements`: target tree size, dependency artifact size, largest static library, partial scan errors.
+- `warning_policy`: advisory WARN only until thresholds are calibrated; do not treat partial scans as clean.
+
+`e2e_runner_profiles`
+- `id`: `tauri-driver`
+- `launcher_evidence`: desktop runtime launcher or driver evidence.
+
+### Electron Desktop
+
+`platform_constraint_profiles`
+- `id`: `electron-renderer-native-api`
+- `applies_when`: Electron config, dependency, directory, or tech-stack marker.
+- `blocked_or_risky_patterns`: direct native Node API access from renderer contexts.
+- `hint`: verify renderer/preload/main-process boundary design rather than assuming renderer native access.
+
+`launch_smoke_profiles`
+- `id`: `electron-launch`
+- `smoke_shape`: run the configured Electron app launch command.
+- `liveness_evidence`: main process starts and renderer loads without immediate runtime rejection.
+
+`e2e_runner_profiles`
+- `id`: `electron-launcher`
+- `launcher_evidence`: Electron launcher evidence.
+
+### Next.js / SSR Web Framework
+
+`platform_constraint_profiles`
+- `id`: `nextjs-ssr-browser-global`
+- `applies_when`: `next.config.*`, Next.js dependency, or equivalent SSR framework config/dependency marker.
+- `blocked_or_risky_patterns`: direct browser globals in server-rendered code paths.
+- `hint`: verify browser-only APIs are gated to client/runtime boundaries.
+
+`framework_convention_profiles`
+- `id`: `nextjs-ssr-web-conventions`
+- `type_policy_rules`: keep server/client DTO names explicit across boundaries.
+
+### React Native / Native Mobile Web Runtime
+
+`platform_constraint_profiles`
+- `id`: `react-native-browser-api`
+- `applies_when`: React Native dependency, native mobile config, or equivalent native mobile runtime marker.
+- `blocked_or_risky_patterns`: DOM/browser APIs that are unavailable in native mobile runtimes.
+- `hint`: verify native runtime APIs instead of browser DOM assumptions.
+
+### FastAPI / Python API With Schema Models
+
+`framework_convention_profiles`
+- `id`: `fastapi-pydantic-schema-models`
+- `applies_when`: FastAPI dependency plus Pydantic/schema model dependency, or equivalent Python API framework with schema models.
+- `type_policy_rules`: preserve schema model field names and serialization aliases across API boundaries.
+- `error_policy_rules`: surface validation failures as structured API errors.
+
+### JavaScript/TypeScript Package Scripts
+
+`build_tool_profiles`
+- `id`: `js-package-scripts`
+- `applies_when`: package manifest with build/typecheck/lint/test scripts.
+- `commands`: run declared package scripts rather than inventing commands.
+- `cwd_rule`: package manifest directory.
+
+### Rust Cargo
+
+`build_tool_profiles`
+- `id`: `rust-cargo`
+- `applies_when`: Rust manifest.
+- `commands`: cargo check/build/test according to gate context.
+- `cwd_rule`: manifest directory.
+
+### Python Project
+
+`build_tool_profiles`
+- `id`: `python-project`
+- `applies_when`: Python project metadata or setup file.
+- `commands`: byte-compile or configured test/lint command.
+- `cwd_rule`: project root unless a package subroot is detected.
+
+### Go Module
+
+`build_tool_profiles`
+- `id`: `go-module`
+- `applies_when`: Go module file.
+- `commands`: go build/test package tree.
+- `cwd_rule`: module root.
+
+### JVM Build Tools
+
+`build_tool_profiles`
+- `id`: `jvm-gradle-maven`
+- `applies_when`: Gradle or Maven build files.
+- `commands`: compile/test tasks matching the detected build tool.
+- `cwd_rule`: build file directory.
+
+### Playwright Browser E2E Runner
+
+`e2e_runner_profiles`
+- `id`: `playwright-browser-e2e`
+- `applies_when`: `playwright.config.*` or Playwright dependency.
+- `run_command`: configured Playwright command if present.
+- `trace_policy`: when the command lacks trace flags, add Playwright trace-on arguments and write traces under `.mpl/e2e-traces/`.
+- `spec_path_patterns`: Playwright spec globs from config or conventional e2e/test directories.
+- `launcher_evidence`: real browser or runtime launcher evidence.
+
+### Cypress Browser E2E Runner
+
+`e2e_runner_profiles`
+- `id`: `cypress-browser-e2e`
+- `applies_when`: `cypress.config.*`, `cypress/`, or Cypress dependency.
+- `run_command`: configured Cypress run command if present.
+- `trace_policy`: no automatic trace injection by default; preserve screenshots/videos and stderr/stdout tails.
+- `spec_path_patterns`: Cypress spec globs from config or `cypress/`.
+- `launcher_evidence`: real browser launcher evidence.
+
+### Puppeteer / Selenium Browser E2E Runner
+
+`e2e_runner_profiles`
+- `id`: `browser-driver-e2e`
+- `applies_when`: Puppeteer or Selenium dependency/config.
+- `run_command`: project-configured command if present; otherwise ask before synthesizing.
+- `trace_policy`: no automatic trace injection by default; preserve stderr/stdout tails.
+- `launcher_evidence`: browser driver launcher evidence.
+
+### Pytest E2E Runner
+
+`e2e_runner_profiles`
+- `id`: `pytest-e2e`
+- `applies_when`: Python project metadata or test directories indicate e2e pytest usage.
+- `run_command`: configured pytest e2e command if present.
+- `trace_policy`: no automatic trace injection by default; preserve stderr/stdout tails.
+- `spec_path_patterns`: Python e2e test paths from project config or test directories.
+- `launcher_evidence`: real API/runtime evidence when the scenario is not unit/mock.
+
+### Custom E2E Runner
+
+`e2e_runner_profiles`
+- `id`: `custom-e2e-runner`
+- `applies_when`: e2e directories or project-specific test command exists without a known runner profile.
+- `run_command`: null until user or project config supplies one.
+- `trace_policy`: no automatic trace injection; preserve stderr/stdout tails for diagnosis.

--- a/hooks/__tests__/mpl-framework-profile-prompts.test.mjs
+++ b/hooks/__tests__/mpl-framework-profile-prompts.test.mjs
@@ -1,0 +1,60 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync, readdirSync, readFileSync, statSync } from 'fs';
+import { join, relative, sep } from 'path';
+
+const PROFILE_REGISTRY = 'commands/references/framework-profiles.md';
+const SCAN_ROOTS = ['agents', 'commands'];
+const FORBIDDEN_RUNTIME_LITERALS = [
+  /\bTauri\b/i,
+  /\bsrc-tauri\b/i,
+  /\bElectron\b/i,
+  /\bNext\.js\b/i,
+  /\bnext\.config\b/i,
+  /\bFastAPI\b/i,
+  /\bReact Native\b/i,
+  /\bPlaywright\b/i,
+  /\bCypress\b/i,
+  /\btauri-driver\b/i,
+];
+
+function posix(path) {
+  return path.split(sep).join('/');
+}
+
+function walkMarkdown(root) {
+  const out = [];
+  if (!existsSync(root)) return out;
+  for (const entry of readdirSync(root)) {
+    const full = join(root, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      out.push(...walkMarkdown(full));
+    } else if (entry.endsWith('.md')) {
+      out.push(posix(relative(process.cwd(), full)));
+    }
+  }
+  return out;
+}
+
+describe('framework-specific prompt literals', () => {
+  it('keeps framework policy literals in the profile registry, not runtime prompts', () => {
+    const files = SCAN_ROOTS.flatMap((root) => walkMarkdown(join(process.cwd(), root)))
+      .filter((file) => file !== PROFILE_REGISTRY);
+
+    const hits = [];
+    for (const file of files) {
+      const lines = readFileSync(file, 'utf-8').split('\n');
+      lines.forEach((line, idx) => {
+        for (const pattern of FORBIDDEN_RUNTIME_LITERALS) {
+          if (pattern.test(line)) {
+            hits.push(`${file}:${idx + 1}: ${line.trim()}`);
+            break;
+          }
+        }
+      });
+    }
+
+    assert.deepEqual(hits, [], `Move framework-specific prompt rules to ${PROFILE_REGISTRY}:\n${hits.join('\n')}`);
+  });
+});


### PR DESCRIPTION
## What
- Add `commands/references/framework-profiles.md` as the single prompt-side registry for framework/tool-specific boundary, platform, launch smoke, resource-risk, build-tool, and E2E runner rules.
- Generalize runtime prompts in `agents/` and `commands/` so they consume profile slots instead of embedding Tauri/Electron/Next/FastAPI/React Native/Playwright/Cypress policy tables directly.
- Add a regression test that fails when framework-specific prompt literals reappear outside the profile registry.

## Why
Core prompts should remain framework-neutral. Stack-specific behavior should be preserved, but managed by framework/tool profiles now and later by dedicated framework skills.

## Design
- Issue: #171
- Profile registry: `commands/references/framework-profiles.md`

## Tests
- `node --test hooks/__tests__/mpl-framework-profile-prompts.test.mjs`
- `node --test hooks/__tests__/mpl-resource-risk.test.mjs`
- `rg -n "Tauri|tauri|Electron|electron|Next\\.js|next\\.config|FastAPI|React Native|Playwright|playwright|Cypress|cypress|src-tauri|tauri dev|tauri-driver" agents commands -g '*.md' --glob '!commands/references/framework-profiles.md'` returns no matches.
- `npm test`

## Agent Review Status

This PR is gated on **2 unique agent reviews** using footer markers.

- [ ] from claude
- [ ] from codex

Closes #171

---
_Awaiting reviews. Merge once the gate is satisfied._
