### PR TITLE
test: harden framework profile prompt guards

### DIFF
--- a/commands/references/framework-profiles.md
+++ b/commands/references/framework-profiles.md
@@ -12,6 +12,11 @@ description: Framework/tool profile registry for boundary scans, platform constr
 
 Profiles are advisory prompt data. They do not replace hooks or machine checks.
 
+### `prompt_guard_literals`
+
+- Framework/tool-specific literal names that must stay in this registry rather than runtime prompts.
+- Use `none` only for generic language/tool families whose names remain acceptable in runtime prompts.
+
 ### `boundary_profiles`
 
 - `id`: stable profile id
@@ -72,6 +77,11 @@ Profiles are advisory prompt data. They do not replace hooks or machine checks.
 
 ### Tauri / Rust Desktop
 
+`prompt_guard_literals`
+- `Tauri`
+- `src-tauri`
+- `tauri-driver`
+
 `boundary_profiles`
 - `id`: `tauri-rust-invoke`
 - `applies_when`: `src-tauri/`, `tauri.conf.json`, `src-tauri/Cargo.toml`, or tech stack contains Tauri.
@@ -115,6 +125,9 @@ Profiles are advisory prompt data. They do not replace hooks or machine checks.
 
 ### Electron Desktop
 
+`prompt_guard_literals`
+- `Electron`
+
 `platform_constraint_profiles`
 - `id`: `electron-renderer-native-api`
 - `applies_when`: Electron config, dependency, directory, or tech-stack marker.
@@ -132,6 +145,10 @@ Profiles are advisory prompt data. They do not replace hooks or machine checks.
 
 ### Next.js / SSR Web Framework
 
+`prompt_guard_literals`
+- `Next.js`
+- `next.config`
+
 `platform_constraint_profiles`
 - `id`: `nextjs-ssr-browser-global`
 - `applies_when`: `next.config.*`, Next.js dependency, or equivalent SSR framework config/dependency marker.
@@ -144,6 +161,9 @@ Profiles are advisory prompt data. They do not replace hooks or machine checks.
 
 ### React Native / Native Mobile Web Runtime
 
+`prompt_guard_literals`
+- `React Native`
+
 `platform_constraint_profiles`
 - `id`: `react-native-browser-api`
 - `applies_when`: React Native dependency, native mobile config, or equivalent native mobile runtime marker.
@@ -151,6 +171,9 @@ Profiles are advisory prompt data. They do not replace hooks or machine checks.
 - `hint`: verify native runtime APIs instead of browser DOM assumptions.
 
 ### FastAPI / Python API With Schema Models
+
+`prompt_guard_literals`
+- `FastAPI`
 
 `framework_convention_profiles`
 - `id`: `fastapi-pydantic-schema-models`
@@ -160,6 +183,9 @@ Profiles are advisory prompt data. They do not replace hooks or machine checks.
 
 ### JavaScript/TypeScript Package Scripts
 
+`prompt_guard_literals`
+- `none`
+
 `build_tool_profiles`
 - `id`: `js-package-scripts`
 - `applies_when`: package manifest with build/typecheck/lint/test scripts.
@@ -167,6 +193,9 @@ Profiles are advisory prompt data. They do not replace hooks or machine checks.
 - `cwd_rule`: package manifest directory.
 
 ### Rust Cargo
+
+`prompt_guard_literals`
+- `none`
 
 `build_tool_profiles`
 - `id`: `rust-cargo`
@@ -176,6 +205,9 @@ Profiles are advisory prompt data. They do not replace hooks or machine checks.
 
 ### Python Project
 
+`prompt_guard_literals`
+- `none`
+
 `build_tool_profiles`
 - `id`: `python-project`
 - `applies_when`: Python project metadata or setup file.
@@ -183,6 +215,9 @@ Profiles are advisory prompt data. They do not replace hooks or machine checks.
 - `cwd_rule`: project root unless a package subroot is detected.
 
 ### Go Module
+
+`prompt_guard_literals`
+- `none`
 
 `build_tool_profiles`
 - `id`: `go-module`
@@ -192,6 +227,9 @@ Profiles are advisory prompt data. They do not replace hooks or machine checks.
 
 ### JVM Build Tools
 
+`prompt_guard_literals`
+- `none`
+
 `build_tool_profiles`
 - `id`: `jvm-gradle-maven`
 - `applies_when`: Gradle or Maven build files.
@@ -199,6 +237,9 @@ Profiles are advisory prompt data. They do not replace hooks or machine checks.
 - `cwd_rule`: build file directory.
 
 ### Playwright Browser E2E Runner
+
+`prompt_guard_literals`
+- `Playwright`
 
 `e2e_runner_profiles`
 - `id`: `playwright-browser-e2e`
@@ -210,6 +251,9 @@ Profiles are advisory prompt data. They do not replace hooks or machine checks.
 
 ### Cypress Browser E2E Runner
 
+`prompt_guard_literals`
+- `Cypress`
+
 `e2e_runner_profiles`
 - `id`: `cypress-browser-e2e`
 - `applies_when`: `cypress.config.*`, `cypress/`, or Cypress dependency.
@@ -220,6 +264,10 @@ Profiles are advisory prompt data. They do not replace hooks or machine checks.
 
 ### Puppeteer / Selenium Browser E2E Runner
 
+`prompt_guard_literals`
+- `Puppeteer`
+- `Selenium`
+
 `e2e_runner_profiles`
 - `id`: `browser-driver-e2e`
 - `applies_when`: Puppeteer or Selenium dependency/config.
@@ -228,6 +276,9 @@ Profiles are advisory prompt data. They do not replace hooks or machine checks.
 - `launcher_evidence`: browser driver launcher evidence.
 
 ### Pytest E2E Runner
+
+`prompt_guard_literals`
+- `none`
 
 `e2e_runner_profiles`
 - `id`: `pytest-e2e`
@@ -238,6 +289,9 @@ Profiles are advisory prompt data. They do not replace hooks or machine checks.
 - `launcher_evidence`: real API/runtime evidence when the scenario is not unit/mock.
 
 ### Custom E2E Runner
+
+`prompt_guard_literals`
+- `none`
 
 `e2e_runner_profiles`
 - `id`: `custom-e2e-runner`

--- a/hooks/__tests__/mpl-framework-profile-prompts.test.mjs
+++ b/hooks/__tests__/mpl-framework-profile-prompts.test.mjs
@@ -57,15 +57,40 @@ function literalPattern(literal) {
   return new RegExp(`${startBoundary}${escaped}${endBoundary}`, 'i');
 }
 
+function parseBacktickBlocks(markdown) {
+  const blocks = [];
+  let current = null;
+
+  for (const line of markdown.split('\n')) {
+    const header = line.match(/^`([^`]+)`$/);
+    if (header) {
+      current = { name: header[1], lines: [] };
+      blocks.push(current);
+      continue;
+    }
+    if (current) {
+      current.lines.push(line);
+    }
+  }
+
+  return blocks;
+}
+
+function parseBacktickListItems(block) {
+  return block.lines
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => line.match(/^- `([^`]+)`$/)?.[1]?.trim())
+    .filter(Boolean);
+}
+
 function parsePromptGuardLiterals(registry) {
   const literals = [];
-  const blockPattern = /^`prompt_guard_literals`\n((?:- `[^`]+`\n?)+)/gm;
-  let match;
 
-  while ((match = blockPattern.exec(registry)) !== null) {
-    for (const line of match[1].trim().split('\n')) {
-      const literal = line.match(/^- `([^`]+)`$/)?.[1];
-      if (literal && literal !== 'none') {
+  for (const block of parseBacktickBlocks(registry)) {
+    if (block.name !== 'prompt_guard_literals') continue;
+    for (const literal of parseBacktickListItems(block)) {
+      if (literal.toLowerCase() !== 'none') {
         literals.push(literal);
       }
     }
@@ -94,12 +119,14 @@ function parseProfileCategoryEntries(sections) {
   const entries = new Map(REQUIRED_PROFILE_CATEGORIES.map((category) => [category, []]));
 
   for (const section of sections) {
-    const blocks = [...section.body.matchAll(/^`([^`]+)`\n([\s\S]*?)(?=\n`[^`]+`\n|\n### |\s*$)/gm)];
-    for (const [, category, body] of blocks) {
-      if (!entries.has(category)) continue;
-      const id = body.match(/^- `id`: `([^`]+)`/m)?.[1];
+    for (const block of parseBacktickBlocks(section.body)) {
+      if (!entries.has(block.name)) continue;
+      const id = block.lines
+        .map((line) => line.trim())
+        .find((line) => line.startsWith('- `id`:'))
+        ?.match(/^- `id`: `([^`]+)`/)?.[1];
       if (id) {
-        entries.get(category).push({ section: section.heading, id });
+        entries.get(block.name).push({ section: section.heading, id });
       }
     }
   }
@@ -134,6 +161,19 @@ describe('framework-specific prompt literals', () => {
     assert.deepEqual(hits, [], `Move framework-specific prompt rules to ${PROFILE_REGISTRY}:\n${hits.join('\n')}`);
   });
 
+  it('parses guard literals defensively', () => {
+    const registry = [
+      '`prompt_guard_literals`',
+      '- `None`',
+      '',
+      '- `Tauri`',
+      '- ` NONE `',
+      '',
+    ].join('\n');
+
+    assert.deepEqual(parsePromptGuardLiterals(registry), ['Tauri']);
+  });
+
   it('keeps the framework profile registry structurally complete', () => {
     const registry = readRepoFile(PROFILE_REGISTRY);
     const contractCategories = parseContractCategories(registry);
@@ -148,7 +188,10 @@ describe('framework-specific prompt literals', () => {
     assert.ok(profileSections.length > 0, 'Profile registry must contain at least one profile section');
 
     const missingGuards = profileSections
-      .filter(({ body }) => !/^`prompt_guard_literals`\n(?:- `[^`]+`\n)+/m.test(body))
+      .filter(({ body }) => {
+        const block = parseBacktickBlocks(body).find(({ name }) => name === 'prompt_guard_literals');
+        return !block || parseBacktickListItems(block).length === 0;
+      })
       .map(({ heading }) => heading);
     assert.deepEqual(missingGuards, [], `Every profile section needs prompt_guard_literals:\n${missingGuards.join('\n')}`);
 
@@ -159,5 +202,23 @@ describe('framework-specific prompt literals', () => {
       }
     }
     assert.deepEqual(emptyCategories, [], `Every supported profile category needs at least one registry entry:\n${emptyCategories.join('\n')}`);
+  });
+
+  it('parses profile ids without relying on id-first ordering', () => {
+    const entries = parseProfileCategoryEntries([
+      {
+        heading: 'Synthetic Build Tool',
+        body: [
+          '`build_tool_profiles`',
+          '- `applies_when`: synthetic manifest',
+          '- `id`: `synthetic-build-tool`',
+          '',
+        ].join('\n'),
+      },
+    ]);
+
+    assert.deepEqual(entries.get('build_tool_profiles'), [
+      { section: 'Synthetic Build Tool', id: 'synthetic-build-tool' },
+    ]);
   });
 });

--- a/hooks/__tests__/mpl-framework-profile-prompts.test.mjs
+++ b/hooks/__tests__/mpl-framework-profile-prompts.test.mjs
@@ -110,6 +110,10 @@ function parseProfileCategoryEntries(sections) {
 describe('framework-specific prompt literals', () => {
   it('keeps framework policy literals in the profile registry, not runtime prompts', () => {
     const guardLiterals = parsePromptGuardLiterals(readRepoFile(PROFILE_REGISTRY));
+    assert.ok(
+      guardLiterals.length > 0,
+      `${PROFILE_REGISTRY} must define at least one concrete prompt_guard_literals entry`,
+    );
     const forbiddenRuntimeLiterals = guardLiterals.map(literalPattern);
     const files = SCAN_ROOTS.flatMap((root) => walkMarkdown(repoPath(root)))
       .filter((file) => file !== PROFILE_REGISTRY);

--- a/hooks/__tests__/mpl-framework-profile-prompts.test.mjs
+++ b/hooks/__tests__/mpl-framework-profile-prompts.test.mjs
@@ -1,25 +1,34 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { existsSync, readdirSync, readFileSync, statSync } from 'fs';
-import { join, relative, sep } from 'path';
+import { dirname, join, relative, resolve, sep } from 'path';
+import { fileURLToPath } from 'url';
 
 const PROFILE_REGISTRY = 'commands/references/framework-profiles.md';
 const SCAN_ROOTS = ['agents', 'commands'];
-const FORBIDDEN_RUNTIME_LITERALS = [
-  /\bTauri\b/i,
-  /\bsrc-tauri\b/i,
-  /\bElectron\b/i,
-  /\bNext\.js\b/i,
-  /\bnext\.config\b/i,
-  /\bFastAPI\b/i,
-  /\bReact Native\b/i,
-  /\bPlaywright\b/i,
-  /\bCypress\b/i,
-  /\btauri-driver\b/i,
+const REQUIRED_PROFILE_CATEGORIES = [
+  'boundary_profiles',
+  'platform_constraint_profiles',
+  'framework_convention_profiles',
+  'launch_smoke_profiles',
+  'build_tool_profiles',
+  'resource_risk_profiles',
+  'e2e_runner_profiles',
 ];
+
+const TEST_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(TEST_DIR, '..', '..');
 
 function posix(path) {
   return path.split(sep).join('/');
+}
+
+function repoPath(...segments) {
+  return join(REPO_ROOT, ...segments);
+}
+
+function readRepoFile(path) {
+  return readFileSync(repoPath(path), 'utf-8');
 }
 
 function walkMarkdown(root) {
@@ -31,22 +40,85 @@ function walkMarkdown(root) {
     if (st.isDirectory()) {
       out.push(...walkMarkdown(full));
     } else if (entry.endsWith('.md')) {
-      out.push(posix(relative(process.cwd(), full)));
+      out.push(posix(relative(REPO_ROOT, full)));
     }
   }
   return out;
 }
 
+function escapeRegExp(literal) {
+  return literal.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function literalPattern(literal) {
+  const escaped = escapeRegExp(literal).replace(/\\ /g, '\\s+');
+  const startBoundary = /^[A-Za-z0-9_]/.test(literal) ? '\\b' : '';
+  const endBoundary = /[A-Za-z0-9_]$/.test(literal) ? '\\b' : '';
+  return new RegExp(`${startBoundary}${escaped}${endBoundary}`, 'i');
+}
+
+function parsePromptGuardLiterals(registry) {
+  const literals = [];
+  const blockPattern = /^`prompt_guard_literals`\n((?:- `[^`]+`\n?)+)/gm;
+  let match;
+
+  while ((match = blockPattern.exec(registry)) !== null) {
+    for (const line of match[1].trim().split('\n')) {
+      const literal = line.match(/^- `([^`]+)`$/)?.[1];
+      if (literal && literal !== 'none') {
+        literals.push(literal);
+      }
+    }
+  }
+
+  return [...new Set(literals)];
+}
+
+function parseContractCategories(registry) {
+  const contract = registry.match(/## Profile Contract\n([\s\S]+?)\n## Profiles/)?.[1] ?? '';
+  return [...contract.matchAll(/^### `([^`]+)`/gm)].map((match) => match[1]);
+}
+
+function parseProfileSections(registry) {
+  const profiles = registry.match(/## Profiles\n([\s\S]+)$/)?.[1] ?? '';
+  return profiles
+    .split(/^### /m)
+    .slice(1)
+    .map((section) => {
+      const [heading, ...body] = section.split('\n');
+      return { heading: heading.trim(), body: body.join('\n') };
+    });
+}
+
+function parseProfileCategoryEntries(sections) {
+  const entries = new Map(REQUIRED_PROFILE_CATEGORIES.map((category) => [category, []]));
+
+  for (const section of sections) {
+    const blocks = [...section.body.matchAll(/^`([^`]+)`\n([\s\S]*?)(?=\n`[^`]+`\n|\n### |\s*$)/gm)];
+    for (const [, category, body] of blocks) {
+      if (!entries.has(category)) continue;
+      const id = body.match(/^- `id`: `([^`]+)`/m)?.[1];
+      if (id) {
+        entries.get(category).push({ section: section.heading, id });
+      }
+    }
+  }
+
+  return entries;
+}
+
 describe('framework-specific prompt literals', () => {
   it('keeps framework policy literals in the profile registry, not runtime prompts', () => {
-    const files = SCAN_ROOTS.flatMap((root) => walkMarkdown(join(process.cwd(), root)))
+    const guardLiterals = parsePromptGuardLiterals(readRepoFile(PROFILE_REGISTRY));
+    const forbiddenRuntimeLiterals = guardLiterals.map(literalPattern);
+    const files = SCAN_ROOTS.flatMap((root) => walkMarkdown(repoPath(root)))
       .filter((file) => file !== PROFILE_REGISTRY);
 
     const hits = [];
     for (const file of files) {
-      const lines = readFileSync(file, 'utf-8').split('\n');
+      const lines = readRepoFile(file).split('\n');
       lines.forEach((line, idx) => {
-        for (const pattern of FORBIDDEN_RUNTIME_LITERALS) {
+        for (const pattern of forbiddenRuntimeLiterals) {
           if (pattern.test(line)) {
             hits.push(`${file}:${idx + 1}: ${line.trim()}`);
             break;
@@ -56,5 +128,32 @@ describe('framework-specific prompt literals', () => {
     }
 
     assert.deepEqual(hits, [], `Move framework-specific prompt rules to ${PROFILE_REGISTRY}:\n${hits.join('\n')}`);
+  });
+
+  it('keeps the framework profile registry structurally complete', () => {
+    const registry = readRepoFile(PROFILE_REGISTRY);
+    const contractCategories = parseContractCategories(registry);
+    const profileSections = parseProfileSections(registry);
+    const profileEntries = parseProfileCategoryEntries(profileSections);
+
+    assert.deepEqual(
+      contractCategories,
+      ['prompt_guard_literals', ...REQUIRED_PROFILE_CATEGORIES],
+      'Profile Contract must declare the prompt guard and all supported profile categories in order',
+    );
+    assert.ok(profileSections.length > 0, 'Profile registry must contain at least one profile section');
+
+    const missingGuards = profileSections
+      .filter(({ body }) => !/^`prompt_guard_literals`\n(?:- `[^`]+`\n)+/m.test(body))
+      .map(({ heading }) => heading);
+    assert.deepEqual(missingGuards, [], `Every profile section needs prompt_guard_literals:\n${missingGuards.join('\n')}`);
+
+    const emptyCategories = [];
+    for (const category of REQUIRED_PROFILE_CATEGORIES) {
+      if (profileEntries.get(category).length === 0) {
+        emptyCategories.push(category);
+      }
+    }
+    assert.deepEqual(emptyCategories, [], `Every supported profile category needs at least one registry entry:\n${emptyCategories.join('\n')}`);
   });
 });


### PR DESCRIPTION
## What
- Moves framework/runtime prompt guard literals into `commands/references/framework-profiles.md` via `prompt_guard_literals`.
- Updates `hooks/__tests__/mpl-framework-profile-prompts.test.mjs` to derive forbidden runtime literals from the registry instead of a hardcoded test list.
- Anchors the prompt scan to the repo root and adds registry structure invariants for required profile categories and per-section guard declarations.

## Why
PR #172 completed prompt generalization, and review follow-up #173 identified guard hardening gaps that could allow future framework-specific literals or malformed profile entries to slip through.

## Design
- Follow-up issue: Closes #173
- Profile registry remains the single source of truth for framework/tool-specific guard literals.

## Verification
- `node --test hooks/__tests__/mpl-framework-profile-prompts.test.mjs`
- `node --test __tests__/mpl-framework-profile-prompts.test.mjs` from `hooks/`
- `git diff --check`
- `npm test` (897 tests / 0 failures)

## Agent Review Status

This PR is gated on **2 unique agent reviews** using footer markers.

- [ ] from claude
- [ ] from codex

---
_Awaiting reviews. Merge once the gate is satisfied._
