### PR TITLE
feat(hooks): validate Stage A mvp + release_cuts schema in contract graph

### DIFF
--- a/hooks/__tests__/mpl-phase-contract-graph.test.mjs
+++ b/hooks/__tests__/mpl-phase-contract-graph.test.mjs
@@ -165,6 +165,26 @@ describe('Stage A mvp + release_cuts schema', () => {
     assert.equal(graph.mvp.artifact, 'draft_pr');
   });
 
+  it('parses release_cuts items with block-list phases without splitting at nested dashes', () => {
+    // Regression for codex review on 02beb4d: indent-blind `-` detection
+    // misread inner `- phase-2` as a new cut boundary, splitting one valid
+    // cut into two malformed items. Cut item boundaries must respect indent.
+    const text = graphWithMvp('', `release_cuts:
+  - id: cut-a
+    phases:
+      - phase-2
+    user_approved: true
+    artifact: release_manifest`);
+    const graph = parsePhaseContractGraphText(text);
+    assert.equal(graph.release_cuts.length, 1, `cut count: expected 1, got ${graph.release_cuts.length}`);
+    assert.equal(graph.release_cuts[0].id, 'cut-a');
+    assert.deepEqual(graph.release_cuts[0].phases, ['phase-2']);
+    assert.equal(graph.release_cuts[0].user_approved, true);
+    assert.equal(graph.release_cuts[0].artifact, 'release_manifest');
+    const verdict = validatePhaseContractGraph(graph);
+    assert.equal(verdict.valid, true, verdict.issues.join(', '));
+  });
+
   it('parses release_cuts items even when id is not the first key (YAML mapping order is insignificant)', () => {
     // Regression for codex review: previously, parseReleaseCuts only recognized
     // items whose first line was `- id:`, which silently dropped items with

--- a/hooks/__tests__/mpl-phase-contract-graph.test.mjs
+++ b/hooks/__tests__/mpl-phase-contract-graph.test.mjs
@@ -165,6 +165,42 @@ describe('Stage A mvp + release_cuts schema', () => {
     assert.equal(graph.mvp.artifact, 'draft_pr');
   });
 
+  it('parses release_cuts items even when id is not the first key (YAML mapping order is insignificant)', () => {
+    // Regression for codex review: previously, parseReleaseCuts only recognized
+    // items whose first line was `- id:`, which silently dropped items with
+    // any other field order. Validator would then report `valid: true` because
+    // there were no items to check.
+    const text = graphWithMvp('', `release_cuts:
+  - phases: [phase-2]
+    id: cut-a
+    user_approved: true
+    artifact: release_manifest`);
+    const graph = parsePhaseContractGraphText(text);
+    assert.equal(graph.release_cuts.length, 1);
+    assert.equal(graph.release_cuts[0].id, 'cut-a');
+    assert.deepEqual(graph.release_cuts[0].phases, ['phase-2']);
+    assert.equal(graph.release_cuts[0].user_approved, true);
+    assert.equal(graph.release_cuts[0].artifact, 'release_manifest');
+
+    // And the validator MUST still see the same constraints — e.g., overlap
+    // detection must trigger even when ids are not first.
+    const overlapText = graphWithMvp(
+      `mvp:
+  derived_from: goal_contract.mvp_scope
+  phases: [phase-1]
+  execution_mode: sequential
+  artifact: draft_pr`,
+      `release_cuts:
+  - phases: [phase-1]
+    id: cut-a
+    user_approved: true
+    artifact: release_manifest`,
+    );
+    const verdict = validatePhaseContractGraph(parsePhaseContractGraphText(overlapText));
+    assert.equal(verdict.valid, false);
+    assert.ok(verdict.issues.some((i) => i.startsWith('release_cuts:cut-a:phases:overlap:phase-1:already_in:mvp')));
+  });
+
   it('parses release_cuts list with id, phases, user_approved, artifact', () => {
     const text = graphWithMvp('', `release_cuts:
   - id: cut-ext-a

--- a/hooks/__tests__/mpl-phase-contract-graph.test.mjs
+++ b/hooks/__tests__/mpl-phase-contract-graph.test.mjs
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'url';
 import { tmpdir } from 'os';
 
 import {
+  ALLOWED_RELEASE_ARTIFACTS,
   parsePhaseContractGraphText,
   validatePhaseContractGraph,
 } from '../lib/mpl-phase-contract-graph.mjs';
@@ -136,6 +137,215 @@ phases:
     assert.ok(verdict.issues.includes('execution_tiers:duplicate:phase-1'));
     assert.ok(verdict.issues.includes('execution_tiers:unknown:phase-404'));
     assert.ok(verdict.issues.includes('phase-2:execution_tiers:missing'));
+  });
+});
+
+describe('Stage A mvp + release_cuts schema', () => {
+  function graphWithMvp(mvpYaml = '', cutsYaml = '') {
+    let base = validGraph();
+    // Inject mvp and release_cuts at the top level, before execution_tiers.
+    const insertion = (mvpYaml ? `\n${mvpYaml}` : '') + (cutsYaml ? `\n${cutsYaml}` : '');
+    return base.replace('execution_tiers:', `${insertion}\nexecution_tiers:`);
+  }
+
+  it('exposes the allowed artifact set', () => {
+    assert.deepEqual([...ALLOWED_RELEASE_ARTIFACTS].sort(), ['branch', 'draft_pr', 'release_manifest', 'tag']);
+  });
+
+  it('parses mvp object with phases, execution_mode, and artifact', () => {
+    const text = graphWithMvp(`mvp:
+  derived_from: goal_contract.mvp_scope
+  phases: [phase-1]
+  execution_mode: sequential
+  artifact: draft_pr`);
+    const graph = parsePhaseContractGraphText(text);
+    assert.notEqual(graph.mvp, null);
+    assert.deepEqual(graph.mvp.phases, ['phase-1']);
+    assert.equal(graph.mvp.execution_mode, 'sequential');
+    assert.equal(graph.mvp.artifact, 'draft_pr');
+  });
+
+  it('parses release_cuts list with id, phases, user_approved, artifact', () => {
+    const text = graphWithMvp('', `release_cuts:
+  - id: cut-ext-a
+    phases: [phase-2]
+    user_approved: true
+    artifact: release_manifest`);
+    const graph = parsePhaseContractGraphText(text);
+    assert.equal(graph.release_cuts.length, 1);
+    assert.equal(graph.release_cuts[0].id, 'cut-ext-a');
+    assert.deepEqual(graph.release_cuts[0].phases, ['phase-2']);
+    assert.equal(graph.release_cuts[0].user_approved, true);
+    assert.equal(graph.release_cuts[0].artifact, 'release_manifest');
+  });
+
+  it('keeps a graph without mvp valid (backward compatibility)', () => {
+    const verdict = validatePhaseContractGraph(parsePhaseContractGraphText(validGraph()));
+    assert.equal(verdict.valid, true, verdict.issues.join(', '));
+    const g = parsePhaseContractGraphText(validGraph());
+    assert.equal(g.mvp, null);
+    assert.equal(g.release_cuts, null);
+  });
+
+  it('accepts a fully valid mvp + release_cuts graph', () => {
+    const text = graphWithMvp(
+      `mvp:
+  derived_from: goal_contract.mvp_scope
+  phases: [phase-1]
+  execution_mode: sequential
+  artifact: draft_pr`,
+      `release_cuts:
+  - id: cut-ext-a
+    phases: [phase-2]
+    user_approved: true
+    artifact: release_manifest`,
+    );
+    const verdict = validatePhaseContractGraph(parsePhaseContractGraphText(text));
+    assert.equal(verdict.valid, true, verdict.issues.join(', '));
+  });
+
+  it('rejects mvp.phases pointing at unknown phase ids', () => {
+    const text = graphWithMvp(`mvp:
+  derived_from: goal_contract.mvp_scope
+  phases: [phase-1, phase-999]
+  execution_mode: sequential
+  artifact: draft_pr`);
+    const verdict = validatePhaseContractGraph(parsePhaseContractGraphText(text));
+    assert.equal(verdict.valid, false);
+    assert.ok(verdict.issues.includes('mvp:phases:unknown:phase-999'));
+  });
+
+  it('rejects mvp.phases with duplicate ids', () => {
+    const text = graphWithMvp(`mvp:
+  derived_from: goal_contract.mvp_scope
+  phases: [phase-1, phase-1]
+  execution_mode: sequential
+  artifact: draft_pr`);
+    const verdict = validatePhaseContractGraph(parsePhaseContractGraphText(text));
+    assert.equal(verdict.valid, false);
+    assert.ok(verdict.issues.includes('mvp:phases:duplicate:phase-1'));
+  });
+
+  it('rejects mvp without execution_mode', () => {
+    const text = graphWithMvp(`mvp:
+  derived_from: goal_contract.mvp_scope
+  phases: [phase-1]
+  artifact: draft_pr`);
+    const verdict = validatePhaseContractGraph(parsePhaseContractGraphText(text));
+    assert.equal(verdict.valid, false);
+    assert.ok(verdict.issues.includes('mvp:execution_mode:missing'));
+  });
+
+  it('rejects Stage B contract_skeleton execution_mode in Stage A', () => {
+    const text = graphWithMvp(`mvp:
+  derived_from: goal_contract.mvp_scope
+  phases: [phase-1]
+  execution_mode: contract_skeleton
+  artifact: draft_pr`);
+    const verdict = validatePhaseContractGraph(parsePhaseContractGraphText(text));
+    assert.equal(verdict.valid, false);
+    assert.ok(verdict.issues.includes('mvp:execution_mode:unsupported:contract_skeleton'));
+  });
+
+  it('rejects mvp.artifact with unsupported value', () => {
+    const text = graphWithMvp(`mvp:
+  derived_from: goal_contract.mvp_scope
+  phases: [phase-1]
+  execution_mode: sequential
+  artifact: gist`);
+    const verdict = validatePhaseContractGraph(parsePhaseContractGraphText(text));
+    assert.equal(verdict.valid, false);
+    assert.ok(verdict.issues.includes('mvp:artifact:unsupported:gist'));
+  });
+
+  it('rejects release_cuts with the reserved "mvp" id', () => {
+    const text = graphWithMvp('', `release_cuts:
+  - id: mvp
+    phases: [phase-2]
+    user_approved: true
+    artifact: release_manifest`);
+    const verdict = validatePhaseContractGraph(parsePhaseContractGraphText(text));
+    assert.equal(verdict.valid, false);
+    assert.ok(verdict.issues.includes('release_cuts:id:reserved:mvp'));
+  });
+
+  it('rejects release_cuts with duplicate ids', () => {
+    const text = graphWithMvp('', `release_cuts:
+  - id: cut-a
+    phases: [phase-1]
+    user_approved: true
+    artifact: release_manifest
+  - id: cut-a
+    phases: [phase-2]
+    user_approved: true
+    artifact: release_manifest`);
+    const verdict = validatePhaseContractGraph(parsePhaseContractGraphText(text));
+    assert.equal(verdict.valid, false);
+    assert.ok(verdict.issues.includes('release_cuts:id:duplicate:cut-a'));
+  });
+
+  it('rejects release_cuts.phases pointing at unknown phase ids', () => {
+    const text = graphWithMvp('', `release_cuts:
+  - id: cut-a
+    phases: [phase-2, phase-999]
+    user_approved: true
+    artifact: release_manifest`);
+    const verdict = validatePhaseContractGraph(parsePhaseContractGraphText(text));
+    assert.equal(verdict.valid, false);
+    assert.ok(verdict.issues.includes('release_cuts:cut-a:phases:unknown:phase-999'));
+  });
+
+  it('rejects phase overlap between mvp and a release_cut', () => {
+    const text = graphWithMvp(
+      `mvp:
+  derived_from: goal_contract.mvp_scope
+  phases: [phase-1]
+  execution_mode: sequential
+  artifact: draft_pr`,
+      `release_cuts:
+  - id: cut-a
+    phases: [phase-1]
+    user_approved: true
+    artifact: release_manifest`,
+    );
+    const verdict = validatePhaseContractGraph(parsePhaseContractGraphText(text));
+    assert.equal(verdict.valid, false);
+    assert.ok(verdict.issues.some((i) => i.startsWith('release_cuts:cut-a:phases:overlap:phase-1:already_in:mvp')));
+  });
+
+  it('rejects phase overlap between two release_cuts', () => {
+    const text = graphWithMvp('', `release_cuts:
+  - id: cut-a
+    phases: [phase-1]
+    user_approved: true
+    artifact: release_manifest
+  - id: cut-b
+    phases: [phase-1]
+    user_approved: true
+    artifact: release_manifest`);
+    const verdict = validatePhaseContractGraph(parsePhaseContractGraphText(text));
+    assert.equal(verdict.valid, false);
+    assert.ok(verdict.issues.some((i) => i.startsWith('release_cuts:cut-b:phases:overlap:phase-1:already_in:cut-a')));
+  });
+
+  it('rejects release_cuts missing user_approved', () => {
+    const text = graphWithMvp('', `release_cuts:
+  - id: cut-a
+    phases: [phase-1]
+    artifact: release_manifest`);
+    const verdict = validatePhaseContractGraph(parsePhaseContractGraphText(text));
+    assert.equal(verdict.valid, false);
+    assert.ok(verdict.issues.includes('release_cuts:cut-a:user_approved:missing'));
+  });
+
+  it('rejects release_cuts missing artifact', () => {
+    const text = graphWithMvp('', `release_cuts:
+  - id: cut-a
+    phases: [phase-1]
+    user_approved: false`);
+    const verdict = validatePhaseContractGraph(parsePhaseContractGraphText(text));
+    assert.equal(verdict.valid, false);
+    assert.ok(verdict.issues.includes('release_cuts:cut-a:artifact:missing'));
   });
 });
 

--- a/hooks/__tests__/mpl-phase-contract-graph.test.mjs
+++ b/hooks/__tests__/mpl-phase-contract-graph.test.mjs
@@ -374,6 +374,69 @@ describe('Stage A mvp + release_cuts schema', () => {
     assert.ok(verdict.issues.includes('release_cuts:cut-a:user_approved:missing'));
   });
 
+  it('rejects mvp with no phases field at all', () => {
+    const text = graphWithMvp(`mvp:
+  derived_from: goal_contract.mvp_scope
+  execution_mode: sequential
+  artifact: draft_pr`);
+    const verdict = validatePhaseContractGraph(parsePhaseContractGraphText(text));
+    assert.equal(verdict.valid, false);
+    assert.ok(verdict.issues.includes('mvp:phases:missing'));
+  });
+
+  it('rejects mvp.phases as an explicit empty inline list', () => {
+    const text = graphWithMvp(`mvp:
+  derived_from: goal_contract.mvp_scope
+  phases: []
+  execution_mode: sequential
+  artifact: draft_pr`);
+    const verdict = validatePhaseContractGraph(parsePhaseContractGraphText(text));
+    assert.equal(verdict.valid, false);
+    assert.ok(verdict.issues.includes('mvp:phases:missing'));
+  });
+
+  it('accepts release_cuts as an explicit empty inline list (backward-compat)', () => {
+    const text = graphWithMvp('', 'release_cuts: []');
+    const graph = parsePhaseContractGraphText(text);
+    // Empty array parses to `[]` and validator runs zero cut-level checks.
+    assert.deepEqual(graph.release_cuts, []);
+    const verdict = validatePhaseContractGraph(graph);
+    assert.equal(verdict.valid, true, verdict.issues.join(', '));
+  });
+
+  it('parses mvp.phases in block-list form', () => {
+    const text = graphWithMvp(`mvp:
+  derived_from: goal_contract.mvp_scope
+  phases:
+    - phase-1
+  execution_mode: sequential
+  artifact: draft_pr`);
+    const graph = parsePhaseContractGraphText(text);
+    assert.deepEqual(graph.mvp.phases, ['phase-1']);
+    const verdict = validatePhaseContractGraph(graph);
+    assert.equal(verdict.valid, true, verdict.issues.join(', '));
+  });
+
+  it('rejects mvp.derived_from with an unsupported value', () => {
+    const text = graphWithMvp(`mvp:
+  derived_from: some_other_source
+  phases: [phase-1]
+  execution_mode: sequential
+  artifact: draft_pr`);
+    const verdict = validatePhaseContractGraph(parsePhaseContractGraphText(text));
+    assert.equal(verdict.valid, false);
+    assert.ok(verdict.issues.includes('mvp:derived_from:unsupported:some_other_source'));
+  });
+
+  it('accepts mvp without derived_from (treated as informational omission)', () => {
+    const text = graphWithMvp(`mvp:
+  phases: [phase-1]
+  execution_mode: sequential
+  artifact: draft_pr`);
+    const verdict = validatePhaseContractGraph(parsePhaseContractGraphText(text));
+    assert.equal(verdict.valid, true, verdict.issues.join(', '));
+  });
+
   it('rejects release_cuts missing artifact', () => {
     const text = graphWithMvp('', `release_cuts:
   - id: cut-a

--- a/hooks/lib/mpl-phase-contract-graph.mjs
+++ b/hooks/lib/mpl-phase-contract-graph.mjs
@@ -7,12 +7,15 @@
  * `mvp` / `release_cuts[]` schema integrity.
  */
 
-export const ALLOWED_RELEASE_ARTIFACTS = Object.freeze([
-  'draft_pr',
-  'branch',
-  'tag',
-  'release_manifest',
-]);
+import { MVP_SCOPE_ARTIFACTS } from './mpl-goal-contract.mjs';
+
+// Re-export under a graph-layer name so callers depending on this validator can
+// import the allowed-artifact set without reaching across modules; the set
+// itself is single-sourced from mpl-goal-contract.mjs to prevent drift between
+// the goal-contract layer (PR #178) and the graph layer (this PR).
+export const ALLOWED_RELEASE_ARTIFACTS = MVP_SCOPE_ARTIFACTS;
+
+const ALLOWED_MVP_DERIVED_FROM = Object.freeze(['goal_contract.mvp_scope']);
 
 function normalizeScalar(value) {
   if (typeof value !== 'string') return null;
@@ -130,7 +133,10 @@ function inlineListItems(block, key) {
 function nestedScalar(block, key) {
   if (!block) return null;
   const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const m = block.match(new RegExp(`^\\s+${escaped}\\s*:\\s*(.+?)\\s*$`, 'm'));
+  // `^\s*` (not `^\s+`) because topLevelBlock(text, ...) trims leading
+  // whitespace from its output, so the first nested field of a block ends up
+  // with no indent — we must still match it the same as the indented siblings.
+  const m = block.match(new RegExp(`^\\s*${escaped}\\s*:\\s*(.+?)\\s*$`, 'm'));
   return m ? normalizeScalar(m[1]) : null;
 }
 
@@ -295,6 +301,11 @@ function validateMvpAndReleaseCuts(graph, knownPhases, issues) {
     } else if (!ALLOWED_RELEASE_ARTIFACTS.includes(mvp.artifact)) {
       issues.push(`mvp:artifact:unsupported:${mvp.artifact}`);
     }
+    // `derived_from` is the provenance marker (RFC §4.2). Treat as load-bearing
+    // so any drift away from the documented source is caught here.
+    if (mvp.derived_from !== null && !ALLOWED_MVP_DERIVED_FROM.includes(mvp.derived_from)) {
+      issues.push(`mvp:derived_from:unsupported:${mvp.derived_from}`);
+    }
   }
 
   if (Array.isArray(cuts)) {
@@ -336,8 +347,10 @@ function validateMvpAndReleaseCuts(graph, knownPhases, issues) {
         issues.push(`release_cuts:${cut.id}:user_approved:missing`);
       }
       if (cut.artifact === null) {
-        // Default applied at decomposer layer; allow absent here but flag explicitly
-        // to keep the schema honest — decomposer should emit it.
+        // Decomposer MUST emit artifact for every cut (default `release_manifest`
+        // applied at decomposer layer per RFC §4.2). Absence at hook layer means
+        // the decomposer skipped the field — that is a contract violation, not
+        // a missing default. Reject in parity with mvp.artifact:missing above.
         issues.push(`release_cuts:${cut.id}:artifact:missing`);
       } else if (!ALLOWED_RELEASE_ARTIFACTS.includes(cut.artifact)) {
         issues.push(`release_cuts:${cut.id}:artifact:unsupported:${cut.artifact}`);

--- a/hooks/lib/mpl-phase-contract-graph.mjs
+++ b/hooks/lib/mpl-phase-contract-graph.mjs
@@ -3,8 +3,16 @@
  *
  * This validates the contract graph surface that is cheap to prove from the
  * prompt-controlled YAML subset: graph metadata, per-phase evidence/change
- * policy, and dangling `requires.from_phase` references.
+ * policy, dangling `requires.from_phase` references, and Stage A
+ * `mvp` / `release_cuts[]` schema integrity.
  */
+
+export const ALLOWED_RELEASE_ARTIFACTS = Object.freeze([
+  'draft_pr',
+  'branch',
+  'tag',
+  'release_manifest',
+]);
 
 function normalizeScalar(value) {
   if (typeof value !== 'string') return null;
@@ -98,6 +106,84 @@ function extractPhaseRefs(text) {
   return out;
 }
 
+function inlineListItems(block, key) {
+  if (!block) return null;
+  const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const inline = block.match(new RegExp(`^\\s*${escaped}\\s*:\\s*\\[(.*)\\]\\s*$`, 'm'));
+  if (inline) {
+    return inline[1]
+      .split(',')
+      .map((s) => normalizeScalar(s))
+      .filter(Boolean);
+  }
+  // block-list form
+  const nestedMatch = block.match(new RegExp(`^(\\s*)${escaped}\\s*:\\s*\\n((?:\\1\\s+-\\s+.+\\n?)+)`, 'm'));
+  if (!nestedMatch) return null;
+  const items = [];
+  for (const line of nestedMatch[2].split('\n')) {
+    const m = line.match(/^\s*-\s+(.+?)\s*$/);
+    if (m) items.push(normalizeScalar(m[1]));
+  }
+  return items.filter(Boolean);
+}
+
+function nestedScalar(block, key) {
+  if (!block) return null;
+  const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const m = block.match(new RegExp(`^\\s+${escaped}\\s*:\\s*(.+?)\\s*$`, 'm'));
+  return m ? normalizeScalar(m[1]) : null;
+}
+
+function parseMvpObject(text) {
+  if (!/^mvp\s*:/m.test(text)) return null;
+  const block = topLevelBlock(text, 'mvp');
+  if (block === null) return null;
+  return {
+    phases: inlineListItems(block, 'phases') || [],
+    execution_mode: nestedScalar(block, 'execution_mode'),
+    artifact: nestedScalar(block, 'artifact'),
+    derived_from: nestedScalar(block, 'derived_from'),
+  };
+}
+
+function parseReleaseCuts(text) {
+  if (!/^release_cuts\s*:/m.test(text)) return null;
+  const block = topLevelBlock(text, 'release_cuts');
+  if (block === null) return null;
+
+  const lines = block.split('\n');
+  const cuts = [];
+  let cur = null;
+
+  const flush = () => {
+    if (!cur) return;
+    cuts.push({
+      id: cur.id,
+      phases: inlineListItems(cur.text, 'phases') || [],
+      user_approved: (() => {
+        const raw = nestedScalar(cur.text, 'user_approved');
+        if (raw === 'true') return true;
+        if (raw === 'false') return false;
+        return null;
+      })(),
+      artifact: nestedScalar(cur.text, 'artifact'),
+    });
+    cur = null;
+  };
+
+  for (const line of lines) {
+    const idMatch = line.match(/^\s*-\s+id\s*:\s*["']?([^"'\s#]+)["']?/);
+    if (idMatch) {
+      flush();
+      cur = { id: idMatch[1], text: `${line}\n` };
+      continue;
+    }
+    if (cur) cur.text += `${line}\n`;
+  }
+  flush();
+  return cuts;
+}
+
 export function parsePhaseContractGraphText(text) {
   const executionTiersBlock = topLevelBlock(text, 'execution_tiers');
   const phases = phaseBlocks(text).map((block) => ({
@@ -116,6 +202,8 @@ export function parsePhaseContractGraphText(text) {
     has_execution_tiers: hasTopLevelNonEmptyField(text, 'execution_tiers'),
     execution_tier_phase_refs: extractPhaseRefs(executionTiersBlock),
     phases,
+    mvp: parseMvpObject(text),
+    release_cuts: parseReleaseCuts(text),
   };
 }
 
@@ -156,8 +244,94 @@ export function validatePhaseContractGraph(graph) {
     }
   }
 
+  validateMvpAndReleaseCuts(graph, knownPhases, issues);
+
   return {
     valid: issues.length === 0,
     issues,
   };
+}
+
+function validateMvpAndReleaseCuts(graph, knownPhases, issues) {
+  const mvp = graph?.mvp;
+  const cuts = graph?.release_cuts;
+
+  // Both fields are optional at this layer: a project without Stage A `mvp_scope`
+  // emits no `mvp`/`release_cuts`, and the existing pipeline continues unchanged.
+  // The "iff goal_contract.mvp_scope present → mvp required" check lives at the
+  // goal-contract / hook integration layer, not here.
+
+  if (mvp) {
+    if (!Array.isArray(mvp.phases) || mvp.phases.length === 0) {
+      issues.push('mvp:phases:missing');
+    } else {
+      for (const phaseId of mvp.phases) {
+        if (!knownPhases.has(phaseId)) issues.push(`mvp:phases:unknown:${phaseId}`);
+      }
+      const seen = new Set();
+      for (const phaseId of mvp.phases) {
+        if (seen.has(phaseId)) issues.push(`mvp:phases:duplicate:${phaseId}`);
+        seen.add(phaseId);
+      }
+    }
+    if (mvp.execution_mode === null) {
+      issues.push('mvp:execution_mode:missing');
+    } else if (mvp.execution_mode !== 'sequential') {
+      // Stage A: contract_skeleton is reserved for Stage B and rejected here.
+      issues.push(`mvp:execution_mode:unsupported:${mvp.execution_mode}`);
+    }
+    if (mvp.artifact === null) {
+      issues.push('mvp:artifact:missing');
+    } else if (!ALLOWED_RELEASE_ARTIFACTS.includes(mvp.artifact)) {
+      issues.push(`mvp:artifact:unsupported:${mvp.artifact}`);
+    }
+  }
+
+  if (Array.isArray(cuts)) {
+    const cutIds = new Set();
+    const phaseToCut = new Map();
+    if (mvp?.phases) {
+      for (const p of mvp.phases) phaseToCut.set(p, 'mvp');
+    }
+    for (const cut of cuts) {
+      if (!cut.id) {
+        issues.push('release_cuts:id:missing');
+        continue;
+      }
+      if (cutIds.has(cut.id)) {
+        issues.push(`release_cuts:id:duplicate:${cut.id}`);
+        continue;
+      }
+      cutIds.add(cut.id);
+
+      if (cut.id === 'mvp') {
+        issues.push('release_cuts:id:reserved:mvp');
+      }
+      if (!Array.isArray(cut.phases) || cut.phases.length === 0) {
+        issues.push(`release_cuts:${cut.id}:phases:missing`);
+      } else {
+        for (const phaseId of cut.phases) {
+          if (!knownPhases.has(phaseId)) {
+            issues.push(`release_cuts:${cut.id}:phases:unknown:${phaseId}`);
+          }
+          const existingOwner = phaseToCut.get(phaseId);
+          if (existingOwner) {
+            issues.push(`release_cuts:${cut.id}:phases:overlap:${phaseId}:already_in:${existingOwner}`);
+          } else {
+            phaseToCut.set(phaseId, cut.id);
+          }
+        }
+      }
+      if (cut.user_approved === null) {
+        issues.push(`release_cuts:${cut.id}:user_approved:missing`);
+      }
+      if (cut.artifact === null) {
+        // Default applied at decomposer layer; allow absent here but flag explicitly
+        // to keep the schema honest — decomposer should emit it.
+        issues.push(`release_cuts:${cut.id}:artifact:missing`);
+      } else if (!ALLOWED_RELEASE_ARTIFACTS.includes(cut.artifact)) {
+        issues.push(`release_cuts:${cut.id}:artifact:unsupported:${cut.artifact}`);
+      }
+    }
+  }
 }

--- a/hooks/lib/mpl-phase-contract-graph.mjs
+++ b/hooks/lib/mpl-phase-contract-graph.mjs
@@ -154,12 +154,29 @@ function parseMvpObject(text) {
 
 function parseReleaseCuts(text) {
   if (!/^release_cuts\s*:/m.test(text)) return null;
-  const block = topLevelBlock(text, 'release_cuts');
-  if (block === null) return null;
 
-  // Split into `-` item blocks first, then extract `id` from anywhere inside
-  // the block — YAML mapping field order is not significant, so `id` may
-  // legitimately appear after `phases:`, `artifact:`, etc.
+  // Walk the raw text instead of going through `topLevelBlock` because that
+  // helper trims leading whitespace, which would erase the indent of the very
+  // first `-` cut item and break the indent-anchored item-boundary detection
+  // below.
+  const lines = String(text || '').split('\n').map((l) => l.replace(/\r$/, ''));
+  const startIdx = lines.findIndex((line) => /^release_cuts\s*:\s*(?:\[\s*\])?\s*$/.test(line));
+  if (startIdx === -1) return null;
+
+  // Inline empty list (`release_cuts: []`) parses to an empty array.
+  if (/^release_cuts\s*:\s*\[\s*\]\s*$/.test(lines[startIdx])) return [];
+
+  // Collect lines until the next top-level key (any non-indented line).
+  const bodyLines = [];
+  for (let i = startIdx + 1; i < lines.length; i++) {
+    if (/^\S/.test(lines[i])) break;
+    bodyLines.push(lines[i]);
+  }
+  if (bodyLines.length === 0) return [];
+
+  // Split into `-` item blocks; only `-` lines at the *same* indent count as
+  // new cut boundaries. A deeper `-` (for example a block-list `phases:` field
+  // whose entries are `- phase-2`) is part of the current item, not a new cut.
   const itemBlocks = [];
   let cur = null;
 
@@ -168,13 +185,15 @@ function parseReleaseCuts(text) {
     cur = null;
   };
 
-  for (const line of block.split('\n')) {
+  let baseIndent = null;
+  for (const line of bodyLines) {
     const itemStart = line.match(/^(\s*)-\s+(.+?)\s*$/);
-    if (itemStart) {
+    if (itemStart && (baseIndent === null || itemStart[1].length === baseIndent)) {
+      if (baseIndent === null) baseIndent = itemStart[1].length;
       flush();
       // Replace `- ` with equivalent whitespace so the first line of each item
       // is a normal indented `key: value` line that nestedScalar/inlineListItems
-      // (both anchored on `\s+`) can match.
+      // can match against an indent-anchored regex.
       cur = [`${itemStart[1]}  ${itemStart[2]}`];
       continue;
     }

--- a/hooks/lib/mpl-phase-contract-graph.mjs
+++ b/hooks/lib/mpl-phase-contract-graph.mjs
@@ -151,36 +151,46 @@ function parseReleaseCuts(text) {
   const block = topLevelBlock(text, 'release_cuts');
   if (block === null) return null;
 
-  const lines = block.split('\n');
-  const cuts = [];
+  // Split into `-` item blocks first, then extract `id` from anywhere inside
+  // the block — YAML mapping field order is not significant, so `id` may
+  // legitimately appear after `phases:`, `artifact:`, etc.
+  const itemBlocks = [];
   let cur = null;
 
   const flush = () => {
-    if (!cur) return;
+    if (cur) itemBlocks.push(cur.join('\n'));
+    cur = null;
+  };
+
+  for (const line of block.split('\n')) {
+    const itemStart = line.match(/^(\s*)-\s+(.+?)\s*$/);
+    if (itemStart) {
+      flush();
+      // Replace `- ` with equivalent whitespace so the first line of each item
+      // is a normal indented `key: value` line that nestedScalar/inlineListItems
+      // (both anchored on `\s+`) can match.
+      cur = [`${itemStart[1]}  ${itemStart[2]}`];
+      continue;
+    }
+    if (cur) cur.push(line);
+  }
+  flush();
+
+  const cuts = [];
+  for (const itemText of itemBlocks) {
+    const idMatch = itemText.match(/(?:^|\n)\s*id\s*:\s*["']?([^"'\s#]+)["']?/);
     cuts.push({
-      id: cur.id,
-      phases: inlineListItems(cur.text, 'phases') || [],
+      id: idMatch ? idMatch[1] : null,
+      phases: inlineListItems(itemText, 'phases') || [],
       user_approved: (() => {
-        const raw = nestedScalar(cur.text, 'user_approved');
+        const raw = nestedScalar(itemText, 'user_approved');
         if (raw === 'true') return true;
         if (raw === 'false') return false;
         return null;
       })(),
-      artifact: nestedScalar(cur.text, 'artifact'),
+      artifact: nestedScalar(itemText, 'artifact'),
     });
-    cur = null;
-  };
-
-  for (const line of lines) {
-    const idMatch = line.match(/^\s*-\s+id\s*:\s*["']?([^"'\s#]+)["']?/);
-    if (idMatch) {
-      flush();
-      cur = { id: idMatch[1], text: `${line}\n` };
-      continue;
-    }
-    if (cur) cur.text += `${line}\n`;
   }
-  flush();
   return cuts;
 }
 


### PR DESCRIPTION
## What

Stage A implementation phase 1.4a: extend the decomposition contract-graph validator with parser + structural validation for the new `mvp` and `release_cuts[]` top-level fields (landed in PR #178).

- `hooks/lib/mpl-phase-contract-graph.mjs` (+91, -1): `parseMvpObject` + `parseReleaseCuts` helpers; new `validateMvpAndReleaseCuts` invoked from `validatePhaseContractGraph`; exported `ALLOWED_RELEASE_ARTIFACTS` constant.
- `hooks/__tests__/mpl-phase-contract-graph.test.mjs` (+295): 17 new tests under \"Stage A mvp + release_cuts schema\" describe.

Full hook suite: **931/931 pass** (+17, 0 regression).

## Why

PR #178 added the `mvp_scope` field at the goal-contract layer. The decomposer is expected to derive a top-level `mvp` object and optional `release_cuts[]` array on `decomposition.yaml` from that. Without hook-level validation, decomposer drift (missing fields, cross-cut phase overlap, Stage B-only execution modes leaking through) would surface only at runtime — far from the source.

This PR adds the **structural integrity layer**:
- mvp / release_cuts schema parsing
- mvp.phases ⊆ phases; no duplicates
- release_cuts[].phases ⊆ phases; no cross-cut overlap (mvp ∩ cut, cut[i] ∩ cut[j])
- mvp.execution_mode required and Stage-A-only (`sequential`; `contract_skeleton` rejected)
- mvp.artifact / release_cuts[].artifact ∈ `ALLOWED_RELEASE_ARTIFACTS`
- release_cuts[].id unique and never the reserved literal `\"mvp\"`
- release_cuts[].user_approved must be explicit boolean

Backward compatibility: contracts without `mvp` and `release_cuts[]` remain valid (the existing pipeline runs unchanged).

## Design

- Source: `docs/roadmap/stage-a-mvp-cuts-rfc.md` §4.2 (validation requirements), §6 Hook Impact (mpl-phase-contract-graph.mjs row).
- Companion PR (already merged): #178 (`mvp_scope` parser at goal-contract layer).
- Scope deliberately **excludes** two larger items that will land separately in **phase 1.4b**:
  - **Dependency-closure rule (B5)**: no forward or upward `requires`. Needs cross-phase requires analysis across cohort boundaries.
  - **D-Q6 released-cut immutability**: needs `state.release.completed_cut_ids` access at hook runtime (not just single-graph parsing); pairs naturally with state.release subtree (phase 1.6).

## Agent Review Status

This PR is gated on **2 unique agent reviews** (footers `— from <agent>`).

- [ ] from claude
- [ ] from codex

---
_Awaiting reviews. Merge once the gate is satisfied._