### PR TITLE
feat: parse and validate optional mvp_scope in goal contract

### DIFF
--- a/docs/schemas/goal-contract.md
+++ b/docs/schemas/goal-contract.md
@@ -99,9 +99,13 @@ Validation rules (enforced by `hooks/lib/mpl-goal-contract.mjs`):
 - `mvp_scope.artifact` MUST be one of the values in `MVP_SCOPE_ARTIFACTS`
   (`draft_pr | branch | tag | release_manifest`).
 
-When `mvp_scope` is declared, the orchestrator routes MVP completion through
-the Stage A release path (`release-gate` → `release-finalize`); see
-`docs/roadmap/stage-a-mvp-cuts-rfc.md` for the full state machine.
+**Current Stage A status: schema only.** Parsing and validation are wired
+through `hooks/lib/mpl-goal-contract.mjs`; declaring `mvp_scope` today has no
+runtime effect beyond schema validation. When the Stage A release-path
+states (`release-gate` and `release-finalize`) and decomposer `mvp`
+derivation land in subsequent commits, MVP completion will route through
+the release path. See `docs/roadmap/stage-a-mvp-cuts-rfc.md` for the full
+target state machine.
 
 ## Runtime Enforcement
 

--- a/docs/schemas/goal-contract.md
+++ b/docs/schemas/goal-contract.md
@@ -74,6 +74,35 @@ deferred_uncertainties: []
 overrides: []
 ```
 
+## Optional: `mvp_scope` (Stage A)
+
+When the user declares an MVP subset during Phase 0, the contract gains an
+optional top-level `mvp_scope` field. Absent = pre-Stage-A behavior (no MVP
+cut; the current sequential pipeline runs unchanged).
+
+```yaml
+mvp_scope:                            # OPTIONAL — omit for current behavior
+  acceptance_criteria: [AC-1, AC-2]   # subset of acceptance_criteria[].id
+  variation_axes: [AX-1]              # subset of variation_axes[].id
+  artifact: draft_pr                  # draft_pr | branch | tag | release_manifest
+```
+
+Validation rules (enforced by `hooks/lib/mpl-goal-contract.mjs`):
+
+- `mvp_scope` itself is optional. Contracts without it remain valid.
+- Every `mvp_scope.acceptance_criteria[]` id MUST exist in the contract's
+  `acceptance_criteria[].id` set.
+- Every `mvp_scope.variation_axes[]` id MUST exist in the contract's
+  `variation_axes[].id` set.
+- `mvp_scope.acceptance_criteria` and `mvp_scope.variation_axes` may not
+  both be empty when `mvp_scope` is present.
+- `mvp_scope.artifact` MUST be one of the values in `MVP_SCOPE_ARTIFACTS`
+  (`draft_pr | branch | tag | release_manifest`).
+
+When `mvp_scope` is declared, the orchestrator routes MVP completion through
+the Stage A release path (`release-gate` → `release-finalize`); see
+`docs/roadmap/stage-a-mvp-cuts-rfc.md` for the full state machine.
+
 ## Runtime Enforcement
 
 - `hooks/mpl-ambiguity-gate.mjs` blocks `mpl-decomposer` dispatch when the

--- a/hooks/__tests__/mpl-goal-contract.test.mjs
+++ b/hooks/__tests__/mpl-goal-contract.test.mjs
@@ -6,6 +6,7 @@ import { tmpdir } from 'os';
 
 import {
   GOAL_CONTRACT_REL_PATH,
+  MVP_SCOPE_ARTIFACTS,
   parseGoalContractText,
   readGoalContract,
   validateGoalContractText,
@@ -137,5 +138,86 @@ describe('goal contract parsing', () => {
     assert.equal(verdict.exists, true);
     assert.equal(verdict.valid, true);
     assert.equal(verdict.contract.mission.project_pivot, 'Avoid false completion');
+  });
+});
+
+describe('goal contract mvp_scope (Stage A)', () => {
+  function mvpScopeBlock(body) {
+    return validGoalContract() + `mvp_scope:\n${body}\n`;
+  }
+
+  it('parses mvp_scope as null when the top-level key is absent', () => {
+    const c = parseGoalContractText(validGoalContract());
+    assert.equal(c.mvp_scope, null);
+  });
+
+  it('keeps the contract valid when mvp_scope is absent (backward compatibility)', () => {
+    const verdict = validateGoalContractText(validGoalContract());
+    assert.equal(verdict.valid, true);
+    assert.equal(verdict.contract.mvp_scope, null);
+  });
+
+  it('parses mvp_scope with inline-list acceptance_criteria, variation_axes, and a supported artifact', () => {
+    const text = mvpScopeBlock('  acceptance_criteria: [AC-1]\n  variation_axes: [AX-1]\n  artifact: draft_pr');
+    const verdict = validateGoalContractText(text);
+    assert.equal(verdict.valid, true, `missing: ${verdict.missing.join(',')}`);
+    assert.deepEqual(verdict.contract.mvp_scope.acceptance_criteria, ['AC-1']);
+    assert.deepEqual(verdict.contract.mvp_scope.variation_axes, ['AX-1']);
+    assert.equal(verdict.contract.mvp_scope.artifact, 'draft_pr');
+  });
+
+  it('parses mvp_scope with block-list acceptance_criteria', () => {
+    const text = mvpScopeBlock('  acceptance_criteria:\n    - AC-1\n  artifact: release_manifest');
+    const c = parseGoalContractText(text);
+    assert.deepEqual(c.mvp_scope.acceptance_criteria, ['AC-1']);
+    assert.equal(c.mvp_scope.artifact, 'release_manifest');
+  });
+
+  it('rejects mvp_scope acceptance_criteria ids that do not exist in the contract', () => {
+    const text = mvpScopeBlock('  acceptance_criteria: [AC-1, AC-999]\n  artifact: draft_pr');
+    const verdict = validateGoalContractText(text);
+    assert.equal(verdict.valid, false);
+    assert.ok(
+      verdict.missing.some((m) => m === 'mvp_scope.acceptance_criteria.unknown_id:AC-999'),
+      `expected unknown AC id in missing; got: ${verdict.missing.join(',')}`,
+    );
+  });
+
+  it('rejects mvp_scope variation_axes ids that do not exist in the contract', () => {
+    const text = mvpScopeBlock('  acceptance_criteria: [AC-1]\n  variation_axes: [AX-99]\n  artifact: tag');
+    const verdict = validateGoalContractText(text);
+    assert.equal(verdict.valid, false);
+    assert.ok(
+      verdict.missing.some((m) => m === 'mvp_scope.variation_axes.unknown_id:AX-99'),
+      `expected unknown AX id in missing; got: ${verdict.missing.join(',')}`,
+    );
+  });
+
+  it('rejects mvp_scope with an unsupported artifact value', () => {
+    const text = mvpScopeBlock('  acceptance_criteria: [AC-1]\n  artifact: gist');
+    const verdict = validateGoalContractText(text);
+    assert.equal(verdict.valid, false);
+    assert.ok(
+      verdict.missing.some((m) => m === 'mvp_scope.artifact.unsupported:gist'),
+      `expected unsupported artifact in missing; got: ${verdict.missing.join(',')}`,
+    );
+  });
+
+  it('rejects mvp_scope when artifact is missing entirely', () => {
+    const text = mvpScopeBlock('  acceptance_criteria: [AC-1]');
+    const verdict = validateGoalContractText(text);
+    assert.equal(verdict.valid, false);
+    assert.ok(verdict.missing.includes('mvp_scope.artifact'));
+  });
+
+  it('rejects mvp_scope when both acceptance_criteria and variation_axes are empty', () => {
+    const text = mvpScopeBlock('  acceptance_criteria: []\n  variation_axes: []\n  artifact: branch');
+    const verdict = validateGoalContractText(text);
+    assert.equal(verdict.valid, false);
+    assert.ok(verdict.missing.includes('mvp_scope.acceptance_criteria_or_variation_axes'));
+  });
+
+  it('exposes the allowed artifact set as MVP_SCOPE_ARTIFACTS', () => {
+    assert.deepEqual([...MVP_SCOPE_ARTIFACTS].sort(), ['branch', 'draft_pr', 'release_manifest', 'tag']);
   });
 });

--- a/hooks/__tests__/mpl-goal-contract.test.mjs
+++ b/hooks/__tests__/mpl-goal-contract.test.mjs
@@ -170,7 +170,33 @@ describe('goal contract mvp_scope (Stage A)', () => {
     const text = mvpScopeBlock('  acceptance_criteria:\n    - AC-1\n  artifact: release_manifest');
     const c = parseGoalContractText(text);
     assert.deepEqual(c.mvp_scope.acceptance_criteria, ['AC-1']);
+    assert.deepEqual(c.mvp_scope.variation_axes, []);
     assert.equal(c.mvp_scope.artifact, 'release_manifest');
+  });
+
+  it('rejects mvp_scope when the block is declared but completely empty', () => {
+    const text = validGoalContract() + 'mvp_scope:\n';
+    const verdict = validateGoalContractText(text);
+    assert.equal(verdict.valid, false);
+    assert.ok(
+      verdict.missing.includes('mvp_scope.acceptance_criteria_or_variation_axes'),
+      `expected empty-block to surface AC/AX-or check; got: ${verdict.missing.join(',')}`,
+    );
+    assert.ok(
+      verdict.missing.includes('mvp_scope.artifact'),
+      `expected empty-block to surface missing artifact; got: ${verdict.missing.join(',')}`,
+    );
+    // The contract.mvp_scope object MUST be non-null so downstream consumers
+    // can distinguish "declared-but-malformed" from "absent".
+    assert.notEqual(verdict.contract.mvp_scope, null);
+  });
+
+  it('rejects mvp_scope when only artifact is declared (no AC/AX keys)', () => {
+    const text = mvpScopeBlock('  artifact: branch');
+    const verdict = validateGoalContractText(text);
+    assert.equal(verdict.valid, false);
+    assert.ok(verdict.missing.includes('mvp_scope.acceptance_criteria_or_variation_axes'));
+    assert.equal(verdict.contract.mvp_scope.artifact, 'branch');
   });
 
   it('rejects mvp_scope acceptance_criteria ids that do not exist in the contract', () => {

--- a/hooks/lib/mpl-goal-contract.mjs
+++ b/hooks/lib/mpl-goal-contract.mjs
@@ -27,6 +27,13 @@ const DEFAULT_REQUIRED_ARTIFACTS = [
   '.mpl/mpl/RUNBOOK.md',
 ];
 
+export const MVP_SCOPE_ARTIFACTS = Object.freeze([
+  'draft_pr',
+  'branch',
+  'tag',
+  'release_manifest',
+]);
+
 function normalizeScalar(value) {
   if (typeof value !== 'string') return null;
   const trimmed = value.trim();
@@ -125,6 +132,17 @@ function sha256(text) {
   return createHash('sha256').update(String(text || '').replace(/\r\n/g, '\n').trim()).digest('hex');
 }
 
+function parseMvpScope(text) {
+  if (!/^mvp_scope\s*:/m.test(text)) return null;
+  const block = extractTopBlock(text, 'mvp_scope');
+  if (!block.trim()) return null;
+  return {
+    acceptance_criteria: listAfterKey(block, 'acceptance_criteria'),
+    variation_axes: listAfterKey(block, 'variation_axes'),
+    artifact: scalarInBlock(block, 'artifact'),
+  };
+}
+
 export function parseGoalContractText(text) {
   const source = extractTopBlock(text, 'source');
   const mission = extractTopBlock(text, 'mission');
@@ -169,6 +187,7 @@ export function parseGoalContractText(text) {
       require_commit: booleanInBlock(completionEvidence, 'require_commit'),
       require_finalize_timestamps: booleanInBlock(completionEvidence, 'require_finalize_timestamps'),
     },
+    mvp_scope: parseMvpScope(text),
     content_sha256: sha256(text),
   };
 }
@@ -214,6 +233,26 @@ export function validateGoalContractText(text) {
   for (const artifact of DEFAULT_REQUIRED_ARTIFACTS) {
     if (!contract.completion_evidence.required_artifacts.includes(artifact)) {
       warnings.push(`completion_evidence.required_artifacts missing recommended ${artifact}`);
+    }
+  }
+
+  if (contract.mvp_scope) {
+    const acIds = new Set(contract.acceptance_criteria);
+    const axIds = new Set(contract.variation_axes);
+    for (const id of contract.mvp_scope.acceptance_criteria) {
+      if (!acIds.has(id)) missing.push(`mvp_scope.acceptance_criteria.unknown_id:${id}`);
+    }
+    for (const id of contract.mvp_scope.variation_axes) {
+      if (!axIds.has(id)) missing.push(`mvp_scope.variation_axes.unknown_id:${id}`);
+    }
+    if (contract.mvp_scope.acceptance_criteria.length === 0
+      && contract.mvp_scope.variation_axes.length === 0) {
+      missing.push('mvp_scope.acceptance_criteria_or_variation_axes');
+    }
+    if (contract.mvp_scope.artifact === null) {
+      missing.push('mvp_scope.artifact');
+    } else if (!MVP_SCOPE_ARTIFACTS.includes(contract.mvp_scope.artifact)) {
+      missing.push(`mvp_scope.artifact.unsupported:${contract.mvp_scope.artifact}`);
     }
   }
 

--- a/hooks/lib/mpl-goal-contract.mjs
+++ b/hooks/lib/mpl-goal-contract.mjs
@@ -133,9 +133,12 @@ function sha256(text) {
 }
 
 function parseMvpScope(text) {
+  // `null` reserved for "key absent" — i.e., the contract opted out of MVP entirely.
+  // A present-but-empty `mvp_scope:` block is a *malformed declaration*: the user
+  // committed to MVP but didn't fill it in. Return an empty-shape object so the
+  // validator surfaces it as missing AC/AX/artifact rather than silently dropping.
   if (!/^mvp_scope\s*:/m.test(text)) return null;
   const block = extractTopBlock(text, 'mvp_scope');
-  if (!block.trim()) return null;
   return {
     acceptance_criteria: listAfterKey(block, 'acceptance_criteria'),
     variation_axes: listAfterKey(block, 'variation_axes'),


### PR DESCRIPTION
## What

Stage A implementation step 1: introduce `mvp_scope` as an optional top-level field on `.mpl/goal-contract.yaml`. Parser + validator + schema doc only — no orchestrator behavior change yet.

- `hooks/lib/mpl-goal-contract.mjs` (+39): `parseMvpScope` helper, `mvp_scope` field on parsed contract, validation rules (id-existence + artifact enum + non-empty-when-present), exported `MVP_SCOPE_ARTIFACTS` constant.
- `hooks/__tests__/mpl-goal-contract.test.mjs` (+82): 10 new tests covering absent / present, inline-list and block-list shapes, unknown AC/AX rejection, unsupported artifact rejection, missing artifact rejection, fully-empty rejection.
- `docs/schemas/goal-contract.md` (+29): new \"Optional: `mvp_scope` (Stage A)\" section.

Full hook test suite: **912/912 pass**.

## Why

The Stage A RFC (`docs/roadmap/stage-a-mvp-cuts-rfc.md`) requires goal-contract to carry a user-declared MVP subset as the entry point of the release path. This commit adds *only* the schema + parser + validator; orchestrator routing (`release-gate` / `release-finalize` states, cohort-aware `phase2-sprint`), interview guided-checklist (D-Q1), and decomposer `mvp` derivation are deliberately scoped out and will land in subsequent commits.

Backward compatibility: contracts without `mvp_scope` remain valid; the parsed field is `null` and existing readiness checks are unchanged.

## Design

- Source RFC: `docs/roadmap/stage-a-mvp-cuts-rfc.md` §4.1 (schema requirements).
- Validation rules: id existence against contract's `acceptance_criteria` / `variation_axes`, `artifact` enum `{draft_pr | branch | tag | release_manifest}`, non-empty when present.
- Schema doc: this PR adds the \"Optional: `mvp_scope` (Stage A)\" section to `docs/schemas/goal-contract.md`.

## Agent Review Status

This PR is gated on **2 unique agent reviews** (footers \`— from <agent>\`).

- [ ] from claude
- [ ] from codex

---
_Awaiting reviews. Merge once the gate is satisfied._