### PR TITLE
feat(decomposer): derive mvp cohort from goal_contract.mvp_scope (Stage A)

### DIFF
--- a/agents/mpl-decomposer.md
+++ b/agents/mpl-decomposer.md
@@ -300,6 +300,62 @@ disallowedTools: Bash,Task,WebFetch,WebSearch,NotebookEdit
     Step 11: Execution tiers
       - Group phases by dependency level (topological tiers).
       - pp_core phases: parallel = false (sequential). Others: parallel = true if no file overlap.
+
+    Step 12: MVP cut derivation (Stage A, only when goal_contract.mvp_scope is present)
+      When `goal_contract.mvp_scope` is ABSENT, **skip this step entirely**:
+      omit both `mvp` and `release_cuts` from the output. The pipeline runs
+      as today with no Stage A release path.
+
+      When `goal_contract.mvp_scope` IS present, derive `mvp.phases` as the
+      set of phase ids whose `goal_trace` intersects the user-declared
+      MVP id set. This is **mechanical id-set mapping** (NOT semantic
+      inference). Per RFC §3.4 / §10 D-Q4, the decomposer MUST NOT infer
+      MVP scope from anything other than `goal_contract.mvp_scope`.
+
+      ```
+      mvp_ac_ids = goal_contract.mvp_scope.acceptance_criteria  # set of AC ids
+      mvp_ax_ids = goal_contract.mvp_scope.variation_axes        # set of AX ids
+      mvp_target_ids = mvp_ac_ids ∪ mvp_ax_ids
+
+      mvp_phases = []
+      for phase in phases (in execution_tiers order):
+        phase_ids = phase.goal_trace.acceptance_criteria ∪ phase.goal_trace.variation_axes
+        if phase_ids ∩ mvp_target_ids != ∅:
+          mvp_phases.append(phase.id)
+
+      # Coverage check: every mvp_scope id must be covered by at least one phase
+      # in mvp_phases. If not, the user's MVP cannot be realized as decomposed.
+      covered_ac = ⋃ phase.goal_trace.acceptance_criteria for phase in mvp_phases
+      covered_ax = ⋃ phase.goal_trace.variation_axes        for phase in mvp_phases
+      missing_ac = mvp_ac_ids - covered_ac
+      missing_ax = mvp_ax_ids - covered_ax
+      if missing_ac or missing_ax:
+        risk_assessment.risks.append({
+          id: "STAGE_A_MVP_COVERAGE_GAP",
+          severity: "HIGH",
+          title: "MVP scope ids not covered by any phase's goal_trace",
+          description: `Missing AC: ${missing_ac.join(',') or 'none'}; Missing AX: ${missing_ax.join(',') or 'none'}. Either revise goal_contract.mvp_scope to drop these ids, add phases that cover them, or extend an existing phase's goal_trace.`,
+          mitigation: "Re-interview to revise mvp_scope, or recompose with additional phases.",
+        })
+        risk_assessment.go_no_go = "NOT_READY"  # block until coverage resolves
+
+      # Cross-cut overlap check (Stage A: decomposer emits ZERO release_cuts,
+      # so no overlap possible from this step. Stage B may auto-propose cuts;
+      # at that point the contract-graph validator (PR #180) catches overlap.)
+
+      Emit on output:
+        mvp = {
+          derived_from: "goal_contract.mvp_scope",
+          phases: mvp_phases,
+          execution_mode: "sequential",      # Stage A only allows sequential
+          artifact: goal_contract.mvp_scope.artifact,
+        }
+        release_cuts = []
+        # Stage A: decomposer does NOT auto-propose extension cuts.
+        # The orchestrator runs MVP cohort first via release-gate/release-finalize
+        # (Phase 1.6, separate landing), then extension phases via existing
+        # execution_tiers. Auto-proposal of cuts is RFC §10 D-Q2 Stage B work.
+      ```
   </Reasoning_Steps>
 
   <Output_Schema>
@@ -501,6 +557,34 @@ disallowedTools: Bash,Task,WebFetch,WebSearch,NotebookEdit
       - tier: number
         phases: [string]
         parallel: boolean
+
+    # Stage A: MVP cohort + release cuts. OPTIONAL — emit only when
+    # `goal_contract.mvp_scope` is present (see Step 12 derivation rules).
+    # When absent, omit both `mvp` and `release_cuts` entirely; the pipeline
+    # runs as today with no Stage A release path.
+    #
+    # The Stage A validators (hooks/lib/mpl-phase-contract-graph.mjs,
+    # landed in PR #180) check:
+    #   - mvp.phases ⊆ phases[], no duplicates
+    #   - mvp.execution_mode == "sequential" (Stage A only)
+    #   - mvp.artifact ∈ {draft_pr, branch, tag, release_manifest}
+    #   - release_cuts[].id unique, not "mvp"; phases ⊆ phases[]
+    #   - no cross-cut phase overlap (mvp ∩ cut, cut[i] ∩ cut[j])
+    mvp:
+      derived_from: "goal_contract.mvp_scope"
+      phases: [string]               # ids whose goal_trace covers mvp_scope AC/AX
+      execution_mode: "sequential"    # Stage A: always sequential
+      artifact: "draft_pr | branch | tag | release_manifest"  # from mvp_scope.artifact
+
+    release_cuts: []
+      # Stage A: decomposer emits EMPTY release_cuts[] when mvp is present.
+      # Auto-proposal of extension cuts is RFC §10 D-Q2 Stage B work.
+      # When present, each entry has shape:
+      #   - id: string                  # unique within release_cuts; never "mvp"
+      #     phases: [string]            # disjoint from mvp.phases and other cuts
+      #     proposed_by: "mpl-decomposer"
+      #     user_approved: boolean      # planning-stage HITL writes; runtime never mutates
+      #     artifact: "draft_pr | branch | tag | release_manifest"
 
     decomposition_rationale: string
 

--- a/agents/mpl-decomposer.md
+++ b/agents/mpl-decomposer.md
@@ -312,6 +312,14 @@ disallowedTools: Bash,Task,WebFetch,WebSearch,NotebookEdit
       inference). Per RFC §3.4 / §10 D-Q4, the decomposer MUST NOT infer
       MVP scope from anything other than `goal_contract.mvp_scope`.
 
+      Schema reference: each phase already carries
+      `goal_trace.acceptance_criteria[]` and `goal_trace.variation_axes[]`
+      under the per-phase Output_Schema (this file, the `goal_trace:` block
+      with `acceptance_criteria: [string]` and `variation_axes: [string]`).
+      Both fields are REQUIRED to be set by every phase (per the existing
+      goal_trace contract, enforced by `mpl-require-goal-trace.mjs`), so
+      both sides of the intersection below are well-defined.
+
       ```
       mvp_ac_ids = goal_contract.mvp_scope.acceptance_criteria  # set of AC ids
       mvp_ax_ids = goal_contract.mvp_scope.variation_axes        # set of AX ids
@@ -323,8 +331,12 @@ disallowedTools: Bash,Task,WebFetch,WebSearch,NotebookEdit
         if phase_ids ∩ mvp_target_ids != ∅:
           mvp_phases.append(phase.id)
 
-      # Coverage check: every mvp_scope id must be covered by at least one phase
-      # in mvp_phases. If not, the user's MVP cannot be realized as decomposed.
+      # ─── Guard 1: COVERAGE ─────────────────────────────────────────────
+      # Every mvp_scope id must be covered by at least one phase in
+      # mvp_phases. If not, the user's MVP cannot be realized as decomposed.
+      # (When mvp_phases ends up empty, the validator's `mvp:phases:missing`
+      # in PR #180 will ALSO reject; that is the safety net. This Step 12
+      # NOT_READY is the user-facing diagnostic with the missing-id list.)
       covered_ac = ⋃ phase.goal_trace.acceptance_criteria for phase in mvp_phases
       covered_ax = ⋃ phase.goal_trace.variation_axes        for phase in mvp_phases
       missing_ac = mvp_ac_ids - covered_ac
@@ -339,9 +351,31 @@ disallowedTools: Bash,Task,WebFetch,WebSearch,NotebookEdit
         })
         risk_assessment.go_no_go = "NOT_READY"  # block until coverage resolves
 
-      # Cross-cut overlap check (Stage A: decomposer emits ZERO release_cuts,
-      # so no overlap possible from this step. Stage B may auto-propose cuts;
-      # at that point the contract-graph validator (PR #180) catches overlap.)
+      # ─── Guard 2: DEPENDENCY CLOSURE (transient, until Phase 1.4b) ─────
+      # Phase 1.6's orchestrator will route the MVP cohort BEFORE extension
+      # phases via release-gate(mvp) → release-finalize(mvp). If any MVP
+      # phase requires a non-MVP phase, that requirement is unsatisfied at
+      # MVP gate time and Hard 1/3 will fail. The durable hook-level check
+      # lives in Phase 1.4b (B5 dependency-closure rule). Until 1.4b lands,
+      # surface the gap here so MVP cannot ship with unsatisfied requires.
+      mvp_id_set = {phase.id for phase in mvp_phases}
+      mvp_requires = ⋃ phase.interface_contract.requires.from_phase
+                       for phase in mvp_phases
+                       (skip entries without from_phase — they are baseline refs)
+      missing_deps = mvp_requires - mvp_id_set
+      if missing_deps:
+        risk_assessment.risks.append({
+          id: "STAGE_A_MVP_DEPENDENCY_GAP",
+          severity: "HIGH",
+          title: "MVP cohort requires phases outside MVP",
+          description: `MVP phases require non-MVP phase ids: ${missing_deps.join(',')}. Stage A runs the MVP cohort before extension phases, so these requirements would be unsatisfied at release-gate(mvp). Either include the missing phases in mvp_scope (re-interview), restructure phases so MVP is self-contained, or wait for Phase 1.4b's hook-level dependency-closure enforcement.`,
+          mitigation: "Re-interview to expand mvp_scope; or restructure phase boundaries.",
+        })
+        risk_assessment.go_no_go = "NOT_READY"
+
+      # Cross-cut overlap check is unnecessary here: decomposer emits ZERO
+      # release_cuts in Stage A, so no overlap is possible. PR #180's
+      # contract-graph validator catches overlap in Stage B when cuts exist.
 
       Emit on output:
         mvp = {
@@ -576,15 +610,15 @@ disallowedTools: Bash,Task,WebFetch,WebSearch,NotebookEdit
       execution_mode: "sequential"    # Stage A: always sequential
       artifact: "draft_pr | branch | tag | release_manifest"  # from mvp_scope.artifact
 
+    # Stage A: decomposer emits release_cuts as an explicit empty list when
+    # mvp is present. Auto-proposal of extension cuts is RFC §10 D-Q2 Stage
+    # B work. When Stage B lands, each entry's shape will be:
+    #   - id: string                  # unique within release_cuts; never "mvp"
+    #     phases: [string]            # disjoint from mvp.phases and other cuts
+    #     proposed_by: "mpl-decomposer"
+    #     user_approved: boolean      # planning-stage HITL writes; runtime never mutates
+    #     artifact: "draft_pr | branch | tag | release_manifest"
     release_cuts: []
-      # Stage A: decomposer emits EMPTY release_cuts[] when mvp is present.
-      # Auto-proposal of extension cuts is RFC §10 D-Q2 Stage B work.
-      # When present, each entry has shape:
-      #   - id: string                  # unique within release_cuts; never "mvp"
-      #     phases: [string]            # disjoint from mvp.phases and other cuts
-      #     proposed_by: "mpl-decomposer"
-      #     user_approved: boolean      # planning-stage HITL writes; runtime never mutates
-      #     artifact: "draft_pr | branch | tag | release_manifest"
 
     decomposition_rationale: string
 


### PR DESCRIPTION
## What

Stage A implementation **phase 1.2**: extend the decomposer agent to emit the Stage A `mvp` object on `decomposition.yaml` by mechanically mapping `goal_contract.mvp_scope` AC/AX ids to phase ids via `goal_trace`.

- `agents/mpl-decomposer.md` (+84 lines, prompt-only):
  - New **Step 12: MVP cut derivation** in Reasoning_Steps
  - Output_Schema gains `mvp` (single object, optional) + `release_cuts: []` (Stage A always empty) top-level fields

## Why

This closes the end-to-end Stage A loop:

```
PR #178: goal-contract.mvp_scope parser
PR #181: interview elicits mvp_scope from user
THIS  → decomposer derives decomposition.mvp from mvp_scope
PR #180: validators reject malformed mvp / release_cuts
Phase 1.6 (next): orchestrator routes MVP cohort via release-gate/release-finalize
```

Before this PR, `mvp_scope` was a dead-end field — parsed and validated but never consumed. After this PR, the decomposer materializes `decomposition.mvp.phases` so the Phase 1.6 orchestrator has something concrete to route on.

Per RFC §3.4 / §10 D-Q4, derivation is **mechanical id-set mapping**, not semantic inference. The decomposer never decides what belongs in MVP — it only walks the user's declaration onto the existing phase graph.

## Design

- Source: `docs/roadmap/stage-a-mvp-cuts-rfc.md` §4.2 (mvp schema), §3.4 (user-declared not inferred), §10 D-Q4 (artifact stance), §10 D-Q2 (cuts auto-proposal is Stage B).
- Coverage check: every `mvp_scope` id MUST be covered by at least one phase's `goal_trace`. Gap → HIGH risk + `go_no_go: NOT_READY`. User must re-interview or recompose.
- Hard-coded narrowing (intentional):
  - `mvp.execution_mode = \"sequential\"` (Stage A only; Stage B `contract_skeleton` deferred)
  - `release_cuts = []` (Stage A; decomposer-auto-proposal is Stage B per RFC §10 D-Q2)
- Companion PRs (all merged): #177 (RFC), #178 (`mvp_scope` parser), #180 (contract-graph validators), #181 (interview elicitation), #179 (Rule 9 immutability for recompose).

## Risk

- Pure prompt change. Hook test suite still 939/939 (unchanged by this commit).
- Backward compat: when `goal_contract.mvp_scope` is absent, decomposer omits both `mvp` and `release_cuts` and the existing pipeline runs as today.
- Coverage gap (HIGH risk + NOT_READY) is the user-protection guard: prevents an MVP cut that secretly doesn't deliver the declared AC/AX from being scheduled.

## Out of scope (separate phase)

- Release-path orchestrator states (`release-gate`, `release-finalize`) — Phase 1.6
- `state.release` subtree + cohort-aware `phase2-sprint` completion — Phase 1.6
- Dependency-closure rule + D-Q6 immutability hook enforcement — Phase 1.4b
- Auto-proposed extension cuts — RFC §10 D-Q2 Stage B

## Agent Review Status

This PR is gated on **2 unique agent reviews** (footers \`— from <agent>\`).

- [ ] from claude
- [ ] from codex

---
_Awaiting reviews. Merge once the gate is satisfied._