### PR TITLE
feat(stage-a-1.6c-i): release-gate scoped Hard 1/2/3 evidence routing

### DIFF
--- a/docs/roadmap/stage-a-resume-1.6c.md
+++ b/docs/roadmap/stage-a-resume-1.6c.md
@@ -1,0 +1,214 @@
+# Stage A — Phase 1.6c Resume Brief
+
+**Date:** 2026-05-24
+**Status:** Pre-implementation. Branch staged, no commits yet beyond this doc.
+**Branch:** `impl/stage-a-release-gate-scoped-gates`
+**Base:** `main` @ `6275fd4` (immediately after PR #185 merge)
+**Source RFC:** `docs/roadmap/stage-a-mvp-cuts-rfc.md`
+**Analysis doc:** `docs/roadmap/parallelism-mvp-analysis.md`
+
+This brief is **self-contained**. A new session should be able to checkout the branch, read this file, and pick up implementation without re-reading the prior 9-PR session's context.
+
+---
+
+## 1. Stage A Cumulative Progress (9 PRs merged into `main`)
+
+| # | PR | Phase | Commit | One-line summary |
+|---|---|---|---|---|
+| #177 | RFC | — | `da62b06` | Stage A MVP/release-cuts analysis + RFC |
+| #178 | 1.1 mvp_scope parser | goal-contract layer | `0ce39c4` | parser + validator + `MVP_SCOPE_ARTIFACTS` constant |
+| #179 | 1.5 Rule 9 immutability | decomposer prompt | `d71fba6` | recompose treats released cut's phases as immutable |
+| #180 | 1.4a schema validators | hook (lib + tests) | `d53c1f0` | mvp + release_cuts schema integrity + cross-cut overlap |
+| #181 | 1.3 interview checklist | phase0 protocol | `d1576c5` | Stage 1.4.5 guided AC/AX checklist + opt-out |
+| #182 | 1.2 decomposer derivation | decomposer prompt | `29fa769` | Step 12 mechanical mvp.phases from mvp_scope (no inference) |
+| #183 | 1.4b dep-closure + D-Q6 | hook + require + tests | `7e35a3c` | dependency-closure rule + released-cut immutability hook |
+| #184 | 1.6a state.release + D-Q7 | state schema + guard | `04827f3` | `state.release` subtree + v4→v5 migration + small-pipeline guard |
+| #185 | 1.6b release-path handlers | orchestrator + tests | `6275fd4` | release-gate / release-finalize handlers + cohort-aware sprint routing |
+
+**End-to-end Stage A flow (single-cohort, mvp-only) is now wired and tested.** Test suite at `main`: **974/974 hook tests pass**.
+
+What works today on `main`:
+1. User opts into MVP via the Stage 1.4.5 guided checklist (#181)
+2. Goal-contract parser stores `mvp_scope` (#178)
+3. Decomposer derives `mvp.phases` via mechanical id-set mapping (#182)
+4. Contract-graph validator + hook reject malformed mvp/release_cuts and mutated released cuts (#180, #183)
+5. Orchestrator routes phase2-sprint → release-gate (cohort active) or phase3-gate (no cohort) (#185)
+6. release-finalize appends cohort to `completed_cut_ids`, clears `current_cut_id`, routes to phase3-gate (#185)
+
+What does **not** yet exist:
+- release-gate currently passes through unconditionally — no scoped Hard 1/2/3 execution
+- release-finalize currently writes no release-manifest, creates no snapshot ref, no git/GitHub artifact
+- Therefore `completed_cut_ids` fills purely from the stub flow; D-Q6 immutability hook is active but exercised only by the test fixture
+
+---
+
+## 2. Phase 1.6c — Goals (one-line)
+
+Make release-gate actually gate, and release-finalize actually finalize.
+
+After 1.6c, a single-cohort Stage A run for a project that declared `mvp_scope` will:
+- Run scoped Hard 1 (full project) + Hard 2 (affected) + Hard 3 (cut interface_contract) at release-gate
+- Block transition to release-finalize on any failure; mirror phase3-gate→phase4-fix loop
+- Write `.mpl/mpl/releases/mvp/release-manifest.json` + `evidence-summary.md` + `gate-results.json`
+- Create the requested user-visible artifact (draft_pr | branch | tag | release_manifest) with graceful fallback on failure
+- D-Q6 immutability hook (PR #183) automatically activates against the populated `completed_cut_ids`
+
+---
+
+## 3. Recommended Sub-split — 1.6c-i / 1.6c-ii / 1.6c-iii
+
+The three sub-phases touch independent surfaces. Splitting them keeps each PR review-friendly.
+
+### 1.6c-i — release-gate scoped Hard 1/2/3 evidence routing
+
+**Scope:** wire release-gate to *consume* release-scoped gate evidence and route on it. Evidence *production* (running scoped commands and writing the json) is mpl-gate-recorder's job and lives outside this PR.
+
+**Files:**
+- `hooks/lib/mpl-state.mjs` — add `state.release.gate_results` (similar shape to top-level `gate_results`); bump `CURRENT_SCHEMA_VERSION` 5 → 6 + add `hooks/lib/migrations/v5-to-v6.mjs` (additive backfill). This matches the pattern PR #184 established for `state.release` and codex flagged on PR #184.
+- `hooks/mpl-phase-controller.mjs` `case 'release-gate'`:
+  - Read `state.release.gate_results` (or fall back to checking `.mpl/mpl/releases/{cut_id}/gate-results.json` on disk — pick **one** SSOT; recommend the in-state field for consistency with phase3-gate's pattern).
+  - **PASS** (all 3 hard gates structured-PASS) → transition to release-finalize.
+  - **FAIL** (any hard gate structured-FAIL) → increment `state.release.fix_loop_count`, transition back to `phase2-sprint`, **PRESERVE** `state.release.current_cut_id`. On `fix_loop_count >= max_fix_loops` (config-driven, default 3), circuit-break: pin `current_cut_id` and surface a user-actionable message; do NOT transition (RFC §5.3.1).
+  - **MISSING** → continue + `stopReason` "[MPL] release-gate(cut_id): awaiting scoped Hard 1/2/3 evidence. Run scoped commands; mpl-gate-recorder will populate state.release.gate_results."
+- `hooks/__tests__/mpl-phase-controller.test.mjs` — tests for PASS / FAIL / MISSING / circuit-break paths.
+
+**Invariant**: release-gate evidence MUST NOT touch `state.gate_results.hard{1,2,3}_*` (those are reserved for whole-pipeline phase3-gate per RFC §5.5). Use a parallel `state.release.gate_results` subtree.
+
+**Gate scope decisions (already pinned in RFC §5.3 / §10 D-Q3):**
+- Hard 1 (build/lint/type): full project scope.
+- Hard 2 (tests): `impact.affected_tests[]` from cut phases; fallback to `.mpl/config.json` `test_command`; write `hard2_fallback: full_project` with reason if used (silent fallback FORBIDDEN).
+- Hard 3 (contracts): cut scope — declared `interface_contract.produces` for phases in `state.release.current_cut_id`.
+
+### 1.6c-ii — release-finalize manifest write + evidence-summary
+
+**Scope:** when release-gate passes (cohort moves to release-finalize), write the release-scoped artifacts before clearing `current_cut_id`.
+
+**Files:**
+- `hooks/mpl-phase-controller.mjs` `case 'release-finalize'`:
+  - After completing the existing append+clear logic, write:
+    - `.mpl/mpl/releases/{cut_id}/release-manifest.json` — contains: `cut_id`, `phases[]`, `goal_trace.acceptance_criteria/variation_axes`, `commit_sha`, `tree_sha`, `snapshot_ref` (placeholder until 1.6c-iii), `gate-results-summary`, `created_at`, `artifact` (from mvp/release_cut.artifact)
+    - `.mpl/mpl/releases/{cut_id}/evidence-summary.md` — human-readable summary of phase evidence + test-agent dispatches + goal_trace coverage
+    - `.mpl/mpl/releases/{cut_id}/gate-results.json` — copy of `state.release.gate_results` for archival
+- New library `hooks/lib/mpl-release-manifest.mjs` for serialization (testable in isolation).
+- `hooks/__tests__/mpl-release-manifest.test.mjs` — unit tests.
+- `hooks/__tests__/mpl-phase-controller.test.mjs` — integration test: release-finalize writes all 3 files with correct content.
+
+**Invariant**: release-finalize MUST NOT set `state.finalize_done=true` and MUST NOT transition `current_phase` to `completed`. Both remain exclusive to phase5-finalize (RFC §5.5). The PR #185 implementation already honors this; preserve it.
+
+### 1.6c-iii — Snapshot ref + git/GitHub artifact creation (RFC §5.4.1)
+
+**Scope:** the optional, externally-visible artifact. This is the highest-risk sub-PR (touches git refs and gh CLI).
+
+**Files:**
+- New `hooks/lib/mpl-release-artifact.mjs` — pure helpers for snapshot ref creation, draft_pr / branch / tag invocation, graceful failure handling.
+- `hooks/mpl-phase-controller.mjs` `case 'release-finalize'`:
+  - After manifest write (1.6c-ii), if `mvp.artifact` / `release_cut.artifact` is one of `draft_pr | branch | tag`, attempt the corresponding action.
+  - On failure: write `artifact_creation_failed` with reason into `release-manifest.json` and surface to user. Continue the lifecycle exit (do NOT block).
+  - `release_manifest` artifact = no-op here (already covered in 1.6c-ii).
+- Snapshot ref: `refs/mpl/releases/{cut_id}` via `git update-ref` (pure git, no remote required for the ref itself).
+- Tag: `git tag mpl-release-{cut_id} {commit_sha}` + `git push origin refs/tags/...` if remote configured.
+- Branch: `git branch mpl/release/{cut_id} {commit_sha}` + push.
+- draft_pr: `gh pr create --draft --base main --head mpl/release/{cut_id}` (requires branch already pushed).
+
+**Critical safety**: every git/gh invocation must be wrapped to never leave the working tree in a partial state. If `git push` fails, the local ref is preserved; user can retry manually.
+
+**Tests**: integration tests with a temporary git repo + mocked gh CLI. See `hooks/__tests__/mpl-phase-controller.test.mjs` `runStopHook` pattern.
+
+---
+
+## 4. Invariants — Do Not Violate
+
+The 9 prior PRs locked down these invariants. Subsequent PRs MUST preserve them:
+
+1. **D-Q6 released-cut immutability**: `completed_cut_ids` is the SSOT for "released" status. Once a cut id is appended, recompose cannot mutate that cut's `phases`. The hook (`hooks/mpl-require-phase-contract-graph.mjs`) enforces this from PR #183. Adding entries here is one-way; never remove from `completed_cut_ids`.
+
+2. **RFC §4.5 lifecycle — never re-enter same cut_id**: phase2-sprint init guard checks `completed_cut_ids.includes('mvp')` before re-setting `current_cut_id`. Do not loosen.
+
+3. **RFC §5.5 whole-pipeline isolation**:
+   - release-gate / release-finalize MUST NOT set `state.finalize_done=true`.
+   - release-gate evidence MUST NOT write `state.gate_results.hard{1,2,3}_*` (reserved for final phase3-gate).
+   - Use `state.release.gate_results` as the parallel release-scoped subtree.
+   - phase3-gate has a defensive guard (PR #185) that reverts to phase2-sprint when an active cohort exists; preserve.
+
+4. **RFC §5.3.1 fix loop scope**: `state.release.fix_loop_count` is separate from top-level `fix_loop_count` (which stays for phase3-gate→phase4-fix). Do not unify.
+
+5. **Stage A single-cohort scope**: decomposer emits `release_cuts: []` (PR #182 per RFC §10 D-Q2). Multi-cohort cut chaining is Stage B. Do not auto-propose extension cuts.
+
+6. **Failed-cohort guard**: sprint with `cohort && failed > 0` stays in phase2-sprint (PR #185 round-2 fix). Routing to phase3-gate would let existing all-PASS gate evidence skip release-finalize.
+
+7. **D-Q7 small-pipeline mutual exclusion**: when `goal_contract.mvp_scope` is present, small-plan entry is blocked (PR #184). Preserve.
+
+---
+
+## 5. Key File Pointers (current `main`)
+
+| Path | Role |
+|---|---|
+| `docs/roadmap/stage-a-mvp-cuts-rfc.md` | Source of truth for all Stage A decisions (D-Q1..D-Q7, §5.3.1 failure path, §5.4.1 snapshot, §5.4.2 cut activation) |
+| `hooks/lib/mpl-state.mjs` | `state.release` subtree + CURRENT_SCHEMA_VERSION=5 (bump to 6 for 1.6c-i) |
+| `hooks/lib/migrations/v4-to-v5.mjs` | Reference for migration shape; add `v5-to-v6.mjs` similarly |
+| `hooks/lib/mpl-goal-contract.mjs` | mvp_scope parser; exports MVP_SCOPE_ARTIFACTS |
+| `hooks/lib/mpl-phase-contract-graph.mjs` | mvp/release_cuts validators + dep-closure + ALLOWED_RELEASE_ARTIFACTS (re-exports MVP_SCOPE_ARTIFACTS) |
+| `hooks/mpl-require-phase-contract-graph.mjs` | D-Q6 immutability hook + SHAPE COMMITMENT block for `completed_cut_ids: string[]` |
+| `hooks/mpl-phase-controller.mjs` | release-gate / release-finalize handlers (stubs today); add evidence read in 1.6c-i, manifest write in 1.6c-ii, artifact creation in 1.6c-iii |
+| `hooks/mpl-gate-recorder.mjs` | Where scoped gate evidence WRITER would live (1.6c-i companion — likely needs a parallel branch for release-scoped recording) |
+| `agents/mpl-decomposer.md` | Rule 9 immutability + Step 12 mvp derivation + `release_cuts: []` Stage A emit |
+| `commands/mpl-run-phase0.md` | Stage 1.4.5 MVP scope checklist |
+
+---
+
+## 6. Next Session Quickstart
+
+```bash
+# Sync local main
+git fetch origin
+git checkout main
+git reset --hard origin/main
+
+# Resume on the staged 1.6c branch
+git checkout impl/stage-a-release-gate-scoped-gates
+
+# Read this brief
+cat docs/roadmap/stage-a-resume-1.6c.md
+
+# Start with 1.6c-i (smallest, most reusable)
+# Edits go in:
+#   hooks/lib/mpl-state.mjs                 (CURRENT_SCHEMA_VERSION bump + state.release.gate_results default)
+#   hooks/lib/migrations/v5-to-v6.mjs       (new file, follows v4-to-v5 template)
+#   hooks/lib/migrations/index.mjs          (register v5ToV6)
+#   hooks/mpl-phase-controller.mjs          (case 'release-gate' read+route logic)
+#   hooks/__tests__/mpl-state.test.mjs      (migration backfill test)
+#   hooks/__tests__/mpl-phase-controller.test.mjs (PASS / FAIL / MISSING / circuit-break)
+
+# After 1.6c-i lands, repeat workflow for 1.6c-ii and 1.6c-iii.
+```
+
+---
+
+## 7. Open Questions to Settle Early in 1.6c-i
+
+These were not closed in the prior 9 PRs and will surface when actual evidence routing lands:
+
+1. **Single SSOT for release-scoped gate evidence**: `state.release.gate_results` (state.json) **or** `.mpl/mpl/releases/{cut_id}/gate-results.json` (file)? Recommend state.json for read-side parity with `state.gate_results`, write-side parity at file in 1.6c-ii. **Decide before authoring 1.6c-i**.
+
+2. **mpl-gate-recorder release-scope routing**: which mechanism tells the recorder "this Bash command's exit code goes into release-scoped evidence, not whole-pipeline"? Options:
+   - (a) recorder inspects `state.release.current_cut_id` and dual-writes if non-null
+   - (b) caller decorates commands with a marker
+   - (c) recorder only routes to release-scoped when `current_phase == 'release-gate'`
+   Recommend (c) as the simplest; document in 1.6c-i PR body.
+
+3. **`max_fix_loops` for release-scoped fix loop**: reuse top-level `state.max_fix_loops` (10) or add `state.release.max_fix_loops` (RFC §5.3.1 suggested 3)? Recommend separate field with default 3; bump to schema v6 alongside `gate_results`.
+
+4. **Hard 2 affected-tests resolution**: who computes the affected set from `impact.affected_tests[]`? Probably the orchestrator / mpl-gate-recorder, NOT the phase-controller. 1.6c-i may need a small helper `hooks/lib/mpl-release-affected.mjs` to expose the logic.
+
+Defer these to in-PR discussion; do not block this resume brief on them.
+
+---
+
+## 8. Risk Note for the New Session
+
+This branch is staged but has no commits yet. The new session can:
+- Either commit this resume brief and use the branch as a 1.6c container (then push to remote for visibility)
+- Or treat the brief as ephemeral context and start 1.6c-i in a fresh branch
+
+Recommend: commit this brief on `impl/stage-a-release-gate-scoped-gates` as the first commit, push, and use the branch for 1.6c-i. Subsequent sub-phases (1.6c-ii, 1.6c-iii) get their own branches off `main` after 1.6c-i merges.

--- a/hooks/__tests__/mpl-gate-recorder.test.mjs
+++ b/hooks/__tests__/mpl-gate-recorder.test.mjs
@@ -250,3 +250,133 @@ describe('mpl-gate-recorder test-agent evidence', () => {
     }), false);
   });
 });
+
+/* ─── Stage A Phase 1.6c-i (PR #186 review fix): Bash gate routing ─── */
+
+describe('mpl-gate-recorder Bash gate routing — release-gate vs whole-pipeline', () => {
+  function runBashHook(dir, { command, exit_code, stdout = '' }) {
+    const input = {
+      cwd: dir,
+      tool_name: 'Bash',
+      tool_input: { command },
+      tool_response: { stdout, exit_code },
+    };
+    return JSON.parse(execFileSync('node', [HOOK_PATH], {
+      input: JSON.stringify(input),
+      encoding: 'utf-8',
+    }));
+  }
+
+  it('current_phase=release-gate routes hard2_coverage into state.release.gate_results (NOT top-level)', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'mpl-gr-release-'));
+    try {
+      // Seed both subtrees so the assertion has a real before/after for
+      // top-level isolation (RFC §5.5).
+      const topLevelBefore = {
+        hard1_passed: null, hard2_passed: null, hard3_passed: null,
+        hard1_baseline: null, hard2_coverage: null, hard3_resilience: null,
+      };
+      seedState(tmp, {
+        current_phase: 'release-gate',
+        gate_results: { ...topLevelBefore },
+        release: {
+          current_cut_id: 'mvp',
+          completed_cut_ids: [],
+          fix_loop_count: 0,
+          pending_artifact: null,
+          gate_results: {
+            hard1_passed: null, hard2_passed: null, hard3_passed: null,
+            hard1_baseline: null, hard2_coverage: null, hard3_resilience: null,
+          },
+          max_fix_loops: 3,
+        },
+      });
+      runBashHook(tmp, { command: 'npm test', exit_code: 0 });
+      const state = readState(tmp);
+      // Scoped subtree got the entry.
+      assert.equal(state.release.gate_results.hard2_coverage.exit_code, 0);
+      assert.equal(state.release.gate_results.hard2_coverage.command, 'npm test');
+      // Top-level untouched (RFC §5.5 isolation).
+      assert.equal(state.gate_results.hard2_coverage, null);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('current_phase=phase3-gate routes hard2_coverage into top-level state.gate_results (unchanged behavior)', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'mpl-gr-phase3-'));
+    try {
+      seedState(tmp, {
+        current_phase: 'phase3-gate',
+        release: {
+          current_cut_id: null, completed_cut_ids: [], fix_loop_count: 0,
+          pending_artifact: null, max_fix_loops: 3,
+          gate_results: {
+            hard1_passed: null, hard2_passed: null, hard3_passed: null,
+            hard1_baseline: null, hard2_coverage: null, hard3_resilience: null,
+          },
+        },
+      });
+      runBashHook(tmp, { command: 'npm test', exit_code: 0 });
+      const state = readState(tmp);
+      assert.equal(state.gate_results.hard2_coverage.exit_code, 0);
+      // Scoped subtree NOT polluted by whole-pipeline evidence.
+      assert.equal(state.release.gate_results.hard2_coverage, null);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('current_phase=phase2-sprint routes to top-level (pre-Stage-A default)', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'mpl-gr-sprint-'));
+    try {
+      seedState(tmp, {
+        current_phase: 'phase2-sprint',
+        release: {
+          current_cut_id: null, completed_cut_ids: [], fix_loop_count: 0,
+          pending_artifact: null, max_fix_loops: 3,
+          gate_results: {
+            hard1_passed: null, hard2_passed: null, hard3_passed: null,
+            hard1_baseline: null, hard2_coverage: null, hard3_resilience: null,
+          },
+        },
+      });
+      runBashHook(tmp, { command: 'npm test', exit_code: 0 });
+      const state = readState(tmp);
+      assert.equal(state.gate_results.hard2_coverage.exit_code, 0);
+      assert.equal(state.release.gate_results.hard2_coverage, null);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('release-gate FAIL exit_code is recorded into release subtree with first-failure-wins semantics', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'mpl-gr-rel-fail-'));
+    try {
+      seedState(tmp, {
+        current_phase: 'release-gate',
+        release: {
+          current_cut_id: 'mvp',
+          completed_cut_ids: [],
+          fix_loop_count: 0,
+          pending_artifact: null,
+          gate_results: {
+            hard1_passed: null, hard2_passed: null, hard3_passed: null,
+            hard1_baseline: null,
+            hard2_coverage: { exit_code: 1, command: 'npm test', timestamp: '2026-05-24T00:00:00Z' },
+            hard3_resilience: null,
+          },
+          max_fix_loops: 3,
+        },
+      });
+      // Second run with PASS — first-failure-wins means the new PASS
+      // overrides the prior failure (fix-loop succeeded). Same semantics
+      // as the top-level branch (lines 303-305 in mpl-gate-recorder.mjs).
+      runBashHook(tmp, { command: 'npm test', exit_code: 0 });
+      const state = readState(tmp);
+      assert.equal(state.release.gate_results.hard2_coverage.exit_code, 0);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/hooks/__tests__/mpl-migrations.test.mjs
+++ b/hooks/__tests__/mpl-migrations.test.mjs
@@ -316,3 +316,131 @@ describe('v1→v2 migration archives raw bytes when legacy file is corrupt (PR #
     assert.equal(archive.legacy_content_corrupt, undefined);
   });
 });
+
+/* ─────────────── v5 → v6: Stage A release-gate scoped evidence ──────────── */
+
+describe('v5 → v6 migration backfills release.gate_results + release.max_fix_loops', () => {
+  let tmpDir;
+  beforeEach(() => { tmpDir = mkdtempSync(join(tmpdir(), 'mpl-v5v6-')); });
+  afterEach(() => { rmSync(tmpDir, { recursive: true, force: true }); });
+
+  function writeRawState(body) {
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    writeFileSync(join(tmpDir, '.mpl', 'state.json'), JSON.stringify(body));
+  }
+
+  it('backfills release.gate_results (parallel to top-level shape) and max_fix_loops default 3', () => {
+    writeRawState({
+      pipeline_id: 'mpl-v5-fixture',
+      current_phase: 'phase2-sprint',
+      schema_version: 5,
+      release: {
+        current_cut_id: null,
+        completed_cut_ids: [],
+        fix_loop_count: 0,
+        pending_artifact: null,
+      },
+    });
+    const state = readState(tmpDir);
+    assert.equal(state.schema_version, CURRENT_SCHEMA_VERSION);
+    assert.deepStrictEqual(state.release.gate_results, {
+      hard1_passed: null, hard2_passed: null, hard3_passed: null,
+      hard1_baseline: null, hard2_coverage: null, hard3_resilience: null,
+    });
+    assert.strictEqual(state.release.max_fix_loops, 3);
+  });
+
+  it('preserves existing v5 release fields across the bump (current_cut_id, completed_cut_ids, fix_loop_count)', () => {
+    writeRawState({
+      pipeline_id: 'mpl-v5-mid-cohort',
+      current_phase: 'release-gate',
+      schema_version: 5,
+      release: {
+        current_cut_id: 'mvp',
+        completed_cut_ids: ['cut-1'],
+        fix_loop_count: 2,
+        pending_artifact: { type: 'draft_pr', target: 'main' },
+      },
+    });
+    const state = readState(tmpDir);
+    assert.strictEqual(state.release.current_cut_id, 'mvp');
+    assert.deepStrictEqual(state.release.completed_cut_ids, ['cut-1']);
+    assert.strictEqual(state.release.fix_loop_count, 2);
+    assert.deepStrictEqual(state.release.pending_artifact, { type: 'draft_pr', target: 'main' });
+    // New fields filled with defaults.
+    assert.strictEqual(state.release.max_fix_loops, 3);
+    assert.strictEqual(state.release.gate_results.hard1_baseline, null);
+  });
+
+  it('preserves a partially-populated release.gate_results (hand-edit scenario), filling only missing keys', () => {
+    writeRawState({
+      pipeline_id: 'mpl-v5-partial-gate',
+      current_phase: 'release-gate',
+      schema_version: 5,
+      release: {
+        current_cut_id: 'mvp',
+        completed_cut_ids: [],
+        fix_loop_count: 0,
+        pending_artifact: null,
+        gate_results: {
+          hard1_baseline: { exit_code: 0, command: 'npm run build' },
+        },
+        max_fix_loops: 5,
+      },
+    });
+    const state = readState(tmpDir);
+    // Existing entry preserved verbatim.
+    assert.deepStrictEqual(state.release.gate_results.hard1_baseline, {
+      exit_code: 0,
+      command: 'npm run build',
+    });
+    // Missing keys filled with null defaults.
+    assert.strictEqual(state.release.gate_results.hard2_coverage, null);
+    assert.strictEqual(state.release.gate_results.hard3_resilience, null);
+    // Caller-supplied max_fix_loops survives.
+    assert.strictEqual(state.release.max_fix_loops, 5);
+  });
+
+  it('resets release.gate_results when on-disk value is malformed (non-object / array)', () => {
+    writeRawState({
+      pipeline_id: 'mpl-v5-bad-gate',
+      current_phase: 'phase2-sprint',
+      schema_version: 5,
+      release: {
+        current_cut_id: null,
+        completed_cut_ids: [],
+        fix_loop_count: 0,
+        pending_artifact: null,
+        gate_results: ['this', 'is', 'wrong'],
+        max_fix_loops: 'three',
+      },
+    });
+    const state = readState(tmpDir);
+    assert.deepStrictEqual(state.release.gate_results, {
+      hard1_passed: null, hard2_passed: null, hard3_passed: null,
+      hard1_baseline: null, hard2_coverage: null, hard3_resilience: null,
+    });
+    assert.strictEqual(state.release.max_fix_loops, 3);
+  });
+
+  it('chains v4 → v5 → v6 when starting from a v4 state.json', () => {
+    // Legacy v4 file with no release subtree at all — exercises the full
+    // additive chain (v4→v5 creates release with defaults; v5→v6 then adds
+    // gate_results + max_fix_loops on top).
+    writeRawState({
+      pipeline_id: 'mpl-v4-legacy',
+      current_phase: 'phase2-sprint',
+      schema_version: 4,
+    });
+    const state = readState(tmpDir);
+    assert.equal(state.schema_version, CURRENT_SCHEMA_VERSION);
+    assert.strictEqual(state.release.current_cut_id, null);
+    assert.deepStrictEqual(state.release.completed_cut_ids, []);
+    assert.strictEqual(state.release.fix_loop_count, 0);
+    assert.strictEqual(state.release.max_fix_loops, 3);
+    assert.deepStrictEqual(state.release.gate_results, {
+      hard1_passed: null, hard2_passed: null, hard3_passed: null,
+      hard1_baseline: null, hard2_coverage: null, hard3_resilience: null,
+    });
+  });
+});

--- a/hooks/__tests__/mpl-phase-controller.test.mjs
+++ b/hooks/__tests__/mpl-phase-controller.test.mjs
@@ -702,15 +702,20 @@ mvp_scope:
     assert.match(out.stopReason, /Phase 3: Quality Gate/);
   });
 
-  it('1.6b: release-gate stub passes through to release-finalize', () => {
+  it('1.6c-i: release-gate with no scoped evidence stays at release-gate (no pass-through)', () => {
+    // Pre-1.6c-i, the release-gate handler was a stub that passed through
+    // unconditionally to release-finalize. After 1.6c-i, the handler reads
+    // state.release.gate_results and routes on PASS/FAIL/MISSING. Without
+    // any scoped evidence (the migration backfills the defaults to null),
+    // the path is MISSING — stay at release-gate and surface guidance.
     mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
     const out = runStopHook(tmpDir, {
       current_phase: 'release-gate',
       release: { current_cut_id: 'mvp', completed_cut_ids: [], fix_loop_count: 0, pending_artifact: null },
     });
     const state = readState();
-    assert.strictEqual(state.current_phase, 'release-finalize');
-    assert.match(out.stopReason, /release-gate\(mvp\).*Phase 1\.6c/);
+    assert.strictEqual(state.current_phase, 'release-gate');
+    assert.match(out.stopReason, /release-gate\(mvp\).*missing scoped Hard 1\/2\/3 evidence/);
   });
 
   it('1.6b: release-gate with no active cohort routes defensively to phase3-gate', () => {
@@ -844,5 +849,173 @@ mvp_scope:
     const state = readState();
     assert.strictEqual(state.current_phase, 'phase2-sprint');
     assert.strictEqual(state.session_status, 'blocked_hook');
+  });
+
+  // ── Stage A Phase 1.6c-i: release-gate scoped Hard 1/2/3 evidence routing ──
+
+  function releaseStateWith(gateResults, opts = {}) {
+    return {
+      current_phase: 'release-gate',
+      release: {
+        current_cut_id: opts.cohort ?? 'mvp',
+        completed_cut_ids: opts.completed ?? [],
+        fix_loop_count: opts.fixCount ?? 0,
+        pending_artifact: null,
+        gate_results: gateResults,
+        max_fix_loops: opts.maxFix ?? 3,
+      },
+    };
+  }
+
+  it('1.6c-i: release-gate PASS (all 3 structured exit_code=0) → transitions to release-finalize', () => {
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    const out = runStopHook(tmpDir, releaseStateWith({
+      hard1_baseline: { exit_code: 0, command: 'build' },
+      hard2_coverage: { exit_code: 0, command: 'test' },
+      hard3_resilience: { exit_code: 0, command: 'contract' },
+    }));
+    const state = readState();
+    assert.strictEqual(state.current_phase, 'release-finalize');
+    assert.match(out.stopReason, /release-gate\(mvp\).*passed.*source=structured/);
+    // Cohort preserved across transition.
+    assert.strictEqual(state.release.current_cut_id, 'mvp');
+  });
+
+  it('1.6c-i: release-gate FAIL within budget → routes back to phase2-sprint, increments fix_loop_count, preserves cohort', () => {
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    const out = runStopHook(tmpDir, releaseStateWith({
+      hard1_baseline: { exit_code: 0, command: 'build' },
+      hard2_coverage: { exit_code: 1, command: 'test', stdout_tail: 'failure detected' },
+      hard3_resilience: { exit_code: 0, command: 'contract' },
+    }, { fixCount: 0, maxFix: 3 }));
+    const state = readState();
+    assert.strictEqual(state.current_phase, 'phase2-sprint');
+    assert.strictEqual(state.release.current_cut_id, 'mvp', 'cohort must be preserved across FAIL→sprint');
+    assert.strictEqual(state.release.fix_loop_count, 1);
+    // Scoped evidence reset so next attempt starts clean.
+    assert.strictEqual(state.release.gate_results.hard1_baseline, null);
+    assert.strictEqual(state.release.gate_results.hard2_coverage, null);
+    assert.strictEqual(state.release.gate_results.hard3_resilience, null);
+    // Top-level state.gate_results isolation is covered by the dedicated
+    // "RFC §5.5 isolation" test below, which seeds the top-level subtree
+    // explicitly so the assertion has a real before/after to compare.
+    assert.match(out.stopReason, /release-gate\(mvp\) FAILED/);
+    assert.match(out.stopReason, /Scoped fix loop 1\/3/);
+    assert.match(out.stopReason, /Returning to phase2-sprint/);
+  });
+
+  it('1.6c-i: release-gate FAIL at threshold → circuit-break: stay at release-gate, pin cohort, surface ⛔', () => {
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    const out = runStopHook(tmpDir, releaseStateWith({
+      hard1_baseline: { exit_code: 0 },
+      hard2_coverage: { exit_code: 2 },
+      hard3_resilience: { exit_code: 0 },
+    }, { fixCount: 2, maxFix: 3 }));
+    const state = readState();
+    // Pin: stay at release-gate, no phase transition.
+    assert.strictEqual(state.current_phase, 'release-gate');
+    assert.strictEqual(state.release.current_cut_id, 'mvp', 'cohort must remain pinned');
+    assert.strictEqual(state.release.fix_loop_count, 3, 'count reaches threshold');
+    // Evidence NOT reset at circuit-break — user needs the failure record.
+    assert.deepStrictEqual(state.release.gate_results.hard2_coverage, { exit_code: 2 });
+    assert.match(out.stopReason, /⛔/);
+    assert.match(out.stopReason, /circuit-break/);
+    assert.match(out.stopReason, /3\/3/);
+    assert.match(out.stopReason, /User intervention required/);
+  });
+
+  it('1.6c-i: release-gate pinned re-entry does NOT double-increment fix_loop_count past max', () => {
+    // Already at threshold (count=3, max=3). Re-entering release-gate (e.g.
+    // user re-triggered the loop without mutating state) must not grow the
+    // counter past the cap.
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    const out = runStopHook(tmpDir, releaseStateWith({
+      hard1_baseline: { exit_code: 0 },
+      hard2_coverage: { exit_code: 2 },
+      hard3_resilience: { exit_code: 0 },
+    }, { fixCount: 3, maxFix: 3 }));
+    const state = readState();
+    assert.strictEqual(state.current_phase, 'release-gate');
+    assert.strictEqual(state.release.fix_loop_count, 3, 'pinned counter must not grow');
+    assert.match(out.stopReason, /⛔/);
+    assert.match(out.stopReason, /3\/3/);
+  });
+
+  it('1.6c-i: release-gate MISSING (zero structured evidence) → continue with stopReason guiding production', () => {
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    const out = runStopHook(tmpDir, releaseStateWith({
+      hard1_baseline: null,
+      hard2_coverage: null,
+      hard3_resilience: null,
+    }));
+    const state = readState();
+    // No transition.
+    assert.strictEqual(state.current_phase, 'release-gate');
+    assert.strictEqual(state.release.fix_loop_count, 0, 'MISSING must not consume fix budget');
+    assert.match(out.stopReason, /release-gate\(mvp\)/);
+    assert.match(out.stopReason, /missing scoped Hard 1\/2\/3 evidence/);
+    assert.match(out.stopReason, /state\.release\.gate_results/);
+  });
+
+  it('1.6c-i: release-gate MISSING (partial — 1 of 3 structured) → continue, lists missing keys', () => {
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    const out = runStopHook(tmpDir, releaseStateWith({
+      hard1_baseline: { exit_code: 0 },
+      hard2_coverage: null,
+      hard3_resilience: null,
+    }));
+    const state = readState();
+    assert.strictEqual(state.current_phase, 'release-gate');
+    assert.match(out.stopReason, /missing scoped Hard 1\/2\/3 evidence/);
+    assert.match(out.stopReason, /hard2_coverage/);
+    assert.match(out.stopReason, /hard3_resilience/);
+    assert.doesNotMatch(out.stopReason, /hard1_baseline/);
+  });
+
+  it('1.6c-i: release-gate FAIL does NOT touch top-level state.gate_results (RFC §5.5 isolation)', () => {
+    // Defense for the RFC §5.5 invariant: scoped release evidence must
+    // never pollute the whole-pipeline gate subtree reserved for the final
+    // phase3-gate. Pre-seed top-level gate_results with PASS values and
+    // verify they survive a release-gate FAIL untouched.
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    runStopHook(tmpDir, {
+      ...releaseStateWith({
+        hard1_baseline: { exit_code: 0 },
+        hard2_coverage: { exit_code: 1 },
+        hard3_resilience: { exit_code: 0 },
+      }),
+      gate_results: {
+        hard1_baseline: { exit_code: 0, command: 'prior whole-pipeline' },
+        hard2_coverage: { exit_code: 0, command: 'prior whole-pipeline' },
+        hard3_resilience: { exit_code: 0, command: 'prior whole-pipeline' },
+      },
+    });
+    const state = readState();
+    // Top-level evidence preserved verbatim.
+    assert.deepStrictEqual(state.gate_results.hard1_baseline, {
+      exit_code: 0, command: 'prior whole-pipeline',
+    });
+    assert.deepStrictEqual(state.gate_results.hard2_coverage, {
+      exit_code: 0, command: 'prior whole-pipeline',
+    });
+    // Release-scoped subtree was reset on FAIL→sprint.
+    assert.strictEqual(state.release.gate_results.hard2_coverage, null);
+  });
+
+  it('1.6c-i: release-gate honors workspace strict mode for missing_gate_evidence', () => {
+    // Strict mode (.mpl/config.json enforcement.missing_gate_evidence:
+    // "block") changes the MISSING surface wording to ⛔ BLOCKED, matching
+    // phase3-gate's behavior so the two gate paths feel consistent.
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    writeFileSync(join(tmpDir, '.mpl', 'config.json'), JSON.stringify({
+      enforcement: { missing_gate_evidence: 'block' },
+    }));
+    const out = runStopHook(tmpDir, releaseStateWith({
+      hard1_baseline: null,
+      hard2_coverage: null,
+      hard3_resilience: null,
+    }));
+    assert.match(out.stopReason, /⛔ BLOCKED/);
+    assert.match(out.stopReason, /Strict enforcement/);
   });
 });

--- a/hooks/__tests__/mpl-phase-controller.test.mjs
+++ b/hooks/__tests__/mpl-phase-controller.test.mjs
@@ -1018,4 +1018,55 @@ mvp_scope:
     assert.match(out.stopReason, /⛔ BLOCKED/);
     assert.match(out.stopReason, /Strict enforcement/);
   });
+
+  it('1.6c-i (PR #186 review): release-gate ALWAYS structured-only — legacy hard1_passed=true alone does NOT pass', () => {
+    // Codex/claude High #2 on PR #186: release subtree had no historical
+    // legacy evidence so the AD-0006 zero-structured legacy boolean
+    // fallback would let a single self-reported `release.gate_results.
+    // hard1_passed=true` bypass the structured-only contract and reach
+    // release-finalize. The adapter now hard-codes strict:true regardless
+    // of workspace `missing_gate_evidence` policy. Verifies the gate
+    // refuses to advance under the legacy-only shape.
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    const out = runStopHook(tmpDir, releaseStateWith({
+      // Legacy booleans only — would have triggered source=legacy PASS
+      // pre-fix because checkGateResults' legacy fallback path returns
+      // allPassed when at least one boolean is true and zero are false.
+      hard1_passed: true,
+      hard2_passed: null,
+      hard3_passed: null,
+      hard1_baseline: null,
+      hard2_coverage: null,
+      hard3_resilience: null,
+    }));
+    const state = readState();
+    // Must STAY at release-gate (no PASS transition).
+    assert.strictEqual(state.current_phase, 'release-gate');
+    assert.match(out.stopReason, /missing scoped Hard 1\/2\/3 evidence/);
+    // No bypass to release-finalize.
+    assert.doesNotMatch(out.stopReason, /Transitioning to release-finalize/);
+  });
+
+  it('1.6c-i (PR #186 review): release-gate strict overrides workspace policy=off (cannot opt-out of structured-only)', () => {
+    // Even when the workspace explicitly turns OFF the missing_gate_evidence
+    // rule, the release-gate must still reject zero-structured + legacy-
+    // boolean evidence. The workspace policy only affects MISSING message
+    // wording for parity with phase3-gate; the structured contract is
+    // non-negotiable on the release path.
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    writeFileSync(join(tmpDir, '.mpl', 'config.json'), JSON.stringify({
+      enforcement: { missing_gate_evidence: 'off' },
+    }));
+    const out = runStopHook(tmpDir, releaseStateWith({
+      hard1_passed: true,
+      hard2_passed: true,
+      hard3_passed: true,  // three legacy booleans — pre-fix would have PASSed
+      hard1_baseline: null,
+      hard2_coverage: null,
+      hard3_resilience: null,
+    }));
+    const state = readState();
+    assert.strictEqual(state.current_phase, 'release-gate');
+    assert.match(out.stopReason, /missing scoped Hard 1\/2\/3 evidence/);
+  });
 });

--- a/hooks/lib/migrations/index.mjs
+++ b/hooks/lib/migrations/index.mjs
@@ -21,6 +21,7 @@ import v1ToV2 from './v1-to-v2.mjs';
 import v2ToV3 from './v2-to-v3.mjs';
 import v3ToV4 from './v3-to-v4.mjs';
 import v4ToV5 from './v4-to-v5.mjs';
+import v5ToV6 from './v5-to-v6.mjs';
 
 /**
  * Ordered registry. Add new entries here when bumping
@@ -31,6 +32,7 @@ export const MIGRATIONS = Object.freeze([
   v2ToV3,
   v3ToV4,
   v4ToV5,
+  v5ToV6,
 ]);
 
 /**

--- a/hooks/lib/migrations/v5-to-v6.mjs
+++ b/hooks/lib/migrations/v5-to-v6.mjs
@@ -1,0 +1,77 @@
+/**
+ * v5 → v6: Stage A release-gate scoped evidence subtree.
+ *
+ * Adds the `release.gate_results` + `release.max_fix_loops` fields consumed
+ * by Phase 1.6c-i `release-gate` handler:
+ *  - `release.gate_results` — parallel to top-level `state.gate_results`,
+ *    written by mpl-gate-recorder when the active phase is `release-gate`
+ *    (RFC §5.5: scoped release evidence MUST NOT mix into the whole-pipeline
+ *    `state.gate_results.hard{1,2,3}_*` subtree).
+ *  - `release.max_fix_loops` — scoped retry budget for the release-gate →
+ *    phase2-sprint fix loop (RFC §5.3.1). Separate from top-level
+ *    `state.max_fix_loops` (default 10) because release-scope failures are
+ *    cohort-local and should circuit-break faster (default 3).
+ *
+ * Backfill is additive: existing v5 state.json keeps every other field
+ * intact and gains the two new release fields with safe defaults so the
+ * release-gate handler transitions cleanly from stub to active routing
+ * once Phase 1.6c-i lands.
+ *
+ * Same backfill pattern as v4→v5 (PR #184 codex review): adding fields to
+ * DEFAULT_STATE without a migration would let legacy v5 state.json read
+ * with `state.release.gate_results === undefined`, then the handler would
+ * have to defensively treat undefined as MISSING. The migration removes
+ * that ambiguity at read time.
+ */
+
+export default {
+  from: 5,
+  to: 6,
+  description:
+    'Additive backfill — Stage A release-gate scoped evidence (release.gate_results, release.max_fix_loops)',
+  migrate(state, _cwd) {
+    const merged = { ...state };
+
+    const existing = merged.release;
+    const gateDefaults = {
+      hard1_passed: null,
+      hard2_passed: null,
+      hard3_passed: null,
+      hard1_baseline: null,
+      hard2_coverage: null,
+      hard3_resilience: null,
+    };
+    const releaseDefaults = {
+      current_cut_id: null,
+      completed_cut_ids: [],
+      fix_loop_count: 0,
+      pending_artifact: null,
+      gate_results: { ...gateDefaults },
+      max_fix_loops: 3,
+    };
+
+    if (!existing || typeof existing !== 'object' || Array.isArray(existing)) {
+      merged.release = { ...releaseDefaults };
+    } else {
+      // Preserve any field already set by v4→v5 or a hand-edit; fill in
+      // only the two new keys.
+      const next = { ...releaseDefaults, ...existing };
+      // Defensive: nested gate_results must be a plain object with the
+      // hard{1,2,3}_* shape. Any non-object replacement (or array) is
+      // reset to defaults; partial objects are merged additively.
+      const existingGate = existing.gate_results;
+      if (!existingGate || typeof existingGate !== 'object' || Array.isArray(existingGate)) {
+        next.gate_results = { ...gateDefaults };
+      } else {
+        next.gate_results = { ...gateDefaults, ...existingGate };
+      }
+      if (typeof next.max_fix_loops !== 'number' || !Number.isFinite(next.max_fix_loops)) {
+        next.max_fix_loops = 3;
+      }
+      merged.release = next;
+    }
+
+    merged.schema_version = 6;
+    return merged;
+  },
+};

--- a/hooks/lib/mpl-state.mjs
+++ b/hooks/lib/mpl-state.mjs
@@ -43,12 +43,20 @@ export const MAX_AMBIGUITY_HISTORY = 10;
  *   `user_intervention_count` (auto-mode honesty counter).
  * - `4` = Goal Contract readiness fields and finalize/security evidence
  *   backfills.
+ * - `5` = Stage A release-path lifecycle subtree (`state.release` with
+ *   `current_cut_id`, `completed_cut_ids`, `fix_loop_count`,
+ *   `pending_artifact`); consumed by D-Q6 immutability hook + Phase 1.6b
+ *   release-gate / release-finalize handlers.
+ * - `6` = Stage A release-gate scoped evidence subtree
+ *   (`state.release.gate_results` parallel to top-level `state.gate_results`,
+ *   `state.release.max_fix_loops` default 3); consumed by Phase 1.6c-i
+ *   release-gate handler for scoped Hard 1/2/3 routing per RFC §5.5.
  *
  * H8 (#116) routes per-version logic through `hooks/lib/migrations/`. To
  * bump this constant, register a new migration entry; see
  * `docs/schemas/migration-policy.md`.
  */
-export const CURRENT_SCHEMA_VERSION = 5;
+export const CURRENT_SCHEMA_VERSION = 6;
 
 /**
  * Legacy execution state file. Pre-P2-6 orchestrator prompts wrote to this
@@ -194,11 +202,33 @@ const DEFAULT_STATE = {
   // NOT transit through `pending_artifact`; the field is opt-in transit only.
   // For projects without `goal_contract.mvp_scope`, this subtree stays at
   // defaults and the release path is never entered (RFC §4.5 lifecycle).
+  //
+  // Phase 1.6c-i additions (schema v6):
+  // `gate_results` mirrors the top-level `gate_results` shape but is
+  // populated by mpl-gate-recorder ONLY when `current_phase ==
+  // 'release-gate'` (RFC §5.5: scoped release evidence MUST NOT mix into
+  // the whole-pipeline `state.gate_results.hard{1,2,3}_*` subtree
+  // reserved for the final phase3-gate). The release-gate handler reuses
+  // `checkGateResults` against this subtree to decide PASS / FAIL /
+  // MISSING.
+  // `max_fix_loops` is the scoped retry budget for the release-gate →
+  // phase2-sprint fix loop (RFC §5.3.1). Separate from top-level
+  // `max_fix_loops` because cohort-local failures should circuit-break
+  // faster (default 3 vs the whole-pipeline default 10).
   release: {
     current_cut_id: null,        // null | "mvp" | "<release_cut.id>"
     completed_cut_ids: [],       // appended on successful release-finalize
     fix_loop_count: 0,           // scoped retries inside release-gate, not phase3-gate
     pending_artifact: null,      // null | { type: "draft_pr"|"branch"|"tag", target: string }
+    gate_results: {              // Phase 1.6c-i: parallel to top-level gate_results; release-scope only
+      hard1_passed: null,
+      hard2_passed: null,
+      hard3_passed: null,
+      hard1_baseline: null,      // { command, exit_code, stdout_tail, timestamp }
+      hard2_coverage: null,
+      hard3_resilience: null,
+    },
+    max_fix_loops: 3,            // RFC §5.3.1: scoped budget; circuit-break message at threshold
   },
   memory: {                  // F-25: 4-Tier Adaptive Memory statistics
     episodic_entries: 0,

--- a/hooks/mpl-gate-recorder.mjs
+++ b/hooks/mpl-gate-recorder.mjs
@@ -279,7 +279,22 @@ try {
       process.exit(0);
     }
 
-    const priorResults = state.gate_results || {};
+    // Stage A Phase 1.6c-i (PR #186 review): route gate evidence based on
+    // current_phase. When the orchestrator is at `release-gate`, scoped
+    // Hard 1/2/3 evidence MUST land in `state.release.gate_results` —
+    // writing to top-level `state.gate_results` would (a) pollute the
+    // whole-pipeline subtree reserved for the final phase3-gate (RFC §5.5
+    // isolation), and (b) leave `state.release.gate_results` empty so the
+    // release-gate handler reads MISSING forever.
+    //
+    // This is the resume doc §7 Q2 option (c) — "recorder routes to
+    // release-scoped only when current_phase == 'release-gate'". The
+    // existing top-level path is preserved unchanged for every other
+    // phase (phase3-gate runs the whole-pipeline gate).
+    const isReleaseGatePhase = state.current_phase === 'release-gate';
+    const priorResults = isReleaseGatePhase
+      ? (state.release?.gate_results || {})
+      : (state.gate_results || {});
     const priorEntry = priorResults[gateName];
     // Convert legacy boolean fields (hard1_passed: true) into structured entry
     // by overwriting; no loss because legacy booleans are self-report and
@@ -297,14 +312,24 @@ try {
       timestamp: new Date().toISOString(),
     };
 
+    function buildPatch(updatedGate) {
+      if (isReleaseGatePhase) {
+        // Merge into state.release.gate_results, preserving sibling
+        // release fields (current_cut_id, completed_cut_ids,
+        // fix_loop_count, etc.) via deepMerge.
+        return { release: { gate_results: { ...priorResults, [gateName]: updatedGate } } };
+      }
+      return { gate_results: { ...priorResults, [gateName]: updatedGate } };
+    }
+
     // First failure wins within a phase (so a later success cannot mask a
     // prior failure). A later fix-loop that writes `exit_code: 0` resets the
     // record — which is intended because the fix did actually pass.
     if (priorEntry && priorEntry.exit_code !== 0 && recordedExit === 0) {
       // Keep the latest on success after prior failure (fix-loop succeeded)
-      writeState(cwd, { gate_results: { ...priorResults, [gateName]: newEntry } });
+      writeState(cwd, buildPatch(newEntry));
     } else if (!priorEntry || priorEntry.exit_code === 0 || recordedExit !== 0) {
-      writeState(cwd, { gate_results: { ...priorResults, [gateName]: newEntry } });
+      writeState(cwd, buildPatch(newEntry));
     }
     ok();
     process.exit(0);

--- a/hooks/mpl-phase-controller.mjs
+++ b/hooks/mpl-phase-controller.mjs
@@ -535,18 +535,27 @@ async function main() {
         break;
       }
 
-      // Reuse the top-level missing_gate_evidence rule so workspace policy
-      // drives both phase3-gate and release-gate consistently. The
-      // cohort-scoped fix budget still uses state.release.max_fix_loops
-      // (default 3), separate from top-level state.max_fix_loops (default
-      // 10) per RFC §5.3.1.
+      // The workspace `missing_gate_evidence` rule only controls MISSING
+      // message wording (in progress vs ⛔ BLOCKED) for parity with
+      // phase3-gate UX. The strict toggle for checkGateResults is ALWAYS
+      // true on release-gate, regardless of policy.
+      //
+      // Rationale (PR #186 codex/claude High #2): `state.release.gate_results`
+      // is a v6 subtree with no historical legacy boolean evidence to
+      // honor. The transitional zero-structured legacy fallback was added
+      // for top-level state.gate_results to ease the AD-0006 migration; on
+      // a brand-new subtree it would let `release.gate_results.hard1_passed
+      // = true` alone trigger PASS → release-finalize, bypassing the
+      // structured-only contract Phase 1.6c-i is meant to enforce.
       const releaseGateRuleAction = resolveRuleAction(cwd, state, 'missing_gate_evidence');
-      const releaseEnforcementStrict = releaseGateRuleAction === 'block';
+      const releaseMissingMessagingStrict = releaseGateRuleAction === 'block';
       // Adapter: checkGateResults reads `state.gate_results`. Wrap the
       // release subtree to reuse the structured-vs-legacy decision tree
-      // without duplicating logic across two gate paths.
+      // without duplicating logic across two gate paths. `strict: true`
+      // is hard-coded (see rationale above) — release-gate ALWAYS requires
+      // structured exits.
       const releaseGates = state.release?.gate_results || {};
-      const releaseResults = checkGateResults({ gate_results: releaseGates }, { strict: releaseEnforcementStrict });
+      const releaseResults = checkGateResults({ gate_results: releaseGates }, { strict: true });
 
       if (releaseResults.allPassed) {
         writeState(cwd, { current_phase: 'release-finalize' });
@@ -616,17 +625,21 @@ async function main() {
       }
 
       // MISSING (zero or partial structured evidence). No transition;
-      // surface guidance and let the orchestrator produce evidence. Strict
-      // mode hard-blocks the wording; non-strict frames as "in progress".
+      // surface guidance and let the orchestrator produce evidence. The
+      // workspace strict policy changes the message wording only — the
+      // structured-only contract is always enforced (see above).
+      //
+      // Note: `missingEvidence` is guaranteed non-empty here because
+      // checkGateResults returns the MISSING branch only when at least
+      // one of hard{1,2,3} is absent. The full-PASS path returns earlier.
       const missing = releaseResults.missingEvidence;
-      const missingLabel = missing.length ? missing.join(', ') : 'all three (none recorded yet)';
-      const verb = releaseEnforcementStrict ? '⛔ BLOCKED' : 'in progress';
-      const tail = releaseEnforcementStrict
+      const verb = releaseMissingMessagingStrict ? '⛔ BLOCKED' : 'in progress';
+      const tail = releaseMissingMessagingStrict
         ? 'Strict enforcement requires all 3 scoped gates to be recorded by mpl-gate-recorder via real Bash exit codes. Self-reported booleans are not accepted.'
         : `Run the missing scoped gates so mpl-gate-recorder writes structured evidence into state.release.gate_results; the loop will continue once all 3 are recorded.`;
       console.log(JSON.stringify({
         continue: true,
-        stopReason: `[MPL] release-gate(${cohort}) ${verb}: missing scoped Hard 1/2/3 evidence (${missingLabel}). ${tail}`
+        stopReason: `[MPL] release-gate(${cohort}) ${verb}: missing scoped Hard 1/2/3 evidence (${missing.join(', ')}). ${tail}`
       }));
       break;
     }

--- a/hooks/mpl-phase-controller.mjs
+++ b/hooks/mpl-phase-controller.mjs
@@ -502,20 +502,27 @@ async function main() {
     // 1/2/3 and release-manifest / artifact creation) ===
 
     case 'release-gate': {
-      // Phase 1.6b: stub handler. Scoped Hard 1/2/3 + release-scoped
-      // gate-results.json land in Phase 1.6c. For now, immediately advance
-      // to release-finalize so the lifecycle exit logic can run.
+      // Phase 1.6c-i: scoped Hard 1/2/3 evidence routing.
       //
-      // Phase 1.6c will:
-      //   - Run scoped Hard 1/2/3 against `state.release.current_cut_id`
-      //     (full Hard 1 project-wide; Hard 2 affected scope; Hard 3 active
-      //      cut's interface_contract — per RFC §5.3 D-Q3)
-      //   - Write `.mpl/mpl/releases/{cut_id}/gate-results.json` (NEVER
-      //     touch `state.gate_results.hard{1,2,3}_*` per RFC §5.5)
-      //   - On failure: increment `state.release.fix_loop_count`, route
-      //     back to `phase2-sprint` for the same cohort (mirror of
-      //     phase3-gate→phase4-fix loop, RFC §5.3.1)
-      //   - On success: transition to release-finalize as today's stub does
+      // Reads `state.release.gate_results` (parallel subtree to top-level
+      // `state.gate_results`, per RFC §5.5 — scoped release evidence MUST
+      // NOT mix into whole-pipeline gates reserved for the final
+      // phase3-gate). mpl-gate-recorder populates this subtree only when
+      // `current_phase == 'release-gate'`; this handler consumes and
+      // routes. Evidence *production* (running scoped commands, deciding
+      // affected-tests scope for Hard 2, etc.) is gate-recorder's
+      // responsibility and lands separately.
+      //
+      // Routing per RFC §5.3.1:
+      //   - PASS → release-finalize
+      //   - FAIL → increment state.release.fix_loop_count, route back to
+      //     phase2-sprint, PRESERVE current_cut_id. Reset scoped
+      //     evidence so the next attempt starts clean.
+      //   - FAIL at threshold (count reaches state.release.max_fix_loops,
+      //     default 3) → circuit-break: pin cohort, stay at release-gate,
+      //     surface user-actionable message. User intervention required.
+      //   - MISSING → continue with stopReason guiding orchestrator to
+      //     produce evidence; same UX as phase3-gate partial/empty paths.
       const cohort = state.release?.current_cut_id;
       if (!cohort) {
         // Defensive: release-gate without an active cohort is a state
@@ -527,11 +534,99 @@ async function main() {
         }));
         break;
       }
-      writeState(cwd, { current_phase: 'release-finalize' });
+
+      // Reuse the top-level missing_gate_evidence rule so workspace policy
+      // drives both phase3-gate and release-gate consistently. The
+      // cohort-scoped fix budget still uses state.release.max_fix_loops
+      // (default 3), separate from top-level state.max_fix_loops (default
+      // 10) per RFC §5.3.1.
+      const releaseGateRuleAction = resolveRuleAction(cwd, state, 'missing_gate_evidence');
+      const releaseEnforcementStrict = releaseGateRuleAction === 'block';
+      // Adapter: checkGateResults reads `state.gate_results`. Wrap the
+      // release subtree to reuse the structured-vs-legacy decision tree
+      // without duplicating logic across two gate paths.
+      const releaseGates = state.release?.gate_results || {};
+      const releaseResults = checkGateResults({ gate_results: releaseGates }, { strict: releaseEnforcementStrict });
+
+      if (releaseResults.allPassed) {
+        writeState(cwd, { current_phase: 'release-finalize' });
+        console.log(JSON.stringify({
+          continue: true,
+          stopReason: `[MPL] release-gate(${cohort}): scoped Hard 1/2/3 passed (source=${releaseResults.source}). Transitioning to release-finalize.`
+        }));
+        break;
+      }
+
+      if (releaseResults.anyFailed) {
+        const existingRelease = state.release || {};
+        const currentReleaseFix = typeof existingRelease.fix_loop_count === 'number'
+          ? existingRelease.fix_loop_count
+          : 0;
+        const releaseMax = typeof existingRelease.max_fix_loops === 'number'
+          ? existingRelease.max_fix_loops
+          : 3;
+        // Avoid runaway increment when already pinned at threshold —
+        // repeated Stop ticks would otherwise grow the counter past the
+        // cap (cosmetic but noisy in /mpl-status).
+        const nextReleaseFix = currentReleaseFix >= releaseMax
+          ? currentReleaseFix
+          : currentReleaseFix + 1;
+        const willCircuitBreak = nextReleaseFix >= releaseMax;
+
+        if (willCircuitBreak) {
+          // Pin cohort, stay at release-gate. Only write when the count
+          // actually changed (skip writeState noise on repeat pinned ticks).
+          if (nextReleaseFix !== currentReleaseFix) {
+            writeState(cwd, {
+              release: { ...existingRelease, fix_loop_count: nextReleaseFix },
+            });
+          }
+          console.log(JSON.stringify({
+            continue: true,
+            stopReason: `[MPL] ⛔ release-gate(${cohort}) circuit-break: release-scoped fix loop ${nextReleaseFix}/${releaseMax} (RFC §5.3.1). ` +
+              `Gate results: H1=${releaseResults.details.hard1}, H2=${releaseResults.details.hard2}, H3=${releaseResults.details.hard3}. ` +
+              `Cohort pinned. User intervention required: fix the failing tasks and reset state.release.fix_loop_count via mpl_state_write, ` +
+              `OR remove the cohort from goal-contract.yaml mvp_scope to abort the release path.`
+          }));
+          break;
+        }
+
+        // Budget remaining → route back to phase2-sprint. Reset scoped
+        // evidence on retry so mpl-gate-recorder writes fresh exits on
+        // the next attempt (same pattern as phase3-gate FAIL path).
+        writeState(cwd, {
+          current_phase: 'phase2-sprint',
+          release: {
+            ...existingRelease,
+            fix_loop_count: nextReleaseFix,
+            gate_results: {
+              hard1_passed: null, hard2_passed: null, hard3_passed: null,
+              hard1_baseline: null, hard2_coverage: null, hard3_resilience: null,
+            },
+          },
+        });
+        console.log(JSON.stringify({
+          continue: true,
+          stopReason: `[MPL] release-gate(${cohort}) FAILED (source=${releaseResults.source}). ` +
+            `H1=${releaseResults.details.hard1}, H2=${releaseResults.details.hard2}, H3=${releaseResults.details.hard3}. ` +
+            `Scoped fix loop ${nextReleaseFix}/${releaseMax}. Returning to phase2-sprint; cohort "${cohort}" preserved. ` +
+            `Fix the failing tasks, then re-run scoped Hard 1/2/3 — mpl-gate-recorder will repopulate state.release.gate_results.`
+        }));
+        break;
+      }
+
+      // MISSING (zero or partial structured evidence). No transition;
+      // surface guidance and let the orchestrator produce evidence. Strict
+      // mode hard-blocks the wording; non-strict frames as "in progress".
+      const missing = releaseResults.missingEvidence;
+      const missingLabel = missing.length ? missing.join(', ') : 'all three (none recorded yet)';
+      const verb = releaseEnforcementStrict ? '⛔ BLOCKED' : 'in progress';
+      const tail = releaseEnforcementStrict
+        ? 'Strict enforcement requires all 3 scoped gates to be recorded by mpl-gate-recorder via real Bash exit codes. Self-reported booleans are not accepted.'
+        : `Run the missing scoped gates so mpl-gate-recorder writes structured evidence into state.release.gate_results; the loop will continue once all 3 are recorded.`;
       console.log(JSON.stringify({
         continue: true,
-        stopReason: `[MPL] release-gate(${cohort}): scoped Hard 1/2/3 execution lands in Phase 1.6c. ` +
-          `Stub passes through to release-finalize.`
+        stopReason: `[MPL] release-gate(${cohort}) ${verb}: missing scoped Hard 1/2/3 evidence (${missingLabel}). ${tail}`
       }));
       break;
     }


### PR DESCRIPTION
## What

Phase 1.6c-i of Stage A — wires the `release-gate` handler to consume scoped gate evidence from `state.release.gate_results` and route per RFC §5.3.1.

- **Schema v5 → v6** with additive migration adding:
  - `state.release.gate_results` — parallel to top-level `state.gate_results`, populated by mpl-gate-recorder when `current_phase == 'release-gate'` only (RFC §5.5 isolation)
  - `state.release.max_fix_loops` — scoped retry budget (default **3**, separate from top-level default 10)
- **`release-gate` handler** (replaces 1.6b stub):
  - PASS → release-finalize
  - FAIL within budget → increment scoped `fix_loop_count`, route back to phase2-sprint preserving `current_cut_id`, reset scoped evidence
  - FAIL at threshold → circuit-break: stay at release-gate, pin cohort, surface ⛔ with user intervention guidance
  - MISSING → continue with stopReason; honors workspace strict mode (block) same as phase3-gate
- **Reuses `checkGateResults`** via a one-line adapter — structured-vs-legacy decision tree stays single-sourced across both gate paths.

## Why

The 1.6b stub immediately passed through to release-finalize regardless of evidence, meaning every cohort shipped without verification. 1.6c-i adds the consumer side of the scoped Hard 1/2/3 gate. Evidence *production* (running scoped commands, deciding Hard 2 affected scope, gate-recorder routing) is intentionally deferred to a follow-up — splitting the surfaces keeps each PR review-friendly per the 1.6c sub-split plan in \`docs/roadmap/stage-a-resume-1.6c.md\`.

## Design

- RFC: \`docs/roadmap/stage-a-mvp-cuts-rfc.md\` §5.3.1 (failure path), §5.5 (whole-pipeline isolation)
- Resume brief: \`docs/roadmap/stage-a-resume-1.6c.md\` §3 (1.6c-i scope), §7 (open questions Q1, Q3 decided here)

### Open question decisions

- **Q1 SSOT**: state.json (state.release.gate_results) — read-side parity with state.gate_results; write-side file mirror lands in 1.6c-ii
- **Q3 max_fix_loops**: separate state.release.max_fix_loops field with default 3 (per RFC §5.3.1)
- **Q2 (gate-recorder routing) / Q4 (affected-tests resolution)**: deferred — this PR is consumer-only

### Invariants preserved

- RFC §5.5: release-gate evidence MUST NOT write `state.gate_results.hard{1,2,3}_*` — verified by the dedicated isolation test
- RFC §5.3.1: scoped `fix_loop_count` separate from top-level; failed cohort stays pinned at circuit-break
- D-Q6 (PR #183): release-finalize is the only writer of `completed_cut_ids`; this PR doesn't touch it

## Test plan

- [x] +13 tests in this PR (5 migration backfill + 8 release-gate routing)
- [x] Full hook suite: **987/987 pass** (974 → 987)
- [x] Updated 1 prior 1.6b test that asserted stub pass-through — now asserts MISSING path (no pass-through)
- [ ] Awaiting agent reviews (claude + codex)

## Agent Review Status

This PR is gated on **2 unique agent reviews** (footers \`— from <agent>\`).

- [ ] from claude
- [ ] from codex

---
_Awaiting reviews. Merge once the gate is satisfied._