### PR TITLE
feat(stage-a-1.6c-ii): release-finalize writes manifest + evidence + gate snapshot

### DIFF
--- a/hooks/__tests__/mpl-phase-controller.test.mjs
+++ b/hooks/__tests__/mpl-phase-controller.test.mjs
@@ -1271,6 +1271,124 @@ release_cuts: []
     assert.match(out.stopReason, /cohort descriptor missing/);
   });
 
+  // PR #187 round-2 (codex + claude): bail on invalid goal-contract.
+  it('1.6c-ii (PR #187 round-2 codex+claude): release-finalize bails when contract.mvp_scope has neither AC nor AX (codex reproducer)', () => {
+    // Codex reproducer: `mvp_scope: { artifact: draft_pr }` only — the
+    // validator flags `mvp_scope.acceptance_criteria_or_variation_axes`
+    // so gcRead.valid=false. Pre-fix the handler ignored gcRead.valid
+    // and shipped a manifest with empty goal_trace, flipping D-Q6
+    // immutability for a cohort with no acceptance criteria.
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    writeFileSync(join(tmpDir, '.mpl', 'goal-contract.yaml'), `
+source:
+  runtime_goal: "x"
+  user_request_hash: "abc"
+mission:
+  goal: "g"
+  project_pivot: "pp"
+  must_ship_outcomes:
+    - "ship"
+ontology:
+  entities:
+    - foo
+variation_axes:
+  - id: AX-1
+    name: ax
+acceptance_criteria:
+  - id: AC-1
+    statement: "ac"
+e2e_policy:
+  real_runtime_required: true
+  mock_allowed: false
+  placeholder_assertions_allowed: false
+security_policy:
+  required: false
+completion_evidence:
+  required_artifacts:
+    - .mpl/mpl/audit-report.json
+  require_commit: false
+  require_finalize_timestamps: true
+mvp_scope:
+  artifact: draft_pr
+`);
+    writeDecompositionWithMvp(tmpDir);
+    const out = runStopHook(tmpDir, {
+      current_phase: 'release-finalize',
+      release: {
+        current_cut_id: 'mvp', completed_cut_ids: [], fix_loop_count: 0,
+        pending_artifact: null, max_fix_loops: 3,
+        gate_results: {
+          hard1_baseline: { exit_code: 0 }, hard2_coverage: { exit_code: 0 }, hard3_resilience: { exit_code: 0 },
+        },
+      },
+    });
+    const state = readState();
+    // No advancement.
+    assert.strictEqual(state.current_phase, 'release-finalize');
+    assert.strictEqual(state.release.current_cut_id, 'mvp');
+    assert.deepStrictEqual(state.release.completed_cut_ids, []);
+    assert.match(out.stopReason, /goal-contract is invalid/);
+    assert.match(out.stopReason, /mvp_scope\.acceptance_criteria_or_variation_axes/);
+    // No file written.
+    assert.equal(existsSync(join(tmpDir, '.mpl', 'mpl', 'releases', 'mvp', 'release-manifest.json')), false);
+  });
+
+  it('1.6c-ii (PR #187 round-2 codex+claude): release-finalize bails when contract validator flags any structural failure (defense-in-depth)', () => {
+    // Any contract validity failure must block release-finalize — even
+    // unrelated-looking ones (e.g., unknown AC id) — because a broken
+    // contract at release-time means goal_trace cannot be trusted.
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    writeFileSync(join(tmpDir, '.mpl', 'goal-contract.yaml'), `
+source:
+  runtime_goal: "x"
+  user_request_hash: "abc"
+mission:
+  goal: "g"
+  project_pivot: "pp"
+  must_ship_outcomes:
+    - "ship"
+ontology:
+  entities:
+    - foo
+variation_axes:
+  - id: AX-1
+    name: ax
+acceptance_criteria:
+  - id: AC-1
+    statement: "ac"
+e2e_policy:
+  real_runtime_required: true
+  mock_allowed: false
+  placeholder_assertions_allowed: false
+security_policy:
+  required: false
+completion_evidence:
+  required_artifacts:
+    - .mpl/mpl/audit-report.json
+  require_commit: false
+  require_finalize_timestamps: true
+mvp_scope:
+  acceptance_criteria: [AC-DOES-NOT-EXIST]
+  variation_axes: [AX-1]
+  artifact: draft_pr
+`);
+    writeDecompositionWithMvp(tmpDir);
+    const out = runStopHook(tmpDir, {
+      current_phase: 'release-finalize',
+      release: {
+        current_cut_id: 'mvp', completed_cut_ids: [], fix_loop_count: 0,
+        pending_artifact: null, max_fix_loops: 3,
+        gate_results: {
+          hard1_baseline: { exit_code: 0 }, hard2_coverage: { exit_code: 0 }, hard3_resilience: { exit_code: 0 },
+        },
+      },
+    });
+    const state = readState();
+    assert.strictEqual(state.current_phase, 'release-finalize');
+    assert.deepStrictEqual(state.release.completed_cut_ids, []);
+    assert.match(out.stopReason, /goal-contract is invalid/);
+  });
+
   it('1.6c-ii (PR #187 codex review): release-finalize refuses to advance when graph.mvp.phases is empty', () => {
     // Decomposer wrote `mvp:` block but `phases: []` (mechanical mapping
     // yielded no membership). Manifest would assert "released" with no

--- a/hooks/__tests__/mpl-phase-controller.test.mjs
+++ b/hooks/__tests__/mpl-phase-controller.test.mjs
@@ -1,7 +1,7 @@
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync } from 'fs';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { tmpdir } from 'os';
@@ -730,10 +730,38 @@ mvp_scope:
   });
 
   it('1.6b: release-finalize appends current cohort to completed_cut_ids and clears current_cut_id', () => {
-    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    // After 1.6c-ii, release-finalize requires goal-contract + decomposition
+    // to build the release-manifest before advancing the lifecycle. Seed
+    // both so the original 1.6b lifecycle assertion still exercises the
+    // append+clear+route path. The helpers `writeGoalContractWithMvp` and
+    // `writeDecompositionWithMvp` are defined in the 1.6c-ii block below;
+    // we inline equivalents here to avoid a forward-declaration dependency.
+    mkdirSync(join(tmpDir, '.mpl', 'mpl'), { recursive: true });
+    writeGoalContractWithMvp(tmpDir);
+    writeFileSync(join(tmpDir, '.mpl', 'mpl', 'decomposition.yaml'), `
+graph_version: "1.0"
+generated_by: mpl-decomposer
+recompose_count: 0
+completed_phase_policy: immutable
+execution_tiers:
+  - tier: 1
+    phases: [phase-1, phase-2]
+mvp:
+  phases: [phase-1, phase-2]
+  execution_mode: sequential
+  artifact: draft_pr
+  derived_from: mvp_scope
+release_cuts: []
+`);
     const out = runStopHook(tmpDir, {
       current_phase: 'release-finalize',
-      release: { current_cut_id: 'mvp', completed_cut_ids: [], fix_loop_count: 0, pending_artifact: null },
+      release: {
+        current_cut_id: 'mvp', completed_cut_ids: [], fix_loop_count: 0, pending_artifact: null,
+        max_fix_loops: 3,
+        gate_results: {
+          hard1_baseline: { exit_code: 0 }, hard2_coverage: { exit_code: 0 }, hard3_resilience: { exit_code: 0 },
+        },
+      },
     });
     const state = readState();
     assert.deepStrictEqual(state.release.completed_cut_ids, ['mvp']);
@@ -1068,5 +1096,183 @@ mvp_scope:
     const state = readState();
     assert.strictEqual(state.current_phase, 'release-gate');
     assert.match(out.stopReason, /missing scoped Hard 1\/2\/3 evidence/);
+  });
+
+  // ── Stage A Phase 1.6c-ii: release-finalize writes manifest + evidence + gate-results ──
+
+  function writeDecompositionWithMvp(dir, { phases = ['phase-1', 'phase-2'], artifact = 'draft_pr' } = {}) {
+    mkdirSync(join(dir, '.mpl', 'mpl'), { recursive: true });
+    writeFileSync(join(dir, '.mpl', 'mpl', 'decomposition.yaml'), `
+graph_version: "1.0"
+generated_by: mpl-decomposer
+recompose_count: 0
+completed_phase_policy: immutable
+execution_tiers:
+  - tier: 1
+    phases: [${phases.join(', ')}]
+mvp:
+  phases: [${phases.join(', ')}]
+  execution_mode: sequential
+  artifact: ${artifact}
+  derived_from: mvp_scope
+release_cuts: []
+`);
+  }
+
+  it('1.6c-ii: release-finalize writes release-manifest.json + evidence-summary.md + gate-results.json under .mpl/mpl/releases/{cut_id}/', () => {
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    writeGoalContractWithMvp(tmpDir);
+    writeDecompositionWithMvp(tmpDir);
+    runStopHook(tmpDir, {
+      current_phase: 'release-finalize',
+      pipeline_id: 'mpl-20260524-mvp-fixture',
+      release: {
+        current_cut_id: 'mvp',
+        completed_cut_ids: [],
+        fix_loop_count: 0,
+        pending_artifact: null,
+        max_fix_loops: 3,
+        gate_results: {
+          hard1_baseline: { exit_code: 0, command: 'npm run build' },
+          hard2_coverage: { exit_code: 0, command: 'npm test' },
+          hard3_resilience: { exit_code: 0, command: 'contract' },
+        },
+      },
+    });
+    const releaseDir = join(tmpDir, '.mpl', 'mpl', 'releases', 'mvp');
+    const manifestPath = join(releaseDir, 'release-manifest.json');
+    const summaryPath = join(releaseDir, 'evidence-summary.md');
+    const gatePath = join(releaseDir, 'gate-results.json');
+
+    assert.ok(existsSync(manifestPath), 'release-manifest.json must exist');
+    assert.ok(existsSync(summaryPath), 'evidence-summary.md must exist');
+    assert.ok(existsSync(gatePath), 'gate-results.json must exist');
+
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'));
+    assert.equal(manifest.cut_id, 'mvp');
+    assert.deepEqual(manifest.phases, ['phase-1', 'phase-2']);
+    assert.deepEqual(manifest.goal_trace.acceptance_criteria, ['AC-1']);
+    assert.deepEqual(manifest.goal_trace.variation_axes, ['AX-1']);
+    assert.equal(manifest.artifact, 'draft_pr');
+    assert.equal(manifest.pipeline_id, 'mpl-20260524-mvp-fixture');
+    // 1.6c-iii placeholders.
+    assert.equal(manifest.commit_sha, null);
+    assert.equal(manifest.tree_sha, null);
+    assert.equal(manifest.snapshot_ref, null);
+    assert.deepEqual(manifest.gate_results_summary, { hard1: true, hard2: true, hard3: true });
+
+    const summary = readFileSync(summaryPath, 'utf-8');
+    assert.match(summary, /# Release evidence — `mvp`/);
+    assert.match(summary, /Artifact:\*\* draft_pr/);
+    assert.match(summary, /`phase-1`/);
+
+    const gate = JSON.parse(readFileSync(gatePath, 'utf-8'));
+    assert.ok(gate.archived_at);
+    assert.equal(gate.gate_results.hard1_baseline.exit_code, 0);
+  });
+
+  it('1.6c-ii: release-finalize advances lifecycle (appends completed_cut_ids, clears current, routes to phase3-gate) AFTER write succeeds', () => {
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    writeGoalContractWithMvp(tmpDir);
+    writeDecompositionWithMvp(tmpDir);
+    const out = runStopHook(tmpDir, {
+      current_phase: 'release-finalize',
+      release: {
+        current_cut_id: 'mvp',
+        completed_cut_ids: [],
+        fix_loop_count: 0,
+        pending_artifact: null,
+        max_fix_loops: 3,
+        gate_results: {
+          hard1_baseline: { exit_code: 0 }, hard2_coverage: { exit_code: 0 }, hard3_resilience: { exit_code: 0 },
+        },
+      },
+    });
+    const state = readState();
+    assert.deepStrictEqual(state.release.completed_cut_ids, ['mvp']);
+    assert.strictEqual(state.release.current_cut_id, null);
+    assert.strictEqual(state.current_phase, 'phase3-gate');
+    assert.match(out.stopReason, /Manifest written to \.mpl\/mpl\/releases\/mvp\//);
+  });
+
+  it('1.6c-ii: release-finalize MUST NOT set finalize_done or transition to completed (RFC §5.5)', () => {
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    writeGoalContractWithMvp(tmpDir);
+    writeDecompositionWithMvp(tmpDir);
+    runStopHook(tmpDir, {
+      current_phase: 'release-finalize',
+      release: {
+        current_cut_id: 'mvp',
+        completed_cut_ids: [],
+        fix_loop_count: 0,
+        pending_artifact: null,
+        max_fix_loops: 3,
+        gate_results: {
+          hard1_baseline: { exit_code: 0 }, hard2_coverage: { exit_code: 0 }, hard3_resilience: { exit_code: 0 },
+        },
+      },
+    });
+    const state = readState();
+    assert.notStrictEqual(state.finalize_done, true, 'finalize_done is exclusive to phase5-finalize');
+    assert.notStrictEqual(state.current_phase, 'completed', 'release path never routes to completed');
+  });
+
+  it('1.6c-ii: release-finalize refuses to advance when contract/decomposition lack cohort descriptor', () => {
+    // No goal-contract, no decomposition → descriptor missing → manifest
+    // would be degraded. Refuse to write, stay at release-finalize,
+    // surface actionable message.
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    const out = runStopHook(tmpDir, {
+      current_phase: 'release-finalize',
+      release: {
+        current_cut_id: 'mvp',
+        completed_cut_ids: [],
+        fix_loop_count: 0,
+        pending_artifact: null,
+        max_fix_loops: 3,
+        gate_results: {
+          hard1_baseline: { exit_code: 0 }, hard2_coverage: { exit_code: 0 }, hard3_resilience: { exit_code: 0 },
+        },
+      },
+    });
+    const state = readState();
+    // No lifecycle advancement.
+    assert.strictEqual(state.current_phase, 'release-finalize');
+    assert.strictEqual(state.release.current_cut_id, 'mvp');
+    assert.deepStrictEqual(state.release.completed_cut_ids, []);
+    assert.match(out.stopReason, /cohort descriptor missing/);
+    // No file created.
+    assert.equal(existsSync(join(tmpDir, '.mpl', 'mpl', 'releases', 'mvp', 'release-manifest.json')), false);
+  });
+
+  it('1.6c-ii: release-finalize re-entry with cohort already in completed_cut_ids overwrites the manifest (idempotent re-write)', () => {
+    // PR #185 idempotency: re-entering release-finalize with a cohort
+    // already in completed_cut_ids did not double-append. 1.6c-ii adds
+    // a file write — re-entry should overwrite the manifest cleanly
+    // (no append, no stale read).
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    writeGoalContractWithMvp(tmpDir);
+    writeDecompositionWithMvp(tmpDir);
+    const releaseDir = join(tmpDir, '.mpl', 'mpl', 'releases', 'mvp');
+    mkdirSync(releaseDir, { recursive: true });
+    writeFileSync(join(releaseDir, 'release-manifest.json'), JSON.stringify({ stale: true }));
+    runStopHook(tmpDir, {
+      current_phase: 'release-finalize',
+      release: {
+        current_cut_id: 'mvp',
+        completed_cut_ids: ['mvp'],
+        fix_loop_count: 0,
+        pending_artifact: null,
+        max_fix_loops: 3,
+        gate_results: {
+          hard1_baseline: { exit_code: 0 }, hard2_coverage: { exit_code: 0 }, hard3_resilience: { exit_code: 0 },
+        },
+      },
+    });
+    const state = readState();
+    assert.deepStrictEqual(state.release.completed_cut_ids, ['mvp'], 'idempotent: no double-append');
+    const manifest = JSON.parse(readFileSync(join(releaseDir, 'release-manifest.json'), 'utf-8'));
+    assert.equal(manifest.cut_id, 'mvp', 'stale manifest overwritten');
+    assert.equal(manifest.stale, undefined, 'stale field gone');
   });
 });

--- a/hooks/__tests__/mpl-phase-controller.test.mjs
+++ b/hooks/__tests__/mpl-phase-controller.test.mjs
@@ -1,7 +1,7 @@
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync } from 'fs';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync, statSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { tmpdir } from 'os';
@@ -731,28 +731,13 @@ mvp_scope:
 
   it('1.6b: release-finalize appends current cohort to completed_cut_ids and clears current_cut_id', () => {
     // After 1.6c-ii, release-finalize requires goal-contract + decomposition
-    // to build the release-manifest before advancing the lifecycle. Seed
-    // both so the original 1.6b lifecycle assertion still exercises the
-    // append+clear+route path. The helpers `writeGoalContractWithMvp` and
-    // `writeDecompositionWithMvp` are defined in the 1.6c-ii block below;
-    // we inline equivalents here to avoid a forward-declaration dependency.
-    mkdirSync(join(tmpDir, '.mpl', 'mpl'), { recursive: true });
+    // to build the release-manifest before advancing the lifecycle. Both
+    // helpers (`writeGoalContractWithMvp`, `writeDecompositionWithMvp`) are
+    // function declarations in this describe block — hoisted, so usable
+    // here even though `writeDecompositionWithMvp` is defined further down.
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
     writeGoalContractWithMvp(tmpDir);
-    writeFileSync(join(tmpDir, '.mpl', 'mpl', 'decomposition.yaml'), `
-graph_version: "1.0"
-generated_by: mpl-decomposer
-recompose_count: 0
-completed_phase_policy: immutable
-execution_tiers:
-  - tier: 1
-    phases: [phase-1, phase-2]
-mvp:
-  phases: [phase-1, phase-2]
-  execution_mode: sequential
-  artifact: draft_pr
-  derived_from: mvp_scope
-release_cuts: []
-`);
+    writeDecompositionWithMvp(tmpDir);
     const out = runStopHook(tmpDir, {
       current_phase: 'release-finalize',
       release: {
@@ -1243,6 +1228,93 @@ release_cuts: []
     assert.match(out.stopReason, /cohort descriptor missing/);
     // No file created.
     assert.equal(existsSync(join(tmpDir, '.mpl', 'mpl', 'releases', 'mvp', 'release-manifest.json')), false);
+  });
+
+  // PR #187 codex High regression: strict-both-required for resolveCutDescriptor.
+  it('1.6c-ii (PR #187 codex review): release-finalize refuses to advance when contract present but decomposition missing', () => {
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    writeGoalContractWithMvp(tmpDir);  // contract only — no decomposition
+    const out = runStopHook(tmpDir, {
+      current_phase: 'release-finalize',
+      release: {
+        current_cut_id: 'mvp', completed_cut_ids: [], fix_loop_count: 0,
+        pending_artifact: null, max_fix_loops: 3,
+        gate_results: {
+          hard1_baseline: { exit_code: 0 }, hard2_coverage: { exit_code: 0 }, hard3_resilience: { exit_code: 0 },
+        },
+      },
+    });
+    const state = readState();
+    assert.strictEqual(state.current_phase, 'release-finalize');
+    assert.strictEqual(state.release.current_cut_id, 'mvp');
+    assert.deepStrictEqual(state.release.completed_cut_ids, []);
+    assert.match(out.stopReason, /cohort descriptor missing/);
+    assert.equal(existsSync(join(tmpDir, '.mpl', 'mpl', 'releases', 'mvp', 'release-manifest.json')), false);
+  });
+
+  it('1.6c-ii (PR #187 codex review): release-finalize refuses to advance when decomposition present but contract missing', () => {
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    writeDecompositionWithMvp(tmpDir);  // decomposition only — no contract
+    const out = runStopHook(tmpDir, {
+      current_phase: 'release-finalize',
+      release: {
+        current_cut_id: 'mvp', completed_cut_ids: [], fix_loop_count: 0,
+        pending_artifact: null, max_fix_loops: 3,
+        gate_results: {
+          hard1_baseline: { exit_code: 0 }, hard2_coverage: { exit_code: 0 }, hard3_resilience: { exit_code: 0 },
+        },
+      },
+    });
+    const state = readState();
+    assert.strictEqual(state.current_phase, 'release-finalize');
+    assert.deepStrictEqual(state.release.completed_cut_ids, []);
+    assert.match(out.stopReason, /cohort descriptor missing/);
+  });
+
+  it('1.6c-ii (PR #187 codex review): release-finalize refuses to advance when graph.mvp.phases is empty', () => {
+    // Decomposer wrote `mvp:` block but `phases: []` (mechanical mapping
+    // yielded no membership). Manifest would assert "released" with no
+    // work — refuse.
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    writeGoalContractWithMvp(tmpDir);
+    writeDecompositionWithMvp(tmpDir, { phases: [] });
+    const out = runStopHook(tmpDir, {
+      current_phase: 'release-finalize',
+      release: {
+        current_cut_id: 'mvp', completed_cut_ids: [], fix_loop_count: 0,
+        pending_artifact: null, max_fix_loops: 3,
+        gate_results: {
+          hard1_baseline: { exit_code: 0 }, hard2_coverage: { exit_code: 0 }, hard3_resilience: { exit_code: 0 },
+        },
+      },
+    });
+    const state = readState();
+    assert.strictEqual(state.current_phase, 'release-finalize');
+    assert.deepStrictEqual(state.release.completed_cut_ids, []);
+    assert.match(out.stopReason, /cohort descriptor missing/);
+  });
+
+  it('1.6c-ii (PR #187 claude review): release artifacts written with 0o644 mode (consumer-friendly)', () => {
+    // Skip on Windows where POSIX file modes do not apply.
+    if (process.platform === 'win32') return;
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    writeGoalContractWithMvp(tmpDir);
+    writeDecompositionWithMvp(tmpDir);
+    runStopHook(tmpDir, {
+      current_phase: 'release-finalize',
+      release: {
+        current_cut_id: 'mvp', completed_cut_ids: [], fix_loop_count: 0,
+        pending_artifact: null, max_fix_loops: 3,
+        gate_results: {
+          hard1_baseline: { exit_code: 0 }, hard2_coverage: { exit_code: 0 }, hard3_resilience: { exit_code: 0 },
+        },
+      },
+    });
+    const releaseDir = join(tmpDir, '.mpl', 'mpl', 'releases', 'mvp');
+    for (const f of ['release-manifest.json', 'evidence-summary.md', 'gate-results.json']) {
+      const mode = statSync(join(releaseDir, f)).mode & 0o777;
+      assert.equal(mode, 0o644, `${f} should have mode 0o644 (got ${mode.toString(8)})`);
+    }
   });
 
   it('1.6c-ii: release-finalize re-entry with cohort already in completed_cut_ids overwrites the manifest (idempotent re-write)', () => {

--- a/hooks/__tests__/mpl-release-manifest.test.mjs
+++ b/hooks/__tests__/mpl-release-manifest.test.mjs
@@ -81,6 +81,32 @@ describe('resolveCutDescriptor', () => {
     assert.equal(d, null);
   });
 
+  // PR #187 round-2 codex+claude High: empty-AC+AX guard symmetric with empty-phases.
+  it('returns null when BOTH mvp_scope.acceptance_criteria and variation_axes are empty arrays', () => {
+    // codex reproducer: `mvp_scope: { artifact: 'draft_pr' }` only — AC/AX
+    // never declared. Library-layer defense against callers bypassing
+    // readGoalContract's validator.
+    const contract = mvpContract({ ac: [], ax: [], artifact: 'draft_pr' });
+    const graph = mvpGraph({ phases: ['phase-1'], artifact: 'draft_pr' });
+    assert.equal(resolveCutDescriptor('mvp', contract, graph), null);
+  });
+
+  it('accepts mvp when ONLY acceptance_criteria is populated (variation_axes empty is fine)', () => {
+    // The validator's `acceptance_criteria_or_variation_axes` flag fires
+    // only when BOTH are empty. A contract with AC but no AX is valid.
+    const contract = mvpContract({ ac: ['AC-1'], ax: [], artifact: 'draft_pr' });
+    const d = resolveCutDescriptor('mvp', contract, mvpGraph());
+    assert.deepEqual(d.acceptance_criteria, ['AC-1']);
+    assert.deepEqual(d.variation_axes, []);
+  });
+
+  it('accepts mvp when ONLY variation_axes is populated (acceptance_criteria empty is fine)', () => {
+    const contract = mvpContract({ ac: [], ax: ['AX-1'], artifact: 'draft_pr' });
+    const d = resolveCutDescriptor('mvp', contract, mvpGraph());
+    assert.deepEqual(d.acceptance_criteria, []);
+    assert.deepEqual(d.variation_axes, ['AX-1']);
+  });
+
   it('returns null when extension cut phases array is empty (same empty-membership guard)', () => {
     const graph = {
       mvp: null,

--- a/hooks/__tests__/mpl-release-manifest.test.mjs
+++ b/hooks/__tests__/mpl-release-manifest.test.mjs
@@ -1,0 +1,306 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildReleaseManifest,
+  buildEvidenceSummary,
+  buildGateResultsSnapshot,
+  resolveCutDescriptor,
+  RELEASE_DIR_REL_PATH,
+} from '../lib/mpl-release-manifest.mjs';
+
+const NOW = '2026-05-24T12:00:00.000Z';
+
+function mvpContract({ ac = ['AC-1', 'AC-2'], ax = ['AX-1'], artifact = 'draft_pr' } = {}) {
+  return {
+    mvp_scope: {
+      acceptance_criteria: ac,
+      variation_axes: ax,
+      artifact,
+    },
+  };
+}
+
+function mvpGraph({ phases = ['phase-1', 'phase-2'], artifact = 'draft_pr' } = {}) {
+  return { mvp: { phases, artifact }, release_cuts: [] };
+}
+
+describe('RELEASE_DIR_REL_PATH constant', () => {
+  it('points at the canonical .mpl/mpl/releases location (matches RFC §5.4)', () => {
+    assert.equal(RELEASE_DIR_REL_PATH, '.mpl/mpl/releases');
+  });
+});
+
+describe('resolveCutDescriptor', () => {
+  it('returns mvp descriptor from graph.mvp + contract.mvp_scope when cutId="mvp"', () => {
+    const d = resolveCutDescriptor('mvp', mvpContract(), mvpGraph());
+    assert.deepEqual(d.phases, ['phase-1', 'phase-2']);
+    assert.deepEqual(d.acceptance_criteria, ['AC-1', 'AC-2']);
+    assert.deepEqual(d.variation_axes, ['AX-1']);
+    assert.equal(d.artifact, 'draft_pr');
+  });
+
+  it('prefers graph.mvp.artifact over contract.mvp_scope.artifact (graph is canonical)', () => {
+    const contract = mvpContract({ artifact: 'tag' });
+    const graph = mvpGraph({ artifact: 'draft_pr' });
+    const d = resolveCutDescriptor('mvp', contract, graph);
+    assert.equal(d.artifact, 'draft_pr');
+  });
+
+  it('falls back to contract.mvp_scope.artifact when graph.mvp.artifact is missing', () => {
+    const contract = mvpContract({ artifact: 'tag' });
+    const graph = { mvp: { phases: ['phase-1'], artifact: null }, release_cuts: [] };
+    const d = resolveCutDescriptor('mvp', contract, graph);
+    assert.equal(d.artifact, 'tag');
+  });
+
+  it('returns null when neither contract.mvp_scope nor graph.mvp exists', () => {
+    assert.equal(resolveCutDescriptor('mvp', {}, { release_cuts: [] }), null);
+  });
+
+  it('resolves an extension cut by id from release_cuts[]', () => {
+    const graph = {
+      mvp: null,
+      release_cuts: [
+        { id: 'cut-1', phases: ['phase-3', 'phase-4'], artifact: 'tag', user_approved: true },
+        { id: 'cut-2', phases: ['phase-5'], artifact: 'branch', user_approved: true },
+      ],
+    };
+    const d = resolveCutDescriptor('cut-2', {}, graph);
+    assert.deepEqual(d.phases, ['phase-5']);
+    assert.equal(d.artifact, 'branch');
+    // Extension cuts don't carry AC/AX in Stage A.
+    assert.deepEqual(d.acceptance_criteria, []);
+    assert.deepEqual(d.variation_axes, []);
+  });
+
+  it('returns null on empty / non-string cutId', () => {
+    assert.equal(resolveCutDescriptor('', mvpContract(), mvpGraph()), null);
+    assert.equal(resolveCutDescriptor(null, mvpContract(), mvpGraph()), null);
+    assert.equal(resolveCutDescriptor(undefined, mvpContract(), mvpGraph()), null);
+  });
+
+  it('returns null when extension cut id is not in release_cuts[]', () => {
+    const graph = { mvp: null, release_cuts: [{ id: 'cut-1', phases: [], artifact: null }] };
+    assert.equal(resolveCutDescriptor('cut-missing', {}, graph), null);
+  });
+});
+
+describe('buildReleaseManifest', () => {
+  it('builds a full manifest for an mvp cohort with all fields populated', () => {
+    const state = {
+      pipeline_id: 'mpl-20260524-mvp-test',
+      release: {
+        current_cut_id: 'mvp',
+        gate_results: {
+          hard1_baseline: { exit_code: 0, command: 'npm run build' },
+          hard2_coverage: { exit_code: 0, command: 'npm test' },
+          hard3_resilience: { exit_code: 0, command: 'contract' },
+        },
+      },
+    };
+    const m = buildReleaseManifest({
+      cutId: 'mvp',
+      state,
+      contract: mvpContract(),
+      graph: mvpGraph(),
+      now: NOW,
+    });
+    assert.equal(m.cut_id, 'mvp');
+    assert.deepEqual(m.phases, ['phase-1', 'phase-2']);
+    assert.deepEqual(m.goal_trace.acceptance_criteria, ['AC-1', 'AC-2']);
+    assert.deepEqual(m.goal_trace.variation_axes, ['AX-1']);
+    // 1.6c-ii placeholders for 1.6c-iii.
+    assert.equal(m.commit_sha, null);
+    assert.equal(m.tree_sha, null);
+    assert.equal(m.snapshot_ref, null);
+    assert.equal(m.artifact_creation_failed, null);
+    assert.deepEqual(m.gate_results_summary, { hard1: true, hard2: true, hard3: true });
+    assert.equal(m.artifact, 'draft_pr');
+    assert.equal(m.created_at, NOW);
+    assert.equal(m.pipeline_id, 'mpl-20260524-mvp-test');
+  });
+
+  it('returns null when no descriptor can be resolved', () => {
+    const m = buildReleaseManifest({
+      cutId: 'mvp',
+      state: { release: {} },
+      contract: null,
+      graph: null,
+      now: NOW,
+    });
+    assert.equal(m, null);
+  });
+
+  it('summarizes gate FAIL as boolean false', () => {
+    const state = {
+      release: {
+        gate_results: {
+          hard1_baseline: { exit_code: 0 },
+          hard2_coverage: { exit_code: 1 },
+          hard3_resilience: { exit_code: 0 },
+        },
+      },
+    };
+    const m = buildReleaseManifest({
+      cutId: 'mvp', state,
+      contract: mvpContract(), graph: mvpGraph(), now: NOW,
+    });
+    assert.deepEqual(m.gate_results_summary, { hard1: true, hard2: false, hard3: true });
+  });
+
+  it('summarizes absent gates as null', () => {
+    const state = { release: { gate_results: {} } };
+    const m = buildReleaseManifest({
+      cutId: 'mvp', state,
+      contract: mvpContract(), graph: mvpGraph(), now: NOW,
+    });
+    assert.deepEqual(m.gate_results_summary, { hard1: null, hard2: null, hard3: null });
+  });
+
+  it('defaults created_at to a fresh ISO timestamp when `now` is omitted', () => {
+    const m = buildReleaseManifest({
+      cutId: 'mvp',
+      state: { release: {} },
+      contract: mvpContract(), graph: mvpGraph(),
+    });
+    assert.match(m.created_at, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+  });
+});
+
+describe('buildGateResultsSnapshot', () => {
+  it('returns a full snapshot with archived_at + clone of release.gate_results', () => {
+    const state = {
+      release: {
+        gate_results: {
+          hard1_passed: true,
+          hard2_passed: false,
+          hard3_passed: null,
+          hard1_baseline: { exit_code: 0, command: 'build' },
+          hard2_coverage: { exit_code: 2, stdout_tail: 'fail' },
+          hard3_resilience: null,
+        },
+      },
+    };
+    const snap = buildGateResultsSnapshot(state, NOW);
+    assert.equal(snap.archived_at, NOW);
+    assert.equal(snap.gate_results.hard1_passed, true);
+    assert.equal(snap.gate_results.hard2_passed, false);
+    assert.deepEqual(snap.gate_results.hard1_baseline, { exit_code: 0, command: 'build' });
+    assert.deepEqual(snap.gate_results.hard2_coverage, { exit_code: 2, stdout_tail: 'fail' });
+    assert.equal(snap.gate_results.hard3_resilience, null);
+  });
+
+  it('does not share object identity with state.release.gate_results entries (defensive clone)', () => {
+    const entry = { exit_code: 0 };
+    const state = { release: { gate_results: { hard1_baseline: entry } } };
+    const snap = buildGateResultsSnapshot(state);
+    assert.notEqual(snap.gate_results.hard1_baseline, entry);
+    // Mutating the source should not bleed into the snapshot.
+    entry.exit_code = 99;
+    assert.equal(snap.gate_results.hard1_baseline.exit_code, 0);
+  });
+
+  it('handles missing state.release gracefully', () => {
+    const snap = buildGateResultsSnapshot({}, NOW);
+    assert.equal(snap.gate_results.hard1_passed, null);
+    assert.equal(snap.gate_results.hard1_baseline, null);
+  });
+});
+
+describe('buildEvidenceSummary', () => {
+  it('renders cohort header + phase status + goal_trace + gate results + dispatches', () => {
+    const state = {
+      pipeline_id: 'mpl-20260524-mvp-test',
+      release: {
+        gate_results: {
+          hard1_baseline: { exit_code: 0 },
+          hard2_coverage: { exit_code: 1 },
+          hard3_resilience: { exit_code: 0 },
+        },
+      },
+      execution: {
+        phase_details: [
+          { id: 'phase-1', status: 'completed' },
+          { id: 'phase-2', status: 'completed' },
+        ],
+      },
+      test_agent_dispatched: {
+        'phase-1': { verdict: 'PASS', tests_total: 5, tests_failed: 0 },
+        'phase-2': { verdict: 'PASS', tests_total: 3, tests_failed: 0 },
+      },
+    };
+    const md = buildEvidenceSummary({
+      cutId: 'mvp', state,
+      contract: mvpContract(), graph: mvpGraph(), now: NOW,
+    });
+    assert.match(md, /^# Release evidence — `mvp`/);
+    assert.match(md, /Pipeline:\*\* mpl-20260524-mvp-test/);
+    assert.match(md, /Artifact:\*\* draft_pr/);
+    assert.match(md, /## Phases/);
+    assert.match(md, /`phase-1` — completed/);
+    assert.match(md, /`phase-2` — completed/);
+    assert.match(md, /## Goal trace/);
+    assert.match(md, /`AC-1`, `AC-2`/);
+    assert.match(md, /`AX-1`/);
+    assert.match(md, /## Gate results/);
+    assert.match(md, /Hard 1.*✅ PASS/);
+    assert.match(md, /Hard 2.*❌ FAIL.*exit 1/);
+    assert.match(md, /Hard 3.*✅ PASS/);
+    assert.match(md, /## Test-agent dispatches/);
+    assert.match(md, /`phase-1` — verdict=PASS, tests=5/);
+  });
+
+  it('shows "(no execution record)" when phase_details is missing for a cut phase', () => {
+    const state = {
+      release: { gate_results: {} },
+      execution: { phase_details: [] },
+      test_agent_dispatched: {},
+    };
+    const md = buildEvidenceSummary({
+      cutId: 'mvp', state,
+      contract: mvpContract(), graph: mvpGraph(), now: NOW,
+    });
+    assert.match(md, /`phase-1` — \(no execution record\)/);
+  });
+
+  it('shows "_(none recorded)_" when AC/AX lists are empty (extension cut)', () => {
+    const graph = {
+      mvp: null,
+      release_cuts: [{ id: 'cut-1', phases: ['phase-3'], artifact: 'branch' }],
+    };
+    const md = buildEvidenceSummary({
+      cutId: 'cut-1',
+      state: { release: { gate_results: {} } },
+      contract: {},
+      graph,
+      now: NOW,
+    });
+    assert.match(md, /Acceptance criteria: _\(none recorded\)_/);
+    assert.match(md, /Variation axes: _\(none recorded\)_/);
+  });
+
+  it('reports missing test-agent evidence when no cohort phase has a dispatch', () => {
+    const state = {
+      release: { gate_results: {} },
+      test_agent_dispatched: { 'phase-other': { verdict: 'PASS' } },
+    };
+    const md = buildEvidenceSummary({
+      cutId: 'mvp', state,
+      contract: mvpContract(), graph: mvpGraph(), now: NOW,
+    });
+    assert.match(md, /_No test-agent evidence recorded for this cohort\._/);
+  });
+
+  it('uses fallback descriptor when cut cannot be resolved (degraded but does not throw)', () => {
+    // E.g., the contract/graph went missing mid-pipeline — the summary still
+    // renders so the user has a reference point in the failure message.
+    const md = buildEvidenceSummary({
+      cutId: 'mvp',
+      state: { release: { gate_results: {} } },
+      contract: null, graph: null, now: NOW,
+    });
+    assert.match(md, /^# Release evidence — `mvp`/);
+    assert.match(md, /Artifact:\*\* \(none requested\)/);
+  });
+});

--- a/hooks/__tests__/mpl-release-manifest.test.mjs
+++ b/hooks/__tests__/mpl-release-manifest.test.mjs
@@ -58,6 +58,54 @@ describe('resolveCutDescriptor', () => {
     assert.equal(resolveCutDescriptor('mvp', {}, { release_cuts: [] }), null);
   });
 
+  // PR #187 codex review High: strict-both-required regression suite.
+  it('returns null when ONLY contract.mvp_scope is present (no graph.mvp) — strict', () => {
+    // Pre-fix: would have returned a descriptor with phases:[] and shipped
+    // a degraded manifest. Now rejects so release-finalize bails.
+    const d = resolveCutDescriptor('mvp', mvpContract(), { mvp: null, release_cuts: [] });
+    assert.equal(d, null);
+  });
+
+  it('returns null when ONLY graph.mvp is present (no contract.mvp_scope) — strict', () => {
+    // Same regression — goal_trace would have been empty without contract,
+    // so the manifest could not satisfy RFC §5.4 goal-trace requirement.
+    const d = resolveCutDescriptor('mvp', { mvp_scope: null }, mvpGraph());
+    assert.equal(d, null);
+  });
+
+  it('returns null when graph.mvp.phases is empty array — empty-membership guard', () => {
+    // Decomposer never derived an mvp membership; shipping an empty-phases
+    // manifest would assert "released" with no work — refuse.
+    const graph = { mvp: { phases: [], artifact: 'draft_pr' }, release_cuts: [] };
+    const d = resolveCutDescriptor('mvp', mvpContract(), graph);
+    assert.equal(d, null);
+  });
+
+  it('returns null when extension cut phases array is empty (same empty-membership guard)', () => {
+    const graph = {
+      mvp: null,
+      release_cuts: [{ id: 'cut-1', phases: [], artifact: 'tag' }],
+    };
+    assert.equal(resolveCutDescriptor('cut-1', {}, graph), null);
+  });
+
+  // PR #187 claude review #4: extension-cut AC/AX auto-pickup (Stage B forward-compat).
+  it('auto-picks extension cut acceptance_criteria/variation_axes when release_cuts[] entry carries them', () => {
+    const graph = {
+      mvp: null,
+      release_cuts: [{
+        id: 'cut-extended',
+        phases: ['phase-7'],
+        artifact: 'tag',
+        acceptance_criteria: ['AC-7', 'AC-8'],  // Stage B forward-compat field
+        variation_axes: ['AX-3'],
+      }],
+    };
+    const d = resolveCutDescriptor('cut-extended', {}, graph);
+    assert.deepEqual(d.acceptance_criteria, ['AC-7', 'AC-8']);
+    assert.deepEqual(d.variation_axes, ['AX-3']);
+  });
+
   it('resolves an extension cut by id from release_cuts[]', () => {
     const graph = {
       mvp: null,
@@ -199,6 +247,22 @@ describe('buildGateResultsSnapshot', () => {
     // Mutating the source should not bleed into the snapshot.
     entry.exit_code = 99;
     assert.equal(snap.gate_results.hard1_baseline.exit_code, 0);
+  });
+
+  it('isolates NESTED mutations via structuredClone (claude #3 forward-compat)', () => {
+    // If a gate entry ever grows a nested object (e.g., diagnostics block),
+    // shallow spread would leak the source mutation through the nested
+    // reference. structuredClone deep-copies so the snapshot is fully
+    // independent. This test future-proofs against shape additions.
+    const breakdown = { warnings: 1, errors: 0 };
+    const entry = { exit_code: 0, diagnostics: { breakdown } };
+    const state = { release: { gate_results: { hard2_coverage: entry } } };
+    const snap = buildGateResultsSnapshot(state);
+    // Mutate the deeply-nested source object after the snapshot is taken.
+    breakdown.warnings = 99;
+    breakdown.errors = 99;
+    assert.equal(snap.gate_results.hard2_coverage.diagnostics.breakdown.warnings, 1);
+    assert.equal(snap.gate_results.hard2_coverage.diagnostics.breakdown.errors, 0);
   });
 
   it('handles missing state.release gracefully', () => {

--- a/hooks/lib/mpl-release-manifest.mjs
+++ b/hooks/lib/mpl-release-manifest.mjs
@@ -1,0 +1,260 @@
+/**
+ * Stage A Phase 1.6c-ii release-manifest serialization helpers.
+ *
+ * Builds the three artifacts written at `release-finalize` exit (per RFC §5.4):
+ *
+ *   .mpl/mpl/releases/{cut_id}/release-manifest.json   — structured manifest
+ *   .mpl/mpl/releases/{cut_id}/evidence-summary.md     — human summary
+ *   .mpl/mpl/releases/{cut_id}/gate-results.json       — archival copy of
+ *                                                        state.release.gate_results
+ *
+ * Snapshot identifiers (`commit_sha`, `tree_sha`, `snapshot_ref`) are written
+ * as placeholders (`null`) here; 1.6c-iii will populate them via
+ * `git rev-parse` / `git update-ref`. The contract surface stays stable so
+ * 1.6c-iii's diff is small (it only fills the placeholders).
+ *
+ * Pure functions: every helper takes its inputs explicitly and returns a
+ * value. No filesystem I/O lives in this module — the caller (phase-controller
+ * release-finalize handler) decides where and when to persist.
+ */
+
+export const RELEASE_DIR_REL_PATH = '.mpl/mpl/releases';
+
+/**
+ * Resolve which cut object describes the cohort being released.
+ *
+ * Stage A: when `cutId === 'mvp'`, source is `graph.mvp` (decomposer-derived,
+ * see PR #182). When `cutId` matches a `release_cuts[].id`, source is that
+ * entry. Returns `null` when the contract or decomposition is missing the
+ * cohort — the caller should treat that as an error and refuse to write.
+ *
+ * @param {string} cutId
+ * @param {object|null} contract - parsed goal contract (parseGoalContractText)
+ * @param {object|null} graph    - parsed phase-contract-graph (parsePhaseContractGraphText)
+ * @returns {{ phases: string[], artifact: string|null,
+ *             acceptance_criteria: string[], variation_axes: string[] } | null}
+ */
+export function resolveCutDescriptor(cutId, contract, graph) {
+  if (typeof cutId !== 'string' || !cutId) return null;
+
+  if (cutId === 'mvp') {
+    const mvpGraph = graph?.mvp;
+    const mvpScope = contract?.mvp_scope;
+    if (!mvpGraph && !mvpScope) return null;
+    return {
+      phases: Array.isArray(mvpGraph?.phases) ? [...mvpGraph.phases] : [],
+      artifact:
+        // Stage A: the decomposer mechanically copies mvp_scope.artifact
+        // into graph.mvp.artifact (PR #182). Prefer the graph entry — it's
+        // the canonical mechanically-derived value. Fall back to the
+        // contract scope when the graph entry is missing (e.g., legacy
+        // decomposition predates 1.2).
+        mvpGraph?.artifact ?? mvpScope?.artifact ?? null,
+      acceptance_criteria: Array.isArray(mvpScope?.acceptance_criteria)
+        ? [...mvpScope.acceptance_criteria]
+        : [],
+      variation_axes: Array.isArray(mvpScope?.variation_axes)
+        ? [...mvpScope.variation_axes]
+        : [],
+    };
+  }
+
+  const releaseCuts = Array.isArray(graph?.release_cuts) ? graph.release_cuts : [];
+  const found = releaseCuts.find((c) => c?.id === cutId);
+  if (!found) return null;
+  return {
+    phases: Array.isArray(found.phases) ? [...found.phases] : [],
+    artifact: found.artifact ?? null,
+    // Extension cuts don't carry AC/AX in Stage A — the contract scope
+    // is mvp-only. Future Stage B may extend; until then leave empty.
+    acceptance_criteria: [],
+    variation_axes: [],
+  };
+}
+
+/**
+ * Build the release-manifest.json payload for a cohort.
+ *
+ * Snapshot identifiers are placeholder `null` values pending 1.6c-iii.
+ * Gate-results summary is a compact { hard1, hard2, hard3 } boolean view
+ * derived from `state.release.gate_results.hard{1,2,3}_{baseline,coverage,resilience}`
+ * exit codes (0 → true, nonzero → false, absent → null).
+ *
+ * @param {{ cutId: string, state: object, contract: object|null,
+ *           graph: object|null, now?: string }} opts
+ * @returns {object|null} manifest object, or null when cut descriptor is missing
+ */
+export function buildReleaseManifest({ cutId, state, contract, graph, now }) {
+  const descriptor = resolveCutDescriptor(cutId, contract, graph);
+  if (!descriptor) return null;
+
+  const release = state?.release || {};
+  const gateResults = release.gate_results || {};
+
+  return {
+    cut_id: cutId,
+    phases: descriptor.phases,
+    goal_trace: {
+      acceptance_criteria: descriptor.acceptance_criteria,
+      variation_axes: descriptor.variation_axes,
+    },
+    // 1.6c-iii will populate these via `git rev-parse HEAD`, `git rev-parse
+    // HEAD^{tree}`, and `git update-ref refs/mpl/releases/{cut_id}`.
+    // Placeholder shape is fixed so the manifest schema is stable across
+    // the 1.6c-ii → 1.6c-iii boundary.
+    commit_sha: null,
+    tree_sha: null,
+    snapshot_ref: null,
+    gate_results_summary: summarizeGateResults(gateResults),
+    artifact: descriptor.artifact,
+    // Optional fault state. 1.6c-iii sets this on git/gh failure; 1.6c-ii
+    // always writes null because no artifact creation happens here.
+    artifact_creation_failed: null,
+    created_at: now || new Date().toISOString(),
+    pipeline_id: state?.pipeline_id || null,
+  };
+}
+
+/**
+ * Boolean view of release-scoped Hard 1/2/3 evidence.
+ * Mirrors the per-gate convention in `checkGateResults` / phase-controller:
+ *   0   → true (PASS)
+ *   ≠0  → false (FAIL)
+ *   absent / non-numeric → null (not recorded)
+ */
+function summarizeGateResults(gates) {
+  const out = { hard1: null, hard2: null, hard3: null };
+  const pairs = [
+    ['hard1', 'hard1_baseline'],
+    ['hard2', 'hard2_coverage'],
+    ['hard3', 'hard3_resilience'],
+  ];
+  for (const [short, structuredKey] of pairs) {
+    const entry = gates?.[structuredKey];
+    if (entry && typeof entry === 'object' && typeof entry.exit_code === 'number') {
+      out[short] = entry.exit_code === 0;
+    }
+  }
+  return out;
+}
+
+/**
+ * Take a release-scoped snapshot of `state.release.gate_results` for archival.
+ *
+ * Pure structural copy — no transformation. Returns `{ hard{1,2,3}_passed,
+ * hard{1,2,3}_{baseline,coverage,resilience} }` matching the in-state shape
+ * so users can diff the file against state.json directly. Captures the
+ * recording timestamp so the archived file is self-dating.
+ */
+export function buildGateResultsSnapshot(state, now) {
+  const gates = state?.release?.gate_results || {};
+  const clone = (entry) => {
+    if (!entry || typeof entry !== 'object') return null;
+    return { ...entry };
+  };
+  return {
+    archived_at: now || new Date().toISOString(),
+    gate_results: {
+      hard1_passed: gates.hard1_passed ?? null,
+      hard2_passed: gates.hard2_passed ?? null,
+      hard3_passed: gates.hard3_passed ?? null,
+      hard1_baseline: clone(gates.hard1_baseline),
+      hard2_coverage: clone(gates.hard2_coverage),
+      hard3_resilience: clone(gates.hard3_resilience),
+    },
+  };
+}
+
+/**
+ * Human-readable evidence summary as Markdown.
+ *
+ * Sections:
+ *   1. Cohort header (cut_id, artifact, created_at)
+ *   2. Phases — list of phase ids in this cut, with status from
+ *      `state.execution.phase_details[]` when available
+ *   3. Goal trace — acceptance_criteria + variation_axes covered
+ *   4. Gate results — Hard 1/2/3 PASS/FAIL/missing (release-scoped)
+ *   5. Test-agent dispatches — phase id → verdict + tests_total when present
+ *
+ * Avoid leaking long stdout_tail blocks; this file is for skimming, not
+ * full forensics. The full evidence is preserved in `gate-results.json`
+ * alongside it.
+ */
+export function buildEvidenceSummary({ cutId, state, contract, graph, now }) {
+  const descriptor = resolveCutDescriptor(cutId, contract, graph) || {
+    phases: [], artifact: null, acceptance_criteria: [], variation_axes: [],
+  };
+  const release = state?.release || {};
+  const gates = release.gate_results || {};
+  const phaseDetails = Array.isArray(state?.execution?.phase_details)
+    ? state.execution.phase_details
+    : [];
+  const phaseStatus = new Map();
+  for (const p of phaseDetails) {
+    if (p?.id) phaseStatus.set(p.id, p.status || 'unknown');
+  }
+
+  const lines = [];
+  lines.push(`# Release evidence — \`${cutId}\``);
+  lines.push('');
+  lines.push(`- **Created:** ${now || new Date().toISOString()}`);
+  lines.push(`- **Pipeline:** ${state?.pipeline_id || '(unknown)'}`);
+  lines.push(`- **Artifact:** ${descriptor.artifact || '(none requested)'}`);
+  lines.push('');
+
+  lines.push('## Phases');
+  if (descriptor.phases.length === 0) {
+    lines.push('_No phases recorded for this cut._');
+  } else {
+    for (const id of descriptor.phases) {
+      const status = phaseStatus.get(id) || '(no execution record)';
+      lines.push(`- \`${id}\` — ${status}`);
+    }
+  }
+  lines.push('');
+
+  lines.push('## Goal trace');
+  lines.push(`- Acceptance criteria: ${formatIdList(descriptor.acceptance_criteria)}`);
+  lines.push(`- Variation axes: ${formatIdList(descriptor.variation_axes)}`);
+  lines.push('');
+
+  lines.push('## Gate results (release-scoped)');
+  const summary = summarizeGateResults(gates);
+  lines.push(`- Hard 1 (build/lint/type): ${formatGate(summary.hard1, gates.hard1_baseline)}`);
+  lines.push(`- Hard 2 (tests): ${formatGate(summary.hard2, gates.hard2_coverage)}`);
+  lines.push(`- Hard 3 (contracts): ${formatGate(summary.hard3, gates.hard3_resilience)}`);
+  lines.push('');
+
+  lines.push('## Test-agent dispatches');
+  const dispatches = state?.test_agent_dispatched || {};
+  const cohortDispatches = descriptor.phases
+    .map((id) => [id, dispatches[id]])
+    .filter(([, d]) => d && typeof d === 'object');
+  if (cohortDispatches.length === 0) {
+    lines.push('_No test-agent evidence recorded for this cohort._');
+  } else {
+    for (const [id, d] of cohortDispatches) {
+      const verdict = d.verdict || '(no verdict)';
+      const total = typeof d.tests_total === 'number' ? d.tests_total : '?';
+      const failed = typeof d.tests_failed === 'number' ? d.tests_failed : '?';
+      lines.push(`- \`${id}\` — verdict=${verdict}, tests=${total} (failed=${failed})`);
+    }
+  }
+  lines.push('');
+
+  return lines.join('\n');
+}
+
+function formatIdList(ids) {
+  if (!Array.isArray(ids) || ids.length === 0) return '_(none recorded)_';
+  return ids.map((id) => `\`${id}\``).join(', ');
+}
+
+function formatGate(boolish, entry) {
+  if (boolish === true) return '✅ PASS';
+  if (boolish === false) {
+    const code = entry && typeof entry.exit_code === 'number' ? ` (exit ${entry.exit_code})` : '';
+    return `❌ FAIL${code}`;
+  }
+  return '— not recorded';
+}

--- a/hooks/lib/mpl-release-manifest.mjs
+++ b/hooks/lib/mpl-release-manifest.mjs
@@ -23,10 +23,19 @@ export const RELEASE_DIR_REL_PATH = '.mpl/mpl/releases';
 /**
  * Resolve which cut object describes the cohort being released.
  *
- * Stage A: when `cutId === 'mvp'`, source is `graph.mvp` (decomposer-derived,
- * see PR #182). When `cutId` matches a `release_cuts[].id`, source is that
- * entry. Returns `null` when the contract or decomposition is missing the
- * cohort — the caller should treat that as an error and refuse to write.
+ * Stage A: when `cutId === 'mvp'`, source REQUIRES both `graph.mvp`
+ * (decomposer-derived, see PR #182) AND `contract.mvp_scope`. The two
+ * artifacts describe different facets of the cohort — graph carries the
+ * mechanically-derived `phases[]` membership, contract carries the
+ * user-declared `acceptance_criteria` / `variation_axes` goal trace.
+ * Allowing one without the other lets a degraded manifest with empty
+ * phases (or missing goal_trace) ship and silently flip D-Q6 immutability
+ * for a cut that never had a real phase set. **Both must be present and
+ * `graph.mvp.phases` must be non-empty.** Returns `null` when either side
+ * is missing or phases are empty — the caller refuses to advance the
+ * lifecycle (PR #187 codex review).
+ *
+ * When `cutId` matches a `release_cuts[].id`, source is that entry.
  *
  * @param {string} cutId
  * @param {object|null} contract - parsed goal contract (parseGoalContractText)
@@ -40,20 +49,29 @@ export function resolveCutDescriptor(cutId, contract, graph) {
   if (cutId === 'mvp') {
     const mvpGraph = graph?.mvp;
     const mvpScope = contract?.mvp_scope;
-    if (!mvpGraph && !mvpScope) return null;
+    // Strict: both sides required (RFC §5.4 — manifest must carry both
+    // phase membership AND goal trace). PR #187 codex review caught the
+    // prior OR logic that silently shipped phases:[] manifests.
+    if (!mvpGraph || !mvpScope) return null;
+    const phases = Array.isArray(mvpGraph.phases) ? [...mvpGraph.phases] : [];
+    // Empty phases means the decomposer never derived an mvp membership
+    // (mechanical id-set mapping yielded nothing); shipping such a
+    // manifest would assert "this cut is released" while listing no
+    // work — refuse.
+    if (phases.length === 0) return null;
     return {
-      phases: Array.isArray(mvpGraph?.phases) ? [...mvpGraph.phases] : [],
+      phases,
       artifact:
         // Stage A: the decomposer mechanically copies mvp_scope.artifact
         // into graph.mvp.artifact (PR #182). Prefer the graph entry — it's
         // the canonical mechanically-derived value. Fall back to the
         // contract scope when the graph entry is missing (e.g., legacy
         // decomposition predates 1.2).
-        mvpGraph?.artifact ?? mvpScope?.artifact ?? null,
-      acceptance_criteria: Array.isArray(mvpScope?.acceptance_criteria)
+        mvpGraph.artifact ?? mvpScope.artifact ?? null,
+      acceptance_criteria: Array.isArray(mvpScope.acceptance_criteria)
         ? [...mvpScope.acceptance_criteria]
         : [],
-      variation_axes: Array.isArray(mvpScope?.variation_axes)
+      variation_axes: Array.isArray(mvpScope.variation_axes)
         ? [...mvpScope.variation_axes]
         : [],
     };
@@ -62,13 +80,21 @@ export function resolveCutDescriptor(cutId, contract, graph) {
   const releaseCuts = Array.isArray(graph?.release_cuts) ? graph.release_cuts : [];
   const found = releaseCuts.find((c) => c?.id === cutId);
   if (!found) return null;
+  const phases = Array.isArray(found.phases) ? [...found.phases] : [];
+  // Same empty-phases guard as the mvp branch.
+  if (phases.length === 0) return null;
   return {
-    phases: Array.isArray(found.phases) ? [...found.phases] : [],
+    phases,
     artifact: found.artifact ?? null,
-    // Extension cuts don't carry AC/AX in Stage A — the contract scope
-    // is mvp-only. Future Stage B may extend; until then leave empty.
-    acceptance_criteria: [],
-    variation_axes: [],
+    // Auto-pick-up if Stage B extends `release_cuts[]` with goal_trace
+    // fields (claude review #4 on PR #187). One-character defense lets
+    // the resolver stay correct without a future code change.
+    acceptance_criteria: Array.isArray(found.acceptance_criteria)
+      ? [...found.acceptance_criteria]
+      : [],
+    variation_axes: Array.isArray(found.variation_axes)
+      ? [...found.variation_axes]
+      : [],
   };
 }
 
@@ -148,9 +174,14 @@ function summarizeGateResults(gates) {
  */
 export function buildGateResultsSnapshot(state, now) {
   const gates = state?.release?.gate_results || {};
+  // structuredClone (not spread) so any nested object inside an entry
+  // — e.g., a future `{ exit_code: 0, details: { ... } }` shape — is
+  // isolated from the source. Today's flat shape works with shallow
+  // copy, but the future-proofing is a one-liner (claude review #3 on
+  // PR #187).
   const clone = (entry) => {
     if (!entry || typeof entry !== 'object') return null;
-    return { ...entry };
+    return structuredClone(entry);
   };
   return {
     archived_at: now || new Date().toISOString(),

--- a/hooks/lib/mpl-release-manifest.mjs
+++ b/hooks/lib/mpl-release-manifest.mjs
@@ -59,6 +59,22 @@ export function resolveCutDescriptor(cutId, contract, graph) {
     // manifest would assert "this cut is released" while listing no
     // work — refuse.
     if (phases.length === 0) return null;
+    const acceptance = Array.isArray(mvpScope.acceptance_criteria)
+      ? [...mvpScope.acceptance_criteria]
+      : [];
+    const axes = Array.isArray(mvpScope.variation_axes)
+      ? [...mvpScope.variation_axes]
+      : [];
+    // Defense-in-depth (PR #187 round-2 codex + claude review): symmetric
+    // empty-membership guard for the goal_trace axis. The goal-contract
+    // validator already flags `mvp_scope.acceptance_criteria_or_variation_axes`
+    // when BOTH AC and AX are empty, but a caller that bypasses
+    // `readGoalContract` (hand-built contract object, contract drift mid-
+    // pipeline) would otherwise ship a manifest with empty `goal_trace` and
+    // flip D-Q6 immutability for a cohort with no acceptance criteria. The
+    // handler also gates on `gcRead.valid` upstream; this is the library-
+    // layer defense for callers that skip that gate.
+    if (acceptance.length === 0 && axes.length === 0) return null;
     return {
       phases,
       artifact:
@@ -68,12 +84,8 @@ export function resolveCutDescriptor(cutId, contract, graph) {
         // contract scope when the graph entry is missing (e.g., legacy
         // decomposition predates 1.2).
         mvpGraph.artifact ?? mvpScope.artifact ?? null,
-      acceptance_criteria: Array.isArray(mvpScope.acceptance_criteria)
-        ? [...mvpScope.acceptance_criteria]
-        : [],
-      variation_axes: Array.isArray(mvpScope.variation_axes)
-        ? [...mvpScope.variation_axes]
-        : [],
+      acceptance_criteria: acceptance,
+      variation_axes: axes,
     };
   }
 

--- a/hooks/mpl-phase-controller.mjs
+++ b/hooks/mpl-phase-controller.mjs
@@ -720,20 +720,26 @@ async function main() {
       const releaseDir = join(cwd, RELEASE_DIR_REL_PATH, cur);
       try {
         mkdirSync(releaseDir, { recursive: true });
+        // 0o644 (not the 0o600 used for state.json): release artifacts
+        // are designed for consumption by CI runners, mpl-status, and
+        // future tooling that may run as a different uid on a shared
+        // dev box / CI agent (claude review #1 on PR #187). state.json
+        // stays 0o600 because it carries session-internal evidence;
+        // these files are the shippable record of the release.
         writeFileSync(
           join(releaseDir, 'release-manifest.json'),
           JSON.stringify(manifest, null, 2) + '\n',
-          { mode: 0o600 }
+          { mode: 0o644 }
         );
         writeFileSync(
           join(releaseDir, 'evidence-summary.md'),
           evidence.endsWith('\n') ? evidence : evidence + '\n',
-          { mode: 0o600 }
+          { mode: 0o644 }
         );
         writeFileSync(
           join(releaseDir, 'gate-results.json'),
           JSON.stringify(gateSnapshot, null, 2) + '\n',
-          { mode: 0o600 }
+          { mode: 0o644 }
         );
       } catch (err) {
         // Manifest write failure must NOT advance the lifecycle (RFC §5.4:

--- a/hooks/mpl-phase-controller.mjs
+++ b/hooks/mpl-phase-controller.mjs
@@ -16,7 +16,7 @@
 
 import { dirname, join } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
-import { existsSync, readFileSync } from 'fs';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -39,6 +39,21 @@ const { resolveRuleAction } = await import(
 // Stage A: goal-contract reader for the D-Q7 small-pipeline guard.
 const { readGoalContract } = await import(
   pathToFileURL(join(__dirname, 'lib', 'mpl-goal-contract.mjs')).href
+);
+
+// Stage A Phase 1.6c-ii: release-manifest serializers for the release-finalize
+// file-write step. Pure helpers; this hook owns the filesystem side.
+const {
+  buildReleaseManifest,
+  buildEvidenceSummary,
+  buildGateResultsSnapshot,
+  RELEASE_DIR_REL_PATH,
+} = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-release-manifest.mjs')).href
+);
+
+const { parsePhaseContractGraphText } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-phase-contract-graph.mjs')).href
 );
 
 // G4 hang detection (#109)
@@ -645,16 +660,89 @@ async function main() {
     }
 
     case 'release-finalize': {
-      // Phase 1.6b: minimal completion logic — record the cohort in
-      // completed_cut_ids, advance current_cut_id, and route.
-      // Manifest write + artifact creation (per-cut snapshot ref +
-      // optional draft_pr/branch/tag) land in Phase 1.6c.
+      // Phase 1.6c-ii: write release-manifest.json + evidence-summary.md +
+      // gate-results.json under .mpl/mpl/releases/{cut_id}/ before the
+      // existing append+clear step. RFC §5.4 requires the manifest write
+      // to precede `completed_cut_ids` append — a cohort is only "released"
+      // (and D-Q6 immutable) once its manifest is shipped.
+      //
+      // Snapshot identifiers (commit_sha/tree_sha/snapshot_ref) are
+      // placeholders here; 1.6c-iii populates them via git rev-parse /
+      // update-ref. Optional user-visible artifact creation (draft_pr /
+      // branch / tag) also lands in 1.6c-iii. The manifest schema is
+      // stable across the 1.6c-ii → 1.6c-iii boundary so the upcoming
+      // diff is small.
+      //
+      // RFC §5.5 invariants preserved: this handler MUST NOT set
+      // `state.finalize_done=true` and MUST NOT transition `current_phase`
+      // to `completed`. Both remain exclusive to phase5-finalize.
       const cur = state.release?.current_cut_id;
       if (!cur) {
         writeState(cwd, { current_phase: 'phase3-gate' });
         console.log(JSON.stringify({
           continue: true,
           stopReason: '[MPL] ⚠ release-finalize entered with no active cohort. Routing to phase3-gate.'
+        }));
+        break;
+      }
+
+      // Read contract + decomposition for the manifest builder. Both are
+      // required: contract supplies goal_trace (AC/AX), decomposition
+      // supplies phases per cut. Missing either is an actionable error —
+      // refuse to write a degraded manifest and stay at release-finalize.
+      const gcRead = readGoalContract(cwd);
+      const contract = gcRead.exists ? gcRead.contract : null;
+      let graph = null;
+      try {
+        const decompPath = join(cwd, '.mpl', 'mpl', 'decomposition.yaml');
+        if (existsSync(decompPath)) {
+          graph = parsePhaseContractGraphText(readFileSync(decompPath, 'utf-8'));
+        }
+      } catch {
+        graph = null;
+      }
+
+      const writtenAt = new Date().toISOString();
+      const manifest = buildReleaseManifest({ cutId: cur, state, contract, graph, now: writtenAt });
+      if (!manifest) {
+        console.log(JSON.stringify({
+          continue: true,
+          stopReason: `[MPL] ⛔ release-finalize(${cur}): cohort descriptor missing from contract/decomposition. ` +
+            `Cannot build release manifest. Verify .mpl/goal-contract.yaml mvp_scope and ` +
+            `.mpl/mpl/decomposition.yaml mvp.phases are present and match the active cut_id. ` +
+            `Staying at release-finalize until resolved.`
+        }));
+        break;
+      }
+      const evidence = buildEvidenceSummary({ cutId: cur, state, contract, graph, now: writtenAt });
+      const gateSnapshot = buildGateResultsSnapshot(state, writtenAt);
+
+      const releaseDir = join(cwd, RELEASE_DIR_REL_PATH, cur);
+      try {
+        mkdirSync(releaseDir, { recursive: true });
+        writeFileSync(
+          join(releaseDir, 'release-manifest.json'),
+          JSON.stringify(manifest, null, 2) + '\n',
+          { mode: 0o600 }
+        );
+        writeFileSync(
+          join(releaseDir, 'evidence-summary.md'),
+          evidence.endsWith('\n') ? evidence : evidence + '\n',
+          { mode: 0o600 }
+        );
+        writeFileSync(
+          join(releaseDir, 'gate-results.json'),
+          JSON.stringify(gateSnapshot, null, 2) + '\n',
+          { mode: 0o600 }
+        );
+      } catch (err) {
+        // Manifest write failure must NOT advance the lifecycle (RFC §5.4:
+        // append only after manifest write succeeds). Surface and pin.
+        console.log(JSON.stringify({
+          continue: true,
+          stopReason: `[MPL] ⛔ release-finalize(${cur}): manifest write failed (${err?.message || 'unknown'}). ` +
+            `Cohort NOT appended to completed_cut_ids. Resolve the filesystem error under ` +
+            `${RELEASE_DIR_REL_PATH}/${cur}/ and let the loop retry.`
         }));
         break;
       }
@@ -682,7 +770,7 @@ async function main() {
       });
       console.log(JSON.stringify({
         continue: true,
-        stopReason: `[MPL] release-finalize(${cur}): cohort completed. ` +
+        stopReason: `[MPL] release-finalize(${cur}): cohort completed. Manifest written to ${RELEASE_DIR_REL_PATH}/${cur}/. ` +
           `Stage A single-cohort path: transitioning to whole-pipeline phase3-gate.`
       }));
       break;

--- a/hooks/mpl-phase-controller.mjs
+++ b/hooks/mpl-phase-controller.mjs
@@ -690,7 +690,30 @@ async function main() {
       // required: contract supplies goal_trace (AC/AX), decomposition
       // supplies phases per cut. Missing either is an actionable error —
       // refuse to write a degraded manifest and stay at release-finalize.
+      //
+      // PR #187 round-2 codex+claude High: an INVALID contract (e.g.,
+      // `mvp_scope: { artifact: draft_pr }` with no AC/AX) was previously
+      // passed through because the handler only checked `gcRead.exists`.
+      // The validator already flags `mvp_scope.acceptance_criteria_or_variation_axes`
+      // and other structural failures; route any `!gcRead.valid` through
+      // the same bail mechanism so a degraded "released" manifest with
+      // empty goal_trace cannot flip D-Q6 immutability. Library-layer
+      // defense (resolveCutDescriptor rejecting empty AC+AX) is the
+      // backstop for callers that bypass `readGoalContract`.
       const gcRead = readGoalContract(cwd);
+      if (gcRead.exists && !gcRead.valid) {
+        const reasonList = Array.isArray(gcRead.missing) && gcRead.missing.length > 0
+          ? gcRead.missing.join(', ')
+          : '(no detail)';
+        console.log(JSON.stringify({
+          continue: true,
+          stopReason: `[MPL] ⛔ release-finalize(${cur}): goal-contract is invalid (${reasonList}). ` +
+            `Cohort NOT appended to completed_cut_ids. Fix .mpl/goal-contract.yaml — the validator at ` +
+            `mpl-goal-contract.validateGoalContractText lists what is required. ` +
+            `Staying at release-finalize until resolved.`
+        }));
+        break;
+      }
       const contract = gcRead.exists ? gcRead.contract : null;
       let graph = null;
       try {


### PR DESCRIPTION
## What

Phase 1.6c-ii of Stage A — wires `release-finalize` to write three artifacts under `.mpl/mpl/releases/{cut_id}/` before advancing the lifecycle (RFC §5.4).

| Artifact | Purpose |
|---|---|
| `release-manifest.json` | Structured manifest: `cut_id`, `phases[]`, `goal_trace.{acceptance_criteria, variation_axes}`, `artifact`, `gate_results_summary`, `pipeline_id`, `created_at` + `commit_sha`/`tree_sha`/`snapshot_ref` placeholders (1.6c-iii fills these) |
| `evidence-summary.md` | Human-readable summary: cohort header, phase status from `state.execution.phase_details`, goal trace, gate verdicts, test-agent dispatches |
| `gate-results.json` | Archival copy of `state.release.gate_results` with `archived_at` timestamp |

## Why

The 1.6c-i handler routed gate evidence into `state.release.gate_results` but ended at "PASS → release-finalize" — release-finalize itself only flipped lifecycle bookkeeping. Without the manifest write, a "released" cohort had no shippable record beyond a flag in `state.json`. 1.6c-ii closes that gap.

## Design

- **RFC** §5.4 — manifest write precedes `completed_cut_ids` append; snapshot ref (§5.4.1) and optional draft_pr/branch/tag artifacts deferred to 1.6c-iii
- **Resume brief** \`docs/roadmap/stage-a-resume-1.6c.md\` §3 (1.6c-ii scope)
- New library \`hooks/lib/mpl-release-manifest.mjs\` — pure serialization. \`resolveCutDescriptor\` resolves \`mvp\` from \`graph.mvp\` + \`contract.mvp_scope\`, extension cuts from \`graph.release_cuts[]\`
- Manifest schema is intentionally **stable** across the 1.6c-ii → 1.6c-iii boundary (snapshot fields are placeholders, not absent) so the upcoming diff is small
- Handler reads \`.mpl/goal-contract.yaml\` + \`.mpl/mpl/decomposition.yaml\`; missing descriptor → refuse to write a degraded manifest, stay at release-finalize, surface actionable message

### Invariants preserved (RFC §5.5)

- release-finalize MUST NOT set \`state.finalize_done=true\` — verified by dedicated test
- release-finalize MUST NOT transition \`current_phase\` to \`completed\` — verified by same test
- D-Q6 (PR #183): \`completed_cut_ids\` is appended ONLY after manifest write succeeds — descriptor-missing test verifies the bail path leaves \`completed_cut_ids\` untouched

## Test plan

- [x] +25 tests in this PR
  - 22 library unit tests (\`hooks/__tests__/mpl-release-manifest.test.mjs\`)
  - 5 phase-controller integration tests (3-file write, lifecycle order, §5.5 non-finalize, descriptor-missing refusal, idempotent re-write)
- [x] Full hook suite: **1019/1019 pass** (993 → 1019)
- [x] Updated 1 prior 1.6b test that asserted lifecycle advancement without seeding contract/decomposition
- [ ] Awaiting agent reviews (claude + codex)

## Agent Review Status

This PR is gated on **2 unique agent reviews** (footers \`— from <agent>\`).

- [ ] from claude
- [ ] from codex

---
_Awaiting reviews. Merge once the gate is satisfied._