### PR TITLE
feat(phase0): add MVP scope guided-checklist step before Goal Contract freeze

### DIFF
--- a/commands/mpl-run-phase0.md
+++ b/commands/mpl-run-phase0.md
@@ -397,12 +397,16 @@ if opt_in == "No":
   mvp_scope = null
 else:
   # Guided checklist for AC ids. When total count exceeds 10, group display
-  # by the user-contract core_scenarios so the list stays navigable. The
-  # selection unit remains the individual AC id regardless of grouping.
+  # by Stage 1.1 `core_scenarios` (the PP-derived scenarios written to
+  # `.mpl/mpl/core-scenarios.yaml`; carried in-memory as the `core_scenarios`
+  # variable produced earlier in this phase, e.g. line 131+ and snapshot
+  # consumer at line 578). NOT `user_contract.scenarios`, which is the E2E
+  # scenario list with a different schema. The selection unit remains the
+  # individual AC id regardless of grouping.
   selected_ac = AskUserQuestion({
     question: "Which acceptance_criteria are in MVP scope? (multi-select)",
     # Option shape: { label: ac.id, description: ac.statement, group: scenario_id_or_null }
-    options: build_ac_options(ac_ids, threshold=10, scenarios=user_contract.core_scenarios),
+    options: build_ac_options(ac_ids, threshold=10, scenarios=core_scenarios),
     multiSelect: true,
   })
   selected_ax = AskUserQuestion({

--- a/commands/mpl-run-phase0.md
+++ b/commands/mpl-run-phase0.md
@@ -279,6 +279,84 @@ Announce: `[MPL] Stage 1.3 complete. user_cases=${result.user_cases.length} defe
 | `scenarios[*]` | Decomposer Step 3-H, Test Agent | E2E scenario seeds |
 | `ambiguity_hints[]` | Stage 2 Ambiguity Resolution | Targeted questions |
 
+### Stage 1.3.5: MVP Scope Selection (Stage A, optional)
+
+Before serializing the Goal Contract, offer the user a guided checklist to
+declare which `acceptance_criteria` / `variation_axes` form the MVP cohort —
+the user-shippable subset that the Stage A release path delivers first via
+`release-gate` → `release-finalize`. When the user declines, omit
+`mvp_scope` entirely and the pipeline runs as today (no Stage A release
+path).
+
+See `docs/roadmap/stage-a-mvp-cuts-rfc.md` §10 D-Q1: guided checklist is the
+chosen wording (rejected: id-only — cognitively hostile; rejected:
+prose-mapped — reintroduces inference). MVP scope is **user-declared**, not
+decomposer-inferred (RFC §3.4 / §10 D-Q4 lineage).
+
+Protocol:
+
+```
+ac_ids = [ac.id for ac in resolved_spec.acceptance_criteria]
+ax_ids = [ax.id for ax in resolved_spec.variation_axes]
+
+opt_in = AskUserQuestion({
+  question: "Declare an MVP subset for Stage A release path?",
+  options: [
+    { label: "Yes — select MVP subset",
+      description: "Pick which AC/AX ids form the MVP cohort. The pipeline ships the MVP via release-gate → release-finalize before extension work." },
+    { label: "No — full pipeline only",
+      description: "Skip Stage A release path. Pipeline runs as today; no mid-pipeline release artifact." },
+  ],
+})
+
+if opt_in == "No":
+  mvp_scope = null
+else:
+  # Guided checklist for AC ids. When total count exceeds 10, group display
+  # by core_scenarios (from user-contract.md) so the list stays navigable.
+  # The selection unit remains the individual AC id regardless of grouping.
+  selected_ac = AskUserQuestion({
+    question: "Which acceptance_criteria are in MVP scope? (multi-select)",
+    options: build_ac_options(ac_ids, threshold=10, scenarios=resolved_spec.core_scenarios),
+    multiSelect: true,
+  })
+  selected_ax = AskUserQuestion({
+    question: "Which variation_axes are in MVP scope? (multi-select; may be empty)",
+    options: build_ax_options(ax_ids),
+    multiSelect: true,
+  })
+
+  # MVP must declare at least one AC or AX (validator rejects both-empty;
+  # see hooks/lib/mpl-goal-contract.mjs MVP_SCOPE_ARTIFACTS check).
+  if len(selected_ac) == 0 and len(selected_ax) == 0:
+    Announce: "[MPL] MVP scope cannot be fully empty — at least one AC or AX required. Retrying."
+    GOTO selected_ac question.
+
+  artifact = AskUserQuestion({
+    question: "What user-visible artifact should the MVP cut produce?",
+    options: [
+      { label: "draft_pr",         description: "Open a draft GitHub PR at the MVP snapshot ref." },
+      { label: "branch",           description: "Push a snapshot branch (mpl/release/mvp) frozen at the MVP commit." },
+      { label: "tag",              description: "Push an immutable tag (mpl-release-mvp) at the MVP commit." },
+      { label: "release_manifest", description: "Manifest only — no git/GitHub artifact. Cheapest, fully offline." },
+    ],
+  })
+
+  mvp_scope = {
+    acceptance_criteria: selected_ac,
+    variation_axes: selected_ax,
+    artifact: artifact,  # one of MVP_SCOPE_ARTIFACTS (validated by mpl-goal-contract.mjs)
+  }
+
+Announce: `[MPL] MVP scope set: AC={len(selected_ac)} AX={len(selected_ax)} artifact={artifact}.` (or "MVP scope: opted out.")
+```
+
+The collected `mvp_scope` is written into the Goal Contract in the next
+stage. The hook `hooks/lib/mpl-goal-contract.mjs` validates id existence
+and artifact enum at write time; the decomposer's `mvp.phases` derivation
+(separate downstream phase) consumes this declaration without ever
+inferring it.
+
 ### Stage 1.4: Goal Contract Freeze
 
 Create `.mpl/goal-contract.yaml` as the pipeline constitution. This is the
@@ -348,6 +426,7 @@ goal_contract = {
   },
   deferred_uncertainties: unresolved-but-accepted ambiguity,
   overrides: [],
+  mvp_scope: mvp_scope,  // OPTIONAL — Stage A; null when user opted out in 1.3.5
 }
 
 Write(".mpl/goal-contract.yaml", serialize(goal_contract))

--- a/commands/mpl-run-phase0.md
+++ b/commands/mpl-run-phase0.md
@@ -279,84 +279,6 @@ Announce: `[MPL] Stage 1.3 complete. user_cases=${result.user_cases.length} defe
 | `scenarios[*]` | Decomposer Step 3-H, Test Agent | E2E scenario seeds |
 | `ambiguity_hints[]` | Stage 2 Ambiguity Resolution | Targeted questions |
 
-### Stage 1.3.5: MVP Scope Selection (Stage A, optional)
-
-Before serializing the Goal Contract, offer the user a guided checklist to
-declare which `acceptance_criteria` / `variation_axes` form the MVP cohort —
-the user-shippable subset that the Stage A release path delivers first via
-`release-gate` → `release-finalize`. When the user declines, omit
-`mvp_scope` entirely and the pipeline runs as today (no Stage A release
-path).
-
-See `docs/roadmap/stage-a-mvp-cuts-rfc.md` §10 D-Q1: guided checklist is the
-chosen wording (rejected: id-only — cognitively hostile; rejected:
-prose-mapped — reintroduces inference). MVP scope is **user-declared**, not
-decomposer-inferred (RFC §3.4 / §10 D-Q4 lineage).
-
-Protocol:
-
-```
-ac_ids = [ac.id for ac in resolved_spec.acceptance_criteria]
-ax_ids = [ax.id for ax in resolved_spec.variation_axes]
-
-opt_in = AskUserQuestion({
-  question: "Declare an MVP subset for Stage A release path?",
-  options: [
-    { label: "Yes — select MVP subset",
-      description: "Pick which AC/AX ids form the MVP cohort. The pipeline ships the MVP via release-gate → release-finalize before extension work." },
-    { label: "No — full pipeline only",
-      description: "Skip Stage A release path. Pipeline runs as today; no mid-pipeline release artifact." },
-  ],
-})
-
-if opt_in == "No":
-  mvp_scope = null
-else:
-  # Guided checklist for AC ids. When total count exceeds 10, group display
-  # by core_scenarios (from user-contract.md) so the list stays navigable.
-  # The selection unit remains the individual AC id regardless of grouping.
-  selected_ac = AskUserQuestion({
-    question: "Which acceptance_criteria are in MVP scope? (multi-select)",
-    options: build_ac_options(ac_ids, threshold=10, scenarios=resolved_spec.core_scenarios),
-    multiSelect: true,
-  })
-  selected_ax = AskUserQuestion({
-    question: "Which variation_axes are in MVP scope? (multi-select; may be empty)",
-    options: build_ax_options(ax_ids),
-    multiSelect: true,
-  })
-
-  # MVP must declare at least one AC or AX (validator rejects both-empty;
-  # see hooks/lib/mpl-goal-contract.mjs MVP_SCOPE_ARTIFACTS check).
-  if len(selected_ac) == 0 and len(selected_ax) == 0:
-    Announce: "[MPL] MVP scope cannot be fully empty — at least one AC or AX required. Retrying."
-    GOTO selected_ac question.
-
-  artifact = AskUserQuestion({
-    question: "What user-visible artifact should the MVP cut produce?",
-    options: [
-      { label: "draft_pr",         description: "Open a draft GitHub PR at the MVP snapshot ref." },
-      { label: "branch",           description: "Push a snapshot branch (mpl/release/mvp) frozen at the MVP commit." },
-      { label: "tag",              description: "Push an immutable tag (mpl-release-mvp) at the MVP commit." },
-      { label: "release_manifest", description: "Manifest only — no git/GitHub artifact. Cheapest, fully offline." },
-    ],
-  })
-
-  mvp_scope = {
-    acceptance_criteria: selected_ac,
-    variation_axes: selected_ax,
-    artifact: artifact,  # one of MVP_SCOPE_ARTIFACTS (validated by mpl-goal-contract.mjs)
-  }
-
-Announce: `[MPL] MVP scope set: AC={len(selected_ac)} AX={len(selected_ax)} artifact={artifact}.` (or "MVP scope: opted out.")
-```
-
-The collected `mvp_scope` is written into the Goal Contract in the next
-stage. The hook `hooks/lib/mpl-goal-contract.mjs` validates id existence
-and artifact enum at write time; the decomposer's `mvp.phases` derivation
-(separate downstream phase) consumes this declaration without ever
-inferring it.
-
 ### Stage 1.4: Goal Contract Freeze
 
 Create `.mpl/goal-contract.yaml` as the pipeline constitution. This is the
@@ -426,10 +348,119 @@ goal_contract = {
   },
   deferred_uncertainties: unresolved-but-accepted ambiguity,
   overrides: [],
-  mvp_scope: mvp_scope,  // OPTIONAL — Stage A; null when user opted out in 1.3.5
 }
+# `mvp_scope` is added by Stage 1.4.5 below — conditionally, only when the
+# user opts in. When omitted, the contract validator treats the absent key as
+# "no Stage A release path" (backward compatible).
 
-Write(".mpl/goal-contract.yaml", serialize(goal_contract))
+# ... continue to Stage 1.4.5 (MVP Scope Selection) before serialize/write.
+```
+
+#### Stage 1.4.5: MVP Scope Selection (Stage A, optional)
+
+After the Goal Contract object has draft `acceptance_criteria[]` and
+`variation_axes[]` populated but **before** it is serialized to disk, offer
+the user a guided checklist to declare an MVP cohort — the user-shippable
+subset that the Stage A release path delivers first via
+`release-gate` → `release-finalize`. When the user declines, the
+`mvp_scope` key is **not added** to the contract object at all (see
+serialization rule below); the pipeline runs as today (no Stage A
+release path).
+
+Sequenced inside Stage 1.4 (rather than as a standalone 1.3.5 step)
+because the AC/AX ids the checklist references are first authored here.
+A 1.3.5 ordering would reference ids that do not yet exist — reviewers
+caught this on the prior commit.
+
+See `docs/roadmap/stage-a-mvp-cuts-rfc.md` §10 D-Q1: guided checklist is
+the chosen wording (rejected: id-only — cognitively hostile; rejected:
+prose-mapped — reintroduces inference). MVP scope is **user-declared**,
+not decomposer-inferred (RFC §3.4 / §10 D-Q4 lineage).
+
+Protocol:
+
+```
+ac_ids = [ac.id for ac in goal_contract.acceptance_criteria]
+ax_ids = [ax.id for ax in goal_contract.variation_axes]
+
+opt_in = AskUserQuestion({
+  question: "Declare an MVP subset for the Stage A release path?",
+  options: [
+    { label: "Yes — select MVP subset",
+      description: "Pick which AC/AX ids form the MVP cohort. The pipeline will ship the MVP via release-gate → release-finalize before extension work." },
+    { label: "No — full pipeline only",
+      description: "Skip Stage A release path. Pipeline runs as today; no mid-pipeline release artifact." },
+  ],
+})
+
+if opt_in == "No":
+  mvp_scope = null
+else:
+  # Guided checklist for AC ids. When total count exceeds 10, group display
+  # by the user-contract core_scenarios so the list stays navigable. The
+  # selection unit remains the individual AC id regardless of grouping.
+  selected_ac = AskUserQuestion({
+    question: "Which acceptance_criteria are in MVP scope? (multi-select)",
+    # Option shape: { label: ac.id, description: ac.statement, group: scenario_id_or_null }
+    options: build_ac_options(ac_ids, threshold=10, scenarios=user_contract.core_scenarios),
+    multiSelect: true,
+  })
+  selected_ax = AskUserQuestion({
+    question: "Which variation_axes are in MVP scope? (multi-select; may be empty)",
+    # Option shape: { label: ax.id, description: ax.name }
+    options: build_ax_options(ax_ids),
+    multiSelect: true,
+  })
+
+  # MVP must declare at least one AC or AX. The validator clause
+  # `mvp_scope.acceptance_criteria_or_variation_axes` in
+  # hooks/lib/mpl-goal-contract.mjs rejects fully-empty declarations.
+  # Re-prompt BOTH questions from scratch (do not preserve previous
+  # selections) until the user picks at least one id.
+  while len(selected_ac) == 0 and len(selected_ax) == 0:
+    Announce: "[MPL] MVP scope cannot be fully empty — pick at least one AC or AX. Re-prompting."
+    selected_ac = AskUserQuestion({...same as above...})
+    selected_ax = AskUserQuestion({...same as above...})
+
+  artifact = AskUserQuestion({
+    question: "What user-visible artifact should the MVP cut produce?",
+    # Stage A status note: the selection is persisted to mvp_scope.artifact.
+    # Actual git/GitHub artifact creation lands with `release-finalize(mvp)`
+    # in a follow-up phase; until then only `release_manifest` is exercisable
+    # — the other three are accepted but inert. (Same temporal-honesty
+    # pattern as `docs/schemas/goal-contract.md` Stage A status callout.)
+    options: [
+      { label: "draft_pr",         description: "(Stage A target) Open a draft GitHub PR at the MVP snapshot ref. Inert until release-finalize lands." },
+      { label: "branch",           description: "(Stage A target) Push a snapshot branch (mpl/release/mvp). Inert until release-finalize lands." },
+      { label: "tag",              description: "(Stage A target) Push an immutable tag (mpl-release-mvp). Inert until release-finalize lands." },
+      { label: "release_manifest", description: "Manifest only — no git/GitHub artifact. Cheapest, fully offline, exercisable today." },
+    ],
+  })
+
+  mvp_scope = {
+    acceptance_criteria: selected_ac,
+    variation_axes: selected_ax,
+    artifact: artifact,
+  }
+
+Announce: `[MPL] MVP scope set: AC=${selected_ac.length} AX=${selected_ax.length} artifact=${artifact}.` (or "MVP scope: opted out.")
+```
+
+**Serialization rule (R1 — critical for opt-out backward compatibility):**
+when `mvp_scope` is `null`, the serializer MUST omit the `mvp_scope` key
+from the YAML output entirely. Writing `mvp_scope: null` or `mvp_scope:`
+would be parsed as a *malformed declaration* by `parseMvpScope` (which
+returns an empty-shape object on present-but-empty blocks per PR #178's
+post-review fix) and the validator would then reject the contract with
+`mvp_scope.acceptance_criteria_or_variation_axes` + `mvp_scope.artifact`
+missing.
+
+```
+contract_for_write = { ...goal_contract }
+if mvp_scope != null:
+  contract_for_write.mvp_scope = mvp_scope
+
+Write(".mpl/goal-contract.yaml", serialize(contract_for_write))
 mpl_state_write({
   goal_contract_set: true,
   goal_contract_path: ".mpl/goal-contract.yaml",


### PR DESCRIPTION
## What

Stage A implementation **phase 1.3**: introduce the new **Stage 1.3.5** step in the Phase 0 protocol that elicits the user-declared `mvp_scope` via a guided checklist before the Goal Contract is serialized.

- `commands/mpl-run-phase0.md` (+79 lines): new sub-stage \"MVP Scope Selection (Stage A, optional)\" between Stage 1.3 (user-contract) and Stage 1.4 (Goal Contract freeze). Protocol covers opt-in/opt-out, AC/AX guided checklists, both-empty retry guard, artifact selection. `goal_contract` template gains optional `mvp_scope` field.

Prompt-only change. No code, no tests added/modified. Hook test suite still 938/938 (unchanged by this commit).

## Why

PR #178 added the `mvp_scope` field at the goal-contract parser layer. PR #180 added structural validation of `mvp` / `release_cuts[]` at the decomposition layer. But until this PR, **no protocol step actually elicits `mvp_scope` from the user** — the field is parseable but never populated.

This PR closes that loop. The RFC §10 D-Q1 decision (guided checklist) lands at the only place where the input naturally exists: Phase 0, between user-contract resolution (where AC/AX ids are finalized) and Goal Contract freeze (where they're written).

Sequencing rationale:
- After 1.3 (user-contract): AC/AX ids exist and the user has just confirmed them — fresh in context.
- Before 1.4 (Goal Contract freeze): the freeze step writes `mvp_scope` into the file atomically; no separate write.
- The opt-out branch yields `mvp_scope: null` and the pipeline runs as today.

## Design

- Source: `docs/roadmap/stage-a-mvp-cuts-rfc.md` §10 D-Q1 (guided checklist over id-only or prose-mapped).
- Companion PRs (already merged): #178 (`mvp_scope` parser), #180 (mvp/release_cuts schema validators at decomposition layer).
- Out of scope (separate follow-up):
  - Decomposer-side `mvp.phases` derivation from `mvp_scope` (consumed by mpl-decomposer's prompt).
  - Release-path orchestrator states (`release-gate`, `release-finalize`).
  - State.release subtree.

## Risk

- Pure prompt change. Reviewable as English protocol; no code path can break at runtime from this PR alone.
- Backward compat: users who opt out get exactly today's behavior. mvp_scope absent → goal-contract validator accepts → no decomposer change → no release path.

## Agent Review Status

This PR is gated on **2 unique agent reviews** (footers `— from <agent>`).

- [ ] from claude
- [ ] from codex

---
_Awaiting reviews. Merge once the gate is satisfied._