### PR TITLE
feat(orchestrator): wire Stage A release path — sprint routing + state handlers (1.6b)

### DIFF
--- a/hooks/__tests__/mpl-phase-controller.test.mjs
+++ b/hooks/__tests__/mpl-phase-controller.test.mjs
@@ -738,6 +738,53 @@ mvp_scope:
     assert.match(out.stopReason, /release-finalize\(mvp\).*whole-pipeline phase3-gate/);
   });
 
+  it('1.6b: phase2-sprint init does NOT re-enter mvp cohort after it is in completed_cut_ids (RFC §4.5)', () => {
+    // Claude review on PR #185: the init guard previously only checked
+    // `current_cut_id == null` and re-set "mvp" on every phase2-sprint entry
+    // when mvp_scope was still in the contract. This violated RFC §4.5
+    // "Never re-entered for the same cut_id within a single pipeline run"
+    // on the phase3-gate → phase4-fix → recompose → phase2-sprint loop.
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    writeGoalContractWithMvp(tmpDir);
+    runStopHook(tmpDir, {
+      current_phase: 'phase2-sprint',
+      release: { current_cut_id: null, completed_cut_ids: ['mvp'], fix_loop_count: 0, pending_artifact: null },
+    });
+    const state = readState();
+    assert.strictEqual(
+      state.release.current_cut_id,
+      null,
+      'init must not re-enter mvp cohort once it is in completed_cut_ids',
+    );
+  });
+
+  it('1.6b: sprint with FAILED TODOs in active cohort routes to phase3-gate, not release-gate (codex high)', () => {
+    // Codex review on PR #185: release-gate stub unconditionally passed
+    // through to release-finalize, which appended the cohort to
+    // completed_cut_ids. So a sprint with FAILED TODOs would mark the
+    // cohort as "released" — flipping D-Q6 immutability on for a cohort
+    // that never actually shipped. The sprint completion now refuses to
+    // enter the release path when failures are present, preserving
+    // current_cut_id for the fix loop to retry later.
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    writeFileSync(join(tmpDir, '.mpl', 'PLAN.md'), `### [x] Task 1\n### [FAILED] Task 2\n`);
+    writeGoalContractWithMvp(tmpDir);
+    const out = runStopHook(tmpDir, {
+      current_phase: 'phase2-sprint',
+      release: { current_cut_id: 'mvp', completed_cut_ids: [], fix_loop_count: 0, pending_artifact: null },
+    });
+    const state = readState();
+    // Must route to phase3-gate (whole-pipeline fix loop), NOT release-gate.
+    assert.strictEqual(state.current_phase, 'phase3-gate');
+    // current_cut_id preserved — release path resumes from a clean sprint
+    // after the fix loop fixes the failure.
+    assert.strictEqual(state.release.current_cut_id, 'mvp');
+    // completed_cut_ids MUST stay empty — the cohort never reached
+    // release-finalize so it was never released.
+    assert.deepStrictEqual(state.release.completed_cut_ids, []);
+    assert.match(out.stopReason, /cannot enter the release path while failures are present/);
+  });
+
   it('1.6b: release-finalize is idempotent — re-entering with cohort already in completed_cut_ids does not double-append', () => {
     mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
     runStopHook(tmpDir, {

--- a/hooks/__tests__/mpl-phase-controller.test.mjs
+++ b/hooks/__tests__/mpl-phase-controller.test.mjs
@@ -758,14 +758,12 @@ mvp_scope:
     );
   });
 
-  it('1.6b: sprint with FAILED TODOs in active cohort routes to phase3-gate, not release-gate (codex high)', () => {
-    // Codex review on PR #185: release-gate stub unconditionally passed
-    // through to release-finalize, which appended the cohort to
-    // completed_cut_ids. So a sprint with FAILED TODOs would mark the
-    // cohort as "released" — flipping D-Q6 immutability on for a cohort
-    // that never actually shipped. The sprint completion now refuses to
-    // enter the release path when failures are present, preserving
-    // current_cut_id for the fix loop to retry later.
+  it('1.6b: sprint with FAILED TODOs in active cohort stays in phase2-sprint (does not route to phase3-gate)', () => {
+    // Codex review on PR #185 (round 2): the original fix routed to
+    // phase3-gate, but with existing all-PASS gate_results that would advance
+    // to phase5-finalize and skip release-finalize entirely. The corrected
+    // fix stays in phase2-sprint so the user/agent clears FAILED TODOs and
+    // re-enters the sprint cleanly, at which point the release path resumes.
     mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
     writeFileSync(join(tmpDir, '.mpl', 'PLAN.md'), `### [x] Task 1\n### [FAILED] Task 2\n`);
     writeGoalContractWithMvp(tmpDir);
@@ -774,15 +772,36 @@ mvp_scope:
       release: { current_cut_id: 'mvp', completed_cut_ids: [], fix_loop_count: 0, pending_artifact: null },
     });
     const state = readState();
-    // Must route to phase3-gate (whole-pipeline fix loop), NOT release-gate.
-    assert.strictEqual(state.current_phase, 'phase3-gate');
-    // current_cut_id preserved — release path resumes from a clean sprint
-    // after the fix loop fixes the failure.
+    // Must STAY in phase2-sprint — neither release-gate nor phase3-gate.
+    assert.strictEqual(state.current_phase, 'phase2-sprint');
     assert.strictEqual(state.release.current_cut_id, 'mvp');
-    // completed_cut_ids MUST stay empty — the cohort never reached
-    // release-finalize so it was never released.
     assert.deepStrictEqual(state.release.completed_cut_ids, []);
-    assert.match(out.stopReason, /cannot enter the release path while failures are present/);
+    assert.match(out.stopReason, /Staying in phase2-sprint/);
+    assert.match(out.stopReason, /Clear the FAILED TODOs/);
+  });
+
+  it('1.6b: phase3-gate defensively reverts to phase2-sprint when release cohort still active (codex round-2 high)', () => {
+    // Defense-in-depth for codex round-2 catch: even if some unknown path
+    // (hand-edited state, partial replay) lands at phase3-gate with an
+    // active release cohort + all-PASS gate evidence, the guard must
+    // refuse to advance to phase5-finalize and instead revert to sprint.
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    const out = runStopHook(tmpDir, {
+      current_phase: 'phase3-gate',
+      release: { current_cut_id: 'mvp', completed_cut_ids: [], fix_loop_count: 0, pending_artifact: null },
+      gate_results: {
+        hard1_baseline: { exit_code: 0 },
+        hard2_coverage: { exit_code: 0 },
+        hard3_resilience: { exit_code: 0 },
+      },
+    });
+    const state = readState();
+    assert.strictEqual(state.current_phase, 'phase2-sprint',
+      'phase3-gate must revert to phase2-sprint when an active cohort exists');
+    assert.strictEqual(state.release.current_cut_id, 'mvp',
+      'current_cut_id must be preserved across the revert');
+    assert.match(out.stopReason, /release cohort .* is still active/);
+    assert.match(out.stopReason, /Reverting to phase2-sprint/);
   });
 
   it('1.6b: release-finalize is idempotent — re-entering with cohort already in completed_cut_ids does not double-append', () => {

--- a/hooks/__tests__/mpl-phase-controller.test.mjs
+++ b/hooks/__tests__/mpl-phase-controller.test.mjs
@@ -613,6 +613,152 @@ completion_evidence:
     assert.match(out.stopReason, /Small Plan in progress/);
   });
 
+  // ── Stage A Phase 1.6b: release-path state handlers + lifecycle writer ──
+
+  function writeGoalContractWithMvp(dir) {
+    writeFileSync(join(dir, '.mpl', 'goal-contract.yaml'), `
+source:
+  runtime_goal: "x"
+  user_request_hash: "abc"
+mission:
+  goal: "g"
+  project_pivot: "pp"
+  must_ship_outcomes:
+    - "ship"
+ontology:
+  entities:
+    - foo
+variation_axes:
+  - id: AX-1
+    name: ax
+acceptance_criteria:
+  - id: AC-1
+    statement: "ac"
+e2e_policy:
+  real_runtime_required: true
+  mock_allowed: false
+  placeholder_assertions_allowed: false
+security_policy:
+  required: false
+completion_evidence:
+  required_artifacts:
+    - .mpl/mpl/audit-report.json
+  require_commit: false
+  require_finalize_timestamps: true
+mvp_scope:
+  acceptance_criteria: [AC-1]
+  variation_axes: [AX-1]
+  artifact: draft_pr
+`);
+  }
+
+  it('1.6b: phase2-sprint lazy-initializes current_cut_id="mvp" when mvp_scope declared', () => {
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    writeGoalContractWithMvp(tmpDir);
+    // Sprint with no PLAN.md → just touches the lifecycle init, then exits
+    // with "no TODOs defined" message. We verify the init wrote current_cut_id.
+    runStopHook(tmpDir, {
+      current_phase: 'phase2-sprint',
+      release: { current_cut_id: null, completed_cut_ids: [], fix_loop_count: 0, pending_artifact: null },
+    });
+    const state = readState();
+    assert.strictEqual(state.release.current_cut_id, 'mvp');
+  });
+
+  it('1.6b: phase2-sprint without mvp_scope leaves current_cut_id null (backward compat)', () => {
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    // No goal-contract file → mvp_scope absent → no cohort init
+    runStopHook(tmpDir, {
+      current_phase: 'phase2-sprint',
+      release: { current_cut_id: null, completed_cut_ids: [], fix_loop_count: 0, pending_artifact: null },
+    });
+    const state = readState();
+    assert.strictEqual(state.release.current_cut_id, null);
+  });
+
+  it('1.6b: phase2-sprint completion with current_cut_id=mvp routes to release-gate', () => {
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    writeFileSync(join(tmpDir, '.mpl', 'PLAN.md'), `### [x] Task 1\n### [x] Task 2\n`);
+    writeGoalContractWithMvp(tmpDir);
+    const out = runStopHook(tmpDir, {
+      current_phase: 'phase2-sprint',
+      release: { current_cut_id: 'mvp', completed_cut_ids: [], fix_loop_count: 0, pending_artifact: null },
+    });
+    const state = readState();
+    assert.strictEqual(state.current_phase, 'release-gate');
+    assert.match(out.stopReason, /Transitioning to release-gate\(mvp\)/);
+  });
+
+  it('1.6b: phase2-sprint completion with current_cut_id=null routes to phase3-gate (existing behavior)', () => {
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    writeFileSync(join(tmpDir, '.mpl', 'PLAN.md'), `### [x] Task 1\n### [x] Task 2\n`);
+    // No goal-contract → init does not set cohort → current_cut_id stays null
+    const out = runStopHook(tmpDir, {
+      current_phase: 'phase2-sprint',
+      release: { current_cut_id: null, completed_cut_ids: [], fix_loop_count: 0, pending_artifact: null },
+    });
+    const state = readState();
+    assert.strictEqual(state.current_phase, 'phase3-gate');
+    assert.match(out.stopReason, /Phase 3: Quality Gate/);
+  });
+
+  it('1.6b: release-gate stub passes through to release-finalize', () => {
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    const out = runStopHook(tmpDir, {
+      current_phase: 'release-gate',
+      release: { current_cut_id: 'mvp', completed_cut_ids: [], fix_loop_count: 0, pending_artifact: null },
+    });
+    const state = readState();
+    assert.strictEqual(state.current_phase, 'release-finalize');
+    assert.match(out.stopReason, /release-gate\(mvp\).*Phase 1\.6c/);
+  });
+
+  it('1.6b: release-gate with no active cohort routes defensively to phase3-gate', () => {
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    const out = runStopHook(tmpDir, {
+      current_phase: 'release-gate',
+      release: { current_cut_id: null, completed_cut_ids: [], fix_loop_count: 0, pending_artifact: null },
+    });
+    const state = readState();
+    assert.strictEqual(state.current_phase, 'phase3-gate');
+    assert.match(out.stopReason, /no active cohort/);
+  });
+
+  it('1.6b: release-finalize appends current cohort to completed_cut_ids and clears current_cut_id', () => {
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    const out = runStopHook(tmpDir, {
+      current_phase: 'release-finalize',
+      release: { current_cut_id: 'mvp', completed_cut_ids: [], fix_loop_count: 0, pending_artifact: null },
+    });
+    const state = readState();
+    assert.deepStrictEqual(state.release.completed_cut_ids, ['mvp']);
+    assert.strictEqual(state.release.current_cut_id, null);
+    assert.strictEqual(state.release.fix_loop_count, 0);
+    assert.strictEqual(state.current_phase, 'phase3-gate');
+    assert.match(out.stopReason, /release-finalize\(mvp\).*whole-pipeline phase3-gate/);
+  });
+
+  it('1.6b: release-finalize is idempotent — re-entering with cohort already in completed_cut_ids does not double-append', () => {
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    runStopHook(tmpDir, {
+      current_phase: 'release-finalize',
+      release: { current_cut_id: 'mvp', completed_cut_ids: ['mvp'], fix_loop_count: 0, pending_artifact: null },
+    });
+    const state = readState();
+    assert.deepStrictEqual(state.release.completed_cut_ids, ['mvp']); // not ['mvp', 'mvp']
+  });
+
+  it('1.6b: release-finalize with no active cohort routes defensively to phase3-gate', () => {
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    const out = runStopHook(tmpDir, {
+      current_phase: 'release-finalize',
+      release: { current_cut_id: null, completed_cut_ids: [], fix_loop_count: 0, pending_artifact: null },
+    });
+    const state = readState();
+    assert.strictEqual(state.current_phase, 'phase3-gate');
+    assert.match(out.stopReason, /no active cohort/);
+  });
+
   it('blocked_hook pre-mark on phase2 complete → blocks Phase 3 transition', () => {
     mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
     writeFileSync(join(tmpDir, '.mpl', 'PLAN.md'), `

--- a/hooks/mpl-phase-controller.mjs
+++ b/hooks/mpl-phase-controller.mjs
@@ -410,14 +410,26 @@ async function main() {
       // advancement happens at release-finalize exit. Without an mvp_scope,
       // current_cut_id stays null and the release path is never entered
       // (existing pipeline behavior preserved).
+      //
+      // RFC §4.5: "Never re-entered for the same cut_id within a single
+      // pipeline run." A cohort already in `completed_cut_ids` MUST NOT be
+      // re-set here, even if `current_cut_id` is null and the contract
+      // still carries `mvp_scope`. This guards the phase3-gate → phase4-fix
+      // → recompose → phase2-sprint loop from spuriously re-running the
+      // mvp release path after the artifact has shipped.
       if (state.release?.current_cut_id == null) {
-        const gc = readGoalContract(cwd);
-        if (gc.exists && gc.contract?.mvp_scope) {
-          writeState(cwd, {
-            release: { ...(state.release || {}), current_cut_id: 'mvp' },
-          });
-          // Re-read so the routing below sees the freshly-set cohort.
-          state = readState(cwd);
+        const already = Array.isArray(state.release?.completed_cut_ids)
+          ? state.release.completed_cut_ids
+          : [];
+        if (!already.includes('mvp')) {
+          const gc = readGoalContract(cwd);
+          if (gc.exists && gc.contract?.mvp_scope) {
+            writeState(cwd, {
+              release: { ...(state.release || {}), current_cut_id: 'mvp' },
+            });
+            // Re-read so the routing below sees the freshly-set cohort.
+            state = readState(cwd);
+          }
         }
       }
 
@@ -443,6 +455,26 @@ async function main() {
         //   (existing pre-Stage-A behavior, unchanged for projects without
         //   mvp_scope)
         const cohort = state.release?.current_cut_id;
+
+        // RFC §10 D-Q6 + Phase 1.4b: a cohort with FAILED TODOs MUST NOT be
+        // recorded as completed. release-finalize would otherwise append the
+        // cohort to `completed_cut_ids` (PR #185 codex review), flipping D-Q6
+        // immutability on for a cohort that never actually shipped its release
+        // artifact. The whole-pipeline phase3-gate path handles failed TODOs
+        // via the existing fix loop; the release path is reserved for cohorts
+        // whose sprint completed cleanly.
+        if (cohort && failed > 0) {
+          writeState(cwd, { current_phase: 'phase3-gate' });
+          console.log(JSON.stringify({
+            continue: true,
+            stopReason: `[MPL] Sprint resolved with FAILED TODOs (${completed} completed, ${failed} failed). ` +
+              `Active cohort "${cohort}" cannot enter the release path while failures are present. ` +
+              `Transitioning to whole-pipeline phase3-gate; the fix loop will run there. ` +
+              `(state.release.current_cut_id preserved; the release path will resume from a clean sprint next time.)`
+          }));
+          break;
+        }
+
         const nextPhase = cohort ? 'release-gate' : 'phase3-gate';
         const target = cohort ? `release-gate(${cohort})` : 'Phase 3: Quality Gate';
         writeState(cwd, { current_phase: nextPhase });
@@ -466,6 +498,17 @@ async function main() {
       // Phase 1.6b: stub handler. Scoped Hard 1/2/3 + release-scoped
       // gate-results.json land in Phase 1.6c. For now, immediately advance
       // to release-finalize so the lifecycle exit logic can run.
+      //
+      // Phase 1.6c will:
+      //   - Run scoped Hard 1/2/3 against `state.release.current_cut_id`
+      //     (full Hard 1 project-wide; Hard 2 affected scope; Hard 3 active
+      //      cut's interface_contract — per RFC §5.3 D-Q3)
+      //   - Write `.mpl/mpl/releases/{cut_id}/gate-results.json` (NEVER
+      //     touch `state.gate_results.hard{1,2,3}_*` per RFC §5.5)
+      //   - On failure: increment `state.release.fix_loop_count`, route
+      //     back to `phase2-sprint` for the same cohort (mirror of
+      //     phase3-gate→phase4-fix loop, RFC §5.3.1)
+      //   - On success: transition to release-finalize as today's stub does
       const cohort = state.release?.current_cut_id;
       if (!cohort) {
         // Defensive: release-gate without an active cohort is a state

--- a/hooks/mpl-phase-controller.mjs
+++ b/hooks/mpl-phase-controller.mjs
@@ -460,17 +460,24 @@ async function main() {
         // recorded as completed. release-finalize would otherwise append the
         // cohort to `completed_cut_ids` (PR #185 codex review), flipping D-Q6
         // immutability on for a cohort that never actually shipped its release
-        // artifact. The whole-pipeline phase3-gate path handles failed TODOs
-        // via the existing fix loop; the release path is reserved for cohorts
-        // whose sprint completed cleanly.
+        // artifact. The release path is reserved for cohorts whose sprint
+        // completed cleanly.
+        //
+        // Codex re-review caught a follow-up: routing to phase3-gate here
+        // would let an existing all-PASS state.gate_results path through to
+        // phase5-finalize while the cohort is still active — whole-pipeline
+        // finalize would start before the release path completes. Stay in
+        // phase2-sprint instead until the FAILED TODOs are cleared in PLAN.md
+        // (user/agent flips [FAILED] → [x] or removes the TODO). The release
+        // path resumes naturally when the sprint completes cleanly.
         if (cohort && failed > 0) {
-          writeState(cwd, { current_phase: 'phase3-gate' });
           console.log(JSON.stringify({
             continue: true,
             stopReason: `[MPL] Sprint resolved with FAILED TODOs (${completed} completed, ${failed} failed). ` +
-              `Active cohort "${cohort}" cannot enter the release path while failures are present. ` +
-              `Transitioning to whole-pipeline phase3-gate; the fix loop will run there. ` +
-              `(state.release.current_cut_id preserved; the release path will resume from a clean sprint next time.)`
+              `Active release cohort "${cohort}" cannot enter the release path while failures are present, ` +
+              `and routing to whole-pipeline phase3-gate would risk advancing past release-finalize when prior ` +
+              `gate evidence is all-PASS. Staying in phase2-sprint. ` +
+              `Clear the FAILED TODOs in PLAN.md (fix the failing tasks, then flip [FAILED] → [x]) to resume the release path.`
           }));
           break;
         }
@@ -574,6 +581,26 @@ async function main() {
     }
 
     case 'phase3-gate': {
+      // Stage A defense-in-depth (RFC §5.5): the whole-pipeline phase3-gate
+      // must never advance to phase5-finalize while a release cohort is
+      // still active. Any prior all-PASS gate_results from a previous run
+      // would otherwise let an in-progress release path's finalize be
+      // skipped. Sprint completion routing already prevents this in normal
+      // flow (failed-cohort case stays in phase2-sprint; clean-cohort case
+      // routes to release-gate), but a hand-edited state.json or a
+      // recompose-driven re-entry could still land here with a live cohort.
+      // Surface and revert.
+      if (state.release?.current_cut_id) {
+        writeState(cwd, { current_phase: 'phase2-sprint' });
+        console.log(JSON.stringify({
+          continue: true,
+          stopReason: `[MPL] ⚠ phase3-gate entered while release cohort "${state.release.current_cut_id}" is still active. ` +
+            `Whole-pipeline finalize must NOT run before release-finalize completes the active cohort. ` +
+            `Reverting to phase2-sprint; complete the cohort's release path first (release-gate → release-finalize).`
+        }));
+        break;
+      }
+
       // Per-rule policy (P0-2, #110): `missing_gate_evidence` resolves the
       // strict toggle for checkGateResults. Default is 'warn' per #110 §정책
       // (transitional — surface only, no block). Workspace can opt-in to

--- a/hooks/mpl-phase-controller.mjs
+++ b/hooks/mpl-phase-controller.mjs
@@ -221,7 +221,7 @@ async function main() {
     return;
   }
 
-  const state = readState(cwd);
+  let state = readState(cwd);
   if (!state) {
     console.log(JSON.stringify({ continue: true, suppressOutput: true }));
     return;
@@ -404,6 +404,23 @@ async function main() {
       // v0.17 (#55): interview_depth guard removed. Phase 0 no longer has
       // light/full dual-track — Stage 1 always runs full depth.
 
+      // Stage A Phase 1.6b: lazy-initialize state.release.current_cut_id
+      // on first sprint entry when goal_contract.mvp_scope is declared.
+      // This is the single lifecycle write point per RFC §4.5: subsequent
+      // advancement happens at release-finalize exit. Without an mvp_scope,
+      // current_cut_id stays null and the release path is never entered
+      // (existing pipeline behavior preserved).
+      if (state.release?.current_cut_id == null) {
+        const gc = readGoalContract(cwd);
+        if (gc.exists && gc.contract?.mvp_scope) {
+          writeState(cwd, {
+            release: { ...(state.release || {}), current_cut_id: 'mvp' },
+          });
+          // Re-read so the routing below sees the freshly-set cohort.
+          state = readState(cwd);
+        }
+      }
+
       // Check PLAN.md completion
       const planStatus = checkPlanStatus(cwd);
       if (!planStatus || planStatus.total === 0) {
@@ -418,11 +435,20 @@ async function main() {
       const remaining = total - completed - failed;
 
       if (remaining === 0) {
-        // All TODOs resolved (completed or failed) → Phase 3
-        writeState(cwd, { current_phase: 'phase3-gate' });
+        // Stage A Phase 1.6b: route based on `state.release.current_cut_id`.
+        // - non-null → cohort active, transition to release-gate (scoped Hard
+        //   1/2/3 will run there once Phase 1.6c lands; for now the stub
+        //   immediately advances to release-finalize)
+        // - null → whole-pipeline complete, transition to phase3-gate
+        //   (existing pre-Stage-A behavior, unchanged for projects without
+        //   mvp_scope)
+        const cohort = state.release?.current_cut_id;
+        const nextPhase = cohort ? 'release-gate' : 'phase3-gate';
+        const target = cohort ? `release-gate(${cohort})` : 'Phase 3: Quality Gate';
+        writeState(cwd, { current_phase: nextPhase });
         console.log(JSON.stringify({
           continue: true,
-          stopReason: `[MPL] All TODOs resolved (${completed} completed, ${failed} failed). Transitioning to Phase 3: Quality Gate.`
+          stopReason: `[MPL] All TODOs resolved (${completed} completed, ${failed} failed). Transitioning to ${target}.`
         }));
       } else {
         console.log(JSON.stringify({
@@ -430,6 +456,77 @@ async function main() {
           stopReason: `[MPL] Phase 2: Sprint in progress. ${completed}/${total} TODOs completed, ${failed} failed, ${remaining} remaining.`
         }));
       }
+      break;
+    }
+
+    // === Stage A Release Path (Phase 1.6b stubs; 1.6c will add scoped Hard
+    // 1/2/3 and release-manifest / artifact creation) ===
+
+    case 'release-gate': {
+      // Phase 1.6b: stub handler. Scoped Hard 1/2/3 + release-scoped
+      // gate-results.json land in Phase 1.6c. For now, immediately advance
+      // to release-finalize so the lifecycle exit logic can run.
+      const cohort = state.release?.current_cut_id;
+      if (!cohort) {
+        // Defensive: release-gate without an active cohort is a state
+        // corruption. Surface and revert to phase3-gate (whole-pipeline).
+        writeState(cwd, { current_phase: 'phase3-gate' });
+        console.log(JSON.stringify({
+          continue: true,
+          stopReason: '[MPL] ⚠ release-gate entered with no active cohort. Reverting to phase3-gate.'
+        }));
+        break;
+      }
+      writeState(cwd, { current_phase: 'release-finalize' });
+      console.log(JSON.stringify({
+        continue: true,
+        stopReason: `[MPL] release-gate(${cohort}): scoped Hard 1/2/3 execution lands in Phase 1.6c. ` +
+          `Stub passes through to release-finalize.`
+      }));
+      break;
+    }
+
+    case 'release-finalize': {
+      // Phase 1.6b: minimal completion logic — record the cohort in
+      // completed_cut_ids, advance current_cut_id, and route.
+      // Manifest write + artifact creation (per-cut snapshot ref +
+      // optional draft_pr/branch/tag) land in Phase 1.6c.
+      const cur = state.release?.current_cut_id;
+      if (!cur) {
+        writeState(cwd, { current_phase: 'phase3-gate' });
+        console.log(JSON.stringify({
+          continue: true,
+          stopReason: '[MPL] ⚠ release-finalize entered with no active cohort. Routing to phase3-gate.'
+        }));
+        break;
+      }
+
+      const existing = state.release || {};
+      const already = Array.isArray(existing.completed_cut_ids) ? existing.completed_cut_ids : [];
+      const completed = already.includes(cur) ? already : [...already, cur];
+
+      // Stage A simplification: decomposer (Phase 1.2 / PR #182) emits
+      // `release_cuts: []` so there is never a "next cut" to advance to.
+      // The orchestrator routes directly to whole-pipeline phase3-gate.
+      // Multi-cohort cut chaining (auto-proposed extension cuts) is RFC
+      // §10 D-Q2 Stage B work.
+      const nextCutId = null;
+      const nextPhase = 'phase3-gate';
+
+      writeState(cwd, {
+        release: {
+          ...existing,
+          completed_cut_ids: completed,
+          current_cut_id: nextCutId,
+          fix_loop_count: 0,
+        },
+        current_phase: nextPhase,
+      });
+      console.log(JSON.stringify({
+        continue: true,
+        stopReason: `[MPL] release-finalize(${cur}): cohort completed. ` +
+          `Stage A single-cohort path: transitioning to whole-pipeline phase3-gate.`
+      }));
       break;
     }
 


### PR DESCRIPTION
## What

Stage A implementation **phase 1.6b**: orchestrator state-machine wiring that consumes the foundation from PR #184 (state.release subtree) and PR #182 (decomposer mvp derivation).

- `hooks/mpl-phase-controller.mjs` (+82, -5): release-gate/release-finalize handlers, phase2-sprint lifecycle init + cohort-aware completion routing
- `hooks/__tests__/mpl-phase-controller.test.mjs` (+165): 9 new tests covering init, routing both directions, both handlers, idempotency, defensive paths

Full hook suite: **971/971 pass** (+9, 0 regression).

## Why — End-to-End Stage A Flow Activated

After this PR, the full Stage A loop runs end-to-end for single-cohort (mvp-only) projects:

```
user declares mvp_scope in interview      (#181)
  → goal-contract.yaml carries mvp_scope  (#178 parser)
  → decomposer derives decomposition.mvp  (#182)
  → THIS PR: sprint inits current_cut_id="mvp"
  → THIS PR: sprint completion → release-gate (cohort active)
  → release-gate stub → release-finalize
  → THIS PR: release-finalize appends mvp to completed_cut_ids
            → clears current_cut_id → phase3-gate
  → D-Q6 immutability hook (#183) now ACTIVE for recompose
```

Before this PR, mvp_scope was parseable + validated + derived but never *routed on*. The release path existed only as state schema (PR #184). This PR is the wiring that makes it actually run.

## Design

- Source: `docs/roadmap/stage-a-mvp-cuts-rfc.md` §5.1 (release path states), §5.4.2 (cut activation), §4.5 (state.release lifecycle), §10 D-Q2 (auto-proposed cuts are Stage B).
- Companion PRs (all merged): #178, #179, #180, #181, #182, #183, #184.
- **Stage A simplification**: decomposer emits `release_cuts: []` (PR #182 per RFC §10 D-Q2), so release-finalize never advances to a next cut — always routes to phase3-gate. Multi-cohort chaining is Stage B work and would require cohort-aware PLAN.md filtering (also Stage B).
- **Lifecycle init location**: lazily inside phase2-sprint case rather than at mpl-decompose. Reason: mpl-decompose case doesn't write current_phase=phase2-sprint itself (orchestrator/commands do). Putting the init at sprint entry makes it robust regardless of who set the phase.

## Risk

- Backward compatible: projects without mvp_scope take the existing phase2-sprint → phase3-gate path unchanged (verified by test "current_cut_id=null routes to phase3-gate").
- Defensive fallbacks: release-gate / release-finalize entered without an active cohort routes to phase3-gate with a warning message (state corruption recovery).
- Idempotent: re-entering release-finalize with cohort already in completed_cut_ids doesn't double-append (verified by test).
- `let state` (was `const`) inside main() — re-reading state after lifecycle init writes. The only assignment is `state = readState(cwd)` after the writeState in phase2-sprint init.

## Out of scope (Phase 1.6c)

- Scoped Hard 1/2/3 inside release-gate (replaces stub passthrough)
- `.mpl/mpl/releases/{cut_id}/gate-results.json` write
- Per-cut snapshot ref (`refs/mpl/releases/{cut_id}`)
- draft_pr / branch / tag artifact creation at release-finalize
- Cohort-aware PLAN.md filtering (multi-cohort prerequisite)

## Agent Review Status

This PR is gated on **2 unique agent reviews** (footers \`— from <agent>\`).

- [ ] from claude
- [ ] from codex

---
_Awaiting reviews. Merge once the gate is satisfied._