### PR TITLE
feat(stage-a-1.6c-iii): snapshot ref + artifact creation in release-finalize

### DIFF
--- a/hooks/__tests__/mpl-phase-controller.test.mjs
+++ b/hooks/__tests__/mpl-phase-controller.test.mjs
@@ -1,7 +1,7 @@
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync, statSync } from 'fs';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync, statSync, readdirSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { tmpdir } from 'os';
@@ -1464,5 +1464,233 @@ mvp_scope:
     const manifest = JSON.parse(readFileSync(join(releaseDir, 'release-manifest.json'), 'utf-8'));
     assert.equal(manifest.cut_id, 'mvp', 'stale manifest overwritten');
     assert.equal(manifest.stale, undefined, 'stale field gone');
+  });
+
+  // ── Stage A Phase 1.6c-iii: snapshot ref + artifact creation ──
+
+  function initGitFixture(dir) {
+    execFileSync('git', ['init', '--initial-branch=main'], { cwd: dir, encoding: 'utf-8' });
+    execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: dir });
+    execFileSync('git', ['config', 'user.name', 'Test'], { cwd: dir });
+    execFileSync('git', ['config', 'commit.gpgsign', 'false'], { cwd: dir });
+    execFileSync('git', ['config', 'tag.gpgSign', 'false'], { cwd: dir });
+    writeFileSync(join(dir, 'README.md'), '# fixture\n');
+    execFileSync('git', ['add', 'README.md'], { cwd: dir });
+    execFileSync('git', ['commit', '-m', 'initial'], { cwd: dir });
+  }
+
+  function readManifest(dir) {
+    return JSON.parse(readFileSync(
+      join(dir, '.mpl', 'mpl', 'releases', 'mvp', 'release-manifest.json'),
+      'utf-8'
+    ));
+  }
+
+  it('1.6c-iii: release-finalize populates manifest.commit_sha / tree_sha / snapshot_ref from git rev-parse', () => {
+    initGitFixture(tmpDir);
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    writeGoalContractWithMvp(tmpDir);
+    writeDecompositionWithMvp(tmpDir);
+    runStopHook(tmpDir, {
+      current_phase: 'release-finalize',
+      release: {
+        current_cut_id: 'mvp', completed_cut_ids: [], fix_loop_count: 0,
+        pending_artifact: null, max_fix_loops: 3,
+        gate_results: {
+          hard1_baseline: { exit_code: 0 }, hard2_coverage: { exit_code: 0 }, hard3_resilience: { exit_code: 0 },
+        },
+      },
+    });
+    const manifest = readManifest(tmpDir);
+    assert.match(manifest.commit_sha, /^[0-9a-f]{40}$/, 'commit_sha populated');
+    assert.match(manifest.tree_sha, /^[0-9a-f]{40}$/, 'tree_sha populated');
+    assert.equal(manifest.snapshot_ref, 'refs/mpl/releases/mvp');
+    // refs/mpl/releases/mvp actually points at HEAD.
+    const refTarget = execFileSync('git', ['rev-parse', 'refs/mpl/releases/mvp'],
+      { cwd: tmpDir, encoding: 'utf-8' }).trim();
+    assert.equal(refTarget, manifest.commit_sha);
+  });
+
+  it('1.6c-iii: release-finalize records artifact_creation_failed when not in a git repo (snapshot ref fails)', () => {
+    // No `git init` — every git call fails. Manifest still written (with
+    // null snapshot fields + artifact_creation_failed.type='snapshot_ref')
+    // and lifecycle still advances per RFC §5.4 best-effort post-step.
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    writeGoalContractWithMvp(tmpDir);
+    writeDecompositionWithMvp(tmpDir);
+    const out = runStopHook(tmpDir, {
+      current_phase: 'release-finalize',
+      release: {
+        current_cut_id: 'mvp', completed_cut_ids: [], fix_loop_count: 0,
+        pending_artifact: null, max_fix_loops: 3,
+        gate_results: {
+          hard1_baseline: { exit_code: 0 }, hard2_coverage: { exit_code: 0 }, hard3_resilience: { exit_code: 0 },
+        },
+      },
+    });
+    const manifest = readManifest(tmpDir);
+    assert.equal(manifest.commit_sha, null);
+    assert.equal(manifest.tree_sha, null);
+    assert.equal(manifest.snapshot_ref, null);
+    assert.equal(manifest.artifact_creation_failed.type, 'snapshot_ref');
+    assert.ok(manifest.artifact_creation_failed.reason);
+    // Lifecycle still advances.
+    const state = readState();
+    assert.strictEqual(state.current_phase, 'phase3-gate');
+    assert.deepStrictEqual(state.release.completed_cut_ids, ['mvp']);
+    assert.match(out.stopReason, /snapshot ref FAILED/);
+  });
+
+  it('1.6c-iii: release-finalize records artifact_creation_failed.tag when no remote (artifact best-effort)', () => {
+    // Git repo set up, snapshot ref succeeds, but no remote so tag push
+    // fails. Per RFC §5.4 ("artifact creation depends on external tools
+    // out of MPL's control"), lifecycle still advances and the failure
+    // is recorded in the manifest.
+    initGitFixture(tmpDir);
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    // Goal-contract artifact = tag (override the default draft_pr).
+    writeFileSync(join(tmpDir, '.mpl', 'goal-contract.yaml'), `
+source:
+  runtime_goal: "x"
+  user_request_hash: "abc"
+mission:
+  goal: "g"
+  project_pivot: "pp"
+  must_ship_outcomes:
+    - "ship"
+ontology:
+  entities:
+    - foo
+variation_axes:
+  - id: AX-1
+    name: ax
+acceptance_criteria:
+  - id: AC-1
+    statement: "ac"
+e2e_policy:
+  real_runtime_required: true
+  mock_allowed: false
+  placeholder_assertions_allowed: false
+security_policy:
+  required: false
+completion_evidence:
+  required_artifacts:
+    - .mpl/mpl/audit-report.json
+  require_commit: false
+  require_finalize_timestamps: true
+mvp_scope:
+  acceptance_criteria: [AC-1]
+  variation_axes: [AX-1]
+  artifact: tag
+`);
+    writeDecompositionWithMvp(tmpDir, { artifact: 'tag' });
+    const out = runStopHook(tmpDir, {
+      current_phase: 'release-finalize',
+      release: {
+        current_cut_id: 'mvp', completed_cut_ids: [], fix_loop_count: 0,
+        pending_artifact: null, max_fix_loops: 3,
+        gate_results: {
+          hard1_baseline: { exit_code: 0 }, hard2_coverage: { exit_code: 0 }, hard3_resilience: { exit_code: 0 },
+        },
+      },
+    });
+    const manifest = readManifest(tmpDir);
+    // Snapshot succeeded.
+    assert.match(manifest.commit_sha, /^[0-9a-f]{40}$/);
+    // Tag failure recorded.
+    assert.equal(manifest.artifact_creation_failed.type, 'tag');
+    assert.match(manifest.artifact_creation_failed.reason, /push failed/);
+    // Lifecycle advances regardless (RFC §5.4 best-effort).
+    const state = readState();
+    assert.strictEqual(state.current_phase, 'phase3-gate');
+    assert.deepStrictEqual(state.release.completed_cut_ids, ['mvp']);
+    assert.match(out.stopReason, /artifact=tag FAILED/);
+    // Local tag exists (push failed but local creation succeeded).
+    const localTag = execFileSync('git', ['rev-parse', 'refs/tags/mpl-release-mvp'],
+      { cwd: tmpDir, encoding: 'utf-8' }).trim();
+    assert.equal(localTag, manifest.commit_sha);
+  });
+
+  it('1.6c-iii: release-finalize with artifact=release_manifest emits snapshot + manifest only, artifact_creation_failed=null', () => {
+    initGitFixture(tmpDir);
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    writeFileSync(join(tmpDir, '.mpl', 'goal-contract.yaml'), `
+source:
+  runtime_goal: "x"
+  user_request_hash: "abc"
+mission:
+  goal: "g"
+  project_pivot: "pp"
+  must_ship_outcomes:
+    - "ship"
+ontology:
+  entities:
+    - foo
+variation_axes:
+  - id: AX-1
+    name: ax
+acceptance_criteria:
+  - id: AC-1
+    statement: "ac"
+e2e_policy:
+  real_runtime_required: true
+  mock_allowed: false
+  placeholder_assertions_allowed: false
+security_policy:
+  required: false
+completion_evidence:
+  required_artifacts:
+    - .mpl/mpl/audit-report.json
+  require_commit: false
+  require_finalize_timestamps: true
+mvp_scope:
+  acceptance_criteria: [AC-1]
+  variation_axes: [AX-1]
+  artifact: release_manifest
+`);
+    writeDecompositionWithMvp(tmpDir, { artifact: 'release_manifest' });
+    const out = runStopHook(tmpDir, {
+      current_phase: 'release-finalize',
+      release: {
+        current_cut_id: 'mvp', completed_cut_ids: [], fix_loop_count: 0,
+        pending_artifact: null, max_fix_loops: 3,
+        gate_results: {
+          hard1_baseline: { exit_code: 0 }, hard2_coverage: { exit_code: 0 }, hard3_resilience: { exit_code: 0 },
+        },
+      },
+    });
+    const manifest = readManifest(tmpDir);
+    assert.match(manifest.commit_sha, /^[0-9a-f]{40}$/);
+    assert.equal(manifest.artifact, 'release_manifest');
+    assert.equal(manifest.artifact_creation_failed, null);
+    // No tag / branch should have been created.
+    assert.throws(() => execFileSync('git', ['rev-parse', 'refs/tags/mpl-release-mvp'],
+      { cwd: tmpDir, encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] }));
+    assert.match(out.stopReason, /artifact=release_manifest \(no external push\)/);
+  });
+
+  it('1.6c-iii: atomic write leaves no .tmp residue on success', () => {
+    initGitFixture(tmpDir);
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    writeGoalContractWithMvp(tmpDir);
+    writeDecompositionWithMvp(tmpDir);
+    runStopHook(tmpDir, {
+      current_phase: 'release-finalize',
+      release: {
+        current_cut_id: 'mvp', completed_cut_ids: [], fix_loop_count: 0,
+        pending_artifact: null, max_fix_loops: 3,
+        gate_results: {
+          hard1_baseline: { exit_code: 0 }, hard2_coverage: { exit_code: 0 }, hard3_resilience: { exit_code: 0 },
+        },
+      },
+    });
+    const releaseDir = join(tmpDir, '.mpl', 'mpl', 'releases', 'mvp');
+    const entries = readdirSync(releaseDir);
+    assert.ok(!entries.some((f) => f.endsWith('.tmp')),
+      `no .tmp residue expected, got: ${entries.join(', ')}`);
+    // Three release artifacts are present at the final paths.
+    assert.ok(entries.includes('release-manifest.json'));
+    assert.ok(entries.includes('evidence-summary.md'));
+    assert.ok(entries.includes('gate-results.json'));
   });
 });

--- a/hooks/__tests__/mpl-phase-controller.test.mjs
+++ b/hooks/__tests__/mpl-phase-controller.test.mjs
@@ -731,10 +731,11 @@ mvp_scope:
 
   it('1.6b: release-finalize appends current cohort to completed_cut_ids and clears current_cut_id', () => {
     // After 1.6c-ii, release-finalize requires goal-contract + decomposition
-    // to build the release-manifest before advancing the lifecycle. Both
-    // helpers (`writeGoalContractWithMvp`, `writeDecompositionWithMvp`) are
-    // function declarations in this describe block — hoisted, so usable
-    // here even though `writeDecompositionWithMvp` is defined further down.
+    // to build the release-manifest before advancing the lifecycle. After
+    // 1.6c-iii, it also requires a git repo so snapshot ref creation
+    // succeeds (RFC §5.4 §232). All helpers are hoisted function
+    // declarations in this describe block.
+    initGitFixture(tmpDir);
     mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
     writeGoalContractWithMvp(tmpDir);
     writeDecompositionWithMvp(tmpDir);
@@ -1105,6 +1106,8 @@ release_cuts: []
   }
 
   it('1.6c-ii: release-finalize writes release-manifest.json + evidence-summary.md + gate-results.json under .mpl/mpl/releases/{cut_id}/', () => {
+    // 1.6c-iii: snapshot ref creation requires a git repo (RFC §5.4 §232).
+    initGitFixture(tmpDir);
     mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
     writeGoalContractWithMvp(tmpDir);
     writeDecompositionWithMvp(tmpDir);
@@ -1140,10 +1143,10 @@ release_cuts: []
     assert.deepEqual(manifest.goal_trace.variation_axes, ['AX-1']);
     assert.equal(manifest.artifact, 'draft_pr');
     assert.equal(manifest.pipeline_id, 'mpl-20260524-mvp-fixture');
-    // 1.6c-iii placeholders.
-    assert.equal(manifest.commit_sha, null);
-    assert.equal(manifest.tree_sha, null);
-    assert.equal(manifest.snapshot_ref, null);
+    // 1.6c-iii populates snapshot identifiers from git rev-parse.
+    assert.match(manifest.commit_sha, /^[0-9a-f]{40}$/);
+    assert.match(manifest.tree_sha, /^[0-9a-f]{40}$/);
+    assert.equal(manifest.snapshot_ref, 'refs/mpl/releases/mvp');
     assert.deepEqual(manifest.gate_results_summary, { hard1: true, hard2: true, hard3: true });
 
     const summary = readFileSync(summaryPath, 'utf-8');
@@ -1157,6 +1160,7 @@ release_cuts: []
   });
 
   it('1.6c-ii: release-finalize advances lifecycle (appends completed_cut_ids, clears current, routes to phase3-gate) AFTER write succeeds', () => {
+    initGitFixture(tmpDir);
     mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
     writeGoalContractWithMvp(tmpDir);
     writeDecompositionWithMvp(tmpDir);
@@ -1181,6 +1185,7 @@ release_cuts: []
   });
 
   it('1.6c-ii: release-finalize MUST NOT set finalize_done or transition to completed (RFC §5.5)', () => {
+    initGitFixture(tmpDir);
     mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
     writeGoalContractWithMvp(tmpDir);
     writeDecompositionWithMvp(tmpDir);
@@ -1415,6 +1420,7 @@ mvp_scope:
   it('1.6c-ii (PR #187 claude review): release artifacts written with 0o644 mode (consumer-friendly)', () => {
     // Skip on Windows where POSIX file modes do not apply.
     if (process.platform === 'win32') return;
+    initGitFixture(tmpDir);
     mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
     writeGoalContractWithMvp(tmpDir);
     writeDecompositionWithMvp(tmpDir);
@@ -1439,7 +1445,10 @@ mvp_scope:
     // PR #185 idempotency: re-entering release-finalize with a cohort
     // already in completed_cut_ids did not double-append. 1.6c-ii adds
     // a file write — re-entry should overwrite the manifest cleanly
-    // (no append, no stale read).
+    // (no append, no stale read). 1.6c-iii requires a git fixture so
+    // snapshot ref creation succeeds (otherwise the bail path fires
+    // before the file write).
+    initGitFixture(tmpDir);
     mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
     writeGoalContractWithMvp(tmpDir);
     writeDecompositionWithMvp(tmpDir);
@@ -1511,10 +1520,12 @@ mvp_scope:
     assert.equal(refTarget, manifest.commit_sha);
   });
 
-  it('1.6c-iii: release-finalize records artifact_creation_failed when not in a git repo (snapshot ref fails)', () => {
-    // No `git init` — every git call fails. Manifest still written (with
-    // null snapshot fields + artifact_creation_failed.type='snapshot_ref')
-    // and lifecycle still advances per RFC §5.4 best-effort post-step.
+  it('1.6c-iii (PR #188 codex review High): release-finalize bails when snapshot ref creation fails — no manifest written, no append', () => {
+    // RFC §5.4 §232: append completed_cut_ids only when gate PASS +
+    // manifest write + snapshot ref creation ALL succeed. The snapshot
+    // ref is the immutability anchor — without it, the manifest pins
+    // nothing. Pre-fix the handler ignored snapshot failure and
+    // advanced the lifecycle with null commit_sha/tree_sha/snapshot_ref.
     mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
     writeGoalContractWithMvp(tmpDir);
     writeDecompositionWithMvp(tmpDir);
@@ -1528,17 +1539,15 @@ mvp_scope:
         },
       },
     });
-    const manifest = readManifest(tmpDir);
-    assert.equal(manifest.commit_sha, null);
-    assert.equal(manifest.tree_sha, null);
-    assert.equal(manifest.snapshot_ref, null);
-    assert.equal(manifest.artifact_creation_failed.type, 'snapshot_ref');
-    assert.ok(manifest.artifact_creation_failed.reason);
-    // Lifecycle still advances.
+    // No advancement.
     const state = readState();
-    assert.strictEqual(state.current_phase, 'phase3-gate');
-    assert.deepStrictEqual(state.release.completed_cut_ids, ['mvp']);
-    assert.match(out.stopReason, /snapshot ref FAILED/);
+    assert.strictEqual(state.current_phase, 'release-finalize');
+    assert.strictEqual(state.release.current_cut_id, 'mvp');
+    assert.deepStrictEqual(state.release.completed_cut_ids, []);
+    assert.match(out.stopReason, /snapshot ref creation failed/);
+    assert.match(out.stopReason, /Cohort NOT appended to completed_cut_ids per RFC/);
+    // No manifest file written (bail happens before file write).
+    assert.equal(existsSync(join(tmpDir, '.mpl', 'mpl', 'releases', 'mvp', 'release-manifest.json')), false);
   });
 
   it('1.6c-iii: release-finalize records artifact_creation_failed.tag when no remote (artifact best-effort)', () => {
@@ -1667,6 +1676,82 @@ mvp_scope:
     assert.throws(() => execFileSync('git', ['rev-parse', 'refs/tags/mpl-release-mvp'],
       { cwd: tmpDir, encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] }));
     assert.match(out.stopReason, /artifact=release_manifest \(no external push\)/);
+  });
+
+  it('1.6c-iii (PR #188 claude #1): release-finalize re-run with artifact=tag does NOT surface spurious "tag already exists"', () => {
+    initGitFixture(tmpDir);
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    writeFileSync(join(tmpDir, '.mpl', 'goal-contract.yaml'), `
+source:
+  runtime_goal: "x"
+  user_request_hash: "abc"
+mission:
+  goal: "g"
+  project_pivot: "pp"
+  must_ship_outcomes:
+    - "ship"
+ontology:
+  entities:
+    - foo
+variation_axes:
+  - id: AX-1
+    name: ax
+acceptance_criteria:
+  - id: AC-1
+    statement: "ac"
+e2e_policy:
+  real_runtime_required: true
+  mock_allowed: false
+  placeholder_assertions_allowed: false
+security_policy:
+  required: false
+completion_evidence:
+  required_artifacts:
+    - .mpl/mpl/audit-report.json
+  require_commit: false
+  require_finalize_timestamps: true
+mvp_scope:
+  acceptance_criteria: [AC-1]
+  variation_axes: [AX-1]
+  artifact: tag
+`);
+    writeDecompositionWithMvp(tmpDir, { artifact: 'tag' });
+    // First run: local tag created, push fails (no remote), advances lifecycle.
+    runStopHook(tmpDir, {
+      current_phase: 'release-finalize',
+      release: {
+        current_cut_id: 'mvp', completed_cut_ids: [], fix_loop_count: 0,
+        pending_artifact: null, max_fix_loops: 3,
+        gate_results: {
+          hard1_baseline: { exit_code: 0 }, hard2_coverage: { exit_code: 0 }, hard3_resilience: { exit_code: 0 },
+        },
+      },
+    });
+    // Second run on the same cohort (e.g., recompose loop re-entry).
+    const out = runStopHook(tmpDir, {
+      current_phase: 'release-finalize',
+      release: {
+        current_cut_id: 'mvp', completed_cut_ids: ['mvp'], fix_loop_count: 0,
+        pending_artifact: null, max_fix_loops: 3,
+        gate_results: {
+          hard1_baseline: { exit_code: 0 }, hard2_coverage: { exit_code: 0 }, hard3_resilience: { exit_code: 0 },
+        },
+      },
+    });
+    // The re-run must NOT surface "tag already exists" — that was the
+    // spurious failure mode pre-fix. The push still soft-fails (no
+    // remote), but the reason now describes the idempotent "exists
+    // locally at same commit" path.
+    assert.doesNotMatch(out.stopReason, /tag already exists/i);
+    const manifest = readManifest(tmpDir);
+    if (manifest.artifact_creation_failed) {
+      assert.equal(manifest.artifact_creation_failed.type, 'tag');
+      assert.match(
+        manifest.artifact_creation_failed.reason,
+        /exists locally at same commit/,
+        `expected idempotent "exists locally" surface, got: ${manifest.artifact_creation_failed.reason}`,
+      );
+    }
   });
 
   it('1.6c-iii: atomic write leaves no .tmp residue on success', () => {

--- a/hooks/__tests__/mpl-release-artifact.test.mjs
+++ b/hooks/__tests__/mpl-release-artifact.test.mjs
@@ -1,0 +1,244 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, chmodSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+import {
+  createSnapshotRef,
+  createArtifactTag,
+  createArtifactBranch,
+  createArtifactDraftPr,
+  attemptArtifactCreation,
+} from '../lib/mpl-release-artifact.mjs';
+
+function git(cwd, args) {
+  return execFileSync('git', args, { cwd, encoding: 'utf-8' });
+}
+
+function initGitRepo(dir) {
+  git(dir, ['init', '--initial-branch=main']);
+  // Local identity so commits work without global config in CI.
+  git(dir, ['config', 'user.email', 'test@example.com']);
+  git(dir, ['config', 'user.name', 'Test']);
+  // Disable GPG signing so tests do not depend on the developer's local
+  // commit.gpgsign / tag.gpgSign / user.signingkey settings (#176 pattern).
+  git(dir, ['config', 'commit.gpgsign', 'false']);
+  git(dir, ['config', 'tag.gpgSign', 'false']);
+  writeFileSync(join(dir, 'README.md'), '# fixture\n');
+  git(dir, ['add', 'README.md']);
+  git(dir, ['commit', '-m', 'initial']);
+}
+
+describe('createSnapshotRef', () => {
+  let tmpDir;
+  beforeEach(() => { tmpDir = mkdtempSync(join(tmpdir(), 'mpl-art-snap-')); });
+  afterEach(() => { rmSync(tmpDir, { recursive: true, force: true }); });
+
+  it('captures commit_sha + tree_sha and creates refs/mpl/releases/{cutId}', () => {
+    initGitRepo(tmpDir);
+    const r = createSnapshotRef(tmpDir, 'mvp');
+    assert.equal(r.ok, true);
+    assert.match(r.commit_sha, /^[0-9a-f]{40}$/);
+    assert.match(r.tree_sha, /^[0-9a-f]{40}$/);
+    assert.equal(r.snapshot_ref, 'refs/mpl/releases/mvp');
+    // Verify the ref actually exists in the repo.
+    const refTarget = git(tmpDir, ['rev-parse', r.snapshot_ref]).trim();
+    assert.equal(refTarget, r.commit_sha);
+  });
+
+  it('is idempotent — re-running on the same HEAD overwrites the ref to the same commit', () => {
+    initGitRepo(tmpDir);
+    const first = createSnapshotRef(tmpDir, 'mvp');
+    const second = createSnapshotRef(tmpDir, 'mvp');
+    assert.equal(second.ok, true);
+    assert.equal(second.commit_sha, first.commit_sha);
+  });
+
+  it('re-points the ref when HEAD advances (release-finalize re-entry after new cohort commits)', () => {
+    initGitRepo(tmpDir);
+    const first = createSnapshotRef(tmpDir, 'mvp');
+    writeFileSync(join(tmpDir, 'extra.md'), '# extra\n');
+    git(tmpDir, ['add', 'extra.md']);
+    git(tmpDir, ['commit', '-m', 'second']);
+    const second = createSnapshotRef(tmpDir, 'mvp');
+    assert.equal(second.ok, true);
+    assert.notEqual(second.commit_sha, first.commit_sha);
+    assert.equal(git(tmpDir, ['rev-parse', second.snapshot_ref]).trim(), second.commit_sha);
+  });
+
+  it('returns ok:false with a reason when cwd is not a git repo', () => {
+    // Fresh tmpDir without git init — every git call will fail.
+    const r = createSnapshotRef(tmpDir, 'mvp');
+    assert.equal(r.ok, false);
+    assert.ok(typeof r.reason === 'string' && r.reason.length > 0);
+  });
+
+  it('returns ok:false when cutId is empty / non-string', () => {
+    initGitRepo(tmpDir);
+    assert.equal(createSnapshotRef(tmpDir, '').ok, false);
+    assert.equal(createSnapshotRef(tmpDir, null).ok, false);
+    assert.equal(createSnapshotRef(tmpDir, undefined).ok, false);
+  });
+});
+
+describe('createArtifactTag', () => {
+  let tmpDir;
+  beforeEach(() => { tmpDir = mkdtempSync(join(tmpdir(), 'mpl-art-tag-')); });
+  afterEach(() => { rmSync(tmpDir, { recursive: true, force: true }); });
+
+  it('creates the local tag but reports ok:false when no origin remote (soft-fail)', () => {
+    initGitRepo(tmpDir);
+    const sha = git(tmpDir, ['rev-parse', 'HEAD']).trim();
+    const r = createArtifactTag(tmpDir, 'mvp', sha);
+    // RFC §5.4: tag creation depends on external tools (remote permissions);
+    // soft-fail when no remote so the user knows the tag exists locally.
+    assert.equal(r.ok, false);
+    assert.match(r.reason, /push failed.*no .?origin.? remote configured/);
+    assert.equal(r.tag, 'mpl-release-mvp');
+    // Local tag exists.
+    const localRef = git(tmpDir, ['rev-parse', 'refs/tags/mpl-release-mvp']).trim();
+    assert.equal(localRef, sha);
+  });
+
+  it('rejects malformed commitSha', () => {
+    initGitRepo(tmpDir);
+    assert.equal(createArtifactTag(tmpDir, 'mvp', 'not-a-sha').ok, false);
+    assert.equal(createArtifactTag(tmpDir, 'mvp', '').ok, false);
+  });
+});
+
+describe('createArtifactBranch', () => {
+  let tmpDir;
+  beforeEach(() => { tmpDir = mkdtempSync(join(tmpdir(), 'mpl-art-branch-')); });
+  afterEach(() => { rmSync(tmpDir, { recursive: true, force: true }); });
+
+  it('creates the local branch but reports ok:false when no origin remote (soft-fail)', () => {
+    initGitRepo(tmpDir);
+    const sha = git(tmpDir, ['rev-parse', 'HEAD']).trim();
+    const r = createArtifactBranch(tmpDir, 'mvp', sha);
+    assert.equal(r.ok, false);
+    assert.match(r.reason, /push failed/);
+    assert.equal(r.branch, 'mpl/release/mvp');
+    // Local branch exists at the snapshot commit.
+    const localRef = git(tmpDir, ['rev-parse', 'refs/heads/mpl/release/mvp']).trim();
+    assert.equal(localRef, sha);
+  });
+});
+
+describe('attemptArtifactCreation dispatch', () => {
+  let tmpDir;
+  beforeEach(() => { tmpDir = mkdtempSync(join(tmpdir(), 'mpl-art-dispatch-')); });
+  afterEach(() => { rmSync(tmpDir, { recursive: true, force: true }); });
+
+  it('returns no-op result for release_manifest artifact (snapshot+manifest only)', () => {
+    initGitRepo(tmpDir);
+    const sha = git(tmpDir, ['rev-parse', 'HEAD']).trim();
+    const r = attemptArtifactCreation({
+      cwd: tmpDir, cutId: 'mvp',
+      artifact: 'release_manifest',
+      commitSha: sha, snapshotRef: 'refs/mpl/releases/mvp',
+    });
+    assert.equal(r.result, null);
+    assert.equal(r.artifact_creation_failed, null);
+  });
+
+  it('returns no-op for null/undefined artifact', () => {
+    const r = attemptArtifactCreation({
+      cwd: tmpDir, cutId: 'mvp', artifact: null,
+      commitSha: '0'.repeat(40), snapshotRef: 'refs/mpl/releases/mvp',
+    });
+    assert.equal(r.artifact_creation_failed, null);
+  });
+
+  it('records artifact_creation_failed when tag push has no remote (soft-fail surfaced to manifest)', () => {
+    initGitRepo(tmpDir);
+    const sha = git(tmpDir, ['rev-parse', 'HEAD']).trim();
+    const r = attemptArtifactCreation({
+      cwd: tmpDir, cutId: 'mvp',
+      artifact: 'tag',
+      commitSha: sha, snapshotRef: 'refs/mpl/releases/mvp',
+    });
+    assert.equal(r.artifact_creation_failed.type, 'tag');
+    assert.match(r.artifact_creation_failed.reason, /push failed/);
+  });
+
+  it('records artifact_creation_failed when branch push has no remote', () => {
+    initGitRepo(tmpDir);
+    const sha = git(tmpDir, ['rev-parse', 'HEAD']).trim();
+    const r = attemptArtifactCreation({
+      cwd: tmpDir, cutId: 'mvp',
+      artifact: 'branch',
+      commitSha: sha, snapshotRef: 'refs/mpl/releases/mvp',
+    });
+    assert.equal(r.artifact_creation_failed.type, 'branch');
+  });
+
+  it('records artifact_creation_failed when draft_pr branch prerequisite fails', () => {
+    initGitRepo(tmpDir);
+    const sha = git(tmpDir, ['rev-parse', 'HEAD']).trim();
+    const r = attemptArtifactCreation({
+      cwd: tmpDir, cutId: 'mvp',
+      artifact: 'draft_pr',
+      commitSha: sha, snapshotRef: 'refs/mpl/releases/mvp',
+    });
+    // No remote → branch push fails → draft_pr surface mentions the
+    // branch prerequisite so the user knows the chain entry point.
+    assert.equal(r.artifact_creation_failed.type, 'draft_pr');
+    assert.match(r.artifact_creation_failed.reason, /branch prerequisite failed/);
+  });
+
+  it('rejects unsupported artifact type', () => {
+    const r = attemptArtifactCreation({
+      cwd: tmpDir, cutId: 'mvp',
+      artifact: 'rocket',
+      commitSha: '0'.repeat(40), snapshotRef: 'refs/mpl/releases/mvp',
+    });
+    assert.equal(r.artifact_creation_failed.type, 'rocket');
+    assert.match(r.artifact_creation_failed.reason, /unsupported artifact type/);
+  });
+});
+
+describe('createArtifactDraftPr soft-fail when gh CLI is unavailable', () => {
+  let tmpDir;
+  let pathBackup;
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'mpl-art-pr-'));
+    pathBackup = process.env.PATH;
+  });
+  afterEach(() => {
+    process.env.PATH = pathBackup;
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns ok:false with reason when `gh` is not on PATH (no throw)', () => {
+    // Override PATH to a single empty dir so gh cannot be found.
+    const isolated = mkdtempSync(join(tmpdir(), 'mpl-art-pr-path-'));
+    try {
+      process.env.PATH = isolated;
+      const r = createArtifactDraftPr(tmpDir, 'mvp', 'mpl/release/mvp', 'refs/mpl/releases/mvp');
+      assert.equal(r.ok, false);
+      assert.match(r.reason, /gh pr create failed/);
+    } finally {
+      rmSync(isolated, { recursive: true, force: true });
+    }
+  });
+
+  it('uses an injected `gh` stub on PATH and surfaces the PR URL on success', () => {
+    // Inject a `gh` shim that prints a canned URL and exits 0.
+    const stubDir = mkdtempSync(join(tmpdir(), 'mpl-art-pr-stub-'));
+    try {
+      const ghPath = join(stubDir, 'gh');
+      writeFileSync(ghPath, '#!/bin/sh\necho "https://github.com/example/repo/pull/42"\n');
+      chmodSync(ghPath, 0o755);
+      process.env.PATH = `${stubDir}:${pathBackup}`;
+      const r = createArtifactDraftPr(tmpDir, 'mvp', 'mpl/release/mvp', 'refs/mpl/releases/mvp');
+      assert.equal(r.ok, true);
+      assert.equal(r.pr_url, 'https://github.com/example/repo/pull/42');
+      assert.equal(r.branch, 'mpl/release/mvp');
+    } finally {
+      rmSync(stubDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/hooks/__tests__/mpl-release-artifact.test.mjs
+++ b/hooks/__tests__/mpl-release-artifact.test.mjs
@@ -81,6 +81,34 @@ describe('createSnapshotRef', () => {
     assert.equal(createSnapshotRef(tmpDir, null).ok, false);
     assert.equal(createSnapshotRef(tmpDir, undefined).ok, false);
   });
+
+  // PR #188 claude review #3: snapshot ref push surface.
+  it('surfaces pushed:false + push_reason when no `origin` remote is configured', () => {
+    initGitRepo(tmpDir);
+    const r = createSnapshotRef(tmpDir, 'mvp');
+    assert.equal(r.ok, true);
+    assert.equal(r.pushed, false);
+    assert.match(r.push_reason, /no .?origin.? remote configured/);
+  });
+
+  it('surfaces pushed:true when origin (bare remote) is configured', () => {
+    initGitRepo(tmpDir);
+    // Wire a bare remote so the push succeeds.
+    const remoteDir = mkdtempSync(join(tmpdir(), 'mpl-art-bare-'));
+    try {
+      git(remoteDir, ['init', '--bare']);
+      git(tmpDir, ['remote', 'add', 'origin', remoteDir]);
+      const r = createSnapshotRef(tmpDir, 'mvp');
+      assert.equal(r.ok, true);
+      assert.equal(r.pushed, true);
+      assert.equal(r.push_reason, null);
+      // Remote actually carries the ref.
+      const remoteSha = git(remoteDir, ['rev-parse', 'refs/mpl/releases/mvp']).trim();
+      assert.equal(remoteSha, r.commit_sha);
+    } finally {
+      rmSync(remoteDir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('createArtifactTag', () => {
@@ -107,6 +135,57 @@ describe('createArtifactTag', () => {
     assert.equal(createArtifactTag(tmpDir, 'mvp', 'not-a-sha').ok, false);
     assert.equal(createArtifactTag(tmpDir, 'mvp', '').ok, false);
   });
+
+  // PR #188 claude review #1: idempotent re-creation.
+  it('idempotent re-run with same commit reports noop:true (no spurious "tag already exists")', () => {
+    initGitRepo(tmpDir);
+    const sha = git(tmpDir, ['rev-parse', 'HEAD']).trim();
+    const first = createArtifactTag(tmpDir, 'mvp', sha);
+    // First run still soft-fails on push (no remote) — that's expected.
+    assert.equal(first.ok, false);
+    assert.equal(first.tag, 'mpl-release-mvp');
+    // Second run: existing-at-same-sha → noop:true (no git tag invocation).
+    const second = createArtifactTag(tmpDir, 'mvp', sha);
+    assert.equal(second.noop, true);
+    assert.equal(second.tag, 'mpl-release-mvp');
+    assert.doesNotMatch(second.reason || '', /already exists/i,
+      'must NOT surface "tag already exists" — that was the pre-fix spurious failure');
+  });
+
+  it('refuses to overwrite an existing tag pointing at a different commit (release immutability)', () => {
+    initGitRepo(tmpDir);
+    const originalSha = git(tmpDir, ['rev-parse', 'HEAD']).trim();
+    createArtifactTag(tmpDir, 'mvp', originalSha);  // creates local tag
+    // Make a new commit so the next snapshot would point at a different SHA.
+    writeFileSync(join(tmpDir, 'second.md'), '# second\n');
+    git(tmpDir, ['add', 'second.md']);
+    git(tmpDir, ['commit', '-m', 'second']);
+    const newSha = git(tmpDir, ['rev-parse', 'HEAD']).trim();
+    assert.notEqual(newSha, originalSha);
+    const r = createArtifactTag(tmpDir, 'mvp', newSha);
+    assert.equal(r.ok, false);
+    assert.match(r.reason, /already exists at different commit/);
+    assert.match(r.reason, /refusing to overwrite/);
+  });
+
+  it('idempotent re-run succeeds (ok:true, noop:true) when origin remote is set up', () => {
+    initGitRepo(tmpDir);
+    const remoteDir = mkdtempSync(join(tmpdir(), 'mpl-art-bare-tag-'));
+    try {
+      git(remoteDir, ['init', '--bare']);
+      git(tmpDir, ['remote', 'add', 'origin', remoteDir]);
+      const sha = git(tmpDir, ['rev-parse', 'HEAD']).trim();
+      const first = createArtifactTag(tmpDir, 'mvp', sha);
+      assert.equal(first.ok, true);
+      assert.equal(first.pushed, true);
+      const second = createArtifactTag(tmpDir, 'mvp', sha);
+      assert.equal(second.ok, true);
+      assert.equal(second.noop, true);
+      assert.equal(second.pushed, true);
+    } finally {
+      rmSync(remoteDir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('createArtifactBranch', () => {
@@ -124,6 +203,30 @@ describe('createArtifactBranch', () => {
     // Local branch exists at the snapshot commit.
     const localRef = git(tmpDir, ['rev-parse', 'refs/heads/mpl/release/mvp']).trim();
     assert.equal(localRef, sha);
+  });
+
+  // PR #188 claude review #1: idempotent re-creation, symmetric with tag.
+  it('idempotent re-run with same commit reports noop:true', () => {
+    initGitRepo(tmpDir);
+    const sha = git(tmpDir, ['rev-parse', 'HEAD']).trim();
+    createArtifactBranch(tmpDir, 'mvp', sha);
+    const second = createArtifactBranch(tmpDir, 'mvp', sha);
+    assert.equal(second.noop, true);
+    assert.equal(second.branch, 'mpl/release/mvp');
+    assert.doesNotMatch(second.reason || '', /already exists/i);
+  });
+
+  it('refuses to overwrite an existing branch pointing at a different commit', () => {
+    initGitRepo(tmpDir);
+    const originalSha = git(tmpDir, ['rev-parse', 'HEAD']).trim();
+    createArtifactBranch(tmpDir, 'mvp', originalSha);
+    writeFileSync(join(tmpDir, 'second.md'), '# second\n');
+    git(tmpDir, ['add', 'second.md']);
+    git(tmpDir, ['commit', '-m', 'second']);
+    const newSha = git(tmpDir, ['rev-parse', 'HEAD']).trim();
+    const r = createArtifactBranch(tmpDir, 'mvp', newSha);
+    assert.equal(r.ok, false);
+    assert.match(r.reason, /already exists at different commit/);
   });
 });
 
@@ -197,6 +300,34 @@ describe('attemptArtifactCreation dispatch', () => {
     });
     assert.equal(r.artifact_creation_failed.type, 'rocket');
     assert.match(r.artifact_creation_failed.reason, /unsupported artifact type/);
+  });
+
+  // PR #188 claude review #1: draft_pr idempotency on re-run skips `gh pr create`
+  // so it cannot fail with "a pull request already exists".
+  it('draft_pr re-run with branch noop skips gh pr create (no spurious "already exists")', () => {
+    initGitRepo(tmpDir);
+    const remoteDir = mkdtempSync(join(tmpdir(), 'mpl-art-bare-pr-'));
+    try {
+      git(remoteDir, ['init', '--bare']);
+      git(tmpDir, ['remote', 'add', 'origin', remoteDir]);
+      const sha = git(tmpDir, ['rev-parse', 'HEAD']).trim();
+      // First attempt: create the branch via the helper. (Skip the actual
+      // PR creation by short-circuiting — we just need the local branch
+      // present so the second run's branch step is a noop.)
+      createArtifactBranch(tmpDir, 'mvp', sha);
+      // Second attempt via attemptArtifactCreation. Branch step is noop;
+      // attemptArtifactCreation should skip the gh pr create call.
+      const second = attemptArtifactCreation({
+        cwd: tmpDir, cutId: 'mvp', artifact: 'draft_pr',
+        commitSha: sha, snapshotRef: 'refs/mpl/releases/mvp',
+      });
+      assert.equal(second.artifact_creation_failed, null,
+        're-run with noop branch must not surface a draft_pr failure');
+      assert.equal(second.result.noop, true);
+      assert.match(second.result.pr_skipped, /branch noop/);
+    } finally {
+      rmSync(remoteDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/hooks/__tests__/mpl-release-artifact.test.mjs
+++ b/hooks/__tests__/mpl-release-artifact.test.mjs
@@ -1,7 +1,7 @@
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync, chmodSync } from 'fs';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, chmodSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 
@@ -302,30 +302,108 @@ describe('attemptArtifactCreation dispatch', () => {
     assert.match(r.artifact_creation_failed.reason, /unsupported artifact type/);
   });
 
-  // PR #188 claude review #1: draft_pr idempotency on re-run skips `gh pr create`
-  // so it cannot fail with "a pull request already exists".
-  it('draft_pr re-run with branch noop skips gh pr create (no spurious "already exists")', () => {
+  // PR #188 claude review #1 + codex round-2: draft_pr idempotency must
+  // VERIFY the PR exists (via gh pr list) before skipping creation. A
+  // branch noop alone is not evidence the PR was actually created.
+  it('draft_pr re-run with existing open PR (verified via gh pr list) reports noop', () => {
     initGitRepo(tmpDir);
     const remoteDir = mkdtempSync(join(tmpdir(), 'mpl-art-bare-pr-'));
+    const stubDir = mkdtempSync(join(tmpdir(), 'mpl-art-pr-stub-noop-'));
+    const pathBackup = process.env.PATH;
     try {
       git(remoteDir, ['init', '--bare']);
       git(tmpDir, ['remote', 'add', 'origin', remoteDir]);
       const sha = git(tmpDir, ['rev-parse', 'HEAD']).trim();
-      // First attempt: create the branch via the helper. (Skip the actual
-      // PR creation by short-circuiting — we just need the local branch
-      // present so the second run's branch step is a noop.)
+      // Fake gh: `gh pr list` returns a canned PR URL; `gh pr create`
+      // would fail if invoked (which it shouldn't be on this path).
+      const ghPath = join(stubDir, 'gh');
+      writeFileSync(ghPath,
+        '#!/bin/sh\n' +
+        'if [ "$1" = "pr" ] && [ "$2" = "list" ]; then\n' +
+        '  echo "https://github.com/example/repo/pull/99"\n' +
+        '  exit 0\n' +
+        'fi\n' +
+        'echo "stub should not run gh pr create on noop path" >&2\n' +
+        'exit 99\n'
+      );
+      chmodSync(ghPath, 0o755);
+      process.env.PATH = `${stubDir}:${pathBackup}`;
+
+      // Seed the local branch so the branch step is a noop.
       createArtifactBranch(tmpDir, 'mvp', sha);
-      // Second attempt via attemptArtifactCreation. Branch step is noop;
-      // attemptArtifactCreation should skip the gh pr create call.
-      const second = attemptArtifactCreation({
+
+      const r = attemptArtifactCreation({
         cwd: tmpDir, cutId: 'mvp', artifact: 'draft_pr',
         commitSha: sha, snapshotRef: 'refs/mpl/releases/mvp',
       });
-      assert.equal(second.artifact_creation_failed, null,
-        're-run with noop branch must not surface a draft_pr failure');
-      assert.equal(second.result.noop, true);
-      assert.match(second.result.pr_skipped, /branch noop/);
+      assert.equal(r.artifact_creation_failed, null,
+        'gh pr list confirmed existing PR; no failure should surface');
+      assert.equal(r.result.noop, true);
+      assert.equal(r.result.pr_url, 'https://github.com/example/repo/pull/99');
+      assert.match(r.result.pr_skipped, /existing open PR found via gh pr list/);
     } finally {
+      process.env.PATH = pathBackup;
+      rmSync(stubDir, { recursive: true, force: true });
+      rmSync(remoteDir, { recursive: true, force: true });
+    }
+  });
+
+  it('draft_pr re-run after prior gh-create failure actually re-invokes gh pr create (codex round-2 regression)', () => {
+    // Codex round-2 reproducer: first run pushed branch but failed at
+    // `gh pr create` (gh missing / auth / API). Second run must NOT
+    // assume the PR exists from the branch noop — it must verify via
+    // gh pr list (returns empty) and then actually call gh pr create.
+    // This test simulates the SECOND run only — we just need to prove
+    // that on a branch-noop + gh-pr-list-returns-empty path, gh pr
+    // create IS invoked.
+    initGitRepo(tmpDir);
+    const remoteDir = mkdtempSync(join(tmpdir(), 'mpl-art-bare-pr-codex-'));
+    const stubDir = mkdtempSync(join(tmpdir(), 'mpl-art-pr-stub-codex-'));
+    const callLog = join(stubDir, 'call.log');
+    const pathBackup = process.env.PATH;
+    try {
+      git(remoteDir, ['init', '--bare']);
+      git(tmpDir, ['remote', 'add', 'origin', remoteDir]);
+      const sha = git(tmpDir, ['rev-parse', 'HEAD']).trim();
+
+      // Fake gh: `gh pr list` returns empty (no existing PR), `gh pr
+      // create` returns a fresh URL + logs the call so we can prove it
+      // actually ran.
+      const ghPath = join(stubDir, 'gh');
+      writeFileSync(ghPath,
+        '#!/bin/sh\n' +
+        `echo "$@" >> ${callLog}\n` +
+        'if [ "$1" = "pr" ] && [ "$2" = "list" ]; then\n' +
+        '  exit 0\n' +
+        'fi\n' +
+        'if [ "$1" = "pr" ] && [ "$2" = "create" ]; then\n' +
+        '  echo "https://github.com/example/repo/pull/200"\n' +
+        '  exit 0\n' +
+        'fi\n' +
+        'exit 1\n'
+      );
+      chmodSync(ghPath, 0o755);
+      process.env.PATH = `${stubDir}:${pathBackup}`;
+
+      // Seed the local branch (representing the prior run's successful
+      // branch push); PR was never created in that prior run.
+      createArtifactBranch(tmpDir, 'mvp', sha);
+
+      const r = attemptArtifactCreation({
+        cwd: tmpDir, cutId: 'mvp', artifact: 'draft_pr',
+        commitSha: sha, snapshotRef: 'refs/mpl/releases/mvp',
+      });
+      // PR creation should succeed on this re-run.
+      assert.equal(r.artifact_creation_failed, null);
+      assert.equal(r.result.pr_url, 'https://github.com/example/repo/pull/200');
+      // Critical check: gh pr create WAS actually invoked. The pre-fix
+      // would have short-circuited on branch noop and never called gh,
+      // leaving the false-positive idempotent success.
+      const log = readFileSync(callLog, 'utf-8');
+      assert.match(log, /pr create/, 'gh pr create must have actually run');
+    } finally {
+      process.env.PATH = pathBackup;
+      rmSync(stubDir, { recursive: true, force: true });
       rmSync(remoteDir, { recursive: true, force: true });
     }
   });

--- a/hooks/lib/mpl-release-artifact.mjs
+++ b/hooks/lib/mpl-release-artifact.mjs
@@ -42,9 +42,27 @@ import { execFileSync } from 'child_process';
  * fine because release-finalize re-entry should re-pin the snapshot to
  * the latest cohort tip.
  *
+ * **HEAD-drift caveat (PR #188 claude review #4)**: the caller is
+ * responsible for ensuring HEAD is at the cohort's terminal commit when
+ * this helper is invoked. Stage A's release-gate → release-finalize is
+ * a tight loop in the normal flow, but if the user makes unrelated
+ * commits between release-gate PASS and release-finalize firing the
+ * snapshot pins those instead of the cohort tip. Stage B will likely
+ * need an explicit "release-finalize must run on the cohort tip"
+ * invariant; until then this is a contract on the caller.
+ *
+ * **Push (PR #188 claude review #3)**: after local ref creation succeeds,
+ * the helper best-effort pushes `snapshot_ref` to `origin` so downstream
+ * consumers (CI, mpl-status, fresh clones) can verify the manifest's
+ * `commit_sha` against the canonical remote pin. Push failure is
+ * non-fatal — the local ref remains the canonical record. The result
+ * object's `pushed` boolean + `push_reason` (set when push fails)
+ * surface this to the caller; lifecycle decisions do NOT depend on
+ * push success.
+ *
  * @param {string} cwd
  * @param {string} cutId
- * @returns {{ok: true, commit_sha: string, tree_sha: string, snapshot_ref: string} | {ok: false, reason: string}}
+ * @returns {{ok: true, commit_sha: string, tree_sha: string, snapshot_ref: string, pushed: boolean, push_reason: string|null} | {ok: false, reason: string}}
  */
 export function createSnapshotRef(cwd, cutId) {
   if (typeof cutId !== 'string' || !cutId) {
@@ -61,9 +79,33 @@ export function createSnapshotRef(cwd, cutId) {
       return { ok: false, reason: `git rev-parse HEAD^{tree} returned unexpected output: ${tree_sha.slice(0, 80)}` };
     }
     git(cwd, ['update-ref', snapshot_ref, commit_sha]);
-    return { ok: true, commit_sha, tree_sha, snapshot_ref };
+    const pushResult = tryPushRef(cwd, snapshot_ref);
+    return {
+      ok: true,
+      commit_sha,
+      tree_sha,
+      snapshot_ref,
+      pushed: pushResult.pushed,
+      push_reason: pushResult.ok ? null : pushResult.reason,
+    };
   } catch (err) {
     return { ok: false, reason: stringifyError(err) };
+  }
+}
+
+/**
+ * Look up the commit a ref currently points at, or `null` if absent /
+ * unreadable. Used by tag/branch creators to make the operation
+ * idempotent (PR #188 claude review #1): if the ref already exists at
+ * the requested commit, treat as no-op rather than failing with "tag
+ * already exists".
+ */
+function refExists(cwd, ref) {
+  try {
+    const sha = git(cwd, ['rev-parse', '--verify', ref]).trim();
+    return /^[0-9a-f]{40}$/.test(sha) ? sha : null;
+  } catch {
+    return null;
   }
 }
 
@@ -84,12 +126,34 @@ export function createArtifactTag(cwd, cutId, commitSha) {
     return { ok: false, reason: 'commitSha must be a 40-char hex string' };
   }
   const tag = `mpl-release-${cutId}`;
+  const tagRef = `refs/tags/${tag}`;
+  // Idempotent re-creation (PR #188 claude review #1): if the tag already
+  // exists at the same commit, treat the local step as a no-op and still
+  // attempt push (a push of an already-pushed ref is also a no-op). If it
+  // exists at a DIFFERENT commit, refuse — overwriting a shipped tag
+  // would silently change an external claim (the whole point of §5.4.1
+  // immutability).
+  const existing = refExists(cwd, tagRef);
+  if (existing === commitSha) {
+    const pushResult = tryPushRef(cwd, tagRef);
+    if (!pushResult.ok) {
+      return { ok: false, reason: `tag exists locally at same commit but push failed: ${pushResult.reason}`, tag, noop: true };
+    }
+    return { ok: true, tag, pushed: pushResult.pushed, noop: true };
+  }
+  if (existing && existing !== commitSha) {
+    return {
+      ok: false,
+      reason: `tag ${tag} already exists at different commit ${existing.slice(0, 12)} — refusing to overwrite a shipped release tag. Delete the stale tag (git tag -d ${tag}) and retry if intentional.`,
+      tag,
+    };
+  }
   try {
     git(cwd, ['tag', tag, commitSha]);
   } catch (err) {
     return { ok: false, reason: `git tag failed: ${stringifyError(err)}`, tag };
   }
-  const pushResult = tryPushRef(cwd, `refs/tags/${tag}`);
+  const pushResult = tryPushRef(cwd, tagRef);
   if (!pushResult.ok) {
     return { ok: false, reason: `tag created locally but push failed: ${pushResult.reason}`, tag };
   }
@@ -110,12 +174,30 @@ export function createArtifactBranch(cwd, cutId, commitSha) {
     return { ok: false, reason: 'commitSha must be a 40-char hex string' };
   }
   const branch = `mpl/release/${cutId}`;
+  const branchRef = `refs/heads/${branch}`;
+  // Same idempotency semantics as createArtifactTag (PR #188 claude #1):
+  // existing-at-same-sha = noop, existing-at-different-sha = refuse.
+  const existing = refExists(cwd, branchRef);
+  if (existing === commitSha) {
+    const pushResult = tryPushRef(cwd, branchRef);
+    if (!pushResult.ok) {
+      return { ok: false, reason: `branch exists locally at same commit but push failed: ${pushResult.reason}`, branch, noop: true };
+    }
+    return { ok: true, branch, pushed: pushResult.pushed, noop: true };
+  }
+  if (existing && existing !== commitSha) {
+    return {
+      ok: false,
+      reason: `branch ${branch} already exists at different commit ${existing.slice(0, 12)} — refusing to overwrite. Delete the stale branch (git branch -D ${branch}) and retry if intentional.`,
+      branch,
+    };
+  }
   try {
     git(cwd, ['branch', branch, commitSha]);
   } catch (err) {
     return { ok: false, reason: `git branch failed: ${stringifyError(err)}`, branch };
   }
-  const pushResult = tryPushRef(cwd, `refs/heads/${branch}`);
+  const pushResult = tryPushRef(cwd, branchRef);
   if (!pushResult.ok) {
     return { ok: false, reason: `branch created locally but push failed: ${pushResult.reason}`, branch };
   }
@@ -200,6 +282,18 @@ export function attemptArtifactCreation(opts) {
       return {
         result: branchResult,
         artifact_creation_failed: { type: 'draft_pr', reason: `branch prerequisite failed: ${branchResult.reason}` },
+      };
+    }
+    // Idempotency (PR #188 claude #1): when the branch step is a noop
+    // (release-finalize re-entry on the same commit), assume the PR
+    // from the prior run is still open and skip `gh pr create`. Re-
+    // running `gh pr create` against an existing PR would fail with
+    // "a pull request already exists" — that's a spurious surface, not
+    // a real artifact failure.
+    if (branchResult.noop) {
+      return {
+        result: { ok: true, branch: branchResult.branch, noop: true, pr_skipped: 'branch noop — assumed PR from prior run still open' },
+        artifact_creation_failed: null,
       };
     }
     const prResult = createArtifactDraftPr(cwd, cutId, branchResult.branch, snapshotRef);

--- a/hooks/lib/mpl-release-artifact.mjs
+++ b/hooks/lib/mpl-release-artifact.mjs
@@ -1,0 +1,258 @@
+/**
+ * Stage A Phase 1.6c-iii release-artifact helpers.
+ *
+ * Three responsibilities (RFC §5.4.1):
+ *
+ *   1. **Snapshot ref** — create `refs/mpl/releases/{cut_id}` pointing at
+ *      HEAD's commit so the cut's state is pinned independently of any
+ *      subsequent working-branch commits. Capture `commit_sha` /
+ *      `tree_sha` for the manifest.
+ *
+ *   2. **User-visible artifacts** (`tag` / `branch` / `draft_pr`) — best-
+ *      effort post-step that operates against the snapshot ref, not the
+ *      current working branch. Failures surface as
+ *      `artifact_creation_failed` in the manifest but do NOT block the
+ *      cohort from being marked released (RFC §5.4: "Tying immutability
+ *      to artifact delivery would create stuck states where the user
+ *      cannot recover").
+ *
+ *   3. **No-op for `release_manifest`** — that artifact type means
+ *      manifest + snapshot ref only, no external push/PR.
+ *
+ * Every git/gh invocation is wrapped in try/catch. The library NEVER
+ * throws — every helper returns a structured `{ok: true, ...}` or
+ * `{ok: false, reason: string}`. The phase-controller decides how to
+ * surface the result (manifest write or stopReason).
+ *
+ * Working-tree safety: snapshot ref creation does not modify the index
+ * or working tree; tag/branch creation are pure ref writes; only the
+ * push step talks to a remote. If push fails the local ref survives so
+ * the user can retry manually.
+ */
+
+import { execFileSync } from 'child_process';
+
+/**
+ * Capture HEAD's commit_sha + tree_sha and create the snapshot ref
+ * `refs/mpl/releases/{cutId}` pointing at the commit. Returns the three
+ * identifiers on success, or a structured failure on any git error.
+ *
+ * `git update-ref` is idempotent — re-running with the same target is a
+ * no-op. Pointing to a new commit overwrites the prior ref, which is
+ * fine because release-finalize re-entry should re-pin the snapshot to
+ * the latest cohort tip.
+ *
+ * @param {string} cwd
+ * @param {string} cutId
+ * @returns {{ok: true, commit_sha: string, tree_sha: string, snapshot_ref: string} | {ok: false, reason: string}}
+ */
+export function createSnapshotRef(cwd, cutId) {
+  if (typeof cutId !== 'string' || !cutId) {
+    return { ok: false, reason: 'cutId must be a non-empty string' };
+  }
+  const snapshot_ref = `refs/mpl/releases/${cutId}`;
+  try {
+    const commit_sha = git(cwd, ['rev-parse', 'HEAD']).trim();
+    if (!/^[0-9a-f]{40}$/.test(commit_sha)) {
+      return { ok: false, reason: `git rev-parse HEAD returned unexpected output: ${commit_sha.slice(0, 80)}` };
+    }
+    const tree_sha = git(cwd, ['rev-parse', 'HEAD^{tree}']).trim();
+    if (!/^[0-9a-f]{40}$/.test(tree_sha)) {
+      return { ok: false, reason: `git rev-parse HEAD^{tree} returned unexpected output: ${tree_sha.slice(0, 80)}` };
+    }
+    git(cwd, ['update-ref', snapshot_ref, commit_sha]);
+    return { ok: true, commit_sha, tree_sha, snapshot_ref };
+  } catch (err) {
+    return { ok: false, reason: stringifyError(err) };
+  }
+}
+
+/**
+ * Create + push a `tag` artifact (`refs/tags/mpl-release-{cutId}`).
+ *
+ * Local tag is created first via `git tag <name> <commit>` (force overwrite
+ * not used — re-running on an existing tag is an error, surfaced as reason).
+ * Push is attempted only when an `origin` remote is configured; missing
+ * remote is treated as a soft-failure (`reason` set, `ok: false`) so the
+ * user knows the tag exists locally but was not published.
+ *
+ * @returns {{ok: true, tag: string, pushed: boolean} | {ok: false, reason: string, tag?: string}}
+ */
+export function createArtifactTag(cwd, cutId, commitSha) {
+  if (typeof cutId !== 'string' || !cutId) return { ok: false, reason: 'cutId must be a non-empty string' };
+  if (typeof commitSha !== 'string' || !/^[0-9a-f]{40}$/.test(commitSha)) {
+    return { ok: false, reason: 'commitSha must be a 40-char hex string' };
+  }
+  const tag = `mpl-release-${cutId}`;
+  try {
+    git(cwd, ['tag', tag, commitSha]);
+  } catch (err) {
+    return { ok: false, reason: `git tag failed: ${stringifyError(err)}`, tag };
+  }
+  const pushResult = tryPushRef(cwd, `refs/tags/${tag}`);
+  if (!pushResult.ok) {
+    return { ok: false, reason: `tag created locally but push failed: ${pushResult.reason}`, tag };
+  }
+  return { ok: true, tag, pushed: pushResult.pushed };
+}
+
+/**
+ * Create + push a `branch` artifact (`mpl/release/{cutId}`).
+ *
+ * The branch points at the snapshot commit, NOT at HEAD-at-release-time
+ * (those may diverge if release-finalize re-runs after later commits).
+ *
+ * @returns {{ok: true, branch: string, pushed: boolean} | {ok: false, reason: string, branch?: string}}
+ */
+export function createArtifactBranch(cwd, cutId, commitSha) {
+  if (typeof cutId !== 'string' || !cutId) return { ok: false, reason: 'cutId must be a non-empty string' };
+  if (typeof commitSha !== 'string' || !/^[0-9a-f]{40}$/.test(commitSha)) {
+    return { ok: false, reason: 'commitSha must be a 40-char hex string' };
+  }
+  const branch = `mpl/release/${cutId}`;
+  try {
+    git(cwd, ['branch', branch, commitSha]);
+  } catch (err) {
+    return { ok: false, reason: `git branch failed: ${stringifyError(err)}`, branch };
+  }
+  const pushResult = tryPushRef(cwd, `refs/heads/${branch}`);
+  if (!pushResult.ok) {
+    return { ok: false, reason: `branch created locally but push failed: ${pushResult.reason}`, branch };
+  }
+  return { ok: true, branch, pushed: pushResult.pushed };
+}
+
+/**
+ * Create a draft PR via `gh pr create --draft`. Requires the release
+ * branch to already exist on the remote. The PR body links the snapshot
+ * ref and includes the canonical "do not push to this branch" warning
+ * from RFC §5.4.1.
+ *
+ * Soft-failures: missing `gh` CLI, missing repo remote, gh auth failure.
+ * All return `{ok: false, reason}` — never throws.
+ *
+ * @returns {{ok: true, pr_url: string, branch: string} | {ok: false, reason: string, branch?: string}}
+ */
+export function createArtifactDraftPr(cwd, cutId, branchName, snapshotRef) {
+  if (typeof cutId !== 'string' || !cutId) return { ok: false, reason: 'cutId must be a non-empty string' };
+  if (typeof branchName !== 'string' || !branchName) return { ok: false, reason: 'branchName must be a non-empty string' };
+  const body =
+    `MPL Stage A release artifact for cut \`${cutId}\`.\n\n` +
+    `**Snapshot ref:** \`${snapshotRef || 'refs/mpl/releases/' + cutId}\`\n\n` +
+    `⚠ Do not push to this branch. Further work happens on the working branch; ` +
+    `subsequent cohort commits do NOT update this PR. This PR is frozen at the snapshot point.`;
+  try {
+    const out = execFileSync('gh', [
+      'pr', 'create',
+      '--draft',
+      '--head', branchName,
+      '--title', `MPL release: ${cutId}`,
+      '--body', body,
+    ], { cwd, encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] });
+    const url = out.trim().split('\n').find((l) => /^https?:\/\//.test(l));
+    return { ok: true, pr_url: url || out.trim(), branch: branchName };
+  } catch (err) {
+    return { ok: false, reason: `gh pr create failed: ${stringifyError(err)}`, branch: branchName };
+  }
+}
+
+/**
+ * Dispatch by artifact type.
+ *
+ * Returns the per-type result plus a normalized `artifact_creation_failed`
+ * field shaped for the release-manifest:
+ *   - successful  → `null` (no failure to report)
+ *   - skipped     → `null` (e.g., `release_manifest` artifact = no-op)
+ *   - failed      → `{ type, reason }` for the manifest to record verbatim
+ *
+ * `release_manifest` and `null`/undefined artifact types are treated as
+ * no-ops — the snapshot ref + manifest file are the artifact in those
+ * cases.
+ *
+ * @param {{cwd: string, cutId: string, artifact: string|null, commitSha: string, snapshotRef: string}} opts
+ * @returns {{result: object|null, artifact_creation_failed: {type: string, reason: string}|null}}
+ */
+export function attemptArtifactCreation(opts) {
+  const { cwd, cutId, artifact, commitSha, snapshotRef } = opts;
+  if (!artifact || artifact === 'release_manifest') {
+    return { result: null, artifact_creation_failed: null };
+  }
+  if (artifact === 'tag') {
+    const r = createArtifactTag(cwd, cutId, commitSha);
+    return {
+      result: r,
+      artifact_creation_failed: r.ok ? null : { type: 'tag', reason: r.reason },
+    };
+  }
+  if (artifact === 'branch') {
+    const r = createArtifactBranch(cwd, cutId, commitSha);
+    return {
+      result: r,
+      artifact_creation_failed: r.ok ? null : { type: 'branch', reason: r.reason },
+    };
+  }
+  if (artifact === 'draft_pr') {
+    // draft_pr requires the release branch on remote. Create+push the
+    // branch first, then open the PR against it. If the branch step
+    // fails, surface that — the PR cannot succeed without it.
+    const branchResult = createArtifactBranch(cwd, cutId, commitSha);
+    if (!branchResult.ok) {
+      return {
+        result: branchResult,
+        artifact_creation_failed: { type: 'draft_pr', reason: `branch prerequisite failed: ${branchResult.reason}` },
+      };
+    }
+    const prResult = createArtifactDraftPr(cwd, cutId, branchResult.branch, snapshotRef);
+    return {
+      result: prResult,
+      artifact_creation_failed: prResult.ok ? null : { type: 'draft_pr', reason: prResult.reason },
+    };
+  }
+  return {
+    result: null,
+    artifact_creation_failed: { type: artifact, reason: `unsupported artifact type: ${artifact}` },
+  };
+}
+
+// ────────────────────────── internals ──────────────────────────
+
+function git(cwd, args) {
+  return execFileSync('git', args, { cwd, encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] });
+}
+
+function hasOriginRemote(cwd) {
+  try {
+    const out = git(cwd, ['remote']);
+    return out.split('\n').map((s) => s.trim()).includes('origin');
+  } catch {
+    return false;
+  }
+}
+
+function tryPushRef(cwd, ref) {
+  // No `origin` configured → treat as soft "skipped" failure so the caller
+  // surfaces that the artifact exists locally but was not published. This
+  // is common in CI/test environments and explicitly tolerated by RFC §5.4
+  // ("artifact creation depends on external tools out of MPL's control").
+  if (!hasOriginRemote(cwd)) {
+    return { ok: false, pushed: false, reason: 'no `origin` remote configured' };
+  }
+  try {
+    git(cwd, ['push', 'origin', ref]);
+    return { ok: true, pushed: true };
+  } catch (err) {
+    return { ok: false, pushed: false, reason: stringifyError(err) };
+  }
+}
+
+function stringifyError(err) {
+  if (!err) return 'unknown error';
+  // execFileSync errors carry stderr in the `stderr` buffer; surface that
+  // rather than the generic message when present so the manifest's
+  // `artifact_creation_failed.reason` is actionable.
+  const stderr = err.stderr && (typeof err.stderr === 'string' ? err.stderr : err.stderr.toString('utf-8'));
+  if (stderr && stderr.trim()) {
+    return stderr.trim().split('\n').slice(0, 3).join(' | ').slice(0, 400);
+  }
+  return String(err.message || err).slice(0, 400);
+}

--- a/hooks/lib/mpl-release-artifact.mjs
+++ b/hooks/lib/mpl-release-artifact.mjs
@@ -205,6 +205,37 @@ export function createArtifactBranch(cwd, cutId, commitSha) {
 }
 
 /**
+ * Look up an existing open PR for the given branch via
+ * `gh pr list --head <branch> --state open`. Returns the PR url if
+ * found, `null` if none, or `null` on any gh failure (caller can then
+ * decide whether to attempt creation). Pure observation — never throws,
+ * never mutates remote state.
+ *
+ * PR #188 round-2 codex review: a `branch` step being a noop ("the
+ * release branch already exists at the same commit") is NOT evidence
+ * that the draft PR was actually created in a prior run — branch push
+ * could have succeeded while `gh pr create` failed (missing gh, auth
+ * failure, API rate limit). Re-running release-finalize must verify
+ * the PR's actual existence before claiming idempotent success.
+ */
+export function findExistingDraftPr(cwd, branchName) {
+  if (typeof branchName !== 'string' || !branchName) return null;
+  try {
+    const out = execFileSync('gh', [
+      'pr', 'list',
+      '--head', branchName,
+      '--state', 'open',
+      '--json', 'url',
+      '--jq', '.[0].url // empty',
+    ], { cwd, encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] });
+    const url = out.trim();
+    return url && /^https?:\/\//.test(url) ? url : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Create a draft PR via `gh pr create --draft`. Requires the release
  * branch to already exist on the remote. The PR body links the snapshot
  * ref and includes the canonical "do not push to this branch" warning
@@ -284,15 +315,24 @@ export function attemptArtifactCreation(opts) {
         artifact_creation_failed: { type: 'draft_pr', reason: `branch prerequisite failed: ${branchResult.reason}` },
       };
     }
-    // Idempotency (PR #188 claude #1): when the branch step is a noop
-    // (release-finalize re-entry on the same commit), assume the PR
-    // from the prior run is still open and skip `gh pr create`. Re-
-    // running `gh pr create` against an existing PR would fail with
-    // "a pull request already exists" — that's a spurious surface, not
-    // a real artifact failure.
-    if (branchResult.noop) {
+    // Idempotency with verification (PR #188 claude #1 + codex round-2):
+    // a branch noop is NOT evidence that the PR exists. Verify via
+    // `gh pr list --head <branch>` first. If a PR is found → idempotent
+    // success (noop). If none found → retry `gh pr create` regardless
+    // of whether the branch step was a noop. This catches the case
+    // where the first run pushed the branch but failed at `gh pr create`
+    // (missing gh, auth failure, API rate limit) — the second run
+    // actually creates the PR instead of falsely reporting success.
+    const existingUrl = findExistingDraftPr(cwd, branchResult.branch);
+    if (existingUrl) {
       return {
-        result: { ok: true, branch: branchResult.branch, noop: true, pr_skipped: 'branch noop — assumed PR from prior run still open' },
+        result: {
+          ok: true,
+          branch: branchResult.branch,
+          pr_url: existingUrl,
+          noop: true,
+          pr_skipped: 'existing open PR found via gh pr list',
+        },
         artifact_creation_failed: null,
       };
     }

--- a/hooks/mpl-phase-controller.mjs
+++ b/hooks/mpl-phase-controller.mjs
@@ -760,22 +760,52 @@ async function main() {
         break;
       }
 
-      // Phase 1.6c-iii: create snapshot ref BEFORE writing the manifest so
-      // commit_sha / tree_sha / snapshot_ref can be recorded. RFC §5.4.1:
-      // "at the start of release-finalize(cut_id), before any artifact-
-      // creation attempt". A snapshot-ref failure is a soft failure — the
-      // manifest is still written (with placeholders) and the failure is
-      // recorded in `artifact_creation_failed.snapshot` so the user has
-      // an actionable record. The lifecycle still advances because RFC
-      // §5.4 explicitly tolerates artifact creation depending on tools
-      // out of MPL's control.
+      // Phase 1.6c-iii: snapshot ref creation MUST succeed before any
+      // file is written or the cohort is marked released. RFC §5.4 §232
+      // explicitly requires "gate PASS + release-manifest write + snapshot
+      // ref creation all succeed" before appending completed_cut_ids;
+      // the snapshot ref is the immutability anchor (the commit that the
+      // shipped manifest claims to pin). PR #188 codex review: prior
+      // implementation flipped through to release on snapshot failure
+      // with null commit_sha/tree_sha/snapshot_ref, which would let
+      // D-Q6 immutability turn on for a manifest that pins nothing.
       const snapshot = createSnapshotRef(cwd, cur);
-      if (snapshot.ok) {
-        manifest.commit_sha = snapshot.commit_sha;
-        manifest.tree_sha = snapshot.tree_sha;
-        manifest.snapshot_ref = snapshot.snapshot_ref;
-      } else {
-        manifest.artifact_creation_failed = { type: 'snapshot_ref', reason: snapshot.reason };
+      if (!snapshot.ok) {
+        console.log(JSON.stringify({
+          continue: true,
+          stopReason: `[MPL] ⛔ release-finalize(${cur}): snapshot ref creation failed (${snapshot.reason}). ` +
+            `Cohort NOT appended to completed_cut_ids per RFC §5.4 (snapshot ref is the immutability anchor). ` +
+            `Resolve the underlying git issue (e.g., not a git repo, detached HEAD) and let the loop retry.`
+        }));
+        break;
+      }
+      manifest.commit_sha = snapshot.commit_sha;
+      manifest.tree_sha = snapshot.tree_sha;
+      manifest.snapshot_ref = snapshot.snapshot_ref;
+
+      // Phase 1.6c-iii: attempt user-visible artifact (tag / branch /
+      // draft_pr) BEFORE writing the manifest so the failure result is
+      // captured in the single canonical manifest write — no re-write,
+      // no disk ↔ stopReason divergence (PR #188 claude review #2).
+      // The attempt is best-effort per RFC §5.4: failures are recorded
+      // in the manifest (artifact_creation_failed) and surfaced to the
+      // user, but they do NOT block `completed_cut_ids` append because
+      // artifact creation depends on external tools (gh CLI, remote
+      // permissions) that are out of MPL's control. Snapshot ref is
+      // distinct from this — it's the immutability anchor and was
+      // already enforced above.
+      let artifactAttempt = null;
+      if (manifest.artifact && manifest.artifact !== 'release_manifest') {
+        artifactAttempt = attemptArtifactCreation({
+          cwd,
+          cutId: cur,
+          artifact: manifest.artifact,
+          commitSha: snapshot.commit_sha,
+          snapshotRef: snapshot.snapshot_ref,
+        });
+        if (artifactAttempt.artifact_creation_failed) {
+          manifest.artifact_creation_failed = artifactAttempt.artifact_creation_failed;
+        }
       }
 
       const evidence = buildEvidenceSummary({ cutId: cur, state, contract, graph, now: writtenAt });
@@ -823,43 +853,6 @@ async function main() {
         break;
       }
 
-      // Phase 1.6c-iii: attempt user-visible artifact (tag / branch /
-      // draft_pr) after manifest write succeeded. Only run when snapshot
-      // ref creation succeeded — without commit_sha we cannot point an
-      // artifact at the cut's terminal commit. The attempt is best-
-      // effort per RFC §5.4: failures are recorded in the manifest
-      // (artifact_creation_failed) and surfaced to the user, but they do
-      // NOT block `completed_cut_ids` append because artifact creation
-      // depends on external tools (gh CLI, remote permissions) that are
-      // out of MPL's control.
-      let artifactAttempt = null;
-      if (snapshot.ok && manifest.artifact && manifest.artifact !== 'release_manifest') {
-        artifactAttempt = attemptArtifactCreation({
-          cwd,
-          cutId: cur,
-          artifact: manifest.artifact,
-          commitSha: snapshot.commit_sha,
-          snapshotRef: snapshot.snapshot_ref,
-        });
-        if (artifactAttempt.artifact_creation_failed) {
-          // Re-write the manifest with the failure recorded so the
-          // shipped record matches the actual outcome.
-          manifest.artifact_creation_failed = artifactAttempt.artifact_creation_failed;
-          try {
-            atomicWriteFile(
-              manifestPath,
-              JSON.stringify(manifest, null, 2) + '\n',
-              0o644
-            );
-          } catch {
-            // Manifest re-write failure is itself non-fatal — the
-            // original manifest (with artifact_creation_failed=null) is
-            // already on disk; the lifecycle should still advance to
-            // honor the "best-effort post-step" contract.
-          }
-        }
-      }
-
       const existing = state.release || {};
       const already = Array.isArray(existing.completed_cut_ids) ? existing.completed_cut_ids : [];
       const completed = already.includes(cur) ? already : [...already, cur];
@@ -881,18 +874,21 @@ async function main() {
         },
         current_phase: nextPhase,
       });
-      // Build a status-aware tail so users immediately see whether the
-      // snapshot/artifact step succeeded or fell back.
-      const snapshotTail = snapshot.ok
-        ? `snapshot ${snapshot.snapshot_ref} @ ${snapshot.commit_sha.slice(0, 12)}`
-        : `⚠ snapshot ref FAILED (${snapshot.reason}) — artifact_creation_failed recorded`;
+      // Build a status-aware tail so users immediately see snapshot +
+      // artifact outcome at the single Stop hook surface. Snapshot is
+      // always ok here (failure path bails earlier); push may be soft-
+      // failed so surface that explicitly.
+      const snapshotTail = snapshot.pushed
+        ? `snapshot ${snapshot.snapshot_ref} @ ${snapshot.commit_sha.slice(0, 12)} (pushed)`
+        : `snapshot ${snapshot.snapshot_ref} @ ${snapshot.commit_sha.slice(0, 12)} (local only, push: ${snapshot.push_reason})`;
       const artifactTail = (() => {
         if (!manifest.artifact || manifest.artifact === 'release_manifest') return 'artifact=release_manifest (no external push)';
-        if (!artifactAttempt) return `artifact=${manifest.artifact} skipped (snapshot ref failed)`;
+        if (!artifactAttempt) return `artifact=${manifest.artifact} skipped`;
         if (artifactAttempt.artifact_creation_failed) {
           return `⚠ artifact=${manifest.artifact} FAILED (${artifactAttempt.artifact_creation_failed.reason})`;
         }
-        return `artifact=${manifest.artifact} created`;
+        const noopSuffix = artifactAttempt.result?.noop ? ' (noop — already at this commit)' : '';
+        return `artifact=${manifest.artifact} created${noopSuffix}`;
       })();
       console.log(JSON.stringify({
         continue: true,

--- a/hooks/mpl-phase-controller.mjs
+++ b/hooks/mpl-phase-controller.mjs
@@ -16,7 +16,8 @@
 
 import { dirname, join } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, readFileSync, writeFileSync, renameSync } from 'fs';
+import { randomBytes } from 'crypto';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -55,6 +56,27 @@ const {
 const { parsePhaseContractGraphText } = await import(
   pathToFileURL(join(__dirname, 'lib', 'mpl-phase-contract-graph.mjs')).href
 );
+
+// Stage A Phase 1.6c-iii: snapshot ref + user-visible artifact creation.
+const { createSnapshotRef, attemptArtifactCreation } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-release-artifact.mjs')).href
+);
+
+/**
+ * Atomic file write — write to a sibling tmp file then rename onto the
+ * final path. Removes the partial-file failure window claude #2 on PR
+ * #187 flagged: if a write is interrupted mid-stream, the final path is
+ * untouched (the tmp is orphaned, which a future release-finalize
+ * re-run reclaims by writing a fresh tmp). All three release artifacts
+ * use this so the on-disk state is always "all three present at the
+ * same generation" or "the prior generation intact" — never a
+ * partial-mix that a consumer could read between writes.
+ */
+function atomicWriteFile(filePath, contents, mode) {
+  const tmp = `${filePath}.${randomBytes(4).toString('hex')}.tmp`;
+  writeFileSync(tmp, contents, { mode });
+  renameSync(tmp, filePath);
+}
 
 // G4 hang detection (#109)
 const { detectHang } = await import(
@@ -737,10 +759,30 @@ async function main() {
         }));
         break;
       }
+
+      // Phase 1.6c-iii: create snapshot ref BEFORE writing the manifest so
+      // commit_sha / tree_sha / snapshot_ref can be recorded. RFC §5.4.1:
+      // "at the start of release-finalize(cut_id), before any artifact-
+      // creation attempt". A snapshot-ref failure is a soft failure — the
+      // manifest is still written (with placeholders) and the failure is
+      // recorded in `artifact_creation_failed.snapshot` so the user has
+      // an actionable record. The lifecycle still advances because RFC
+      // §5.4 explicitly tolerates artifact creation depending on tools
+      // out of MPL's control.
+      const snapshot = createSnapshotRef(cwd, cur);
+      if (snapshot.ok) {
+        manifest.commit_sha = snapshot.commit_sha;
+        manifest.tree_sha = snapshot.tree_sha;
+        manifest.snapshot_ref = snapshot.snapshot_ref;
+      } else {
+        manifest.artifact_creation_failed = { type: 'snapshot_ref', reason: snapshot.reason };
+      }
+
       const evidence = buildEvidenceSummary({ cutId: cur, state, contract, graph, now: writtenAt });
       const gateSnapshot = buildGateResultsSnapshot(state, writtenAt);
 
       const releaseDir = join(cwd, RELEASE_DIR_REL_PATH, cur);
+      const manifestPath = join(releaseDir, 'release-manifest.json');
       try {
         mkdirSync(releaseDir, { recursive: true });
         // 0o644 (not the 0o600 used for state.json): release artifacts
@@ -749,20 +791,25 @@ async function main() {
         // dev box / CI agent (claude review #1 on PR #187). state.json
         // stays 0o600 because it carries session-internal evidence;
         // these files are the shippable record of the release.
-        writeFileSync(
-          join(releaseDir, 'release-manifest.json'),
+        //
+        // Atomic temp+rename (claude review #2 on PR #187) so a mid-write
+        // failure leaves the on-disk state at the prior generation
+        // instead of an asymmetric "manifest written but summary
+        // missing" state.
+        atomicWriteFile(
+          manifestPath,
           JSON.stringify(manifest, null, 2) + '\n',
-          { mode: 0o644 }
+          0o644
         );
-        writeFileSync(
+        atomicWriteFile(
           join(releaseDir, 'evidence-summary.md'),
           evidence.endsWith('\n') ? evidence : evidence + '\n',
-          { mode: 0o644 }
+          0o644
         );
-        writeFileSync(
+        atomicWriteFile(
           join(releaseDir, 'gate-results.json'),
           JSON.stringify(gateSnapshot, null, 2) + '\n',
-          { mode: 0o644 }
+          0o644
         );
       } catch (err) {
         // Manifest write failure must NOT advance the lifecycle (RFC §5.4:
@@ -774,6 +821,43 @@ async function main() {
             `${RELEASE_DIR_REL_PATH}/${cur}/ and let the loop retry.`
         }));
         break;
+      }
+
+      // Phase 1.6c-iii: attempt user-visible artifact (tag / branch /
+      // draft_pr) after manifest write succeeded. Only run when snapshot
+      // ref creation succeeded — without commit_sha we cannot point an
+      // artifact at the cut's terminal commit. The attempt is best-
+      // effort per RFC §5.4: failures are recorded in the manifest
+      // (artifact_creation_failed) and surfaced to the user, but they do
+      // NOT block `completed_cut_ids` append because artifact creation
+      // depends on external tools (gh CLI, remote permissions) that are
+      // out of MPL's control.
+      let artifactAttempt = null;
+      if (snapshot.ok && manifest.artifact && manifest.artifact !== 'release_manifest') {
+        artifactAttempt = attemptArtifactCreation({
+          cwd,
+          cutId: cur,
+          artifact: manifest.artifact,
+          commitSha: snapshot.commit_sha,
+          snapshotRef: snapshot.snapshot_ref,
+        });
+        if (artifactAttempt.artifact_creation_failed) {
+          // Re-write the manifest with the failure recorded so the
+          // shipped record matches the actual outcome.
+          manifest.artifact_creation_failed = artifactAttempt.artifact_creation_failed;
+          try {
+            atomicWriteFile(
+              manifestPath,
+              JSON.stringify(manifest, null, 2) + '\n',
+              0o644
+            );
+          } catch {
+            // Manifest re-write failure is itself non-fatal — the
+            // original manifest (with artifact_creation_failed=null) is
+            // already on disk; the lifecycle should still advance to
+            // honor the "best-effort post-step" contract.
+          }
+        }
       }
 
       const existing = state.release || {};
@@ -797,9 +881,23 @@ async function main() {
         },
         current_phase: nextPhase,
       });
+      // Build a status-aware tail so users immediately see whether the
+      // snapshot/artifact step succeeded or fell back.
+      const snapshotTail = snapshot.ok
+        ? `snapshot ${snapshot.snapshot_ref} @ ${snapshot.commit_sha.slice(0, 12)}`
+        : `⚠ snapshot ref FAILED (${snapshot.reason}) — artifact_creation_failed recorded`;
+      const artifactTail = (() => {
+        if (!manifest.artifact || manifest.artifact === 'release_manifest') return 'artifact=release_manifest (no external push)';
+        if (!artifactAttempt) return `artifact=${manifest.artifact} skipped (snapshot ref failed)`;
+        if (artifactAttempt.artifact_creation_failed) {
+          return `⚠ artifact=${manifest.artifact} FAILED (${artifactAttempt.artifact_creation_failed.reason})`;
+        }
+        return `artifact=${manifest.artifact} created`;
+      })();
       console.log(JSON.stringify({
         continue: true,
         stopReason: `[MPL] release-finalize(${cur}): cohort completed. Manifest written to ${RELEASE_DIR_REL_PATH}/${cur}/. ` +
+          `${snapshotTail}. ${artifactTail}. ` +
           `Stage A single-cohort path: transitioning to whole-pipeline phase3-gate.`
       }));
       break;


### PR DESCRIPTION
## What

Phase 1.6c-iii — final Stage A phase. Fills the snapshot-ref placeholders 1.6c-ii left and adds the optional user-visible artifact (`tag` / `branch` / `draft_pr`) per RFC §5.4.1.

### Snapshot ref

At the start of `release-finalize`, before manifest serialize:
- `git rev-parse HEAD` → `commit_sha`
- `git rev-parse HEAD^{tree}` → `tree_sha`
- `git update-ref refs/mpl/releases/{cut_id} <commit>` → `snapshot_ref`

These three fields populate the manifest. On any git failure (not a repo, etc.) the manifest is still written with null placeholders and `artifact_creation_failed = {type: 'snapshot_ref', reason}`. Lifecycle still advances (RFC §5.4 best-effort post-step).

### Artifact creation

| Type | Action |
|---|---|
| `release_manifest` | no-op (snapshot + manifest only) |
| `tag` | `git tag mpl-release-{cut_id}` + push to origin |
| `branch` | `git branch mpl/release/{cut_id}` + push to origin |
| `draft_pr` | branch + push prerequisite, then `gh pr create --draft` with body linking the snapshot ref + "do not push to this branch" warning |

Library NEVER throws — every helper returns `{ok: true, ...}` or `{ok: false, reason}`. Soft-fail surface for missing remote + missing `gh` CLI. Local refs survive push failures for manual retry.

### Picked up from PR #187 deferred items

- **claude #2 (atomic write)**: all 3 release artifacts now write through temp+rename helper. Mid-write failure leaves prior generation intact instead of partial-mix.
- **claude #5 (graph helper)**: not extracted — would not reduce surface meaningfully; leaving inline read+parse.

### Failure surfacing

`release-finalize` stopReason now ends with a status-aware tail:
- `snapshot refs/mpl/releases/mvp @ <sha12>. artifact=tag created.`
- `⚠ snapshot ref FAILED (...) — artifact_creation_failed recorded. artifact=tag skipped (snapshot ref failed).`
- `snapshot refs/mpl/releases/mvp @ <sha12>. ⚠ artifact=tag FAILED (...).`

## Why

Closes Stage A. After this PR, a single-cohort MVP project:
1. opts into MVP via Stage 1.4.5 checklist (PR #181)
2. runs release-gate scoped Hard 1/2/3 (PR #186)
3. ships at release-finalize with manifest + evidence + gate snapshot (PR #187)
4. **gets a snapshot-pinned commit + optional user-visible artifact (this PR)**

## Design

- RFC: \`docs/roadmap/stage-a-mvp-cuts-rfc.md\` §5.4.1
- Resume brief: \`docs/roadmap/stage-a-resume-1.6c.md\` §3 (1.6c-iii scope)

## Test plan

- [x] +21 tests in this PR (16 library unit + 5 phase-controller integration)
- [x] Full hook suite: **1055/1055 pass** (1034 → 1055)
- [x] Atomic write verified by no-.tmp-residue assertion
- [x] gh stub injected via PATH override for draft_pr success path
- [ ] Awaiting agent reviews (claude + codex)

## Agent Review Status

This PR is gated on **2 unique agent reviews** (footers \`— from <agent>\`).

- [ ] from claude
- [ ] from codex

---
_Awaiting reviews. Merge once the gate is satisfied._