### PR TITLE
feat(hooks): enforce dependency-closure (B5) and released-cut immutability (D-Q6)

### DIFF
--- a/hooks/__tests__/mpl-phase-contract-graph.test.mjs
+++ b/hooks/__tests__/mpl-phase-contract-graph.test.mjs
@@ -588,6 +588,100 @@ execution_tiers:`);
     const verdict = validatePhaseContractGraph(parsePhaseContractGraphText(validGraph()));
     assert.equal(verdict.valid, true, verdict.issues.join(', '));
   });
+
+  it('rejects approved cut whose require resolves only into a DECLINED earlier cut (RFC B8)', () => {
+    // Codex high-severity: a declined cut (user_approved: false) is NOT a
+    // release-path cohort — its phases run as non-cut tail, AFTER all
+    // release-path cuts. So a later approved cut MUST NOT count a declined
+    // cut's phases as "already materialized."
+    //
+    // Fixture: cut-a declined with [phase-1]; cut-b approved with [phase-2].
+    // phase-2 requires phase-1. At cut-b's release-gate, phase-1 doesn't
+    // exist yet (cut-a is tail, runs later). Must be flagged.
+    const text = dcGraph('', `release_cuts:
+  - id: cut-a
+    phases: [phase-1]
+    user_approved: false
+    artifact: release_manifest
+  - id: cut-b
+    phases: [phase-2]
+    user_approved: true
+    artifact: release_manifest`);
+    const verdict = validatePhaseContractGraph(parsePhaseContractGraphText(text));
+    assert.equal(verdict.valid, false);
+    assert.ok(
+      verdict.issues.includes('release_cuts:cut-b:phases:phase-2:requires:outside_cohort:phase-1'),
+      `expected declined-cut-as-tail to surface dep-closure issue; got: ${verdict.issues.join(', ')}`,
+    );
+  });
+
+  it('skips dep-closure for declined cuts themselves (tail semantics, final phase3-gate covers)', () => {
+    // A declined cut's OWN phase requires are not release-path concerns —
+    // they run as tail and are verified at final phase3-gate. The dep-
+    // closure check must not produce issues for declined cuts themselves.
+    //
+    // Fixture: mvp = [phase-1]; cut-a declined with [phase-2]. phase-2
+    // requires phase-1 — which is in mvp. But even if cut-a's phase-2 had
+    // required some non-cohort phase, dep-closure would skip the check
+    // because cut-a is declined.
+    const text = dcGraph(
+      `mvp:
+  derived_from: goal_contract.mvp_scope
+  phases: [phase-1]
+  execution_mode: sequential
+  artifact: draft_pr`,
+      `release_cuts:
+  - id: cut-a
+    phases: [phase-2]
+    user_approved: false
+    artifact: release_manifest`,
+    );
+    const verdict = validatePhaseContractGraph(parsePhaseContractGraphText(text));
+    assert.equal(verdict.valid, true, verdict.issues.join(', '));
+  });
+
+  it('parser: requires_from_phases extracts only entries with from_phase, ignoring baseline-only requires', () => {
+    // Pin the parser contract that validateDependencyClosure depends on:
+    // a `requires:` list mixing a from_phase entry and a baseline-only entry
+    // (no from_phase key) must yield ONLY the from_phase id.
+    //
+    // Fixture: phase-2 requires both phase-1 (from_phase) AND a baseline
+    // artifact (no from_phase). Only phase-1 is subject to closure check.
+    // Therefore mvp = [phase-2] alone still flags phase-1 as out-of-cohort
+    // (the from_phase entry), but does NOT flag the baseline entry.
+    const text = validGraph()
+      .replace(
+        `interface_contract:
+      requires:
+        - type: artifact
+          name: bootstrap
+          from_phase: phase-1
+      produces: []`,
+        `interface_contract:
+      requires:
+        - type: artifact
+          name: bootstrap
+          from_phase: phase-1
+        - type: artifact
+          name: baseline_only_dep
+      produces: []`,
+      )
+      .replace('execution_tiers:', `mvp:
+  derived_from: goal_contract.mvp_scope
+  phases: [phase-2]
+  execution_mode: sequential
+  artifact: draft_pr
+execution_tiers:`);
+    const verdict = validatePhaseContractGraph(parsePhaseContractGraphText(text));
+    // Should fail ONLY because of phase-1 (the from_phase entry) being
+    // out of cohort. The baseline_only_dep entry must NOT appear.
+    assert.equal(verdict.valid, false);
+    assert.ok(verdict.issues.includes('mvp:phases:phase-2:requires:outside_cohort:phase-1'));
+    assert.ok(
+      !verdict.issues.some((i) => i.includes('baseline_only_dep')),
+      `baseline-only require must not be subject to closure; got: ${verdict.issues.join(', ')}`,
+    );
+  });
 });
 
 describe('mpl-require-phase-contract-graph hook integration', () => {
@@ -707,6 +801,27 @@ describe('mpl-require-phase-contract-graph hook integration', () => {
   artifact: draft_pr`);
     const r = runHook(mutated);
     assert.equal(r.continue, true);
+  });
+
+  it('D-Q6: blocks reorder-only mutations of a released cut (Rule 9 alignment)', () => {
+    // PR #179's Rule 9 forbids "add a phase id to, remove one from, OR
+    // reorder phases within a released cut's .phases list." `phasesEqual`
+    // is order-sensitive by design — pin that contract.
+    const priorMvp = `mvp:
+  derived_from: goal_contract.mvp_scope
+  phases: [phase-1, phase-2]
+  execution_mode: sequential
+  artifact: draft_pr`;
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'decomposition.yaml'), graphWithMvp(priorMvp));
+    seedStateWithReleased(['mvp']);
+    const reordered = graphWithMvp(`mvp:
+  derived_from: goal_contract.mvp_scope
+  phases: [phase-2, phase-1]
+  execution_mode: sequential
+  artifact: draft_pr`);
+    const r = runHook(reordered);
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason, /released_cut:mvp:phases:mutated/);
   });
 
   it('D-Q6: no-op for projects whose state.json lacks state.release (pre-Phase-1.6)', () => {

--- a/hooks/__tests__/mpl-phase-contract-graph.test.mjs
+++ b/hooks/__tests__/mpl-phase-contract-graph.test.mjs
@@ -169,12 +169,23 @@ describe('Stage A mvp + release_cuts schema', () => {
     // Regression for codex review on 02beb4d: indent-blind `-` detection
     // misread inner `- phase-2` as a new cut boundary, splitting one valid
     // cut into two malformed items. Cut item boundaries must respect indent.
-    const text = graphWithMvp('', `release_cuts:
+    //
+    // The fixture also includes mvp=[phase-1] so cut-a's phase-2 dependency
+    // on phase-1 resolves through the earlier cohort (mvp) for the new
+    // dependency-closure validator (Phase 1.4b).
+    const text = graphWithMvp(
+      `mvp:
+  derived_from: goal_contract.mvp_scope
+  phases: [phase-1]
+  execution_mode: sequential
+  artifact: draft_pr`,
+      `release_cuts:
   - id: cut-a
     phases:
       - phase-2
     user_approved: true
-    artifact: release_manifest`);
+    artifact: release_manifest`,
+    );
     const graph = parsePhaseContractGraphText(text);
     assert.equal(graph.release_cuts.length, 1, `cut count: expected 1, got ${graph.release_cuts.length}`);
     assert.equal(graph.release_cuts[0].id, 'cut-a');
@@ -468,6 +479,117 @@ describe('Stage A mvp + release_cuts schema', () => {
   });
 });
 
+describe('Stage A dependency-closure rule (Phase 1.4b)', () => {
+  // Helper: build a graph with two phases where phase-2 requires phase-1.
+  // mvp/cut yaml inserted before `execution_tiers:`.
+  function dcGraph(mvpYaml, cutsYaml = '') {
+    const insertion = (mvpYaml ? `\n${mvpYaml}` : '') + (cutsYaml ? `\n${cutsYaml}` : '');
+    return validGraph().replace('execution_tiers:', `${insertion}\nexecution_tiers:`);
+  }
+
+  it('rejects mvp.phases that requires a non-mvp phase (out of cohort)', () => {
+    // mvp = [phase-2] only. phase-2 requires phase-1, but phase-1 not in mvp.
+    // MVP cohort runs in isolation at release-gate(mvp); its requires must
+    // resolve inside the cohort or baseline. phase-1 here is neither.
+    const text = dcGraph(`mvp:
+  derived_from: goal_contract.mvp_scope
+  phases: [phase-2]
+  execution_mode: sequential
+  artifact: draft_pr`);
+    const verdict = validatePhaseContractGraph(parsePhaseContractGraphText(text));
+    assert.equal(verdict.valid, false);
+    assert.ok(verdict.issues.includes('mvp:phases:phase-2:requires:outside_cohort:phase-1'));
+  });
+
+  it('accepts mvp that fully encloses its dependency chain', () => {
+    const text = dcGraph(`mvp:
+  derived_from: goal_contract.mvp_scope
+  phases: [phase-1, phase-2]
+  execution_mode: sequential
+  artifact: draft_pr`);
+    const verdict = validatePhaseContractGraph(parsePhaseContractGraphText(text));
+    assert.equal(verdict.valid, true, verdict.issues.join(', '));
+  });
+
+  it('accepts release_cuts whose require resolves into mvp (earlier cohort)', () => {
+    // mvp = [phase-1]; cut-a = [phase-2]; phase-2.requires.from_phase = phase-1.
+    // mvp executes first per RFC §5.4.2 array order; phase-1 is materialized
+    // by the time cut-a's release-gate runs.
+    const text = dcGraph(
+      `mvp:
+  derived_from: goal_contract.mvp_scope
+  phases: [phase-1]
+  execution_mode: sequential
+  artifact: draft_pr`,
+      `release_cuts:
+  - id: cut-a
+    phases: [phase-2]
+    user_approved: true
+    artifact: release_manifest`,
+    );
+    const verdict = validatePhaseContractGraph(parsePhaseContractGraphText(text));
+    assert.equal(verdict.valid, true, verdict.issues.join(', '));
+  });
+
+  it('rejects release_cuts whose require resolves to a LATER cut (forward reference)', () => {
+    // Three-phase graph: phase-3 requires phase-1.
+    // mvp empty; cut-a = [phase-3]; cut-b = [phase-1].
+    // cut-a runs before cut-b per array order, so phase-3's require on
+    // phase-1 is unsatisfied at cut-a's release-gate. Forward reference.
+    const text = validGraph()
+      .replace('  - id: phase-2', `  - id: phase-3
+    evidence_required: [command]
+    change_policy: append_delta_only
+    resource_locks: []
+    interface_contract:
+      requires:
+        - type: artifact
+          name: bootstrap
+          from_phase: phase-1
+      produces: []
+  - id: phase-2`)
+      .replace('phases: [phase-2]\n    parallel: false', 'phases: [phase-2, phase-3]\n    parallel: false')
+      .replace('execution_tiers:', `release_cuts:
+  - id: cut-a
+    phases: [phase-3]
+    user_approved: true
+    artifact: release_manifest
+  - id: cut-b
+    phases: [phase-1]
+    user_approved: true
+    artifact: release_manifest
+execution_tiers:`);
+    const verdict = validatePhaseContractGraph(parsePhaseContractGraphText(text));
+    assert.equal(verdict.valid, false);
+    assert.ok(
+      verdict.issues.includes('release_cuts:cut-a:phases:phase-3:requires:outside_cohort:phase-1'),
+      `expected forward-ref issue; got: ${verdict.issues.join(', ')}`,
+    );
+  });
+
+  it('treats requires entries without from_phase as baseline (no validation error)', () => {
+    // The validator's `requires_from_phases` extractor only records entries
+    // with an explicit `from_phase`. requires that omit `from_phase` are
+    // baseline references and must NOT produce dependency-closure errors.
+    const text = dcGraph(`mvp:
+  derived_from: goal_contract.mvp_scope
+  phases: [phase-1]
+  execution_mode: sequential
+  artifact: draft_pr`);
+    // phase-1 has `requires: []`, which is the canonical baseline-only case.
+    const verdict = validatePhaseContractGraph(parsePhaseContractGraphText(text));
+    assert.equal(verdict.valid, true, verdict.issues.join(', '));
+  });
+
+  it('does not run dependency-closure on graphs without mvp or release_cuts', () => {
+    // Pre-Stage-A graphs (no mvp_scope) must remain valid even when phases
+    // have cross-phase requires. The dependency-closure rule only applies
+    // when Stage A cohort structure is declared.
+    const verdict = validatePhaseContractGraph(parsePhaseContractGraphText(validGraph()));
+    assert.equal(verdict.valid, true, verdict.issues.join(', '));
+  });
+});
+
 describe('mpl-require-phase-contract-graph hook integration', () => {
   it('allows a valid graph', () => {
     const r = runHook(validGraph());
@@ -500,6 +622,110 @@ describe('mpl-require-phase-contract-graph hook integration', () => {
     const r = runHook('phases:\n  - id: phase-1\n', {
       config: { phase_contract_graph_required: false },
     });
+    assert.equal(r.continue, true);
+  });
+
+  // ── D-Q6 released-cut immutability (Phase 1.4b) ─────────────────────────
+  // Hook only enforces when `state.release.completed_cut_ids` is non-empty
+  // (Phase 1.6 territory). Until then, the check is a no-op — these tests
+  // simulate the Phase 1.6+ state shape by seeding it directly.
+
+  function graphWithMvp(mvpYaml) {
+    return validGraph().replace('execution_tiers:', `${mvpYaml}\nexecution_tiers:`);
+  }
+
+  function seedStateWithReleased(cutIds) {
+    writeFileSync(join(tmp, '.mpl', 'state.json'), JSON.stringify({
+      schema_version: CURRENT_SCHEMA_VERSION,
+      current_phase: 'mpl-decompose',
+      release: { completed_cut_ids: cutIds },
+    }));
+  }
+
+  it('D-Q6: blocks decomposition writes that mutate a released mvp.phases list', () => {
+    // Seed prior decomposition.yaml with mvp=[phase-1] and mark "mvp" as released.
+    const priorMvp = `mvp:
+  derived_from: goal_contract.mvp_scope
+  phases: [phase-1]
+  execution_mode: sequential
+  artifact: draft_pr`;
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'decomposition.yaml'), graphWithMvp(priorMvp));
+    seedStateWithReleased(['mvp']);
+
+    // New write tries to change mvp.phases to [phase-1, phase-2] — must block.
+    const mutated = graphWithMvp(`mvp:
+  derived_from: goal_contract.mvp_scope
+  phases: [phase-1, phase-2]
+  execution_mode: sequential
+  artifact: draft_pr`);
+    const r = runHook(mutated);
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason, /released_cut:mvp:phases:mutated/);
+  });
+
+  it('D-Q6: allows non-mutating re-writes of a released cut', () => {
+    const mvpYaml = `mvp:
+  derived_from: goal_contract.mvp_scope
+  phases: [phase-1]
+  execution_mode: sequential
+  artifact: draft_pr`;
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'decomposition.yaml'), graphWithMvp(mvpYaml));
+    seedStateWithReleased(['mvp']);
+    // Identical write — should pass.
+    const r = runHook(graphWithMvp(mvpYaml));
+    assert.equal(r.continue, true);
+  });
+
+  it('D-Q6: blocks removal of a released cut from the graph', () => {
+    const priorMvp = `mvp:
+  derived_from: goal_contract.mvp_scope
+  phases: [phase-1]
+  execution_mode: sequential
+  artifact: draft_pr`;
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'decomposition.yaml'), graphWithMvp(priorMvp));
+    seedStateWithReleased(['mvp']);
+    // New write drops mvp entirely — released cut cannot be removed.
+    const r = runHook(validGraph());
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason, /released_cut:mvp:removed_from_graph/);
+  });
+
+  it('D-Q6: pre-release iteration is unconstrained (cut not yet in completed_cut_ids)', () => {
+    // Same prior graph but state.release.completed_cut_ids is empty — mvp is
+    // not yet released, so the user is free to edit mvp.phases.
+    const priorMvp = `mvp:
+  derived_from: goal_contract.mvp_scope
+  phases: [phase-1]
+  execution_mode: sequential
+  artifact: draft_pr`;
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'decomposition.yaml'), graphWithMvp(priorMvp));
+    seedStateWithReleased([]); // explicit empty
+    const mutated = graphWithMvp(`mvp:
+  derived_from: goal_contract.mvp_scope
+  phases: [phase-1, phase-2]
+  execution_mode: sequential
+  artifact: draft_pr`);
+    const r = runHook(mutated);
+    assert.equal(r.continue, true);
+  });
+
+  it('D-Q6: no-op for projects whose state.json lacks state.release (pre-Phase-1.6)', () => {
+    // Default state seeded in beforeEach has no `release` subtree. The
+    // immutability check returns [] and the hook does not block on the
+    // mvp.phases diff.
+    const priorMvp = `mvp:
+  derived_from: goal_contract.mvp_scope
+  phases: [phase-1]
+  execution_mode: sequential
+  artifact: draft_pr`;
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'decomposition.yaml'), graphWithMvp(priorMvp));
+    // state.json from beforeEach has no `release` field.
+    const mutated = graphWithMvp(`mvp:
+  derived_from: goal_contract.mvp_scope
+  phases: [phase-1, phase-2]
+  execution_mode: sequential
+  artifact: draft_pr`);
+    const r = runHook(mutated);
     assert.equal(r.continue, true);
   });
 });

--- a/hooks/lib/mpl-phase-contract-graph.mjs
+++ b/hooks/lib/mpl-phase-contract-graph.mjs
@@ -376,4 +376,64 @@ function validateMvpAndReleaseCuts(graph, knownPhases, issues) {
       }
     }
   }
+
+  // Dependency-closure rule (RFC §4.2 / B5, hook layer for Phase 1.4b).
+  // The decomposer carries a transient check in its prompt (Phase 1.2 Step 12
+  // Guard 2). This is the durable enforcement at write time.
+  //
+  // Rule: a phase's `requires.from_phase` must resolve to:
+  //   - another phase in the SAME cohort, OR
+  //   - a phase in an EARLIER cohort (mvp, or release_cuts before this one in
+  //     the array order — Stage A serializes cuts per RFC §5.4.2 "array order"),
+  //   - OR baseline pre-existing code (no from_phase entry).
+  //
+  // The Stage B `contract_skeleton` mode would allow parallel cuts and need a
+  // dependency-graph DAG check; Stage A serializes cuts so a simple "earlier
+  // cohort" set check is sufficient.
+  validateDependencyClosure(graph, mvp, cuts, issues);
+}
+
+function validateDependencyClosure(graph, mvp, cuts, issues) {
+  if (!Array.isArray(graph?.phases)) return;
+  // Only run when Stage A release fields are present.
+  if (!mvp && !Array.isArray(cuts)) return;
+
+  const phaseRequires = new Map();
+  for (const p of graph.phases) {
+    phaseRequires.set(p.id, Array.isArray(p.requires_from_phases) ? p.requires_from_phases : []);
+  }
+
+  // MVP cohort: every requires.from_phase must be inside mvp.phases or baseline (absent).
+  if (mvp?.phases?.length) {
+    const mvpSet = new Set(mvp.phases);
+    for (const mvpPhaseId of mvp.phases) {
+      const reqs = phaseRequires.get(mvpPhaseId) || [];
+      for (const req of reqs) {
+        if (!mvpSet.has(req)) {
+          issues.push(`mvp:phases:${mvpPhaseId}:requires:outside_cohort:${req}`);
+        }
+      }
+    }
+  }
+
+  // Extension cuts: walk in declared order; each cut can reach into its own
+  // phases plus everything from earlier cohorts (mvp + earlier cuts). Stage A
+  // executes cuts sequentially per RFC §5.4.2, so prior-cohort phases are
+  // guaranteed to be available by the time a later cut's release-gate runs.
+  if (Array.isArray(cuts)) {
+    const earlierPhases = new Set(mvp?.phases || []);
+    for (const cut of cuts) {
+      if (!cut.id || !Array.isArray(cut.phases)) continue;
+      const cutSet = new Set(cut.phases);
+      for (const cutPhaseId of cut.phases) {
+        const reqs = phaseRequires.get(cutPhaseId) || [];
+        for (const req of reqs) {
+          if (!cutSet.has(req) && !earlierPhases.has(req)) {
+            issues.push(`release_cuts:${cut.id}:phases:${cutPhaseId}:requires:outside_cohort:${req}`);
+          }
+        }
+      }
+      for (const p of cut.phases) earlierPhases.add(p);
+    }
+  }
 }

--- a/hooks/lib/mpl-phase-contract-graph.mjs
+++ b/hooks/lib/mpl-phase-contract-graph.mjs
@@ -417,13 +417,27 @@ function validateDependencyClosure(graph, mvp, cuts, issues) {
   }
 
   // Extension cuts: walk in declared order; each cut can reach into its own
-  // phases plus everything from earlier cohorts (mvp + earlier cuts). Stage A
-  // executes cuts sequentially per RFC §5.4.2, so prior-cohort phases are
-  // guaranteed to be available by the time a later cut's release-gate runs.
+  // phases plus everything from earlier *approved* cohorts (mvp + earlier
+  // approved cuts). Stage A executes approved cuts sequentially per RFC
+  // §5.4.2, so prior-approved-cohort phases are guaranteed to be available
+  // by the time a later cut's release-gate runs.
+  //
+  // `user_approved !== true` cuts are NOT release-path cohorts (RFC §10 D-Q2
+  // / B8): their phases run as non-cut tail under normal execution_tiers
+  // scheduling, AFTER all release-path cuts have completed. So:
+  //   - A declined cut's phases MUST NOT count as earlier cohort for later
+  //     approved cuts (would falsely satisfy a release-path dependency).
+  //   - A declined cut's own phase requires are NOT release-path concerns
+  //     and the dep-closure check skips them (final phase3-gate covers tail).
   if (Array.isArray(cuts)) {
     const earlierPhases = new Set(mvp?.phases || []);
     for (const cut of cuts) {
       if (!cut.id || !Array.isArray(cut.phases)) continue;
+      // Skip declined cuts entirely: not subject to release-path closure
+      // and must not be added to earlierPhases (would let a later approved
+      // cut falsely satisfy its requires through a tail phase).
+      if (cut.user_approved !== true) continue;
+
       const cutSet = new Set(cut.phases);
       for (const cutPhaseId of cut.phases) {
         const reqs = phaseRequires.get(cutPhaseId) || [];

--- a/hooks/mpl-require-phase-contract-graph.mjs
+++ b/hooks/mpl-require-phase-contract-graph.mjs
@@ -52,10 +52,21 @@ function collectDecompositionTexts(toolInput) {
 
 function readCompletedCutIds(cwd) {
   // Returns the set of cut ids whose `release-finalize` has shipped.
-  // Source of truth is `state.release.completed_cut_ids` in `.mpl/state.json`,
-  // which Phase 1.6 will write. Until Phase 1.6 lands, the field is absent
-  // and we return an empty set — the immutability check below becomes a no-op
-  // for graphs whose state doesn't yet carry release lifecycle data.
+  //
+  // SHAPE COMMITMENT — Phase 1.6 must align with this consumer:
+  //   state.release.completed_cut_ids: string[]
+  //
+  // The path/shape is defined by RFC §4.5 (state.release subtree) and by
+  // PR #179's Rule 9 extension that references the same set. When Phase 1.6
+  // lands the writer, the schema MUST emit a flat `string[]` so the diff
+  // below remains a single hash-set lookup. Any richer audit trail (e.g.,
+  // per-cut finalized_at timestamps) must live in a sibling field so this
+  // consumer keeps working unchanged. If Phase 1.6 needs to evolve the
+  // shape, update this consumer first or both atomically.
+  //
+  // Until Phase 1.6 lands, the field is absent and we return an empty set
+  // — the immutability check below becomes a no-op for graphs whose state
+  // doesn't yet carry release lifecycle data.
   const path = join(cwd, '.mpl', 'state.json');
   if (!existsSync(path)) return new Set();
   try {
@@ -117,7 +128,14 @@ function validateReleasedCutImmutability(cwd, newGraph) {
   for (const cutId of completed) {
     const oldPhases = oldCutPhases.get(cutId);
     const newPhases = newCutPhases.get(cutId);
-    if (oldPhases === undefined) continue; // released cut absent from old graph (degenerate); cannot diff
+    // Intentionally silent on `oldPhases === undefined`: a released cut id
+    // listed in state but missing from the prior decomposition is a
+    // state↔graph drift signal that should be diagnosed by a separate
+    // consistency check, not this immutability hook. This hook's job is
+    // mutation-detection on a present-on-both-sides cut — it cannot diff
+    // what it cannot see. Surfacing it here would block legitimate graph
+    // repairs after a recompose where the cut entry was already lost.
+    if (oldPhases === undefined) continue;
     if (newPhases === undefined) {
       issues.push(`released_cut:${cutId}:removed_from_graph`);
       continue;

--- a/hooks/mpl-require-phase-contract-graph.mjs
+++ b/hooks/mpl-require-phase-contract-graph.mjs
@@ -7,6 +7,7 @@
  * or dangling phase dependencies.
  */
 
+import { existsSync, readFileSync } from 'fs';
 import { dirname, join } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 
@@ -49,6 +50,85 @@ function collectDecompositionTexts(toolInput) {
     .map((entry) => entry.text);
 }
 
+function readCompletedCutIds(cwd) {
+  // Returns the set of cut ids whose `release-finalize` has shipped.
+  // Source of truth is `state.release.completed_cut_ids` in `.mpl/state.json`,
+  // which Phase 1.6 will write. Until Phase 1.6 lands, the field is absent
+  // and we return an empty set — the immutability check below becomes a no-op
+  // for graphs whose state doesn't yet carry release lifecycle data.
+  const path = join(cwd, '.mpl', 'state.json');
+  if (!existsSync(path)) return new Set();
+  try {
+    const text = readFileSync(path, 'utf-8');
+    const state = JSON.parse(text);
+    const ids = state?.release?.completed_cut_ids;
+    if (!Array.isArray(ids)) return new Set();
+    return new Set(ids.filter((id) => typeof id === 'string'));
+  } catch {
+    return new Set();
+  }
+}
+
+function readExistingDecomposition(cwd) {
+  const path = join(cwd, '.mpl', 'mpl', 'decomposition.yaml');
+  if (!existsSync(path)) return null;
+  try {
+    return readFileSync(path, 'utf-8');
+  } catch {
+    return null;
+  }
+}
+
+function cutPhasesById(graph) {
+  // Return Map<cut_id_or_"mvp", string[] of phase ids in declared order>.
+  const out = new Map();
+  if (graph?.mvp?.phases) out.set('mvp', [...graph.mvp.phases]);
+  if (Array.isArray(graph?.release_cuts)) {
+    for (const cut of graph.release_cuts) {
+      if (cut?.id) out.set(cut.id, Array.isArray(cut.phases) ? [...cut.phases] : []);
+    }
+  }
+  return out;
+}
+
+function phasesEqual(a, b) {
+  if (!Array.isArray(a) || !Array.isArray(b)) return false;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+  return true;
+}
+
+function validateReleasedCutImmutability(cwd, newGraph) {
+  // RFC §10 D-Q6: once a cut id is in state.release.completed_cut_ids, its
+  // phase membership is frozen. The corresponding release-manifest has been
+  // shipped externally; mutating the phase list would invalidate the artifact.
+  // Pre-release iteration (cut id NOT yet in completed_cut_ids) remains free.
+  const completed = readCompletedCutIds(cwd);
+  if (completed.size === 0) return []; // no released cuts → nothing to enforce
+
+  const existingText = readExistingDecomposition(cwd);
+  if (!existingText) return []; // no prior graph to compare against → first write
+
+  const existingGraph = parsePhaseContractGraphText(existingText);
+  const oldCutPhases = cutPhasesById(existingGraph);
+  const newCutPhases = cutPhasesById(newGraph);
+
+  const issues = [];
+  for (const cutId of completed) {
+    const oldPhases = oldCutPhases.get(cutId);
+    const newPhases = newCutPhases.get(cutId);
+    if (oldPhases === undefined) continue; // released cut absent from old graph (degenerate); cannot diff
+    if (newPhases === undefined) {
+      issues.push(`released_cut:${cutId}:removed_from_graph`);
+      continue;
+    }
+    if (!phasesEqual(oldPhases, newPhases)) {
+      issues.push(`released_cut:${cutId}:phases:mutated:old=[${oldPhases.join(',')}]:new=[${newPhases.join(',')}]`);
+    }
+  }
+  return issues;
+}
+
 async function main() {
   const raw = await readStdin();
   if (!raw.trim()) return ok();
@@ -74,6 +154,10 @@ async function main() {
     const graph = parsePhaseContractGraphText(text);
     const verdict = validatePhaseContractGraph(graph);
     issues.push(...verdict.issues);
+    // D-Q6 released-cut immutability — only meaningful once state.release
+    // exists (Phase 1.6+). Returns [] today for graphs whose state.json
+    // lacks `state.release.completed_cut_ids`.
+    issues.push(...validateReleasedCutImmutability(cwd, graph));
   }
 
   if (issues.length > 0) {
@@ -81,7 +165,7 @@ async function main() {
     const more = issues.length > 12 ? ` (+${issues.length - 12} more)` : '';
     block(
       `[MPL Phase Contract Graph] decomposition.yaml is not a valid phase contract graph: ${shown}${more}. ` +
-        `Add graph metadata, execution_tiers, per-phase evidence_required/change_policy/resource_locks, and valid interface requires.from_phase refs.`
+        `Add graph metadata, execution_tiers, per-phase evidence_required/change_policy/resource_locks, valid interface requires.from_phase refs, and (when state.release exists) preserve released-cut phase membership.`
     );
     return;
   }


### PR DESCRIPTION
## What

Stage A implementation **phase 1.4b**: extend the contract-graph validator and require hook with the two checks deferred from PR #180 (Phase 1.4a):

- **B5 dependency-closure** (lib validator): no forward or upward `requires` between Stage A cohorts
- **D-Q6 released-cut immutability** (require hook): once `state.release.completed_cut_ids` lists a cut, its phase list is frozen

### Files changed

- `hooks/lib/mpl-phase-contract-graph.mjs` (+58, -3): new `validateDependencyClosure` invoked from `validateMvpAndReleaseCuts`
- `hooks/mpl-require-phase-contract-graph.mjs` (+82, +0): new `validateReleasedCutImmutability` invoked alongside graph validator. Reads `.mpl/state.json` for `state.release.completed_cut_ids`, diffs prior `.mpl/mpl/decomposition.yaml` against new write
- `hooks/__tests__/mpl-phase-contract-graph.test.mjs` (+233, +0): 12 new tests (7 dep-closure unit, 5 D-Q6 hook integration). 1 prior fixture (block-list parser regression) updated to include mvp so its cut's dependency resolves through the new closure check

Full hook suite: **950/950 pass** (+11 net, 0 regression).

## Why

PR #180 (Phase 1.4a) deferred two checks intentionally — they needed cross-phase requires analysis and `state.release` runtime access respectively. Without them:

- An MVP cohort could ship with `requires.from_phase` pointing at a non-MVP phase. The MVP gate would fail at runtime (Phase 1.6 release-gate) far from the source. The decomposer's transient guard from Phase 1.2 Step 12 surfaces it but only at decomposition time; this PR is the durable check at write time.
- A recompose could silently mutate `mvp.phases` after `release-finalize(mvp)` has shipped — invalidating the released artifact. PR #179 added the agent-prompt rule (Rule 9 extension); this PR is the hook-level enforcement.

## Design

- **Source**: `docs/roadmap/stage-a-mvp-cuts-rfc.md` §4.2 (B5 dependency-closure), §10 D-Q6 (released-cut immutability), §5.4.2 (cut activation/ordering — Stage A serializes cuts per declared array order)
- **Companion PRs (merged)**: #178 (`mvp_scope` parser), #179 (Rule 9 immutability prompt), #180 (Phase 1.4a schema validators), #181 (interview elicitation), #182 (decomposer mvp derivation + transient deps guard)
- **Forward-compat**: D-Q6 hook is a no-op until `state.release` exists (Phase 1.6+). The check is wired now so 1.6 doesn't need a second visit to this layer.

## Issue tokens

| Token | Severity | Cause |
|---|---|---|
| `mvp:phases:<id>:requires:outside_cohort:<dep>` | block | MVP phase requires non-MVP phase |
| `release_cuts:<cutId>:phases:<id>:requires:outside_cohort:<dep>` | block | cut phase requires later cut or non-cohort phase |
| `released_cut:<id>:phases:mutated:old=[...]:new=[...]` | block | recompose changed a released cut's phase list |
| `released_cut:<id>:removed_from_graph` | block | recompose removed a released cut entirely |

## Risk

- Pure validator + hook extension. Backward compatibility: pre-Stage-A graphs (no mvp/release_cuts) skip dep-closure; pre-Phase-1.6 projects (no `state.release` in state.json) skip immutability.
- Block-list parser regression fixture (PR #180 codex review) updated to include mvp — its prior shape happened to violate the new dep-closure rule. Behaviour change is intentional and explicit (test comment cites Phase 1.4b).

## Out of scope (separate phase)

- Orchestrator release-path states (`release-gate`, `release-finalize`) — Phase 1.6
- `state.release` subtree write path — Phase 1.6
- Cohort-aware `phase2-sprint` completion — Phase 1.6

## Agent Review Status

This PR is gated on **2 unique agent reviews** (footers \`— from <agent>\`).

- [ ] from claude
- [ ] from codex

---
_Awaiting reviews. Merge once the gate is satisfied._