### PR TITLE
fix(state): derive legacy gate booleans for state.release.gate_results

### DIFF
--- a/hooks/__tests__/mpl-state.test.mjs
+++ b/hooks/__tests__/mpl-state.test.mjs
@@ -134,6 +134,62 @@ describe('readState / writeState', () => {
     assert.strictEqual(state.gate_results.hard3_passed, null);
   });
 
+  // Stage A post-merge audit fix #1: derivation must apply to BOTH gate
+  // subtrees (top-level + state.release.gate_results) so the release-
+  // finalize gate-results.json archive is not stuck at stale `null`.
+  it('derives legacy gate booleans for state.release.gate_results (Stage A scoped subtree)', () => {
+    const ent = (exit_code) => ({ command: 'npm test', exit_code, stdout_tail: '', timestamp: 'now' });
+    writeState(tmpDir, {
+      current_phase: 'release-gate',
+      release: {
+        current_cut_id: 'mvp',
+        completed_cut_ids: [],
+        fix_loop_count: 0,
+        pending_artifact: null,
+        max_fix_loops: 3,
+        gate_results: {
+          hard1_baseline: ent(0),
+          hard2_coverage: ent(2),
+          hard3_resilience: ent(0),
+        },
+      },
+    });
+    const state = readState(tmpDir);
+    assert.strictEqual(state.release.gate_results.hard1_passed, true);
+    assert.strictEqual(state.release.gate_results.hard2_passed, false);
+    assert.strictEqual(state.release.gate_results.hard3_passed, true);
+    // Top-level subtree must remain untouched (RFC §5.5 isolation):
+    // release-scoped derivation does NOT bleed into whole-pipeline gates.
+    assert.strictEqual(state.gate_results.hard1_passed, null);
+    assert.strictEqual(state.gate_results.hard2_passed, null);
+    assert.strictEqual(state.gate_results.hard3_passed, null);
+  });
+
+  it('release.gate_results derivation respects the same partial-structured semantics', () => {
+    // When only some scoped entries are present, derive only those —
+    // missing entries stay null. Mirrors the top-level partial test above.
+    const ent = (exit_code) => ({ command: 'npm test', exit_code });
+    writeState(tmpDir, {
+      current_phase: 'release-gate',
+      release: {
+        current_cut_id: 'mvp',
+        completed_cut_ids: [],
+        fix_loop_count: 0,
+        pending_artifact: null,
+        max_fix_loops: 3,
+        gate_results: {
+          hard1_baseline: ent(0),
+          // hard2_coverage / hard3_resilience absent
+          hard2_passed: true,  // self-reported legacy — must be cleared
+        },
+      },
+    });
+    const state = readState(tmpDir);
+    assert.strictEqual(state.release.gate_results.hard1_passed, true);
+    assert.strictEqual(state.release.gate_results.hard2_passed, null);
+    assert.strictEqual(state.release.gate_results.hard3_passed, null);
+  });
+
   it('clears hook-block companion fields when blocked_hook status clears', () => {
     writeState(tmpDir, {
       current_phase: 'phase2-sprint',

--- a/hooks/lib/mpl-state.mjs
+++ b/hooks/lib/mpl-state.mjs
@@ -637,9 +637,23 @@ function recordRunbookTransition(cwd, prev, merged) {
  * to null or contradict the machine evidence. Once any structured gate signal
  * exists, legacy values for missing/malformed structured gates are cleared
  * instead of mixing self-report with machine evidence.
+ *
+ * Applies to BOTH gate subtrees — top-level `state.gate_results` (whole-
+ * pipeline phase3-gate) and `state.release.gate_results` (Stage A scoped
+ * release-gate, RFC §5.5 isolation). The release subtree was added in
+ * schema v6 but the original derivation only touched top-level, leaving
+ * `state.release.gate_results.hard{1,2,3}_passed` stuck at `null` —
+ * cosmetic on its own (release-gate routing reads structured exit codes
+ * directly), but `buildGateResultsSnapshot` archives the booleans into
+ * `gate-results.json` shipped with each release. Driving both subtrees
+ * here keeps the archived snapshot honest.
  */
 function deriveLegacyGateBooleans(state) {
-  const gr = state?.gate_results;
+  applyLegacyGateDerivation(state?.gate_results);
+  applyLegacyGateDerivation(state?.release?.gate_results);
+}
+
+function applyLegacyGateDerivation(gr) {
   if (!gr || typeof gr !== 'object') return;
   const pairs = [
     ['hard1_baseline', 'hard1_passed'],


### PR DESCRIPTION
## What

Post-Stage-A audit fix #1. Extends \`deriveLegacyGateBooleans()\` to also process \`state.release.gate_results\` (the Stage A scoped subtree added in PR #186), not just top-level \`state.gate_results\`.

## Why

Stage A audit surfaced this: the v6 release subtree's \`hard{1,2,3}_passed\` booleans stayed \`null\` forever even when structured exit codes were present, because the derivation helper hardcoded the top-level subtree. The \`gate-results.json\` archive written by release-finalize (PR #187) then carried stale \`null\` booleans alongside truthful structured entries — cosmetic on the routing side (release-gate consumes structured exit codes directly with \`strict:true\`), but misleading for consumers reading the shipped archive.

## Design

- Split into thin dispatcher (\`deriveLegacyGateBooleans\`) + per-subtree helper (\`applyLegacyGateDerivation\`).
- Each derivation runs in place on its own subtree — RFC §5.5 isolation preserved (release-scoped derivation does NOT mutate top-level, and vice-versa).
- Identical per-subtree semantics: partial-structured stays partial, self-reported legacy on absent structured entries gets cleared.

## Test plan

- [x] +2 regression tests covering the release subtree derivation (full + partial structured), with explicit isolation assertion
- [x] Full hook suite: **1067/1067 pass** (1065 → 1067)
- [ ] Awaiting agent reviews (claude + codex)

## Agent Review Status

This PR is gated on **2 unique agent reviews** (footers \`— from <agent>\`).

- [ ] from claude
- [ ] from codex

---
_Awaiting reviews. Merge once the gate is satisfied._