### PR TITLE
feat(state): add Stage A release-path state subtree + small-pipeline guard (D-Q7)

### DIFF
--- a/hooks/__tests__/mpl-phase-controller.test.mjs
+++ b/hooks/__tests__/mpl-phase-controller.test.mjs
@@ -573,6 +573,46 @@ mvp_scope:
     assert.match(out.stopReason, /Small Plan in progress/);
   });
 
+  it('D-Q7: allows small-plan when goal_contract exists but mvp_scope is absent (transitional case)', () => {
+    // Most projects during Stage A rollout have a goal-contract.yaml from
+    // prior runs but never declared mvp_scope. The guard's optional-chain
+    // (`gc.contract?.mvp_scope`) must yield undefined → falsy → no block.
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    writeFileSync(join(tmpDir, '.mpl', 'goal-contract.yaml'), `
+source:
+  runtime_goal: "x"
+  user_request_hash: "abc"
+mission:
+  goal: "g"
+  project_pivot: "pp"
+  must_ship_outcomes:
+    - "ship"
+ontology:
+  entities:
+    - foo
+variation_axes:
+  - id: AX-1
+    name: ax
+acceptance_criteria:
+  - id: AC-1
+    statement: "ac"
+e2e_policy:
+  real_runtime_required: true
+  mock_allowed: false
+  placeholder_assertions_allowed: false
+security_policy:
+  required: false
+completion_evidence:
+  required_artifacts:
+    - .mpl/mpl/audit-report.json
+  require_commit: false
+  require_finalize_timestamps: true
+`);
+    const out = runStopHook(tmpDir, { current_phase: 'small-plan' });
+    assert.strictEqual(out.continue, true);
+    assert.match(out.stopReason, /Small Plan in progress/);
+  });
+
   it('blocked_hook pre-mark on phase2 complete → blocks Phase 3 transition', () => {
     mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
     writeFileSync(join(tmpDir, '.mpl', 'PLAN.md'), `

--- a/hooks/__tests__/mpl-phase-controller.test.mjs
+++ b/hooks/__tests__/mpl-phase-controller.test.mjs
@@ -519,6 +519,60 @@ describe('G4 hang detection (#109) Stop hook integration', () => {
     assert.strictEqual(state.session_status, 'verification_hang');
   });
 
+  it('D-Q7: blocks small-plan entry when goal_contract.mvp_scope is declared', () => {
+    // RFC §10 D-Q7: small-pipeline and mvp_scope are mutually exclusive.
+    // When the contract declares an MVP, small-plan must refuse to enter
+    // rather than silently downgrading away from the Stage A release path.
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    // Minimal valid contract with mvp_scope.
+    writeFileSync(join(tmpDir, '.mpl', 'goal-contract.yaml'), `
+source:
+  runtime_goal: "x"
+  user_request_hash: "abc"
+mission:
+  goal: "g"
+  project_pivot: "pp"
+  must_ship_outcomes:
+    - "ship"
+ontology:
+  entities:
+    - foo
+variation_axes:
+  - id: AX-1
+    name: ax
+acceptance_criteria:
+  - id: AC-1
+    statement: "ac"
+e2e_policy:
+  real_runtime_required: true
+  mock_allowed: false
+  placeholder_assertions_allowed: false
+security_policy:
+  required: false
+completion_evidence:
+  required_artifacts:
+    - .mpl/mpl/audit-report.json
+  require_commit: false
+  require_finalize_timestamps: true
+mvp_scope:
+  acceptance_criteria: [AC-1]
+  variation_axes: [AX-1]
+  artifact: draft_pr
+`);
+    const out = runStopHook(tmpDir, { current_phase: 'small-plan' });
+    assert.strictEqual(out.continue, false);
+    assert.strictEqual(out.decision, 'block');
+    assert.match(out.reason, /small-pipeline is not available when goal_contract\.mvp_scope is declared/);
+  });
+
+  it('D-Q7: allows small-plan entry when goal_contract.mvp_scope is absent', () => {
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    // No goal-contract file → mvp_scope is absent → small-plan must proceed.
+    const out = runStopHook(tmpDir, { current_phase: 'small-plan' });
+    assert.strictEqual(out.continue, true);
+    assert.match(out.stopReason, /Small Plan in progress/);
+  });
+
   it('blocked_hook pre-mark on phase2 complete → blocks Phase 3 transition', () => {
     mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
     writeFileSync(join(tmpDir, '.mpl', 'PLAN.md'), `

--- a/hooks/__tests__/mpl-state.test.mjs
+++ b/hooks/__tests__/mpl-state.test.mjs
@@ -622,3 +622,54 @@ describe('P2-6 drift detection', () => {
     assert.deepStrictEqual(r.details, []);
   });
 });
+
+describe('Stage A release-path state (Phase 1.6a)', () => {
+  let tmpDir;
+  beforeEach(() => { tmpDir = mkdtempSync(join(tmpdir(), 'mpl-state-release-')); });
+  afterEach(() => rmSync(tmpDir, { recursive: true, force: true }));
+
+  it('initState seeds the release subtree with defaults', () => {
+    initState(tmpDir, 'release-test-feature');
+    const state = readState(tmpDir);
+    assert.ok(state.release, 'release subtree must exist on init');
+    assert.strictEqual(state.release.current_cut_id, null);
+    assert.deepStrictEqual(state.release.completed_cut_ids, []);
+    assert.strictEqual(state.release.fix_loop_count, 0);
+    assert.strictEqual(state.release.pending_artifact, null);
+  });
+
+  it('writeState accepts release-gate and release-finalize as valid phases (no warning)', () => {
+    initState(tmpDir, 'release-test-feature');
+    // Capture console.error to ensure no VALID_PHASES warning is emitted.
+    const captured = [];
+    const originalError = console.error;
+    console.error = (...args) => { captured.push(args.join(' ')); };
+    try {
+      writeState(tmpDir, { current_phase: 'release-gate' });
+      writeState(tmpDir, { current_phase: 'release-finalize' });
+    } finally {
+      console.error = originalError;
+    }
+    const warnings = captured.filter((m) => m.includes('Unrecognized current_phase'));
+    assert.deepStrictEqual(
+      warnings,
+      [],
+      `release-gate / release-finalize must be in VALID_PHASES; got warnings: ${warnings.join(' || ')}`,
+    );
+  });
+
+  it('writeState preserves release subtree updates (deep merge)', () => {
+    initState(tmpDir, 'release-test-feature');
+    writeState(tmpDir, {
+      release: {
+        current_cut_id: 'mvp',
+        completed_cut_ids: [],
+        fix_loop_count: 0,
+        pending_artifact: { type: 'draft_pr', target: 'pr-123' },
+      },
+    });
+    const state = readState(tmpDir);
+    assert.strictEqual(state.release.current_cut_id, 'mvp');
+    assert.deepStrictEqual(state.release.pending_artifact, { type: 'draft_pr', target: 'pr-123' });
+  });
+});

--- a/hooks/__tests__/mpl-state.test.mjs
+++ b/hooks/__tests__/mpl-state.test.mjs
@@ -658,6 +658,45 @@ describe('Stage A release-path state (Phase 1.6a)', () => {
     );
   });
 
+  it('v4 → v5 migration: legacy state.json without release subtree is backfilled on read', () => {
+    // Codex high-severity catch on PR #184: adding state.release to
+    // DEFAULT_STATE alone doesn't backfill existing v4 state.json. The v4→v5
+    // migration must fill release defaults when the field is absent.
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    writeFileSync(join(tmpDir, '.mpl', 'state.json'), JSON.stringify({
+      schema_version: 4,
+      current_phase: 'phase2-sprint',
+      pipeline_id: 'legacy-pipeline-v4',
+    }));
+    const state = readState(tmpDir);
+    assert.strictEqual(state.schema_version, CURRENT_SCHEMA_VERSION);
+    assert.ok(state.release, 'release subtree must be backfilled on legacy state read');
+    assert.strictEqual(state.release.current_cut_id, null);
+    assert.deepStrictEqual(state.release.completed_cut_ids, []);
+    assert.strictEqual(state.release.fix_loop_count, 0);
+    assert.strictEqual(state.release.pending_artifact, null);
+    // Existing fields preserved verbatim.
+    assert.strictEqual(state.current_phase, 'phase2-sprint');
+    assert.strictEqual(state.pipeline_id, 'legacy-pipeline-v4');
+  });
+
+  it('v4 → v5 migration: partial release subtree gets defaults filled, existing values preserved', () => {
+    // If a forward-port left a partial release object (e.g. only
+    // completed_cut_ids set), the migration must preserve that and fill
+    // the missing fields.
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    writeFileSync(join(tmpDir, '.mpl', 'state.json'), JSON.stringify({
+      schema_version: 4,
+      current_phase: 'release-gate',
+      release: { completed_cut_ids: ['mvp'] },
+    }));
+    const state = readState(tmpDir);
+    assert.deepStrictEqual(state.release.completed_cut_ids, ['mvp']); // preserved
+    assert.strictEqual(state.release.current_cut_id, null);            // backfilled
+    assert.strictEqual(state.release.fix_loop_count, 0);               // backfilled
+    assert.strictEqual(state.release.pending_artifact, null);          // backfilled
+  });
+
   it('writeState preserves release subtree updates (deep merge)', () => {
     initState(tmpDir, 'release-test-feature');
     writeState(tmpDir, {

--- a/hooks/lib/migrations/index.mjs
+++ b/hooks/lib/migrations/index.mjs
@@ -20,6 +20,7 @@
 import v1ToV2 from './v1-to-v2.mjs';
 import v2ToV3 from './v2-to-v3.mjs';
 import v3ToV4 from './v3-to-v4.mjs';
+import v4ToV5 from './v4-to-v5.mjs';
 
 /**
  * Ordered registry. Add new entries here when bumping
@@ -29,6 +30,7 @@ export const MIGRATIONS = Object.freeze([
   v1ToV2,
   v2ToV3,
   v3ToV4,
+  v4ToV5,
 ]);
 
 /**

--- a/hooks/lib/migrations/v4-to-v5.mjs
+++ b/hooks/lib/migrations/v4-to-v5.mjs
@@ -1,0 +1,56 @@
+/**
+ * v4 → v5: Stage A release-path state subtree.
+ *
+ * Adds the `release` subtree consumed by:
+ *  - Phase 1.4b D-Q6 immutability hook (PR #183) — reads
+ *    `state.release.completed_cut_ids` as SSOT for released cuts.
+ *  - Phase 1.6b orchestrator (subsequent PR) — writes
+ *    `current_cut_id` / `fix_loop_count` / `pending_artifact` during
+ *    release-gate / release-finalize transitions.
+ *
+ * Backfill is additive: existing v4 state.json keeps every other field
+ * intact and gains `release` with safe defaults so the D-Q6 consumer
+ * transitions cleanly from no-op to active enforcement once Phase 1.6b
+ * starts writing to it.
+ *
+ * Codex review on PR #184 (1.6a) flagged the original 1.6a commit for
+ * adding the subtree to DEFAULT_STATE without bumping the schema version
+ * — existing v4 state.json files would silently lack the field, breaking
+ * the deep-merge claim in the PR body. This migration is the fix.
+ */
+
+export default {
+  from: 4,
+  to: 5,
+  description:
+    'Additive backfill — Stage A release-path state subtree (current_cut_id, completed_cut_ids, fix_loop_count, pending_artifact)',
+  migrate(state, _cwd) {
+    const merged = { ...state };
+
+    const existing = merged.release;
+    const releaseDefaults = {
+      current_cut_id: null,
+      completed_cut_ids: [],
+      fix_loop_count: 0,
+      pending_artifact: null,
+    };
+
+    if (!existing || typeof existing !== 'object' || Array.isArray(existing)) {
+      merged.release = { ...releaseDefaults };
+    } else {
+      // Preserve any field that was already set by a hand-edit / forward-
+      // ported state file; fill in only the missing defaults.
+      merged.release = { ...releaseDefaults, ...existing };
+      // Defensive: completed_cut_ids must be an array of strings.
+      if (!Array.isArray(merged.release.completed_cut_ids)) {
+        merged.release.completed_cut_ids = [];
+      }
+      if (typeof merged.release.fix_loop_count !== 'number') {
+        merged.release.fix_loop_count = 0;
+      }
+    }
+
+    merged.schema_version = 5;
+    return merged;
+  },
+};

--- a/hooks/lib/mpl-state.mjs
+++ b/hooks/lib/mpl-state.mjs
@@ -68,6 +68,12 @@ const VALID_PHASES = new Set([
   'phase1a-research', 'phase1b-plan',
   'phase2-sprint', 'phase3-gate', 'phase4-fix', 'phase5-finalize',
   'small-plan', 'small-sprint', 'small-verify',
+  // Stage A release path (RFC §5.1): scoped Hard 1/2/3 + release-manifest
+  // delivery for a single cohort (mvp or an approved release_cut). Routed
+  // into from phase2-sprint per cohort-aware completion (Phase 1.6b).
+  // Neither state sets `finalize_done=true`; that remains exclusive to
+  // phase5-finalize (RFC §5.5).
+  'release-gate', 'release-finalize',
   'completed'
 ]);
 
@@ -169,6 +175,26 @@ const DEFAULT_STATE = {
     mode: 'full',           // 'full' (3-stage) | 'light' (stage 1 only) | 'standalone'
     error: null,            // failure error message
     degraded_stages: []     // stages with partial failures, e.g. ['stage2']
+  },
+  // Stage A release-path lifecycle (RFC §4.5).
+  // `current_cut_id` carries the active cohort while phase2-sprint /
+  // release-gate / release-finalize execute that cohort's phases. Cleared
+  // (advanced to next eligible cut, or null) at release-finalize exit per
+  // RFC §5.4.2 cut activation rules.
+  // `completed_cut_ids` is the SSOT consumed by D-Q6 immutability hook
+  // (mpl-require-phase-contract-graph.mjs SHAPE COMMITMENT block).
+  // `fix_loop_count` is release-path scoped — does NOT touch the top-level
+  // `fix_loop_count` reserved for whole-pipeline phase3-gate.
+  // `pending_artifact` carries the user-visible artifact descriptor (draft_pr
+  // | branch | tag) requested by mvp.artifact / release_cuts[].artifact
+  // between release-gate PASS and release-finalize artifact attempt.
+  // For projects without `goal_contract.mvp_scope`, this subtree stays at
+  // defaults and the release path is never entered (RFC §4.5 lifecycle).
+  release: {
+    current_cut_id: null,        // null | "mvp" | "<release_cut.id>"
+    completed_cut_ids: [],       // appended on successful release-finalize
+    fix_loop_count: 0,           // scoped retries inside release-gate, not phase3-gate
+    pending_artifact: null,      // null | { type: "draft_pr"|"branch"|"tag", target: string }
   },
   memory: {                  // F-25: 4-Tier Adaptive Memory statistics
     episodic_entries: 0,

--- a/hooks/lib/mpl-state.mjs
+++ b/hooks/lib/mpl-state.mjs
@@ -48,7 +48,7 @@ export const MAX_AMBIGUITY_HISTORY = 10;
  * bump this constant, register a new migration entry; see
  * `docs/schemas/migration-policy.md`.
  */
-export const CURRENT_SCHEMA_VERSION = 4;
+export const CURRENT_SCHEMA_VERSION = 5;
 
 /**
  * Legacy execution state file. Pre-P2-6 orchestrator prompts wrote to this
@@ -188,6 +188,10 @@ const DEFAULT_STATE = {
   // `pending_artifact` carries the user-visible artifact descriptor (draft_pr
   // | branch | tag) requested by mvp.artifact / release_cuts[].artifact
   // between release-gate PASS and release-finalize artifact attempt.
+  // `release_manifest` — the fourth allowed mvp.artifact value — is the
+  // always-emitted artifact at release-finalize (RFC §5.4 / §10 D-Q4: "release
+  // manifest always; PR/branch/tag only when explicitly requested") and does
+  // NOT transit through `pending_artifact`; the field is opt-in transit only.
   // For projects without `goal_contract.mvp_scope`, this subtree stays at
   // defaults and the release path is never entered (RFC §4.5 lifecycle).
   release: {

--- a/hooks/mpl-phase-controller.mjs
+++ b/hooks/mpl-phase-controller.mjs
@@ -36,6 +36,11 @@ const { resolveRuleAction } = await import(
   pathToFileURL(join(__dirname, 'lib', 'mpl-enforcement.mjs')).href
 );
 
+// Stage A: goal-contract reader for the D-Q7 small-pipeline guard.
+const { readGoalContract } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-goal-contract.mjs')).href
+);
+
 // G4 hang detection (#109)
 const { detectHang } = await import(
   pathToFileURL(join(__dirname, 'lib', 'mpl-hang-detector.mjs')).href
@@ -554,6 +559,26 @@ async function main() {
     // === Small Pipeline Phases (3-Phase Lightweight) ===
 
     case 'small-plan': {
+      // RFC §10 D-Q7: small-pipeline and `mvp_scope` are mutually exclusive.
+      // Small-pipeline answers "the whole task is small, run a lightweight
+      // pipeline." MVP cut answers "the task is large, ship a subset first."
+      // Conflating the two doubles the state-machine complexity for marginal
+      // gain. When mvp_scope is declared, the project MUST take the full MPL
+      // pipeline with the release path; small-pipeline entry is rejected
+      // here rather than silently downgrading the contract.
+      const gc = readGoalContract(cwd);
+      if (gc.exists && gc.contract?.mvp_scope) {
+        console.log(JSON.stringify({
+          continue: false,
+          decision: 'block',
+          reason: '[MPL] small-pipeline is not available when goal_contract.mvp_scope is declared. ' +
+            'Use the full MPL pipeline so the Stage A release path (release-gate → release-finalize) ' +
+            'can deliver the user-declared MVP cohort. ' +
+            'Either run the full pipeline (recommended) or remove mvp_scope from .mpl/goal-contract.yaml and re-enter small-plan.'
+        }));
+        break;
+      }
+
       // Small Plan: orchestrator handles, no auto-transition
       console.log(JSON.stringify({
         continue: true,

--- a/hooks/mpl-phase-controller.mjs
+++ b/hooks/mpl-phase-controller.mjs
@@ -588,6 +588,14 @@ async function main() {
     }
 
     case 'small-sprint': {
+      // D-Q7 guard intentionally fires only at `case 'small-plan'`. If a
+      // user lands here after entering small-plan with mvp_scope absent
+      // (legitimate path), the contract may have been edited mid-flow to
+      // add mvp_scope. Re-checking here is *not* supported in Phase 1.6a
+      // — the cost is replicating the guard in three places (-sprint,
+      // -verify) for an edge case where the user is intentionally
+      // restructuring mid-pipeline. Recommended workflow for that case:
+      // cancel the small pipeline and restart with the full pipeline.
       // Check PLAN.md completion (reuse checkPlanStatus)
       const smallPlanStatus = checkPlanStatus(cwd);
       if (!smallPlanStatus || smallPlanStatus.total === 0) {


### PR DESCRIPTION
## What

Stage A implementation **phase 1.6a**: introduce the foundational state-layer pieces that subsequent 1.6b/1.6c orchestrator work will route on.

- `hooks/lib/mpl-state.mjs`: add `release-gate` + `release-finalize` to VALID_PHASES; add `state.release` subtree to DEFAULT_STATE
- `hooks/mpl-phase-controller.mjs`: D-Q7 small-pipeline guard — blocks small-plan entry when `mvp_scope` declared
- `hooks/__tests__/mpl-state.test.mjs`: 3 new tests (initState seeds release defaults; VALID_PHASES acceptance; deep-merge release updates)
- `hooks/__tests__/mpl-phase-controller.test.mjs`: 2 new tests (D-Q7 block + allow paths)

Full hook suite: **959/959 pass** (+5 new, 0 regression).

## Why

PR #183's D-Q6 immutability hook already documents the SHAPE COMMITMENT for `state.release.completed_cut_ids`. That hook was forward-compat (no-op when the subtree is absent). This PR adds the actual subtree so Phase 1.6b's orchestrator state-transitions can write to it, and so the D-Q6 hook transitions from no-op to active enforcement once the writer lands.

D-Q7 was previously a Phase 1.6 deliverable; isolating it here keeps it close to the small-pipeline branch it gates and avoids a heavier 1.6b PR carrying an unrelated router policy change.

## Design

- Source: `docs/roadmap/stage-a-mvp-cuts-rfc.md` §4.5 (state.release subtree), §5.1 (release path state machine), §10 D-Q7 (small-pipeline mutual exclusion).
- Companion PRs (all merged): #178 (mvp_scope parser), #179 (Rule 9 immutability prompt), #180 (Phase 1.4a schema validators), #181 (interview), #182 (decomposer derivation), #183 (Phase 1.4b dep-closure + D-Q6 hook).
- Backward compat: state.release defaults make the subtree inert for projects without `goal_contract.mvp_scope`. D-Q7 guard returns continue=true when the goal-contract is missing or absent of mvp_scope (existing small-pipeline flow unchanged).
- Hard-coded narrowing (intentional): no state.release writer in this PR — that's Phase 1.6b's job. This PR is the schema + guard only.

## Out of scope (Phase 1.6b, 1.6c)

- `release-gate` / `release-finalize` state handlers in mpl-phase-controller
- Cohort-aware `phase2-sprint` completion (filter PLAN.md TODOs by `state.release.current_cut_id`)
- Lifecycle writer: set current_cut_id on mpl-decompose→phase2-sprint when mvp_scope declared; advance/clear on release-finalize exit
- Scoped Hard 1/2/3 in release-gate
- release-finalize artifact creation (per-cut snapshot ref + draft_pr/branch/tag)

## Risk

Pure additive state schema + one router guard. Zero existing test regressions. The new release subtree fields are all optional with safe defaults; existing state.json files without the subtree continue to work (writeState deep-merges so any read fills defaults).

## Agent Review Status

This PR is gated on **2 unique agent reviews** (footers \`— from <agent>\`).

- [ ] from claude
- [ ] from codex

---
_Awaiting reviews. Merge once the gate is satisfied._