### PR TITLE
Unify goal-contract baseline hashing

### DIFF
--- a/docs/findings/2026-05-26-decomposer-cost-and-deadlock.md
+++ b/docs/findings/2026-05-26-decomposer-cost-and-deadlock.md
@@ -1,0 +1,173 @@
+# Decomposer Cost: Structural Bloat + Goal-Contract Hash Deadlock
+
+- **Date**: 2026-05-26
+- **Severity**: High — "1시간+ retry / 산출물 0" 사고가 메인 레포 코드로 재현 가능
+- **Status**: Phase 1 patch covers the hash-normalization/truncation deadlock. Decomposer 구조 개선은 후속 Phase.
+- **Related**: `harness_lab/MPL/docs/findings/2026-05-26-goal-trace-hash-truncation-deadlock.md` (원본 deadlock 보고)
+
+## 요약
+
+"decomposer 가 너무 오래 걸리고 컨텍스트를 많이 먹는다" 는 증상은 **두 개의 독립된 문제가 섞인 결과**다. 이 둘을 분리해서 보지 않으면 잘못된 곳을 고치게 된다.
+
+| 가닥 | 원인 | 증상 | 처방 | 우선순위 |
+|------|------|------|------|----------|
+| **1. Goal-contract hash deadlock** | Phase 0 baseline 은 raw bytes hash, guards 는 normalized text hash 비교 + 훅이 sha256 을 `.slice(0,12)` 로 표시 + baseline.yaml 에 길이 검증 없음 | 정상 baseline 도 trailing newline 으로 즉시 drift 가능. LLM 워커가 12자를 정답으로 오인하면 baseline 영구 손상 → Write 영구 차단 → 토큰만 태우며 retry | 공유 normalized hash + 64hex 검증 + full hash 메시지 | 즉시 |
+| **2. Decomposer 구조적 비대** | 단일 Opus 호출이 1,700+ lines YAML 한 번에 생성. 출력의 25% 는 기계적 필드 | 정상 케이스에서도 latency 크고 context 점유 큼 | 기계적 필드 → post-processing, 스키마/의사코드 외부화 | hash-deadlock fix 이후 |
+
+가닥 1 을 안 고치면 가닥 2 의 어떤 개선도 같은 deadlock 에 다시 빠진다 (출력이 1,300 lines 로 줄어도 동일 hash drift 에 막힘).
+
+---
+
+## 가닥 1 · Goal-Contract Hash Deadlock
+
+### 메커니즘 (4-단계 결함 체인)
+
+0. **Hash algorithm mismatch**: baseline writer 가 `.mpl/goal-contract.yaml` 파일 raw bytes 를 해시하고, guards 는 CRLF→LF + trim 된 normalized text hash 를 비교. trailing newline 하나로 Phase 0 직후 drift 가능.
+1. **Display truncation**: 훅이 가독성 위해 12자만 표시 → `"baseline=43aaf36b9bf7, current=97c94a8c3254"`
+2. **LLM 의 시스템/사용자 텍스트 동등 취급**: 워커가 truncated 12자를 "올바른 현재 해시"로 오인
+3. **baseline.yaml 에 12자만 작성**: 어떤 schema/length 검증도 없음 → 통과
+4. **영구 불일치**: `"43aaf36b9bf7" !== <64자 실제 normalized hash>` → 모든 decomposition.yaml/finalize Write 영구 차단
+
+여기에 baseline-guard 의 `.baseline-renewal` sentinel 이 의도된 회복 경로인데 **parent 가 "stale artifact" 로 잘못 청소** → 회복 경로마저 차단 (deadlock 보고 §Fix 4 참조).
+
+### 메인 레포 (2026-05-26 기준) 에서 재확인된 위치
+
+**이전 `hooks/lib/mpl-baseline.mjs`**
+```javascript
+const hash = sha256File(cwd, relPath); // raw bytes hash
+```
+✅ root cause: goal-contract baseline hash 가 guard 의 normalized `content_sha256` 과 다른 알고리즘.
+
+**이전 `hooks/mpl-require-goal-trace.mjs:88`**
+```javascript
+`(baseline=${baseline.hash.slice(0, 12)}, current=${goal.contract.content_sha256.slice(0, 12)}). `
+```
+✅ secondary cause: guard message 가 full hash 를 숨겨 12자 baseline 손상 가능성을 키움.
+
+**이전 `hooks/lib/mpl-goal-contract.mjs:302-315`**
+```javascript
+export function readBaselineGoalContractHash(cwd) {
+  // ...
+  const hash = scalarInBlock(goalBlock, 'sha256');
+  return { exists: true, hash };  // ← 길이 검증 없음
+}
+```
+✅ secondary cause: 12자/non-hex baseline hash 를 corruption 으로 차단하지 않음.
+
+### 재현 타임라인 (ygg-exp22 V1)
+
+- 07:48 dispatch → 08:13 첫 Write 차단 → 08:25~31 다수 retry 차단
+- 08:44 워커가 sentinel + baseline 에 truncated 12자 작성
+- 08:49 첫 subagent 51분 / 2,671 tokens / 산출물 0
+- 08:51 parent 가 sentinel 을 stale 로 청소 + 재dispatch
+- 09:00+ retry 도 동일 deadlock 반복 → 1h 40m+ 진행, 산출물 여전히 0
+
+### Fix (외과적, 작음)
+
+**Fix 1 — baseline 과 guard 가 공유 normalized hash 사용**
+
+`hooks/lib/mpl-goal-contract.mjs` 에 normalized helper 를 두고:
+- `parseGoalContractText().content_sha256`
+- Phase 0 baseline 의 `artifacts.goal_contract.sha256`
+- decomposition/finalize guard 비교
+
+모두 동일하게 CRLF→LF + trim 후 SHA-256 을 사용한다. raw `shasum` 과 MPL normalized hash 는 다를 수 있음을 메시지에 명시한다.
+
+**Fix 2 — 훅 메시지에서 truncation 제거**
+
+`hooks/mpl-require-goal-trace.mjs:88`
+```javascript
+block(
+  `[MPL Goal Trace] Cannot write decomposition.yaml — .mpl/goal-contract.yaml drifted from baseline.yaml ` +
+    `(baseline=${baseline.hash}, current=${goal.contract.content_sha256}). ` +
+    `These are MPL normalized hashes; raw shasum may differ because MPL normalizes CRLF to LF and trims surrounding whitespace. ` +
+    `Re-run Phase 0 renewal before recomposing.`
+);
+```
+
+**Fix 3 — baseline 의 sha256 길이/형식 검증**
+
+`hooks/lib/mpl-goal-contract.mjs:302-315`
+```javascript
+const hash = scalarInBlock(goalBlock, 'sha256');
+if (hash && !/^[0-9a-f]{64}$/.test(hash)) {
+  return { exists: true, hash: null, error: `corrupted: expected 64 lowercase hex` };
+}
+return { exists: true, hash };
+```
+훅이 이 에러를 감지하면 별도 메시지 ("baseline.yaml 손상: sha256 truncated/non-hex, 전체 재생성 필요") 출력. 워커가 같은 함정에 다시 빠지지 않게 됨. finalize guard 도 같은 fail-closed 경로를 사용한다.
+
+**Fix 4 (권장) — Sentinel cleanup 휴리스틱 점검**
+
+Parent 가 `.baseline-renewal` 을 stale 로 판단한 근거가 무엇이었는지 추적 필요. Sentinel 은 의도된 unblock 경로인데 정리되면 deadlock 으로 회귀.
+
+---
+
+## 가닥 2 · Decomposer 구조적 비대
+
+(이 가닥은 가닥 1 패치 후 측정해서 ROI 가 정직하게 보일 때 진행하는 게 맞다.)
+
+### 실측
+
+- 에이전트 프롬프트 본문: **698 lines** (`agents/mpl-decomposer.md`)
+- 디스패치 입력: pivot-points + goal-contract + codebase-analysis + raw-scan + core-scenarios + design-intent + user-contract + baseline ≈ **920 lines**
+- 출력 (ygg-exp21 실측): **1,754 lines / 22 phases** ≈ **75~80 lines/phase**, 단일 Opus 호출
+
+병목은 컨텍스트보다 **단일 호출 generation latency**.
+
+### 결정자(decomposer) 가 흡수한 책임 (v0.17 #57 이후)
+
+페이즈 분할/순서 + type_policy 합성 + error_spec 합성 + contract_files 경계 열거 + e2e_scenarios 합성 + probing_hints + risk_patterns 열거 + invariants 매핑 + risk pre-mortem + execution_tiers + mvp 컷 유도. 각 흡수 결정은 합리적이었지만 **누적 부하**가 문제.
+
+### 출력 중 LLM 추론 불필요한 (mechanical) 필드
+
+다음은 명시적으로 "기계적 매핑" 인데 매번 LLM 이 다시 생성:
+
+| 필드 | 근거 | 출처 |
+|------|------|------|
+| `risk_patterns` | `mpl-run-decompose.md` Step 2b 가 이미 결정론적으로 주입 | 이중 작업 |
+| `probing_hints` | `phase_domain` → hint 테이블 룩업 | Step 9.5 의 테이블 |
+| `invariants` | design-intent.yaml 에서 `applies_to_phases` 필터 후 verbatim copy | Step 9.7: "번역·재해석 금지" 명시 |
+| `mvp.phases` | id-set 교집합 | RFC §10 D-Q4: "mechanical id-set mapping (NOT semantic inference)" |
+| `error_spec.raw_audit_counts` | raw-scan 의 수치를 그대로 복사 | 단순 복사 |
+
+이 다섯 항목만 출력 스키마에서 빼도 phase 당 15~20 lines × 25 phases ≈ **400 lines (출력의 ~25%) 축소**, 환각 위험 0.
+
+### 프롬프트 자체의 비대
+
+- Output_Schema YAML: 280+ lines
+- Step 12 MVP 유도 의사코드: 70 lines (이미 결정론적 로직)
+- 다수의 hint 테이블 + profile reference
+
+추론에 쓰는 게 아니라 형식 규약이라 매 호출마다 컨텍스트에 들어가는 게 낭비.
+
+### 단일-Write 강제 → 훅 블록시 풀-재생성
+
+`covers` / `goal_trace` / `contract_files` 훅 중 하나라도 거부하면 1,700 lines 전체 재생성. 점진적 패치 경로 없음.
+
+### 옵션 (덜→더 침습적)
+
+**옵션 A — 기계적 필드 → post-processing (low-risk, 즉시 효과)**
+`risk_patterns`, `probing_hints`, `invariants`, `mvp.phases`, `raw_audit_counts` 를 에이전트 출력 스키마에서 제거, `mpl-run-decompose.md` Step 3 post-processing 이 결정론적으로 합성. 출력 25% 축소, 환각 표면 축소.
+
+**옵션 B — Skeleton + Enrichment 2-단계 (medium)**
+1단계 Opus: id/name/scope/impact/interface_contract/goal_trace 만 (≈25 lines/phase).
+2단계 per-phase Sonnet 병렬: type_policy, error_spec, contract_files, verification_plan.
+Wall-time 은 1단계 Opus 호출 시간에 수렴. trade-off: 오케스트레이터 복잡도↑, phase 간 일관성 확보를 위해 1단계에서 anchor 박아야 함.
+
+**옵션 C — 프롬프트 다이어트 (medium)**
+Output_Schema 를 `agents/references/decomposition-schema.yaml` 로 추출, Step 12 의사코드를 `commands/lib/derive-mvp-phases.mjs` 헬퍼로 빼내기. 프롬프트는 참조만. 추정 -300 lines.
+
+**옵션 D — 점진적 Write 경로 (heavy)**
+훅이 특정 phase 의 특정 필드를 거부했을 때 부분-Edit 허용. v0.17.2 "authoring authority" 규칙과 충돌하므로 별도 RFC 필요.
+
+---
+
+## 권장 실행 순서
+
+1. **즉시**: normalized hash 공유 + full hash 메시지 + baseline 64hex 검증 패치. 영향: deadlock 차단.
+2. **Fix 후 측정**: 동일 시나리오 재실행, decomposer baseline wall-time / token / context 측정. 옵션 A~D 의 ROI 가 정직하게 보임.
+3. **그다음 옵션 A**: 기계적 필드 5개 → post-processing.
+4. **마지막 옵션 C**: 프롬프트 다이어트. B 는 측정 후 결정.
+
+Hash-deadlock fix 없이 옵션 A~C 만 진행하면: **출력이 줄어도 같은 hash deadlock 에 다시 빠진다**. 순서가 바뀌면 안 됨.

--- a/hooks/__tests__/mpl-baseline.test.mjs
+++ b/hooks/__tests__/mpl-baseline.test.mjs
@@ -16,6 +16,7 @@ import {
   BASELINE_FILE,
   RENEWAL_FLAG_FILE,
 } from '../lib/mpl-baseline.mjs';
+import { hashNormalizedGoalContractText } from '../lib/mpl-goal-contract.mjs';
 
 function createTempRepo() {
   const dir = mkdtempSync(join(tmpdir(), 'mpl-baseline-'));
@@ -63,7 +64,8 @@ describe('buildBaseline', () => {
 
   it('captures git base_sha and artifact hashes', () => {
     mkdirSync(join(dir, '.mpl'), { recursive: true });
-    writeFileSync(join(dir, '.mpl/goal-contract.yaml'), 'mission:\n  goal: test\n');
+    const goalContractText = 'mission:\n  goal: test\n';
+    writeFileSync(join(dir, '.mpl/goal-contract.yaml'), goalContractText);
     writeFileSync(join(dir, '.mpl/pivot-points.md'), '## PP-1\nAuth is immutable');
 
     const b = buildBaseline(dir, {
@@ -80,6 +82,8 @@ describe('buildBaseline', () => {
     assert.ok(b.artifacts.pivot_points);
     assert.ok(b.artifacts.goal_contract);
     assert.equal(b.artifacts.goal_contract.sha256.length, 64);
+    assert.equal(b.artifacts.goal_contract.sha256, hashNormalizedGoalContractText(goalContractText));
+    assert.notEqual(b.artifacts.goal_contract.sha256, sha256File(dir, '.mpl/goal-contract.yaml'));
     assert.equal(b.artifacts.pivot_points.sha256.length, 64);
     assert.equal(b.artifacts.core_scenarios, null);  // file absent
     assert.equal(b.ambiguity.final_score, 0.18);

--- a/hooks/__tests__/mpl-goal-contract.test.mjs
+++ b/hooks/__tests__/mpl-goal-contract.test.mjs
@@ -7,7 +7,9 @@ import { tmpdir } from 'os';
 import {
   GOAL_CONTRACT_REL_PATH,
   MVP_SCOPE_ARTIFACTS,
+  hashNormalizedGoalContractText,
   parseGoalContractText,
+  readBaselineGoalContractHash,
   readGoalContract,
   validateGoalContractText,
 } from '../lib/mpl-goal-contract.mjs';
@@ -138,6 +140,27 @@ describe('goal contract parsing', () => {
     assert.equal(verdict.exists, true);
     assert.equal(verdict.valid, true);
     assert.equal(verdict.contract.mission.project_pivot, 'Avoid false completion');
+  });
+
+  it('uses the shared normalized hash helper for content_sha256', () => {
+    const text = `${validGoalContract()}\n`;
+    const c = parseGoalContractText(text);
+    assert.equal(c.content_sha256, hashNormalizedGoalContractText(text));
+  });
+
+  it('validates baseline goal contract hashes as lowercase 64-char hex', () => {
+    mkdirSync(join(tmp, '.mpl', 'mpl'), { recursive: true });
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'baseline.yaml'), `
+artifacts:
+  goal_contract:
+    path: ".mpl/goal-contract.yaml"
+    sha256: "43aaf36b9bf7"
+`);
+    const baseline = readBaselineGoalContractHash(tmp);
+    assert.equal(baseline.exists, true);
+    assert.equal(baseline.hash, null);
+    assert.match(baseline.error, /expected 64 lowercase hex/);
+    assert.equal(baseline.rawHash, '43aaf36b9bf7');
   });
 });
 

--- a/hooks/__tests__/mpl-goal-contract.test.mjs
+++ b/hooks/__tests__/mpl-goal-contract.test.mjs
@@ -146,6 +146,8 @@ describe('goal contract parsing', () => {
     const text = `${validGoalContract()}\n`;
     const c = parseGoalContractText(text);
     assert.equal(c.content_sha256, hashNormalizedGoalContractText(text));
+    assert.equal(hashNormalizedGoalContractText(`\n${text}`), c.content_sha256);
+    assert.equal(hashNormalizedGoalContractText(`\uFEFF${text}`), c.content_sha256);
   });
 
   it('validates baseline goal contract hashes as lowercase 64-char hex', () => {
@@ -161,6 +163,20 @@ artifacts:
     assert.equal(baseline.hash, null);
     assert.match(baseline.error, /expected 64 lowercase hex/);
     assert.equal(baseline.rawHash, '43aaf36b9bf7');
+  });
+
+  it('treats an existing baseline without goal_contract.sha256 as corrupt', () => {
+    mkdirSync(join(tmp, '.mpl', 'mpl'), { recursive: true });
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'baseline.yaml'), `
+artifacts:
+  pivot_points:
+    path: ".mpl/pivot-points.md"
+    sha256: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+`);
+    const baseline = readBaselineGoalContractHash(tmp);
+    assert.equal(baseline.exists, true);
+    assert.equal(baseline.hash, null);
+    assert.equal(baseline.error, 'missing_goal_contract_sha256');
   });
 });
 

--- a/hooks/__tests__/mpl-goal-trace.test.mjs
+++ b/hooks/__tests__/mpl-goal-trace.test.mjs
@@ -12,6 +12,7 @@ import {
   validateMvpGoalTraceCoverage,
 } from '../lib/mpl-goal-trace.mjs';
 import { readGoalContract } from '../lib/mpl-goal-contract.mjs';
+import { buildBaseline, writeBaseline } from '../lib/mpl-baseline.mjs';
 import { parsePhaseContractGraphText } from '../lib/mpl-phase-contract-graph.mjs';
 import { CURRENT_SCHEMA_VERSION } from '../lib/mpl-state.mjs';
 
@@ -170,6 +171,20 @@ describe('mpl-require-goal-trace hook integration', () => {
     assert.equal(r.continue, true);
   });
 
+  it('allows complete goal trace when Phase 0 baseline used the normalized goal-contract hash', () => {
+    const baseline = buildBaseline(tmp, {
+      pipelineId: 'mpl-test',
+      userRequest: 'Build app',
+      accumulatedResponses: '',
+      ambiguity: { final_score: 0.1, threshold_met: true, override: null, rounds: 1 },
+      codebaseSkipped: true,
+    });
+    writeBaseline(tmp, baseline);
+
+    const r = runHook(decomposition());
+    assert.equal(r.continue, true);
+  });
+
   it('blocks MultiEdit writes with missing top-level goal_contract_hash', () => {
     const r = runHook(null, {
       toolName: 'MultiEdit',
@@ -201,9 +216,22 @@ phases:
   });
 
   it('blocks when baseline goal contract hash differs from current goal contract', () => {
-    const r = runHook(decomposition(), { baselineHash: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef' });
+    const baselineHash = 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef';
+    const currentHash = goalHash();
+    const r = runHook(decomposition(), { baselineHash });
     assert.equal(r.decision, 'block');
     assert.match(r.reason, /drifted from baseline/);
+    assert.match(r.reason, new RegExp(baselineHash));
+    assert.match(r.reason, new RegExp(currentHash));
+    assert.match(r.reason, /raw shasum may differ/);
+  });
+
+  it('blocks explicitly when baseline goal contract hash is truncated', () => {
+    const r = runHook(decomposition(), { baselineHash: '43aaf36b9bf7' });
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason, /corrupt baseline\.yaml goal_contract sha256/);
+    assert.match(r.reason, /expected 64 lowercase hex/);
+    assert.match(r.reason, /43aaf36b9bf7/);
   });
 
   it('allows opt-out via goal_trace_required=false', () => {

--- a/hooks/__tests__/mpl-goal-trace.test.mjs
+++ b/hooks/__tests__/mpl-goal-trace.test.mjs
@@ -179,6 +179,7 @@ describe('mpl-require-goal-trace hook integration', () => {
       ambiguity: { final_score: 0.1, threshold_met: true, override: null, rounds: 1 },
       codebaseSkipped: true,
     });
+    assert.equal(baseline.artifacts.goal_contract.sha256, goalHash());
     writeBaseline(tmp, baseline);
 
     const r = runHook(decomposition());
@@ -232,6 +233,18 @@ phases:
     assert.match(r.reason, /corrupt baseline\.yaml goal_contract sha256/);
     assert.match(r.reason, /expected 64 lowercase hex/);
     assert.match(r.reason, /43aaf36b9bf7/);
+  });
+
+  it('blocks explicitly when baseline exists without goal_contract sha256', () => {
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'baseline.yaml'), `
+artifacts:
+  pivot_points:
+    path: ".mpl/pivot-points.md"
+    sha256: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+`);
+    const r = runHook(decomposition());
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason, /missing_goal_contract_sha256/);
   });
 
   it('allows opt-out via goal_trace_required=false', () => {

--- a/hooks/__tests__/mpl-require-finalize-artifacts.test.mjs
+++ b/hooks/__tests__/mpl-require-finalize-artifacts.test.mjs
@@ -184,4 +184,17 @@ artifacts:
     assert.match(r.reason, /expected 64 lowercase hex/);
     assert.match(r.reason, /43aaf36b9bf7/);
   });
+
+  it('blocks explicitly when baseline exists without goal_contract sha256', () => {
+    writeArtifacts();
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'baseline.yaml'), `
+artifacts:
+  pivot_points:
+    path: ".mpl/pivot-points.md"
+    sha256: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+`);
+    const r = runHook();
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason, /missing_goal_contract_sha256/);
+  });
 });

--- a/hooks/__tests__/mpl-require-finalize-artifacts.test.mjs
+++ b/hooks/__tests__/mpl-require-finalize-artifacts.test.mjs
@@ -154,15 +154,34 @@ describe('mpl-require-finalize-artifacts hook', () => {
   it('blocks when current goal contract hash drifted from baseline', () => {
     writeArtifacts();
     const currentHash = readGoalContract(tmp).contract.content_sha256;
+    const baselineHash = 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef';
     assert.equal(currentHash.length, 64);
     writeFileSync(join(tmp, '.mpl', 'mpl', 'baseline.yaml'), `
 artifacts:
   goal_contract:
     path: ".mpl/goal-contract.yaml"
-    sha256: "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+    sha256: "${baselineHash}"
 `);
     const r = runHook();
     assert.equal(r.decision, 'block');
     assert.match(r.reason, /goal contract drifted from baseline/);
+    assert.match(r.reason, new RegExp(baselineHash));
+    assert.match(r.reason, new RegExp(currentHash));
+    assert.match(r.reason, /raw shasum may differ/);
+  });
+
+  it('blocks explicitly when baseline goal contract hash is corrupt', () => {
+    writeArtifacts();
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'baseline.yaml'), `
+artifacts:
+  goal_contract:
+    path: ".mpl/goal-contract.yaml"
+    sha256: "43aaf36b9bf7"
+`);
+    const r = runHook();
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason, /corrupt baseline\.yaml goal_contract sha256/);
+    assert.match(r.reason, /expected 64 lowercase hex/);
+    assert.match(r.reason, /43aaf36b9bf7/);
   });
 });

--- a/hooks/lib/mpl-baseline.mjs
+++ b/hooks/lib/mpl-baseline.mjs
@@ -41,6 +41,7 @@ import { existsSync, readFileSync, statSync, mkdirSync, writeFileSync } from 'fs
 import { join, resolve } from 'path';
 import { execSync } from 'child_process';
 import { createHash } from 'crypto';
+import { GOAL_CONTRACT_REL_PATH, hashNormalizedGoalContractFile } from './mpl-goal-contract.mjs';
 
 const BASELINE_PATH = '.mpl/mpl/baseline.yaml';
 const RENEWAL_FLAG = '.mpl/mpl/.baseline-renewal';
@@ -100,8 +101,8 @@ export function buildBaseline(cwd, {
   const porcelain = git(cwd, 'status --porcelain');
   const workingTreeClean = porcelain === '';
 
-  const artifactFor = (relPath) => {
-    const hash = sha256File(cwd, relPath);
+  const artifactFor = (relPath, hashFn = sha256File) => {
+    const hash = hashFn(cwd, relPath);
     return hash ? { path: relPath, sha256: hash } : null;
   };
 
@@ -116,7 +117,7 @@ export function buildBaseline(cwd, {
       working_tree_clean: workingTreeClean,
     },
     artifacts: {
-      goal_contract: artifactFor('.mpl/goal-contract.yaml'),
+      goal_contract: artifactFor(GOAL_CONTRACT_REL_PATH, hashNormalizedGoalContractFile),
       pivot_points: artifactFor('.mpl/pivot-points.md'),
       core_scenarios: artifactFor('.mpl/mpl/core-scenarios.yaml'),
       design_intent: artifactFor('.mpl/mpl/phase0/design-intent.yaml'),

--- a/hooks/lib/mpl-goal-contract.mjs
+++ b/hooks/lib/mpl-goal-contract.mjs
@@ -20,6 +20,7 @@ import { createHash } from 'crypto';
 
 export const GOAL_CONTRACT_REL_PATH = '.mpl/goal-contract.yaml';
 export const BASELINE_REL_PATH = '.mpl/mpl/baseline.yaml';
+const LOWER_HEX_SHA256_RE = /^[0-9a-f]{64}$/;
 
 const DEFAULT_REQUIRED_ARTIFACTS = [
   '.mpl/mpl/audit-report.json',
@@ -128,8 +129,22 @@ function idsInTopList(text, key, prefixRe) {
   return out;
 }
 
+export function normalizeGoalContractText(text) {
+  return String(text || '').replace(/\r\n/g, '\n').trim();
+}
+
+export function hashNormalizedGoalContractText(text) {
+  return createHash('sha256').update(normalizeGoalContractText(text)).digest('hex');
+}
+
+export function hashNormalizedGoalContractFile(cwd, relPath = GOAL_CONTRACT_REL_PATH) {
+  const path = join(cwd, relPath);
+  if (!existsSync(path)) return null;
+  return hashNormalizedGoalContractText(readFileSync(path, 'utf-8'));
+}
+
 function sha256(text) {
-  return createHash('sha256').update(String(text || '').replace(/\r\n/g, '\n').trim()).digest('hex');
+  return hashNormalizedGoalContractText(text);
 }
 
 function parseMvpScope(text) {
@@ -301,16 +316,24 @@ export function readGoalContract(cwd) {
 
 export function readBaselineGoalContractHash(cwd) {
   const path = join(cwd, BASELINE_REL_PATH);
-  if (!existsSync(path)) return { exists: false, hash: null };
+  if (!existsSync(path)) return { exists: false, hash: null, error: null, rawHash: null };
   try {
     const text = readFileSync(path, 'utf-8');
     const block = extractTopBlock(text, 'artifacts');
     const goalBlockMatch = block.match(/^\s+goal_contract\s*:\s*\n((?:\s{4}.+\n?)*)/m);
     const goalBlock = goalBlockMatch ? goalBlockMatch[1] : '';
     const hash = scalarInBlock(goalBlock, 'sha256');
-    return { exists: true, hash };
+    if (hash && !LOWER_HEX_SHA256_RE.test(hash)) {
+      return {
+        exists: true,
+        hash: null,
+        error: `corrupt_goal_contract_sha256: expected 64 lowercase hex characters, got ${hash.length}`,
+        rawHash: hash,
+      };
+    }
+    return { exists: true, hash, error: null, rawHash: hash };
   } catch {
-    return { exists: true, hash: null };
+    return { exists: true, hash: null, error: 'unreadable_baseline', rawHash: null };
   }
 }
 

--- a/hooks/lib/mpl-goal-contract.mjs
+++ b/hooks/lib/mpl-goal-contract.mjs
@@ -130,6 +130,8 @@ function idsInTopList(text, key, prefixRe) {
 }
 
 export function normalizeGoalContractText(text) {
+  // Goal contracts are YAML-shaped MPL artifacts. Leading/trailing whitespace
+  // and UTF-8 BOMs are non-semantic for this contract hash.
   return String(text || '').replace(/\r\n/g, '\n').trim();
 }
 
@@ -141,10 +143,6 @@ export function hashNormalizedGoalContractFile(cwd, relPath = GOAL_CONTRACT_REL_
   const path = join(cwd, relPath);
   if (!existsSync(path)) return null;
   return hashNormalizedGoalContractText(readFileSync(path, 'utf-8'));
-}
-
-function sha256(text) {
-  return hashNormalizedGoalContractText(text);
 }
 
 function parseMvpScope(text) {
@@ -206,7 +204,7 @@ export function parseGoalContractText(text) {
       require_finalize_timestamps: booleanInBlock(completionEvidence, 'require_finalize_timestamps'),
     },
     mvp_scope: parseMvpScope(text),
-    content_sha256: sha256(text),
+    content_sha256: hashNormalizedGoalContractText(text),
   };
 }
 
@@ -323,6 +321,14 @@ export function readBaselineGoalContractHash(cwd) {
     const goalBlockMatch = block.match(/^\s+goal_contract\s*:\s*\n((?:\s{4}.+\n?)*)/m);
     const goalBlock = goalBlockMatch ? goalBlockMatch[1] : '';
     const hash = scalarInBlock(goalBlock, 'sha256');
+    if (!hash) {
+      return {
+        exists: true,
+        hash: null,
+        error: 'missing_goal_contract_sha256',
+        rawHash: null,
+      };
+    }
     if (hash && !LOWER_HEX_SHA256_RE.test(hash)) {
       return {
         exists: true,
@@ -332,8 +338,13 @@ export function readBaselineGoalContractHash(cwd) {
       };
     }
     return { exists: true, hash, error: null, rawHash: hash };
-  } catch {
-    return { exists: true, hash: null, error: 'unreadable_baseline', rawHash: null };
+  } catch (error) {
+    return {
+      exists: true,
+      hash: null,
+      error: `unreadable_baseline: ${error?.message || 'unknown error'}`,
+      rawHash: null,
+    };
   }
 }
 

--- a/hooks/mpl-require-finalize-artifacts.mjs
+++ b/hooks/mpl-require-finalize-artifacts.mjs
@@ -207,10 +207,21 @@ async function main() {
   const contract = goal.valid ? goal.contract : null;
   if (cfg.goal_contract_required !== false && contract?.content_sha256) {
     const baseline = readBaselineGoalContractHash(cwd);
+    if (baseline.error) {
+      block(
+        `[MPL Finalize Guard] Cannot set finalize_done=true — corrupt baseline.yaml goal_contract sha256 ` +
+          `(${baseline.error}${baseline.rawHash ? `: ${baseline.rawHash}` : ''}). ` +
+          `Expected the 64-character lowercase normalized SHA-256 for .mpl/goal-contract.yaml. ` +
+          `Raw shasum may differ because MPL normalizes CRLF to LF and trims surrounding whitespace before hashing. ` +
+          `Re-run Phase 0 renewal before finalizing.`
+      );
+      return;
+    }
     if (baseline.hash && baseline.hash !== contract.content_sha256) {
       block(
         `[MPL Finalize Guard] Cannot set finalize_done=true — goal contract drifted from baseline.yaml ` +
-          `(baseline=${baseline.hash.slice(0, 12)}, current=${contract.content_sha256.slice(0, 12)}). ` +
+          `(baseline=${baseline.hash}, current=${contract.content_sha256}). ` +
+          `These are MPL normalized hashes; raw shasum may differ because MPL normalizes CRLF to LF and trims surrounding whitespace. ` +
           `Re-run Phase 0 renewal before finalizing.`
       );
       return;

--- a/hooks/mpl-require-goal-trace.mjs
+++ b/hooks/mpl-require-goal-trace.mjs
@@ -82,10 +82,21 @@ async function main() {
   }
 
   const baseline = readBaselineGoalContractHash(cwd);
+  if (baseline.error) {
+    block(
+      `[MPL Goal Trace] Cannot write decomposition.yaml — corrupt baseline.yaml goal_contract sha256 ` +
+        `(${baseline.error}${baseline.rawHash ? `: ${baseline.rawHash}` : ''}). ` +
+        `Expected the 64-character lowercase normalized SHA-256 for .mpl/goal-contract.yaml. ` +
+        `Raw shasum may differ because MPL normalizes CRLF to LF and trims surrounding whitespace before hashing. ` +
+        `Re-run Phase 0 renewal before recomposing.`
+    );
+    return;
+  }
   if (baseline.hash && baseline.hash !== goal.contract.content_sha256) {
     block(
       `[MPL Goal Trace] Cannot write decomposition.yaml — .mpl/goal-contract.yaml drifted from baseline.yaml ` +
-        `(baseline=${baseline.hash.slice(0, 12)}, current=${goal.contract.content_sha256.slice(0, 12)}). ` +
+        `(baseline=${baseline.hash}, current=${goal.contract.content_sha256}). ` +
+        `These are MPL normalized hashes; raw shasum may differ because MPL normalizes CRLF to LF and trims surrounding whitespace. ` +
         `Re-run Phase 0 renewal before recomposing.`
     );
     return;


### PR DESCRIPTION
## What
- Share a normalized goal-contract hash helper across goal-contract parsing and Phase 0 baseline generation.
- Store `.mpl/goal-contract.yaml` baseline hashes using the same normalized CRLF-to-LF + trim algorithm that guards compare.
- Validate baseline goal-contract hashes as 64-character lowercase hex and fail closed on corrupt baseline hashes.
- Show full normalized hashes in goal trace/finalize drift blocks and warn that raw `shasum` may differ.
- Add regression tests for trailing-newline baseline parity, corrupt/truncated baseline hashes, and finalize guard parity.
- Add finding documentation for the corrected raw-vs-normalized root cause and truncation deadlock.

## Why
Closes #195.

A Phase 0 baseline could record a raw file hash while goal-trace/finalize guards compared a normalized content hash. A harmless trailing newline could therefore look like immediate goal-contract drift, and truncated/corrupt baseline hashes were not clearly blocked.

## Design
- `docs/findings/2026-05-26-decomposer-cost-and-deadlock.md`
- Shared helper in `hooks/lib/mpl-goal-contract.mjs`

## Verification
- `node --test hooks/__tests__/mpl-baseline.test.mjs`
- `node --test hooks/__tests__/mpl-goal-contract.test.mjs`
- `node --test hooks/__tests__/mpl-goal-trace.test.mjs`
- `node --test hooks/__tests__/mpl-require-finalize-artifacts.test.mjs`
- `npm test`
- `git diff --check`

## Agent Review Status

This PR is gated on **2 unique agent reviews** using footer markers.

- [x] from claude
- [x] from codex

---
_Awaiting reviews. Merge once the gate is satisfied._

