### PR TITLE
Make execution_tiers scheduler decisions observable (#205)

### DIFF
--- a/commands/mpl-run-execute.md
+++ b/commands/mpl-run-execute.md
@@ -82,33 +82,83 @@ for each wave in waves:
 
   ready_but_blocked = phase_ids - wave when blocked by file overlap, resource lock, or dependency frontier
   record ready_but_blocked_reason for each blocked phase in the tier reconciliation artifact
-  record_scheduler_event({
-    pipeline_id: state.pipeline_id,
-    run_started_at: state.started_at,
-    tier: tier.tier,
-    phases: phase_ids,
-    wave,
-    selected_mode: wave.length > 1 ? "parallel" : "parallel_rejected",
-    parallel_requested: true,
-    worker_cap: max_phase_workers,
-    rejection_reasons_by_phase: ready_but_blocked_reason,
-    worktree_slots: wave.length > 1 ? planned_slot_ids : []
-  })
 
-  // Multi-worktree pool. Reuse up to max_phase_workers isolated slots after
-  // verifying each worktree has the current base branch commit reachable.
-  worktree_pool = ensure_worktree_pool(size: min(max_phase_workers, wave.length))
-  append state.worktree_pool_history entries for every slot creation/reuse:
-    { tier, phase_id, slot_id, worktree_path, base_ref, started_at, completed_at }
-  // Distinct from state.worktree_history (HIGH-risk isolation lifecycle in
-  // mpl-run-execute-context.md §5: { phase_id, branch, path, risk_level,
-  // result, timestamp }). Two writers, two consumers, two arrays.
+  if wave.length == 1:
+    // Cannot parallelize at all — emit rejection BEFORE the single-phase
+    // execution. The rejection itself is a planning decision, not an
+    // execution outcome, so it is safe to log here.
+    record_scheduler_event({
+      pipeline_id: state.pipeline_id,
+      run_started_at: state.started_at,
+      tier: tier.tier,
+      phases: phase_ids,
+      wave,
+      selected_mode: "parallel_rejected",
+      parallel_requested: true,
+      worker_cap: max_phase_workers,
+      rejection_reasons_by_phase: ready_but_blocked_reason,
+      worktree_slots: []
+    })
+    execute_single_phase(wave[0])
+    continue
 
-  results = parallel_map(wave, fn(phase_id, slot):
-    seed = generate_phase_seed(phase_id, all_prior_summaries)
-    context = assemble_context(phase_id, seed)
-    return execute_phase(context, isolation: worktree_pool[slot])
-  , max_concurrent: min(max_phase_workers, wave.length))
+  // wave.length > 1 — attempt actual parallel execution. The "parallel"
+  // event MUST NOT be emitted before the wave finishes successfully; a pool
+  // setup or worker dispatch failure would otherwise leave a row that
+  // satisfies the run-summary even though no parallel work happened. Emit
+  // the outcome event AFTER parallel_map returns, with the actual worktree
+  // slot ids used. On failure, emit a parallel_failed event so the
+  // partial-failure path stays visible.
+  try:
+    // Multi-worktree pool. Reuse up to max_phase_workers isolated slots
+    // after verifying each worktree has the current base branch commit
+    // reachable.
+    worktree_pool = ensure_worktree_pool(size: min(max_phase_workers, wave.length))
+    append state.worktree_pool_history entries for every slot creation/reuse:
+      { tier, phase_id, slot_id, worktree_path, base_ref, started_at, completed_at }
+    // Distinct from state.worktree_history (HIGH-risk isolation lifecycle
+    // in mpl-run-execute-context.md §5: { phase_id, branch, path,
+    // risk_level, result, timestamp }). Two writers, two consumers, two
+    // arrays.
+
+    results = parallel_map(wave, fn(phase_id, slot):
+      seed = generate_phase_seed(phase_id, all_prior_summaries)
+      context = assemble_context(phase_id, seed)
+      return execute_phase(context, isolation: worktree_pool[slot])
+    , max_concurrent: min(max_phase_workers, wave.length))
+
+    // Emit the proof-of-execution event. selected_mode:"parallel" means
+    // the wave actually ran in parallel, not that it was planned to.
+    record_scheduler_event({
+      pipeline_id: state.pipeline_id,
+      run_started_at: state.started_at,
+      tier: tier.tier,
+      phases: phase_ids,
+      wave,
+      selected_mode: "parallel",
+      parallel_requested: true,
+      worker_cap: max_phase_workers,
+      rejection_reasons_by_phase: ready_but_blocked_reason,
+      worktree_slots: actual_slot_ids_used
+    })
+  catch err:
+    // Pool setup, worker dispatch, or per-phase execution failed before the
+    // wave completed. Emit a distinct mode so finalize does not count this
+    // as parallel execution.
+    record_scheduler_event({
+      pipeline_id: state.pipeline_id,
+      run_started_at: state.started_at,
+      tier: tier.tier,
+      phases: phase_ids,
+      wave,
+      selected_mode: "parallel_failed",
+      parallel_requested: true,
+      worker_cap: max_phase_workers,
+      rejection_reasons_by_phase: ready_but_blocked_reason,
+      worktree_slots: [],
+      failure_reason: err.message
+    })
+    raise
 
   // Merge worktree results sequentially in decomposition order.
   for each result in sort_by_decomposition_order(results):
@@ -154,7 +204,11 @@ unique per-run scope key is `state.started_at` (ISO timestamp set once at
 - `tier`
 - `phases`
 - `parallel_requested`
-- `selected_mode`: `skipped | sequential | parallel | parallel_rejected`
+- `selected_mode`: `skipped | sequential | parallel | parallel_rejected |
+  parallel_failed`. `parallel` is the proof-of-execution mode — emit only
+  AFTER `parallel_map` returns successfully. `parallel_failed` is for pool
+  setup, worker dispatch, or per-phase failures inside the wave. The
+  finalize summary counts ONLY `parallel` toward `tiers_parallel_executed`.
 - `rejection_reasons` or `rejection_reasons_by_phase`
 - `worker_cap`
 - `worktree_slots`

--- a/commands/mpl-run-execute.md
+++ b/commands/mpl-run-execute.md
@@ -45,6 +45,7 @@ if phase_ids.length == 0:
   record_scheduler_event({
     pipeline_id: state.pipeline_id,
     run_started_at: state.started_at,
+    recompose_count: decomposition.recompose_count,
     tier: tier.tier,
     phases: tier.phases,
     selected_mode: "skipped",
@@ -59,6 +60,7 @@ if tier.parallel != true or phase_ids.length == 1:
   record_scheduler_event({
     pipeline_id: state.pipeline_id,
     run_started_at: state.started_at,
+    recompose_count: decomposition.recompose_count,
     tier: tier.tier,
     phases: phase_ids,
     selected_mode: "sequential",
@@ -90,6 +92,7 @@ for each wave in waves:
     record_scheduler_event({
       pipeline_id: state.pipeline_id,
       run_started_at: state.started_at,
+      recompose_count: decomposition.recompose_count,
       tier: tier.tier,
       phases: phase_ids,
       wave,
@@ -132,6 +135,7 @@ for each wave in waves:
     record_scheduler_event({
       pipeline_id: state.pipeline_id,
       run_started_at: state.started_at,
+      recompose_count: decomposition.recompose_count,
       tier: tier.tier,
       phases: phase_ids,
       wave,
@@ -148,6 +152,7 @@ for each wave in waves:
     record_scheduler_event({
       pipeline_id: state.pipeline_id,
       run_started_at: state.started_at,
+      recompose_count: decomposition.recompose_count,
       tier: tier.tier,
       phases: phase_ids,
       wave,
@@ -200,6 +205,12 @@ unique per-run scope key is `state.started_at` (ISO timestamp set once at
 - `run_started_at` (= `state.started_at` at write time; the actual
   per-run unique key. `pipeline_id` alone collides on same-day same-slug
   reruns, so the finalizer filters by `pipeline_id AND run_started_at`.)
+- `recompose_count` (= `decomposition.recompose_count` at write time;
+  APPEND-MODE/RECOMPOSE-MODE rewrites `execution_tiers` mid-run, and the
+  same tier number can mean different phases before vs. after a
+  recompose. Without this key, a stale parallel event for tier N
+  pre-recompose could satisfy the post-recompose tier N. Finalizer
+  filters on this too.)
 - `timestamp` (event emission time; distinct from `run_started_at`)
 - `tier`
 - `phases`

--- a/commands/mpl-run-execute.md
+++ b/commands/mpl-run-execute.md
@@ -47,6 +47,8 @@ if phase_ids.length == 0:
     run_started_at: state.started_at,
     recompose_count: decomposition.recompose_count,
     tier: tier.tier,
+    wave_index: 0,
+    timestamp: now_iso(),
     phases: tier.phases,
     selected_mode: "skipped",
     parallel_requested: tier.parallel == true,
@@ -62,6 +64,8 @@ if tier.parallel != true or phase_ids.length == 1:
     run_started_at: state.started_at,
     recompose_count: decomposition.recompose_count,
     tier: tier.tier,
+    wave_index: 0,
+    timestamp: now_iso(),
     phases: phase_ids,
     selected_mode: "sequential",
     parallel_requested: tier.parallel == true,
@@ -79,7 +83,7 @@ waves = split_into_conflict_free_waves(phase_ids, rules:
   - every interface_contract.requires[].from_phase is already completed or in an earlier tier
 )
 
-for each wave in waves:
+for each (wave, wave_index) in enumerate(waves):
   announce: "[MPL] Tier {tier.tier}: executing {wave.length} phase(s) with max {max_phase_workers} workers"
 
   ready_but_blocked = phase_ids - wave when blocked by file overlap, resource lock, or dependency frontier
@@ -94,6 +98,8 @@ for each wave in waves:
       run_started_at: state.started_at,
       recompose_count: decomposition.recompose_count,
       tier: tier.tier,
+      wave_index: wave_index,
+      timestamp: now_iso(),
       phases: phase_ids,
       wave,
       selected_mode: "parallel_rejected",
@@ -137,6 +143,8 @@ for each wave in waves:
       run_started_at: state.started_at,
       recompose_count: decomposition.recompose_count,
       tier: tier.tier,
+      wave_index: wave_index,
+      timestamp: now_iso(),
       phases: phase_ids,
       wave,
       selected_mode: "parallel",
@@ -154,6 +162,8 @@ for each wave in waves:
       run_started_at: state.started_at,
       recompose_count: decomposition.recompose_count,
       tier: tier.tier,
+      wave_index: wave_index,
+      timestamp: now_iso(),
       phases: phase_ids,
       wave,
       selected_mode: "parallel_failed",
@@ -211,8 +221,14 @@ unique per-run scope key is `state.started_at` (ISO timestamp set once at
   recompose. Without this key, a stale parallel event for tier N
   pre-recompose could satisfy the post-recompose tier N. Finalizer
   filters on this too.)
-- `timestamp` (event emission time; distinct from `run_started_at`)
 - `tier`
+- `wave_index` (per-tier wave counter, 0 for the skipped/sequential
+  branches and the zero-based wave index inside the `for each wave`
+  loop. Required so two same-tier `parallel_rejected` or
+  `parallel_failed` events do not collapse on the dedupe key.)
+- `timestamp` (ISO event-emission time; distinct from `run_started_at`.
+  Always set via `now_iso()` so two events emitted in the same
+  millisecond still differ when combined with `wave_index`.)
 - `phases`
 - `parallel_requested`
 - `selected_mode`: `skipped | sequential | parallel | parallel_rejected |

--- a/commands/mpl-run-execute.md
+++ b/commands/mpl-run-execute.md
@@ -43,6 +43,7 @@ phase_ids = tier.phases.filter(id => !is_completed(id))
 
 if phase_ids.length == 0:
   record_scheduler_event({
+    pipeline_id: state.pipeline_id,
     tier: tier.tier,
     phases: tier.phases,
     selected_mode: "skipped",
@@ -55,6 +56,7 @@ if phase_ids.length == 0:
 
 if tier.parallel != true or phase_ids.length == 1:
   record_scheduler_event({
+    pipeline_id: state.pipeline_id,
     tier: tier.tier,
     phases: phase_ids,
     selected_mode: "sequential",
@@ -79,6 +81,7 @@ for each wave in waves:
   ready_but_blocked = phase_ids - wave when blocked by file overlap, resource lock, or dependency frontier
   record ready_but_blocked_reason for each blocked phase in the tier reconciliation artifact
   record_scheduler_event({
+    pipeline_id: state.pipeline_id,
     tier: tier.tier,
     phases: phase_ids,
     wave,
@@ -134,8 +137,12 @@ run_cumulative_tests(phase_ids)
 
 `record_scheduler_event(...)` is mandatory telemetry. Append one JSON line to
 `.mpl/mpl/profile/phase-scheduler.jsonl` and mirror the latest 50 entries in
-`state.phase_scheduler_history`. Every row must include:
+`state.phase_scheduler_history`. The JSONL file is persistent across pipeline
+starts — `pipeline_id` on every row is what scopes events to the current run
+when the finalizer aggregates. Every row must include:
 
+- `pipeline_id` (= `state.pipeline_id` at write time; required so the
+  finalizer can filter out rows from prior runs in the same profile file)
 - `timestamp`
 - `tier`
 - `phases`

--- a/commands/mpl-run-execute.md
+++ b/commands/mpl-run-execute.md
@@ -42,9 +42,23 @@ For each tier in ascending `tier` order:
 phase_ids = tier.phases.filter(id => !is_completed(id))
 
 if phase_ids.length == 0:
+  record_scheduler_event({
+    tier: tier.tier,
+    phases: tier.phases,
+    selected_mode: "skipped",
+    parallel_requested: tier.parallel == true,
+    rejection_reasons: ["all_phases_already_completed"]
+  })
   continue
 
 if tier.parallel != true or phase_ids.length == 1:
+  record_scheduler_event({
+    tier: tier.tier,
+    phases: phase_ids,
+    selected_mode: "sequential",
+    parallel_requested: tier.parallel == true,
+    rejection_reasons: tier.parallel == true ? ["single_ready_phase"] : ["tier_parallel_false"]
+  })
   for each phase_id in phase_ids:
     execute_single_phase(phase_id)  // normal flow: 4.0.5 → 4.1 → 4.2 → 4.3 → 4.8
   continue
@@ -60,10 +74,22 @@ for each wave in waves:
 
   ready_but_blocked = phase_ids - wave when blocked by file overlap, resource lock, or dependency frontier
   record ready_but_blocked_reason for each blocked phase in the tier reconciliation artifact
+  record_scheduler_event({
+    tier: tier.tier,
+    phases: phase_ids,
+    wave,
+    selected_mode: wave.length > 1 ? "parallel" : "parallel_rejected",
+    parallel_requested: true,
+    worker_cap: max_phase_workers,
+    rejection_reasons_by_phase: ready_but_blocked_reason,
+    worktree_slots: wave.length > 1 ? planned_slot_ids : []
+  })
 
   // Multi-worktree pool. Reuse up to max_phase_workers isolated slots after
   // verifying each worktree has the current base branch commit reachable.
   worktree_pool = ensure_worktree_pool(size: min(max_phase_workers, wave.length))
+  append state.worktree_history entries for every slot creation/reuse:
+    { tier, phase_id, slot_id, worktree_path, base_ref, started_at, completed_at }
 
   results = parallel_map(wave, fn(phase_id, slot):
     seed = generate_phase_seed(phase_id, all_prior_summaries)
@@ -98,6 +124,26 @@ else:
 
 run_cumulative_tests(phase_ids)
 ```
+
+`record_scheduler_event(...)` is mandatory telemetry. Append one JSON line to
+`.mpl/mpl/profile/phase-scheduler.jsonl` and mirror the latest 50 entries in
+`state.phase_scheduler_history`. Every row must include:
+
+- `timestamp`
+- `tier`
+- `phases`
+- `parallel_requested`
+- `selected_mode`: `skipped | sequential | parallel | parallel_rejected`
+- `rejection_reasons` or `rejection_reasons_by_phase`
+- `worker_cap`
+- `worktree_slots`
+
+If no tier ever records `selected_mode:"parallel"` in a run with
+`execution_tiers[].parallel:true`, the final run summary MUST explain why phase
+parallelism was not used. Do not add a separate `phase_dependencies` field for
+this purpose; dependency-frontier safety comes from existing phase
+`depends_on`/`interface_contract.requires[].from_phase` plus
+`execution_tiers`.
 
 For each single phase execution:
 

--- a/commands/mpl-run-execute.md
+++ b/commands/mpl-run-execute.md
@@ -47,7 +47,9 @@ if phase_ids.length == 0:
     phases: tier.phases,
     selected_mode: "skipped",
     parallel_requested: tier.parallel == true,
-    rejection_reasons: ["all_phases_already_completed"]
+    rejection_reasons: ["all_phases_already_completed"],
+    worker_cap: max_phase_workers,
+    worktree_slots: []
   })
   continue
 
@@ -57,7 +59,9 @@ if tier.parallel != true or phase_ids.length == 1:
     phases: phase_ids,
     selected_mode: "sequential",
     parallel_requested: tier.parallel == true,
-    rejection_reasons: tier.parallel == true ? ["single_ready_phase"] : ["tier_parallel_false"]
+    rejection_reasons: tier.parallel == true ? ["single_ready_phase"] : ["tier_parallel_false"],
+    worker_cap: max_phase_workers,
+    worktree_slots: []
   })
   for each phase_id in phase_ids:
     execute_single_phase(phase_id)  // normal flow: 4.0.5 → 4.1 → 4.2 → 4.3 → 4.8
@@ -88,8 +92,11 @@ for each wave in waves:
   // Multi-worktree pool. Reuse up to max_phase_workers isolated slots after
   // verifying each worktree has the current base branch commit reachable.
   worktree_pool = ensure_worktree_pool(size: min(max_phase_workers, wave.length))
-  append state.worktree_history entries for every slot creation/reuse:
+  append state.worktree_pool_history entries for every slot creation/reuse:
     { tier, phase_id, slot_id, worktree_path, base_ref, started_at, completed_at }
+  // Distinct from state.worktree_history (HIGH-risk isolation lifecycle in
+  // mpl-run-execute-context.md §5: { phase_id, branch, path, risk_level,
+  // result, timestamp }). Two writers, two consumers, two arrays.
 
   results = parallel_map(wave, fn(phase_id, slot):
     seed = generate_phase_seed(phase_id, all_prior_summaries)
@@ -140,10 +147,15 @@ run_cumulative_tests(phase_ids)
 
 If no tier ever records `selected_mode:"parallel"` in a run with
 `execution_tiers[].parallel:true`, the final run summary MUST explain why phase
-parallelism was not used. Do not add a separate `phase_dependencies` field for
-this purpose; dependency-frontier safety comes from existing phase
-`depends_on`/`interface_contract.requires[].from_phase` plus
-`execution_tiers`.
+parallelism was not used. The enforcement path is `commands/mpl-run-finalize.md`
+Step 5.4 `scheduler` block — it reads `.mpl/mpl/profile/phase-scheduler.jsonl`
+(falling back to `state.phase_scheduler_history`) and emits a `scheduler`
+section in `.mpl/mpl/profile/run-summary.json` per
+`commands/schemas/run-summary.json`.
+
+Do not add a separate `phase_dependencies` field for this purpose;
+dependency-frontier safety comes from existing phase `depends_on` /
+`interface_contract.requires[].from_phase` plus `execution_tiers`.
 
 For each single phase execution:
 

--- a/commands/mpl-run-execute.md
+++ b/commands/mpl-run-execute.md
@@ -44,6 +44,7 @@ phase_ids = tier.phases.filter(id => !is_completed(id))
 if phase_ids.length == 0:
   record_scheduler_event({
     pipeline_id: state.pipeline_id,
+    run_started_at: state.started_at,
     tier: tier.tier,
     phases: tier.phases,
     selected_mode: "skipped",
@@ -57,6 +58,7 @@ if phase_ids.length == 0:
 if tier.parallel != true or phase_ids.length == 1:
   record_scheduler_event({
     pipeline_id: state.pipeline_id,
+    run_started_at: state.started_at,
     tier: tier.tier,
     phases: phase_ids,
     selected_mode: "sequential",
@@ -82,6 +84,7 @@ for each wave in waves:
   record ready_but_blocked_reason for each blocked phase in the tier reconciliation artifact
   record_scheduler_event({
     pipeline_id: state.pipeline_id,
+    run_started_at: state.started_at,
     tier: tier.tier,
     phases: phase_ids,
     wave,
@@ -138,12 +141,16 @@ run_cumulative_tests(phase_ids)
 `record_scheduler_event(...)` is mandatory telemetry. Append one JSON line to
 `.mpl/mpl/profile/phase-scheduler.jsonl` and mirror the latest 50 entries in
 `state.phase_scheduler_history`. The JSONL file is persistent across pipeline
-starts — `pipeline_id` on every row is what scopes events to the current run
-when the finalizer aggregates. Every row must include:
+starts and `state.pipeline_id` is NOT unique on its own (it is
+`mpl-{date}-{slug}`, so same-day reruns of the same feature share it). The
+unique per-run scope key is `state.started_at` (ISO timestamp set once at
+`initState`). The finalizer filters by both. Every row must include:
 
-- `pipeline_id` (= `state.pipeline_id` at write time; required so the
-  finalizer can filter out rows from prior runs in the same profile file)
-- `timestamp`
+- `pipeline_id` (= `state.pipeline_id` at write time)
+- `run_started_at` (= `state.started_at` at write time; the actual
+  per-run unique key. `pipeline_id` alone collides on same-day same-slug
+  reruns, so the finalizer filters by `pipeline_id AND run_started_at`.)
+- `timestamp` (event emission time; distinct from `run_started_at`)
 - `tier`
 - `phases`
 - `parallel_requested`

--- a/commands/mpl-run-finalize.md
+++ b/commands/mpl-run-finalize.md
@@ -751,6 +751,14 @@ tiers_parallel_executed = count of distinct event.tier in
 tiers_with_missing_telemetry = expected_parallel_tiers minus
   the set of event.tier values present in events
 tiers_parallel_rejected = tiers_parallel_requested - tiers_parallel_executed
+// Wave-level visibility. A tier can split into multiple waves and emit
+// both a parallel and a parallel_rejected event; the tier-level rollup
+// above would otherwise hide the partial-rejection signal.
+waves_parallel_rejected = count of events where
+  event.selected_mode == "parallel_rejected"
+tiers_with_partial_rejection = set of event.tier where the tier has
+  BOTH a selected_mode == "parallel" event AND a selected_mode ==
+  "parallel_rejected" event
 
 scheduler = {
   tiers_total,
@@ -758,22 +766,29 @@ scheduler = {
   tiers_parallel_executed,
   tiers_parallel_rejected,
   tiers_with_missing_telemetry: <list of tier ids>,
+  waves_parallel_rejected,
+  tiers_with_partial_rejection: <list of tier ids>,
   rejection_reasons: union of event.rejection_reasons and the values of
                      event.rejection_reasons_by_phase across all events
                      (deduplicated),
   no_parallel_explanation: required (non-null) when
     tiers_parallel_requested > 0 AND
-    (tiers_parallel_executed == 0 OR tiers_with_missing_telemetry is
-     non-empty); otherwise null. The string MUST name either the
-     dominant rejection reasons (when telemetry is present) or the list
-     of tiers with missing telemetry (when not).
+    (tiers_parallel_executed == 0 OR
+     tiers_with_missing_telemetry is non-empty OR
+     tiers_with_partial_rejection is non-empty);
+    otherwise null. The string MUST name either the dominant rejection
+    reasons (when telemetry is present), the list of tiers with missing
+    telemetry (when not), or the tiers with partial rejection plus
+    their rejection reasons (when some waves rejected and others ran).
 }
 ```
 
 The `no_parallel_explanation` field is the enforcement point for the MUST in
 `commands/mpl-run-execute.md`: a run that requested parallelism but never
 reached it — including because the scheduler never recorded an event for a
-parallel-requested tier — cannot finalize with a null/missing explanation.
+parallel-requested tier, or because some waves within a tier rejected
+parallelism even though others ran — cannot finalize with a null/missing
+explanation.
 
 Profile data enables:
 1. **Learn optimal token budget by complexity**: derive average tokens per grade from past profiles

--- a/commands/mpl-run-finalize.md
+++ b/commands/mpl-run-finalize.md
@@ -715,7 +715,37 @@ Generate full run profile at `.mpl/mpl/profile/run-summary.json`.
 
 > See [`commands/schemas/run-summary.json`](schemas/run-summary.json) for the full schema.
 >
-> **Shape**: `run_id` · `complexity` (grade/score) · `cache` (phase0_hit/saved_tokens) · `phases[]` (per-phase tokens/duration_ms/pass_rate/micro_fixes) · `phase5_gate` · `totals`.
+> **Shape**: `run_id` · `complexity` (grade/score) · `cache` (phase0_hit/saved_tokens) · `phases[]` (per-phase tokens/duration_ms/pass_rate/micro_fixes) · `phase5_gate` · `totals` · `scheduler` (Exp22 R6).
+
+**Scheduler aggregation (Exp22 R6 / #205)**:
+
+```
+events = read_jsonl(".mpl/mpl/profile/phase-scheduler.jsonl") or
+         state.phase_scheduler_history or []
+tiers_total = count of distinct event.tier
+tiers_parallel_requested = count of distinct event.tier where any
+  event for that tier has parallel_requested == true
+tiers_parallel_executed = count of distinct event.tier where any
+  event for that tier has selected_mode == "parallel"
+tiers_parallel_rejected = tiers_parallel_requested - tiers_parallel_executed
+
+scheduler = {
+  tiers_total,
+  tiers_parallel_requested,
+  tiers_parallel_executed,
+  tiers_parallel_rejected,
+  rejection_reasons: union of event.rejection_reasons and the values of
+                     event.rejection_reasons_by_phase across all events
+                     (deduplicated),
+  no_parallel_explanation: <string> when
+    tiers_parallel_requested > 0 AND tiers_parallel_executed == 0, naming
+    the dominant rejection reasons; null otherwise.
+}
+```
+
+The `no_parallel_explanation` field is the enforcement point for the MUST in
+`commands/mpl-run-execute.md`: a run that requested parallelism but never
+reached it cannot finalize with a null/missing explanation.
 
 Profile data enables:
 1. **Learn optimal token budget by complexity**: derive average tokens per grade from past profiles

--- a/commands/mpl-run-finalize.md
+++ b/commands/mpl-run-finalize.md
@@ -730,8 +730,15 @@ decomposition = Read(".mpl/mpl/decomposition.yaml")
 expected_parallel_tiers = set of tier ids where
   decomposition.execution_tiers[].parallel == true
 
-events = read_jsonl(".mpl/mpl/profile/phase-scheduler.jsonl") or
-         state.phase_scheduler_history or []
+raw_events = read_jsonl(".mpl/mpl/profile/phase-scheduler.jsonl") or
+             state.phase_scheduler_history or []
+// .mpl/mpl/profile/ is persistent across pipeline starts. Without
+// pipeline_id scoping, stale rows from a prior run can satisfy the
+// current decomposition's parallel-requested tiers and mask missing
+// telemetry. The executor stamps every event with pipeline_id; the
+// finalizer filters here.
+events = raw_events.filter(e => e.pipeline_id == state.pipeline_id)
+
 tiers_total = decomposition.execution_tiers.length
 tiers_parallel_requested = expected_parallel_tiers.size
 tiers_parallel_executed = count of distinct event.tier in

--- a/commands/mpl-run-finalize.md
+++ b/commands/mpl-run-finalize.md
@@ -750,13 +750,18 @@ expected_parallel_tiers = set of tier ids where
 // de-duplicate so a degraded write on one side cannot manufacture
 // false missing telemetry.
 //
-// Two events are the same when they share
-// (pipeline_id, run_started_at, tier, timestamp, selected_mode).
+// Two events are the same when they share the full identity tuple. The
+// dedupe key MUST match hooks/lib/mpl-scheduler-aggregate.mjs:eventKey
+// exactly — including recompose_count and wave_index — or a generated
+// summary will be rejected by the finalize-artifacts guard for an
+// aggregate mismatch:
+//   (pipeline_id, run_started_at, recompose_count, tier, wave_index,
+//    timestamp, selected_mode)
 jsonl_events = read_jsonl(".mpl/mpl/profile/phase-scheduler.jsonl") or []
 state_events = state.phase_scheduler_history or []
 raw_events = dedupe_by(
   jsonl_events.concat(state_events),
-  e => `${e.pipeline_id}|${e.run_started_at}|${e.tier}|${e.timestamp}|${e.selected_mode}`
+  e => `${e.pipeline_id}|${e.run_started_at}|${e.recompose_count}|${e.tier}|${e.wave_index}|${e.timestamp}|${e.selected_mode}`
 )
 
 // .mpl/mpl/profile/ is persistent across pipeline starts. pipeline_id

--- a/commands/mpl-run-finalize.md
+++ b/commands/mpl-run-finalize.md
@@ -727,8 +727,20 @@ silently pass the no-parallel MUST.
 
 ```
 decomposition = Read(".mpl/mpl/decomposition.yaml")
+// Mirror the executor's legacy fallback (mpl-run-execute.md Step 4.0):
+// when execution_tiers is missing or empty, synthesize one
+// {tier, phases:[phase.id], parallel:false} entry per phase. Without
+// this, a legacy/resumed run with no execution_tiers would crash here
+// (empty set, undefined .length) before run-summary.json is written, and
+// the completion guard would fail closed even though the run executed.
+execution_tiers = decomposition.execution_tiers
+if not execution_tiers or execution_tiers.length == 0:
+  execution_tiers = decomposition.phases.map((p, i) => ({
+    tier: i + 1, phases: [p.id], parallel: false
+  }))
+
 expected_parallel_tiers = set of tier ids where
-  decomposition.execution_tiers[].parallel == true
+  execution_tiers[].parallel == true
 
 raw_events = read_jsonl(".mpl/mpl/profile/phase-scheduler.jsonl") or
              state.phase_scheduler_history or []
@@ -743,8 +755,12 @@ events = raw_events.filter(e =>
   e.pipeline_id == state.pipeline_id &&
   e.run_started_at == state.started_at)
 
-tiers_total = decomposition.execution_tiers.length
+tiers_total = execution_tiers.length
 tiers_parallel_requested = expected_parallel_tiers.size
+// "parallel" is the proof-of-execution mode in the executor — emitted only
+// after parallel_map returns successfully. Pool setup, worker dispatch,
+// and per-phase failures emit selected_mode:"parallel_failed" instead, so
+// they are not counted here.
 tiers_parallel_executed = count of distinct event.tier in
   expected_parallel_tiers where any event for that tier has
   selected_mode == "parallel"
@@ -756,6 +772,12 @@ tiers_parallel_rejected = tiers_parallel_requested - tiers_parallel_executed
 // above would otherwise hide the partial-rejection signal.
 waves_parallel_rejected = count of events where
   event.selected_mode == "parallel_rejected"
+// Failed parallel waves (pool setup, dispatch, or per-phase errors that
+// caused the wave to raise). Distinct from parallel_rejected (planning
+// could not parallelize) — these are runtime failures of a wave that was
+// supposed to execute in parallel.
+waves_parallel_failed = count of events where
+  event.selected_mode == "parallel_failed"
 tiers_with_partial_rejection = set of event.tier where the tier has
   BOTH a selected_mode == "parallel" event AND a selected_mode ==
   "parallel_rejected" event
@@ -767,6 +789,7 @@ scheduler = {
   tiers_parallel_rejected,
   tiers_with_missing_telemetry: <list of tier ids>,
   waves_parallel_rejected,
+  waves_parallel_failed,
   tiers_with_partial_rejection: <list of tier ids>,
   rejection_reasons: union of event.rejection_reasons and the values of
                      event.rejection_reasons_by_phase across all events
@@ -775,11 +798,13 @@ scheduler = {
     tiers_parallel_requested > 0 AND
     (tiers_parallel_executed == 0 OR
      tiers_with_missing_telemetry is non-empty OR
-     tiers_with_partial_rejection is non-empty);
+     tiers_with_partial_rejection is non-empty OR
+     waves_parallel_failed > 0);
     otherwise null. The string MUST name either the dominant rejection
     reasons (when telemetry is present), the list of tiers with missing
-    telemetry (when not), or the tiers with partial rejection plus
-    their rejection reasons (when some waves rejected and others ran).
+    telemetry (when not), the tiers with partial rejection plus their
+    rejection reasons (when some waves rejected and others ran), or the
+    failure reasons (when waves attempted parallel execution and failed).
 }
 ```
 

--- a/commands/mpl-run-finalize.md
+++ b/commands/mpl-run-finalize.md
@@ -719,14 +719,26 @@ Generate full run profile at `.mpl/mpl/profile/run-summary.json`.
 
 **Scheduler aggregation (Exp22 R6 / #205)**:
 
+The truth of "did this run request parallelism" lives in
+`.mpl/mpl/decomposition.yaml`, not in the event log. Deriving
+`tiers_parallel_requested` from `phase-scheduler.jsonl` alone would let a run
+with empty/missing telemetry collapse to `tiers_parallel_requested == 0` and
+silently pass the no-parallel MUST.
+
 ```
+decomposition = Read(".mpl/mpl/decomposition.yaml")
+expected_parallel_tiers = set of tier ids where
+  decomposition.execution_tiers[].parallel == true
+
 events = read_jsonl(".mpl/mpl/profile/phase-scheduler.jsonl") or
          state.phase_scheduler_history or []
-tiers_total = count of distinct event.tier
-tiers_parallel_requested = count of distinct event.tier where any
-  event for that tier has parallel_requested == true
-tiers_parallel_executed = count of distinct event.tier where any
-  event for that tier has selected_mode == "parallel"
+tiers_total = decomposition.execution_tiers.length
+tiers_parallel_requested = expected_parallel_tiers.size
+tiers_parallel_executed = count of distinct event.tier in
+  expected_parallel_tiers where any event for that tier has
+  selected_mode == "parallel"
+tiers_with_missing_telemetry = expected_parallel_tiers minus
+  the set of event.tier values present in events
 tiers_parallel_rejected = tiers_parallel_requested - tiers_parallel_executed
 
 scheduler = {
@@ -734,18 +746,23 @@ scheduler = {
   tiers_parallel_requested,
   tiers_parallel_executed,
   tiers_parallel_rejected,
+  tiers_with_missing_telemetry: <list of tier ids>,
   rejection_reasons: union of event.rejection_reasons and the values of
                      event.rejection_reasons_by_phase across all events
                      (deduplicated),
-  no_parallel_explanation: <string> when
-    tiers_parallel_requested > 0 AND tiers_parallel_executed == 0, naming
-    the dominant rejection reasons; null otherwise.
+  no_parallel_explanation: required (non-null) when
+    tiers_parallel_requested > 0 AND
+    (tiers_parallel_executed == 0 OR tiers_with_missing_telemetry is
+     non-empty); otherwise null. The string MUST name either the
+     dominant rejection reasons (when telemetry is present) or the list
+     of tiers with missing telemetry (when not).
 }
 ```
 
 The `no_parallel_explanation` field is the enforcement point for the MUST in
 `commands/mpl-run-execute.md`: a run that requested parallelism but never
-reached it cannot finalize with a null/missing explanation.
+reached it — including because the scheduler never recorded an event for a
+parallel-requested tier — cannot finalize with a null/missing explanation.
 
 Profile data enables:
 1. **Learn optimal token budget by complexity**: derive average tokens per grade from past profiles

--- a/commands/mpl-run-finalize.md
+++ b/commands/mpl-run-finalize.md
@@ -814,7 +814,11 @@ scheduler = {
   tiers_with_partial_rejection: <list of tier ids>,
   rejection_reasons: union of event.rejection_reasons and the values of
                      event.rejection_reasons_by_phase across all events
-                     (deduplicated),
+                     (deduplicated), plus event.failure_reason values for
+                     parallel_failed waves,
+  affected_tier_ids: sorted list of expected_parallel_tiers that did not
+                     reach selected_mode == "parallel", that the
+                     no_parallel_explanation MUST reference by id,
   no_parallel_explanation: required (non-null) when
     tiers_parallel_requested > 0 AND
     (tiers_parallel_executed < tiers_parallel_requested OR

--- a/commands/mpl-run-finalize.md
+++ b/commands/mpl-run-finalize.md
@@ -742,8 +742,23 @@ if not execution_tiers or execution_tiers.length == 0:
 expected_parallel_tiers = set of tier ids where
   execution_tiers[].parallel == true
 
-raw_events = read_jsonl(".mpl/mpl/profile/phase-scheduler.jsonl") or
-             state.phase_scheduler_history or []
+// Union both sources. The JSONL file is persistent and the state
+// mirror is the ring-buffered last-50 snapshot — neither alone is
+// authoritative. If JSONL writes were truncated or the file was hand-
+// edited, the state mirror may carry the latest events; if the state
+// ring evicted older rows, the JSONL may carry them. Union them and
+// de-duplicate so a degraded write on one side cannot manufacture
+// false missing telemetry.
+//
+// Two events are the same when they share
+// (pipeline_id, run_started_at, tier, timestamp, selected_mode).
+jsonl_events = read_jsonl(".mpl/mpl/profile/phase-scheduler.jsonl") or []
+state_events = state.phase_scheduler_history or []
+raw_events = dedupe_by(
+  jsonl_events.concat(state_events),
+  e => `${e.pipeline_id}|${e.run_started_at}|${e.tier}|${e.timestamp}|${e.selected_mode}`
+)
+
 // .mpl/mpl/profile/ is persistent across pipeline starts. pipeline_id
 // alone is NOT a unique run key — initState derives it as
 // mpl-{date}-{slug}, so same-day reruns of the same feature collide.
@@ -796,15 +811,17 @@ scheduler = {
                      (deduplicated),
   no_parallel_explanation: required (non-null) when
     tiers_parallel_requested > 0 AND
-    (tiers_parallel_executed == 0 OR
+    (tiers_parallel_executed < tiers_parallel_requested OR
      tiers_with_missing_telemetry is non-empty OR
      tiers_with_partial_rejection is non-empty OR
      waves_parallel_failed > 0);
-    otherwise null. The string MUST name either the dominant rejection
-    reasons (when telemetry is present), the list of tiers with missing
-    telemetry (when not), the tiers with partial rejection plus their
-    rejection reasons (when some waves rejected and others ran), or the
-    failure reasons (when waves attempted parallel execution and failed).
+    otherwise null. The `tiers_parallel_executed < tiers_parallel_requested`
+    trigger covers BOTH the full-miss case (executed == 0) and the
+    partial-miss case (some requested tiers parallelized, others
+    rejected/skipped). The string MUST name the rejected tier ids, their
+    selected modes, and the dominant rejection reasons (or missing
+    telemetry tiers, partial-rejection tiers, or failure reasons,
+    whichever applies).
 }
 ```
 

--- a/commands/mpl-run-finalize.md
+++ b/commands/mpl-run-finalize.md
@@ -768,7 +768,13 @@ raw_events = dedupe_by(
 //   - prior reruns of the same pipeline_id drop out via run_started_at
 events = raw_events.filter(e =>
   e.pipeline_id == state.pipeline_id &&
-  e.run_started_at == state.started_at)
+  e.run_started_at == state.started_at &&
+  e.recompose_count == decomposition.recompose_count)
+// recompose_count guards against APPEND-MODE / RECOMPOSE-MODE rewrites
+// (mpl-run-decompose.md Step 3-F): the executor can rebuild execution_tiers
+// mid-run, and a stale pre-recompose parallel event for tier N would
+// otherwise satisfy the post-recompose tier N (different phases). Bind
+// events to the decomposition version they were emitted under.
 
 tiers_total = execution_tiers.length
 tiers_parallel_requested = expected_parallel_tiers.size

--- a/commands/mpl-run-finalize.md
+++ b/commands/mpl-run-finalize.md
@@ -732,12 +732,16 @@ expected_parallel_tiers = set of tier ids where
 
 raw_events = read_jsonl(".mpl/mpl/profile/phase-scheduler.jsonl") or
              state.phase_scheduler_history or []
-// .mpl/mpl/profile/ is persistent across pipeline starts. Without
-// pipeline_id scoping, stale rows from a prior run can satisfy the
-// current decomposition's parallel-requested tiers and mask missing
-// telemetry. The executor stamps every event with pipeline_id; the
-// finalizer filters here.
-events = raw_events.filter(e => e.pipeline_id == state.pipeline_id)
+// .mpl/mpl/profile/ is persistent across pipeline starts. pipeline_id
+// alone is NOT a unique run key — initState derives it as
+// mpl-{date}-{slug}, so same-day reruns of the same feature collide.
+// state.started_at (set once at initState, ISO timestamp with ms
+// resolution) is the actual per-run key. Filter on BOTH so that:
+//   - prior pipelines (different slug/date) drop out via pipeline_id
+//   - prior reruns of the same pipeline_id drop out via run_started_at
+events = raw_events.filter(e =>
+  e.pipeline_id == state.pipeline_id &&
+  e.run_started_at == state.started_at)
 
 tiers_total = decomposition.execution_tiers.length
 tiers_parallel_requested = expected_parallel_tiers.size

--- a/commands/schemas/run-summary.json
+++ b/commands/schemas/run-summary.json
@@ -14,12 +14,13 @@
   ],
   "phase5_gate": { "final_pass_rate": 100, "decision": "skip", "fix_tokens": 0 },
   "totals": { "tokens": 49500, "duration_ms": 210000, "micro_fixes": 1, "retries": 0 },
-  "_scheduler_comment": "Exp22 R6 (#205): aggregated from .mpl/mpl/profile/phase-scheduler.jsonl (fallback state.phase_scheduler_history). no_parallel_explanation is non-null when tiers_parallel_requested > 0 and tiers_parallel_executed == 0.",
+  "_scheduler_comment": "Exp22 R6 (#205): tiers_parallel_requested derives from decomposition.yaml execution_tiers[].parallel==true (the truth), not from phase-scheduler.jsonl. tiers_with_missing_telemetry lists parallel-requested tiers whose events never reached the JSONL/state mirror. no_parallel_explanation is non-null when tiers_parallel_requested > 0 AND (tiers_parallel_executed == 0 OR tiers_with_missing_telemetry is non-empty).",
   "scheduler": {
     "tiers_total": 3,
     "tiers_parallel_requested": 1,
     "tiers_parallel_executed": 1,
     "tiers_parallel_rejected": 0,
+    "tiers_with_missing_telemetry": [],
     "rejection_reasons": [],
     "no_parallel_explanation": null
   }

--- a/commands/schemas/run-summary.json
+++ b/commands/schemas/run-summary.json
@@ -25,6 +25,7 @@
     "waves_parallel_failed": 0,
     "tiers_with_partial_rejection": [],
     "rejection_reasons": [],
+    "affected_tier_ids": [],
     "no_parallel_explanation": null
   }
 }

--- a/commands/schemas/run-summary.json
+++ b/commands/schemas/run-summary.json
@@ -14,13 +14,15 @@
   ],
   "phase5_gate": { "final_pass_rate": 100, "decision": "skip", "fix_tokens": 0 },
   "totals": { "tokens": 49500, "duration_ms": 210000, "micro_fixes": 1, "retries": 0 },
-  "_scheduler_comment": "Exp22 R6 (#205): tiers_parallel_requested derives from decomposition.yaml execution_tiers[].parallel==true (the truth), not from phase-scheduler.jsonl. tiers_with_missing_telemetry lists parallel-requested tiers whose events never reached the JSONL/state mirror. no_parallel_explanation is non-null when tiers_parallel_requested > 0 AND (tiers_parallel_executed == 0 OR tiers_with_missing_telemetry is non-empty).",
+  "_scheduler_comment": "Exp22 R6 (#205): tiers_parallel_requested derives from decomposition.yaml execution_tiers[].parallel==true (the truth), not from phase-scheduler.jsonl. tiers_with_missing_telemetry lists parallel-requested tiers whose events never reached the JSONL/state mirror. waves_parallel_rejected + tiers_with_partial_rejection preserve wave-level rejection signal that would otherwise be hidden by the tier-level rollup. no_parallel_explanation is non-null when tiers_parallel_requested > 0 AND (tiers_parallel_executed == 0 OR tiers_with_missing_telemetry is non-empty OR tiers_with_partial_rejection is non-empty).",
   "scheduler": {
     "tiers_total": 3,
     "tiers_parallel_requested": 1,
     "tiers_parallel_executed": 1,
     "tiers_parallel_rejected": 0,
     "tiers_with_missing_telemetry": [],
+    "waves_parallel_rejected": 0,
+    "tiers_with_partial_rejection": [],
     "rejection_reasons": [],
     "no_parallel_explanation": null
   }

--- a/commands/schemas/run-summary.json
+++ b/commands/schemas/run-summary.json
@@ -13,5 +13,14 @@
     { "id": "phase-4",  "tokens":  5000, "duration_ms": 30000, "pass_rate": 100, "micro_fixes": 0 }
   ],
   "phase5_gate": { "final_pass_rate": 100, "decision": "skip", "fix_tokens": 0 },
-  "totals": { "tokens": 49500, "duration_ms": 210000, "micro_fixes": 1, "retries": 0 }
+  "totals": { "tokens": 49500, "duration_ms": 210000, "micro_fixes": 1, "retries": 0 },
+  "_scheduler_comment": "Exp22 R6 (#205): aggregated from .mpl/mpl/profile/phase-scheduler.jsonl (fallback state.phase_scheduler_history). no_parallel_explanation is non-null when tiers_parallel_requested > 0 and tiers_parallel_executed == 0.",
+  "scheduler": {
+    "tiers_total": 3,
+    "tiers_parallel_requested": 1,
+    "tiers_parallel_executed": 1,
+    "tiers_parallel_rejected": 0,
+    "rejection_reasons": [],
+    "no_parallel_explanation": null
+  }
 }

--- a/commands/schemas/run-summary.json
+++ b/commands/schemas/run-summary.json
@@ -22,6 +22,7 @@
     "tiers_parallel_rejected": 0,
     "tiers_with_missing_telemetry": [],
     "waves_parallel_rejected": 0,
+    "waves_parallel_failed": 0,
     "tiers_with_partial_rejection": [],
     "rejection_reasons": [],
     "no_parallel_explanation": null

--- a/hooks/__tests__/mpl-execution-tiers-observability.test.mjs
+++ b/hooks/__tests__/mpl-execution-tiers-observability.test.mjs
@@ -31,6 +31,10 @@ describe('execution_tiers observability contract', () => {
         `record_scheduler_event block missing run_started_at:\n${block}`);
       assert.match(block, /recompose_count/,
         `record_scheduler_event block missing recompose_count:\n${block}`);
+      assert.match(block, /wave_index/,
+        `record_scheduler_event block missing wave_index:\n${block}`);
+      assert.match(block, /timestamp: now_iso\(\)/,
+        `record_scheduler_event block missing timestamp:\n${block}`);
       assert.match(block, /worker_cap/,
         `record_scheduler_event block missing worker_cap:\n${block}`);
       assert.match(block, /worktree_slots/,

--- a/hooks/__tests__/mpl-execution-tiers-observability.test.mjs
+++ b/hooks/__tests__/mpl-execution-tiers-observability.test.mjs
@@ -61,9 +61,24 @@ describe('execution_tiers observability contract', () => {
     const schemaText = readFileSync(join(process.cwd(), 'commands', 'schemas', 'run-summary.json'), 'utf-8');
     const schema = JSON.parse(schemaText);
     assert.ok(schema.scheduler, 'run-summary.json must include a scheduler example block');
-    for (const k of ['tiers_total', 'tiers_parallel_requested', 'tiers_parallel_executed', 'tiers_parallel_rejected', 'tiers_with_missing_telemetry', 'rejection_reasons', 'no_parallel_explanation']) {
+    for (const k of ['tiers_total', 'tiers_parallel_requested', 'tiers_parallel_executed', 'tiers_parallel_rejected', 'tiers_with_missing_telemetry', 'waves_parallel_rejected', 'tiers_with_partial_rejection', 'rejection_reasons', 'no_parallel_explanation']) {
       assert.ok(k in schema.scheduler, `scheduler block missing required key: ${k}`);
     }
+  });
+
+  it('finalize aggregation preserves wave-level partial rejection within a tier', () => {
+    // Codex round-5 review on PR #213: one tier can split into multiple
+    // waves and emit BOTH a parallel and a parallel_rejected event. The
+    // tier-level rollup (tiers_parallel_rejected = requested - executed)
+    // would otherwise treat the tier as fully executed and hide the
+    // single-wave rejection — the exact partial-parallelism case the
+    // telemetry is meant to surface. Pin the wave-level signal.
+    const finalize = readFileSync(join(process.cwd(), 'commands', 'mpl-run-finalize.md'), 'utf-8');
+    assert.match(finalize, /waves_parallel_rejected/);
+    assert.match(finalize, /tiers_with_partial_rejection/);
+    // The no_parallel_explanation MUST trigger when partial rejection occurs,
+    // not only when full rejection or missing telemetry occurs.
+    assert.match(finalize, /tiers_with_partial_rejection is non-empty/);
   });
 
   it('finalize filters scheduler events by both pipeline_id AND run_started_at so stale profile rows cannot satisfy a new run', () => {

--- a/hooks/__tests__/mpl-execution-tiers-observability.test.mjs
+++ b/hooks/__tests__/mpl-execution-tiers-observability.test.mjs
@@ -61,9 +61,48 @@ describe('execution_tiers observability contract', () => {
     const schemaText = readFileSync(join(process.cwd(), 'commands', 'schemas', 'run-summary.json'), 'utf-8');
     const schema = JSON.parse(schemaText);
     assert.ok(schema.scheduler, 'run-summary.json must include a scheduler example block');
-    for (const k of ['tiers_total', 'tiers_parallel_requested', 'tiers_parallel_executed', 'tiers_parallel_rejected', 'tiers_with_missing_telemetry', 'waves_parallel_rejected', 'tiers_with_partial_rejection', 'rejection_reasons', 'no_parallel_explanation']) {
+    for (const k of ['tiers_total', 'tiers_parallel_requested', 'tiers_parallel_executed', 'tiers_parallel_rejected', 'tiers_with_missing_telemetry', 'waves_parallel_rejected', 'waves_parallel_failed', 'tiers_with_partial_rejection', 'rejection_reasons', 'no_parallel_explanation']) {
       assert.ok(k in schema.scheduler, `scheduler block missing required key: ${k}`);
     }
+  });
+
+  it('parallel event is emitted AFTER parallel_map success; pool/dispatch failures emit parallel_failed', () => {
+    // Codex round-6 review on PR #213: emitting selected_mode:"parallel"
+    // before ensure_worktree_pool/parallel_map run lets a setup or worker
+    // failure leave a successful-looking row that satisfies the run
+    // summary. The lifecycle must be:
+    //   - wave.length == 1: emit parallel_rejected before single-phase exec
+    //   - wave.length > 1: emit parallel AFTER parallel_map succeeds, or
+    //                      parallel_failed in the catch branch
+    const exec = readFileSync(join(process.cwd(), 'commands', 'mpl-run-execute.md'), 'utf-8');
+    assert.match(exec, /parallel_failed/,
+      'execute prompt must define a parallel_failed mode for pool/dispatch errors');
+    assert.match(exec, /MUST NOT be emitted before the wave finishes successfully/,
+      'execute prompt must state the lifecycle invariant in prose');
+    // The parallel-event block must sit AFTER parallel_map(...) in the prompt.
+    const parallelMapIdx = exec.indexOf('parallel_map(wave,');
+    const parallelEventIdx = exec.indexOf('selected_mode: "parallel",');
+    assert.ok(parallelMapIdx > 0, 'parallel_map(...) block must exist');
+    assert.ok(parallelEventIdx > 0, 'selected_mode:"parallel" event must exist');
+    assert.ok(parallelEventIdx > parallelMapIdx,
+      'selected_mode:"parallel" event must appear AFTER the parallel_map(...) call in the executor prompt');
+
+    const finalize = readFileSync(join(process.cwd(), 'commands', 'mpl-run-finalize.md'), 'utf-8');
+    assert.match(finalize, /waves_parallel_failed/,
+      'finalize aggregation must surface waves_parallel_failed');
+    assert.match(finalize, /waves_parallel_failed > 0/,
+      'no_parallel_explanation must trigger on parallel_failed waves');
+  });
+
+  it('finalize handles missing/empty execution_tiers with the same legacy fallback as the executor', () => {
+    // Codex round-6 review on PR #213: finalize read decomposition.execution_tiers
+    // directly, but the executor still documents a synthesized fallback
+    // when the field is missing/empty. A legacy or resumed run would have
+    // crashed finalize aggregation before run-summary.json was written.
+    const finalize = readFileSync(join(process.cwd(), 'commands', 'mpl-run-finalize.md'), 'utf-8');
+    assert.match(finalize, /Mirror the executor's legacy fallback/);
+    assert.match(finalize, /if not execution_tiers or execution_tiers\.length == 0/);
+    assert.match(finalize, /decomposition\.phases\.map/);
   });
 
   it('finalize aggregation preserves wave-level partial rejection within a tier', () => {

--- a/hooks/__tests__/mpl-execution-tiers-observability.test.mjs
+++ b/hooks/__tests__/mpl-execution-tiers-observability.test.mjs
@@ -13,13 +13,12 @@ describe('execution_tiers observability contract', () => {
     assert.match(text, /Do not add a separate `phase_dependencies` field/);
   });
 
-  it('skipped, sequential, parallel, and parallel_rejected events all carry pipeline_id + worker_cap + worktree_slots', () => {
-    // Codex review on PR #213: the mandatory-fields paragraph lists worker_cap
-    // and worktree_slots, but earlier examples omitted them for skipped /
-    // sequential events. Codex round 3 added pipeline_id (the JSONL profile
-    // file is persistent across pipeline starts, so without per-run scoping
-    // stale events can vacuously satisfy the current decomposition). Pin
-    // the executor prompt so every documented event block carries all three.
+  it('every record_scheduler_event block carries pipeline_id + run_started_at + worker_cap + worktree_slots', () => {
+    // Codex r1: worker_cap/worktree_slots missing from skipped+sequential.
+    // Codex r3: pipeline_id added because JSONL profile is persistent.
+    // Codex r4: pipeline_id alone is not unique (mpl-{date}-{slug} collides
+    // on same-day same-feature reruns); add state.started_at as run_started_at
+    // for genuine per-run uniqueness.
     const text = readFileSync(join(process.cwd(), 'commands', 'mpl-run-execute.md'), 'utf-8');
     const blockPattern = /record_scheduler_event\(\{[^}]*\}\)/gs;
     const blocks = text.match(blockPattern) || [];
@@ -28,6 +27,8 @@ describe('execution_tiers observability contract', () => {
     for (const block of blocks) {
       assert.match(block, /pipeline_id/,
         `record_scheduler_event block missing pipeline_id:\n${block}`);
+      assert.match(block, /run_started_at/,
+        `record_scheduler_event block missing run_started_at:\n${block}`);
       assert.match(block, /worker_cap/,
         `record_scheduler_event block missing worker_cap:\n${block}`);
       assert.match(block, /worktree_slots/,
@@ -65,20 +66,23 @@ describe('execution_tiers observability contract', () => {
     }
   });
 
-  it('finalize filters scheduler events by pipeline_id so stale profile rows cannot satisfy a new run', () => {
-    // Codex round-3 review on PR #213: `.mpl/mpl/profile/` is persistent
-    // across pipeline starts, and tier numbers are reused across
-    // decompositions. Without per-run scoping, a prior run's
-    // selected_mode:"parallel" for tier 1 can make the current run report
-    // tiers_parallel_executed > 0 and avoid tiers_with_missing_telemetry,
-    // silently masking the exact failure mode this change exists to expose.
+  it('finalize filters scheduler events by both pipeline_id AND run_started_at so stale profile rows cannot satisfy a new run', () => {
+    // Codex r3: `.mpl/mpl/profile/` is persistent — stale rows from prior
+    // pipelines must drop out. Codex r4: pipeline_id is mpl-{date}-{slug},
+    // not unique on same-day same-feature reruns; state.started_at (ISO
+    // timestamp with ms resolution) is the actual per-run key. Filter on
+    // BOTH so rows survive only when they belong to this exact run.
     const exec = readFileSync(join(process.cwd(), 'commands', 'mpl-run-execute.md'), 'utf-8');
-    assert.match(exec, /pipeline_id` \(= `state\.pipeline_id` at write time/,
-      'execute prompt must require pipeline_id on every event with the rationale');
+    assert.match(exec, /run_started_at` \(= `state\.started_at` at write time/,
+      'execute prompt must require run_started_at on every event with the rationale');
+    assert.match(exec, /pipeline_id` alone collides on same-day same-slug/,
+      'execute prompt must document why pipeline_id alone is insufficient');
 
     const finalize = readFileSync(join(process.cwd(), 'commands', 'mpl-run-finalize.md'), 'utf-8');
     assert.match(finalize, /e\.pipeline_id == state\.pipeline_id/,
-      'finalize aggregation must filter events by the current pipeline_id');
+      'finalize aggregation must filter events by pipeline_id');
+    assert.match(finalize, /e\.run_started_at == state\.started_at/,
+      'finalize aggregation must also filter events by run_started_at');
     assert.match(finalize, /persistent across pipeline starts/,
       'finalize must explain why the filter exists so the contract cannot regress');
   });

--- a/hooks/__tests__/mpl-execution-tiers-observability.test.mjs
+++ b/hooks/__tests__/mpl-execution-tiers-observability.test.mjs
@@ -56,8 +56,24 @@ describe('execution_tiers observability contract', () => {
     const schemaText = readFileSync(join(process.cwd(), 'commands', 'schemas', 'run-summary.json'), 'utf-8');
     const schema = JSON.parse(schemaText);
     assert.ok(schema.scheduler, 'run-summary.json must include a scheduler example block');
-    for (const k of ['tiers_total', 'tiers_parallel_requested', 'tiers_parallel_executed', 'tiers_parallel_rejected', 'rejection_reasons', 'no_parallel_explanation']) {
+    for (const k of ['tiers_total', 'tiers_parallel_requested', 'tiers_parallel_executed', 'tiers_parallel_rejected', 'tiers_with_missing_telemetry', 'rejection_reasons', 'no_parallel_explanation']) {
       assert.ok(k in schema.scheduler, `scheduler block missing required key: ${k}`);
     }
+  });
+
+  it('finalize derives tiers_parallel_requested from decomposition.yaml, not from the event log', () => {
+    // Codex round-2 review on PR #213: deriving the denominator from the
+    // event log lets a run with empty/missing telemetry silently pass the
+    // no-parallel MUST with tiers_parallel_requested == 0. The truth lives
+    // in decomposition.execution_tiers[].parallel; the event log is only
+    // the evidence-of-execution side. Pin the aggregation prompt so the
+    // denominator cannot regress back to event-only.
+    const finalize = readFileSync(join(process.cwd(), 'commands', 'mpl-run-finalize.md'), 'utf-8');
+    assert.match(finalize, /decomposition\.yaml/);
+    assert.match(finalize, /execution_tiers\[\]\.parallel == true/);
+    assert.match(finalize, /tiers_with_missing_telemetry/);
+    // The MUST must trigger when telemetry is missing for a parallel-requested
+    // tier, not only when an event with selected_mode:"parallel" is absent.
+    assert.match(finalize, /tiers_with_missing_telemetry is\s*non-empty/);
   });
 });

--- a/hooks/__tests__/mpl-execution-tiers-observability.test.mjs
+++ b/hooks/__tests__/mpl-execution-tiers-observability.test.mjs
@@ -13,17 +13,21 @@ describe('execution_tiers observability contract', () => {
     assert.match(text, /Do not add a separate `phase_dependencies` field/);
   });
 
-  it('skipped, sequential, parallel, and parallel_rejected events all carry worker_cap + worktree_slots', () => {
+  it('skipped, sequential, parallel, and parallel_rejected events all carry pipeline_id + worker_cap + worktree_slots', () => {
     // Codex review on PR #213: the mandatory-fields paragraph lists worker_cap
     // and worktree_slots, but earlier examples omitted them for skipped /
-    // sequential events. Pin the executor prompt so every documented event
-    // block actually includes those fields.
+    // sequential events. Codex round 3 added pipeline_id (the JSONL profile
+    // file is persistent across pipeline starts, so without per-run scoping
+    // stale events can vacuously satisfy the current decomposition). Pin
+    // the executor prompt so every documented event block carries all three.
     const text = readFileSync(join(process.cwd(), 'commands', 'mpl-run-execute.md'), 'utf-8');
     const blockPattern = /record_scheduler_event\(\{[^}]*\}\)/gs;
     const blocks = text.match(blockPattern) || [];
     assert.ok(blocks.length >= 3,
       `expected at least 3 record_scheduler_event() blocks, found ${blocks.length}`);
     for (const block of blocks) {
+      assert.match(block, /pipeline_id/,
+        `record_scheduler_event block missing pipeline_id:\n${block}`);
       assert.match(block, /worker_cap/,
         `record_scheduler_event block missing worker_cap:\n${block}`);
       assert.match(block, /worktree_slots/,
@@ -59,6 +63,24 @@ describe('execution_tiers observability contract', () => {
     for (const k of ['tiers_total', 'tiers_parallel_requested', 'tiers_parallel_executed', 'tiers_parallel_rejected', 'tiers_with_missing_telemetry', 'rejection_reasons', 'no_parallel_explanation']) {
       assert.ok(k in schema.scheduler, `scheduler block missing required key: ${k}`);
     }
+  });
+
+  it('finalize filters scheduler events by pipeline_id so stale profile rows cannot satisfy a new run', () => {
+    // Codex round-3 review on PR #213: `.mpl/mpl/profile/` is persistent
+    // across pipeline starts, and tier numbers are reused across
+    // decompositions. Without per-run scoping, a prior run's
+    // selected_mode:"parallel" for tier 1 can make the current run report
+    // tiers_parallel_executed > 0 and avoid tiers_with_missing_telemetry,
+    // silently masking the exact failure mode this change exists to expose.
+    const exec = readFileSync(join(process.cwd(), 'commands', 'mpl-run-execute.md'), 'utf-8');
+    assert.match(exec, /pipeline_id` \(= `state\.pipeline_id` at write time/,
+      'execute prompt must require pipeline_id on every event with the rationale');
+
+    const finalize = readFileSync(join(process.cwd(), 'commands', 'mpl-run-finalize.md'), 'utf-8');
+    assert.match(finalize, /e\.pipeline_id == state\.pipeline_id/,
+      'finalize aggregation must filter events by the current pipeline_id');
+    assert.match(finalize, /persistent across pipeline starts/,
+      'finalize must explain why the filter exists so the contract cannot regress');
   });
 
   it('finalize derives tiers_parallel_requested from decomposition.yaml, not from the event log', () => {

--- a/hooks/__tests__/mpl-execution-tiers-observability.test.mjs
+++ b/hooks/__tests__/mpl-execution-tiers-observability.test.mjs
@@ -1,0 +1,22 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+describe('execution_tiers observability contract', () => {
+  it('requires scheduler telemetry for every tier decision', () => {
+    const text = readFileSync(join(process.cwd(), 'commands', 'mpl-run-execute.md'), 'utf-8');
+    assert.match(text, /record_scheduler_event/);
+    assert.match(text, /\.mpl\/mpl\/profile\/phase-scheduler\.jsonl/);
+    assert.match(text, /state\.phase_scheduler_history/);
+    assert.match(text, /selected_mode.*parallel_rejected/s);
+    assert.match(text, /Do not add a separate `phase_dependencies` field/);
+  });
+
+  it('requires worktree_history entries for parallel slot creation or reuse', () => {
+    const text = readFileSync(join(process.cwd(), 'commands', 'mpl-run-execute.md'), 'utf-8');
+    assert.match(text, /append state\.worktree_history entries/);
+    assert.match(text, /slot_id/);
+    assert.match(text, /worktree_path/);
+  });
+});

--- a/hooks/__tests__/mpl-execution-tiers-observability.test.mjs
+++ b/hooks/__tests__/mpl-execution-tiers-observability.test.mjs
@@ -94,6 +94,33 @@ describe('execution_tiers observability contract', () => {
       'no_parallel_explanation must trigger on parallel_failed waves');
   });
 
+  it('no_parallel_explanation triggers on partial parallelism (executed < requested), not only on full miss', () => {
+    // Codex round-7 review on PR #213: requiring tiers_parallel_executed == 0
+    // lets a run with two parallel:true tiers where ONE parallelized and the
+    // OTHER was rejected finalize with no_parallel_explanation = null.
+    // The MUST must compare executed against requested.
+    const finalize = readFileSync(join(process.cwd(), 'commands', 'mpl-run-finalize.md'), 'utf-8');
+    assert.match(finalize, /tiers_parallel_executed < tiers_parallel_requested/,
+      'no_parallel_explanation trigger must compare executed against requested');
+    // The old full-miss-only trigger must NOT be the sole condition anymore.
+    assert.doesNotMatch(finalize, /tiers_parallel_executed == 0 OR\n\s+tiers_with_missing_telemetry/,
+      'no_parallel_explanation must not gate on executed == 0 alone');
+    // The explanation string MUST name the rejected tier ids when partial.
+    assert.match(finalize, /rejected tier ids/);
+  });
+
+  it('finalize unions JSONL events with state.phase_scheduler_history so a degraded JSONL cannot manufacture false missing telemetry', () => {
+    // Codex round-7 review on PR #213: reading jsonl OR state.history means
+    // if JSONL parses (even with stale or truncated rows), the state mirror
+    // is never consulted. Union both sources and de-duplicate so degraded
+    // writes on one side cannot fake missing telemetry.
+    const finalize = readFileSync(join(process.cwd(), 'commands', 'mpl-run-finalize.md'), 'utf-8');
+    assert.match(finalize, /jsonl_events =/);
+    assert.match(finalize, /state_events = state\.phase_scheduler_history/);
+    assert.match(finalize, /dedupe_by/);
+    assert.match(finalize, /jsonl_events\.concat\(state_events\)/);
+  });
+
   it('finalize handles missing/empty execution_tiers with the same legacy fallback as the executor', () => {
     // Codex round-6 review on PR #213: finalize read decomposition.execution_tiers
     // directly, but the executor still documents a synthesized fallback

--- a/hooks/__tests__/mpl-execution-tiers-observability.test.mjs
+++ b/hooks/__tests__/mpl-execution-tiers-observability.test.mjs
@@ -13,10 +13,51 @@ describe('execution_tiers observability contract', () => {
     assert.match(text, /Do not add a separate `phase_dependencies` field/);
   });
 
-  it('requires worktree_history entries for parallel slot creation or reuse', () => {
+  it('skipped, sequential, parallel, and parallel_rejected events all carry worker_cap + worktree_slots', () => {
+    // Codex review on PR #213: the mandatory-fields paragraph lists worker_cap
+    // and worktree_slots, but earlier examples omitted them for skipped /
+    // sequential events. Pin the executor prompt so every documented event
+    // block actually includes those fields.
     const text = readFileSync(join(process.cwd(), 'commands', 'mpl-run-execute.md'), 'utf-8');
-    assert.match(text, /append state\.worktree_history entries/);
+    const blockPattern = /record_scheduler_event\(\{[^}]*\}\)/gs;
+    const blocks = text.match(blockPattern) || [];
+    assert.ok(blocks.length >= 3,
+      `expected at least 3 record_scheduler_event() blocks, found ${blocks.length}`);
+    for (const block of blocks) {
+      assert.match(block, /worker_cap/,
+        `record_scheduler_event block missing worker_cap:\n${block}`);
+      assert.match(block, /worktree_slots/,
+        `record_scheduler_event block missing worktree_slots:\n${block}`);
+    }
+  });
+
+  it('parallel-pool slot lifecycle uses state.worktree_pool_history (separate from HIGH-risk isolation worktree_history)', () => {
+    // Claude review on PR #213: the new parallel-pool writer must not share
+    // an array with the existing HIGH-risk isolation writer in
+    // commands/mpl-run-execute-context.md §5 — the shapes are incompatible.
+    const text = readFileSync(join(process.cwd(), 'commands', 'mpl-run-execute.md'), 'utf-8');
+    assert.match(text, /append state\.worktree_pool_history entries/);
+    assert.doesNotMatch(text, /append state\.worktree_history entries/,
+      'parallel-pool writer must use worktree_pool_history, not worktree_history');
     assert.match(text, /slot_id/);
     assert.match(text, /worktree_path/);
+  });
+
+  it('finalize Step 5.4 wires phase-scheduler telemetry into run-summary scheduler block', () => {
+    // Codex review on PR #213: the executor's "final run summary MUST explain
+    // why phase parallelism was not used" needs an enforcement path. Pin the
+    // finalize prompt + run-summary schema so the MUST is reachable.
+    const finalize = readFileSync(join(process.cwd(), 'commands', 'mpl-run-finalize.md'), 'utf-8');
+    assert.match(finalize, /phase-scheduler\.jsonl/);
+    assert.match(finalize, /tiers_parallel_requested/);
+    assert.match(finalize, /tiers_parallel_executed/);
+    assert.match(finalize, /no_parallel_explanation/);
+
+    const schemaText = readFileSync(join(process.cwd(), 'commands', 'schemas', 'run-summary.json'), 'utf-8');
+    const schema = JSON.parse(schemaText);
+    assert.ok(schema.scheduler, 'run-summary.json must include a scheduler example block');
+    for (const k of ['tiers_total', 'tiers_parallel_requested', 'tiers_parallel_executed', 'tiers_parallel_rejected', 'rejection_reasons', 'no_parallel_explanation']) {
+      assert.ok(k in schema.scheduler, `scheduler block missing required key: ${k}`);
+    }
   });
 });

--- a/hooks/__tests__/mpl-execution-tiers-observability.test.mjs
+++ b/hooks/__tests__/mpl-execution-tiers-observability.test.mjs
@@ -13,7 +13,7 @@ describe('execution_tiers observability contract', () => {
     assert.match(text, /Do not add a separate `phase_dependencies` field/);
   });
 
-  it('every record_scheduler_event block carries pipeline_id + run_started_at + worker_cap + worktree_slots', () => {
+  it('every record_scheduler_event block carries pipeline_id + run_started_at + recompose_count + worker_cap + worktree_slots', () => {
     // Codex r1: worker_cap/worktree_slots missing from skipped+sequential.
     // Codex r3: pipeline_id added because JSONL profile is persistent.
     // Codex r4: pipeline_id alone is not unique (mpl-{date}-{slug} collides
@@ -29,6 +29,8 @@ describe('execution_tiers observability contract', () => {
         `record_scheduler_event block missing pipeline_id:\n${block}`);
       assert.match(block, /run_started_at/,
         `record_scheduler_event block missing run_started_at:\n${block}`);
+      assert.match(block, /recompose_count/,
+        `record_scheduler_event block missing recompose_count:\n${block}`);
       assert.match(block, /worker_cap/,
         `record_scheduler_event block missing worker_cap:\n${block}`);
       assert.match(block, /worktree_slots/,
@@ -147,23 +149,32 @@ describe('execution_tiers observability contract', () => {
     assert.match(finalize, /tiers_with_partial_rejection is non-empty/);
   });
 
-  it('finalize filters scheduler events by both pipeline_id AND run_started_at so stale profile rows cannot satisfy a new run', () => {
+  it('finalize filters scheduler events by pipeline_id + run_started_at + recompose_count so stale profile rows cannot satisfy a new run', () => {
     // Codex r3: `.mpl/mpl/profile/` is persistent — stale rows from prior
-    // pipelines must drop out. Codex r4: pipeline_id is mpl-{date}-{slug},
-    // not unique on same-day same-feature reruns; state.started_at (ISO
-    // timestamp with ms resolution) is the actual per-run key. Filter on
-    // BOTH so rows survive only when they belong to this exact run.
+    // pipelines must drop out. r4: pipeline_id is mpl-{date}-{slug}, not
+    // unique on same-day same-feature reruns; state.started_at is the
+    // actual per-run key. r8: APPEND-MODE/RECOMPOSE-MODE rewrites
+    // execution_tiers mid-run, so the same tier number can mean different
+    // phases pre- vs post-recompose. Filter on all three keys so events
+    // survive only when they belong to this exact run AT this decomposition
+    // version.
     const exec = readFileSync(join(process.cwd(), 'commands', 'mpl-run-execute.md'), 'utf-8');
     assert.match(exec, /run_started_at` \(= `state\.started_at` at write time/,
       'execute prompt must require run_started_at on every event with the rationale');
     assert.match(exec, /pipeline_id` alone collides on same-day same-slug/,
       'execute prompt must document why pipeline_id alone is insufficient');
+    assert.match(exec, /recompose_count` \(= `decomposition\.recompose_count` at write time/,
+      'execute prompt must require recompose_count on every event');
+    assert.match(exec, /APPEND-MODE\/RECOMPOSE-MODE rewrites/,
+      'execute prompt must document why recompose_count is required');
 
     const finalize = readFileSync(join(process.cwd(), 'commands', 'mpl-run-finalize.md'), 'utf-8');
     assert.match(finalize, /e\.pipeline_id == state\.pipeline_id/,
       'finalize aggregation must filter events by pipeline_id');
     assert.match(finalize, /e\.run_started_at == state\.started_at/,
       'finalize aggregation must also filter events by run_started_at');
+    assert.match(finalize, /e\.recompose_count == decomposition\.recompose_count/,
+      'finalize aggregation must also filter events by recompose_count');
     assert.match(finalize, /persistent across pipeline starts/,
       'finalize must explain why the filter exists so the contract cannot regress');
   });

--- a/hooks/__tests__/mpl-execution-tiers-observability.test.mjs
+++ b/hooks/__tests__/mpl-execution-tiers-observability.test.mjs
@@ -138,6 +138,23 @@ describe('execution_tiers observability contract', () => {
     assert.match(finalize, /decomposition\.phases\.map/);
   });
 
+  it('finalize prompt dedupe key includes recompose_count + wave_index (must match hook eventKey)', () => {
+    // Codex round-13 review on PR #213: a narrower dedupe key in the
+    // finalize prompt than in hooks/lib/mpl-scheduler-aggregate.mjs would
+    // generate a run-summary that the hook then rejects. Pin both keys
+    // to the same 7-tuple.
+    const finalize = readFileSync(join(process.cwd(), 'commands', 'mpl-run-finalize.md'), 'utf-8');
+    assert.match(finalize, /pipeline_id.*run_started_at.*recompose_count.*tier.*wave_index.*timestamp.*selected_mode/s,
+      'finalize prompt dedupe key must include all 7 identity fields');
+    // The hook side (eventKey) — pin the same fields so a future refactor
+    // cannot drift the two apart.
+    const aggregateSrc = readFileSync(join(process.cwd(), 'hooks', 'lib', 'mpl-scheduler-aggregate.mjs'), 'utf-8');
+    for (const field of ['pipeline_id', 'run_started_at', 'recompose_count', 'tier', 'wave_index', 'timestamp', 'selected_mode']) {
+      assert.match(aggregateSrc, new RegExp(`e\\?\\.${field}`),
+        `mpl-scheduler-aggregate eventKey must reference ${field}`);
+    }
+  });
+
   it('finalize aggregation preserves wave-level partial rejection within a tier', () => {
     // Codex round-5 review on PR #213: one tier can split into multiple
     // waves and emit BOTH a parallel and a parallel_rejected event. The

--- a/hooks/__tests__/mpl-migrations.test.mjs
+++ b/hooks/__tests__/mpl-migrations.test.mjs
@@ -444,3 +444,104 @@ describe('v5 → v6 migration backfills release.gate_results + release.max_fix_l
     });
   });
 });
+
+/* ─────── v6 → v7: Exp22 R6 scheduler observability backfill ─────── */
+
+describe('v6 → v7 migration backfills phase_scheduler_history + worktree_pool_history', () => {
+  let tmpDir;
+  beforeEach(() => { tmpDir = mkdtempSync(join(tmpdir(), 'mpl-v6v7-')); });
+  afterEach(() => { rmSync(tmpDir, { recursive: true, force: true }); });
+
+  function writeRawState(body) {
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    writeFileSync(join(tmpDir, '.mpl', 'state.json'), JSON.stringify(body));
+  }
+
+  it('backfills phase_scheduler_history and worktree_pool_history as empty arrays on a v6 fixture', () => {
+    writeRawState({
+      pipeline_id: 'mpl-v6-fixture',
+      current_phase: 'phase2-sprint',
+      schema_version: 6,
+      release: {
+        current_cut_id: null,
+        completed_cut_ids: [],
+        fix_loop_count: 0,
+        pending_artifact: null,
+        gate_results: {
+          hard1_passed: null, hard2_passed: null, hard3_passed: null,
+          hard1_baseline: null, hard2_coverage: null, hard3_resilience: null,
+        },
+        max_fix_loops: 3,
+      },
+    });
+    const state = readState(tmpDir);
+    assert.equal(state.schema_version, CURRENT_SCHEMA_VERSION);
+    assert.deepStrictEqual(state.phase_scheduler_history, []);
+    assert.deepStrictEqual(state.worktree_pool_history, []);
+  });
+
+  it('preserves a pre-existing phase_scheduler_history array (hand-written or partial-rollout case)', () => {
+    const existing = [
+      { tier: 0, phases: ['phase-1'], selected_mode: 'sequential', parallel_requested: false },
+    ];
+    writeRawState({
+      pipeline_id: 'mpl-v6-partial',
+      current_phase: 'phase2-sprint',
+      schema_version: 6,
+      phase_scheduler_history: existing,
+      release: {
+        current_cut_id: null, completed_cut_ids: [], fix_loop_count: 0,
+        pending_artifact: null,
+        gate_results: {
+          hard1_passed: null, hard2_passed: null, hard3_passed: null,
+          hard1_baseline: null, hard2_coverage: null, hard3_resilience: null,
+        },
+        max_fix_loops: 3,
+      },
+    });
+    const state = readState(tmpDir);
+    assert.deepStrictEqual(state.phase_scheduler_history, existing);
+    assert.deepStrictEqual(state.worktree_pool_history, []);
+  });
+
+  it('keeps existing worktree_history (HIGH-risk isolation array) untouched while adding worktree_pool_history', () => {
+    // Claude review on PR #213: the two arrays must NOT collide. Verify
+    // v6 worktree_history survives the v6→v7 bump verbatim.
+    const isolationEntries = [
+      { phase_id: 'phase-3', branch: 'mpl-isolated-phase-3', path: '/tmp/wt', risk_level: 'HIGH', result: 'merged', timestamp: '2026-05-01T00:00:00Z' },
+    ];
+    writeRawState({
+      pipeline_id: 'mpl-v6-worktree',
+      current_phase: 'phase2-sprint',
+      schema_version: 6,
+      worktree_history: isolationEntries,
+      release: {
+        current_cut_id: null, completed_cut_ids: [], fix_loop_count: 0,
+        pending_artifact: null,
+        gate_results: {
+          hard1_passed: null, hard2_passed: null, hard3_passed: null,
+          hard1_baseline: null, hard2_coverage: null, hard3_resilience: null,
+        },
+        max_fix_loops: 3,
+      },
+    });
+    const state = readState(tmpDir);
+    assert.deepStrictEqual(state.worktree_history, isolationEntries);
+    assert.deepStrictEqual(state.worktree_pool_history, []);
+  });
+
+  it('chains v5 → v6 → v7 when starting from a v5 state.json', () => {
+    writeRawState({
+      pipeline_id: 'mpl-v5-legacy',
+      current_phase: 'phase2-sprint',
+      schema_version: 5,
+    });
+    const state = readState(tmpDir);
+    assert.equal(state.schema_version, CURRENT_SCHEMA_VERSION);
+    // v5→v6 backfill still applies
+    assert.strictEqual(state.release.max_fix_loops, 3);
+    // v6→v7 backfill on top
+    assert.deepStrictEqual(state.phase_scheduler_history, []);
+    assert.deepStrictEqual(state.worktree_pool_history, []);
+  });
+});

--- a/hooks/__tests__/mpl-require-finalize-artifacts.test.mjs
+++ b/hooks/__tests__/mpl-require-finalize-artifacts.test.mjs
@@ -361,6 +361,53 @@ execution_tiers:
     assert.match(r.reason, /scheduler:tiers_parallel_executed_mismatch:computed=0,summary=1/);
   });
 
+  it('parses top-level inline execution_tiers (`execution_tiers: [{...}]`) and still enforces the MUST', () => {
+    // Codex round-14 review on PR #213: same-line top-level inline list
+    // is valid YAML and used elsewhere in the repo. Previously this
+    // returned zero tiers and silently disabled enforcement.
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'audit-report.json'), JSON.stringify({ verdict: 'pass' }));
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'RUNBOOK.md'), '# MPL Pipeline RUNBOOK\n\n## Pipeline Complete\n');
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'decomposition.yaml'), `
+recompose_count: 0
+phases:
+  - id: phase-1
+  - id: phase-2
+execution_tiers: [{ tier: 9, phases: [phase-1, phase-2], parallel: true }]
+`);
+    writeSummaryScheduler({
+      tiers_total: 1,
+      tiers_parallel_requested: 1,
+      tiers_parallel_executed: 0,
+      tiers_parallel_rejected: 1,
+      tiers_with_missing_telemetry: [9],
+      waves_parallel_rejected: 0,
+      waves_parallel_failed: 0,
+      tiers_with_partial_rejection: [],
+      rejection_reasons: [],
+      no_parallel_explanation: null,
+    });
+    const r = runHook();
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason, /scheduler:no_parallel_explanation_required_but_missing/);
+  });
+
+  it('fails closed when execution_tiers has an unsupported same-line scalar value', () => {
+    // Codex round-14 review on PR #213: any non-list same-line value
+    // (e.g. `execution_tiers: null`) must fail closed instead of being
+    // treated as zero tiers.
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'audit-report.json'), JSON.stringify({ verdict: 'pass' }));
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'RUNBOOK.md'), '# MPL Pipeline RUNBOOK\n\n## Pipeline Complete\n');
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'decomposition.yaml'), `
+recompose_count: 0
+phases:
+  - id: phase-1
+execution_tiers: null
+`);
+    const r = runHook();
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason, /scheduler:decomposition_execution_tiers_unparseable/);
+  });
+
   it('parses execution_tiers with YAML line comments and still enforces the MUST', () => {
     // Codex round-13 review on PR #213: `execution_tiers: # scheduler`
     // and `parallel: true  # independent` are valid YAML. The previous

--- a/hooks/__tests__/mpl-require-finalize-artifacts.test.mjs
+++ b/hooks/__tests__/mpl-require-finalize-artifacts.test.mjs
@@ -356,6 +356,125 @@ execution_tiers:
     assert.match(r.reason, /scheduler:tiers_parallel_executed_mismatch:computed=0,summary=1/);
   });
 
+  it('parses inline-map execution_tiers and still enforces the MUST', () => {
+    // Codex round-11 review on PR #213: the YAML peek only recognized the
+    // block form. Inline-map `- { tier: 4, parallel: true, ... }` (a valid
+    // YAML form used elsewhere in the repo) parsed as zero tiers and the
+    // guard skipped the scheduler MUST. Pin support for inline form.
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'audit-report.json'), JSON.stringify({ verdict: 'pass' }));
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'RUNBOOK.md'), '# MPL Pipeline RUNBOOK\n\n## Pipeline Complete\n');
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'decomposition.yaml'), `
+recompose_count: 0
+phases:
+  - id: phase-1
+  - id: phase-2
+execution_tiers:
+  - { tier: 4, phases: [phase-1, phase-2], parallel: true }
+`);
+    // No events — telemetry missing — should block.
+    writeSummaryScheduler({
+      tiers_total: 1,
+      tiers_parallel_requested: 1,
+      tiers_parallel_executed: 0,
+      tiers_parallel_rejected: 1,
+      tiers_with_missing_telemetry: [4],
+      waves_parallel_rejected: 0,
+      waves_parallel_failed: 0,
+      tiers_with_partial_rejection: [],
+      rejection_reasons: [],
+      no_parallel_explanation: null,
+    });
+    const r = runHook();
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason, /scheduler:no_parallel_explanation_required_but_missing/);
+  });
+
+  it('parses reordered-key execution_tiers (parallel before tier) without skipping the MUST', () => {
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'audit-report.json'), JSON.stringify({ verdict: 'pass' }));
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'RUNBOOK.md'), '# MPL Pipeline RUNBOOK\n\n## Pipeline Complete\n');
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'decomposition.yaml'), `
+recompose_count: 0
+phases:
+  - id: phase-1
+  - id: phase-2
+execution_tiers:
+  - parallel: true
+    tier: 7
+    phases: [phase-1, phase-2]
+`);
+    writeSummaryScheduler({
+      tiers_total: 1,
+      tiers_parallel_requested: 1,
+      tiers_parallel_executed: 0,
+      tiers_parallel_rejected: 1,
+      tiers_with_missing_telemetry: [7],
+      waves_parallel_rejected: 0,
+      waves_parallel_failed: 0,
+      tiers_with_partial_rejection: [],
+      rejection_reasons: [],
+      no_parallel_explanation: null,
+    });
+    const r = runHook();
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason, /scheduler:no_parallel_explanation_required_but_missing/);
+  });
+
+  it('blocks finalize when summary under-reports a rejected wave or names the wrong missing tier', () => {
+    // Codex round-11 review on PR #213: scalar+length checks let a summary
+    // pass with the right shape but wrong contents. Compare the full
+    // aggregate, including exact tier ids and waves_parallel_rejected.
+    writeArtifacts();
+    writeDecompositionWithParallelTier();
+    // Two parallel_rejected events for tier 1.
+    writeSchedulerEvents([
+      { tier: 1, selected_mode: 'parallel_rejected', timestamp: '2026-05-27T00:00:03Z' },
+      { tier: 1, selected_mode: 'parallel_rejected', timestamp: '2026-05-27T00:00:04Z' },
+    ]);
+    writeSummaryScheduler({
+      tiers_total: 1,
+      tiers_parallel_requested: 1,
+      tiers_parallel_executed: 0,
+      tiers_parallel_rejected: 1,
+      tiers_with_missing_telemetry: [],
+      waves_parallel_rejected: 1,   // lie — actually 2
+      waves_parallel_failed: 0,
+      tiers_with_partial_rejection: [],
+      rejection_reasons: [],
+      no_parallel_explanation: 'parallelism rejected by file overlap',
+    });
+    const r = runHook();
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason, /scheduler:waves_parallel_rejected_mismatch:computed=2,summary=1/);
+  });
+
+  it('blocks finalize when execution_tiers is present but unparseable (fail-closed)', () => {
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'audit-report.json'), JSON.stringify({ verdict: 'pass' }));
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'RUNBOOK.md'), '# MPL Pipeline RUNBOOK\n\n## Pipeline Complete\n');
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'decomposition.yaml'), `
+recompose_count: 0
+phases:
+  - id: phase-1
+execution_tiers:
+  - this_is_not_a_tier_field: 1
+    parallel: true
+`);
+    writeSummaryScheduler({
+      tiers_total: 0,
+      tiers_parallel_requested: 0,
+      tiers_parallel_executed: 0,
+      tiers_parallel_rejected: 0,
+      tiers_with_missing_telemetry: [],
+      waves_parallel_rejected: 0,
+      waves_parallel_failed: 0,
+      tiers_with_partial_rejection: [],
+      rejection_reasons: [],
+      no_parallel_explanation: null,
+    });
+    const r = runHook();
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason, /scheduler:decomposition_execution_tiers_unparseable/);
+  });
+
   it('does not enforce the scheduler MUST when decomposition declares no parallel tier', () => {
     writeArtifacts();
     writeFileSync(join(tmp, '.mpl', 'mpl', 'decomposition.yaml'), `

--- a/hooks/__tests__/mpl-require-finalize-artifacts.test.mjs
+++ b/hooks/__tests__/mpl-require-finalize-artifacts.test.mjs
@@ -564,6 +564,43 @@ execution_tiers:
     assert.match(r.reason, /scheduler:decomposition_execution_tiers_unparseable/);
   });
 
+  it('collects rejection_reasons from successful parallel events too (wave-split deferred phases)', () => {
+    // Codex/claude round-16 review on PR #213: the executor records
+    // ready_but_blocked_reason on the parallel event itself when a wave
+    // split defers some phases to a later wave. The hook must include
+    // those reasons in its computed union or a faithful summary gets
+    // wedged.
+    writeArtifacts();
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'decomposition.yaml'), `
+recompose_count: 0
+phases:
+  - id: phase-1
+  - id: phase-2
+execution_tiers:
+  - tier: 1
+    phases: [phase-1, phase-2]
+    parallel: true
+`);
+    writeSchedulerEvents([
+      { tier: 1, selected_mode: 'parallel',
+        rejection_reasons_by_phase: { 'phase-3': ['file_overlap'] } },
+    ]);
+    writeSummaryScheduler({
+      tiers_total: 1,
+      tiers_parallel_requested: 1,
+      tiers_parallel_executed: 1,
+      tiers_parallel_rejected: 0,
+      tiers_with_missing_telemetry: [],
+      waves_parallel_rejected: 0,
+      waves_parallel_failed: 0,
+      tiers_with_partial_rejection: [],
+      rejection_reasons: ['file_overlap'],
+      no_parallel_explanation: null,
+    });
+    const r = runHook();
+    assert.equal(r.continue, true);
+  });
+
   it('collects rejection_reasons from sequential/skipped events on parallel-requested tiers', () => {
     // Codex round-15 review on PR #213: the executor emits
     // rejection_reasons (e.g. ["single_ready_phase"]) on sequential

--- a/hooks/__tests__/mpl-require-finalize-artifacts.test.mjs
+++ b/hooks/__tests__/mpl-require-finalize-artifacts.test.mjs
@@ -197,4 +197,89 @@ artifacts:
     assert.equal(r.decision, 'block');
     assert.match(r.reason, /missing_goal_contract_sha256/);
   });
+
+  /* ───────── Exp22 R6 / #205: scheduler observability guard ───────── */
+
+  function writeDecompositionWithParallelTier() {
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'decomposition.yaml'), `
+phases:
+  - id: phase-1
+  - id: phase-2
+execution_tiers:
+  - tier: 1
+    phases: [phase-1, phase-2]
+    parallel: true
+`);
+  }
+
+  function writeSummaryScheduler(scheduler) {
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'profile', 'run-summary.json'),
+      JSON.stringify({ run_id: 'r1', scheduler }));
+  }
+
+  it('blocks finalize when decomposition declares a parallel tier but run-summary.scheduler is missing', () => {
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'audit-report.json'), JSON.stringify({ verdict: 'pass' }));
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'profile', 'run-summary.json'), JSON.stringify({ run_id: 'r1' }));
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'RUNBOOK.md'), '# MPL Pipeline RUNBOOK\n\n## Pipeline Complete\n');
+    writeDecompositionWithParallelTier();
+    const r = runHook();
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason, /scheduler:block_missing/);
+  });
+
+  it('blocks finalize when parallel-requested tiers were not executed and no_parallel_explanation is null', () => {
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'audit-report.json'), JSON.stringify({ verdict: 'pass' }));
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'RUNBOOK.md'), '# MPL Pipeline RUNBOOK\n\n## Pipeline Complete\n');
+    writeDecompositionWithParallelTier();
+    writeSummaryScheduler({
+      tiers_total: 1,
+      tiers_parallel_requested: 1,
+      tiers_parallel_executed: 0,
+      tiers_parallel_rejected: 1,
+      tiers_with_missing_telemetry: [],
+      waves_parallel_rejected: 1,
+      waves_parallel_failed: 0,
+      tiers_with_partial_rejection: [],
+      rejection_reasons: ['file_overlap'],
+      no_parallel_explanation: null,
+    });
+    const r = runHook();
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason, /scheduler:no_parallel_explanation_required_but_missing/);
+  });
+
+  it('allows finalize when parallel-requested tier failed at runtime but no_parallel_explanation is filled', () => {
+    writeArtifacts();
+    writeDecompositionWithParallelTier();
+    writeSummaryScheduler({
+      tiers_total: 1,
+      tiers_parallel_requested: 1,
+      tiers_parallel_executed: 0,
+      tiers_parallel_rejected: 0,
+      tiers_with_missing_telemetry: [],
+      waves_parallel_rejected: 0,
+      waves_parallel_failed: 1,
+      tiers_with_partial_rejection: [],
+      rejection_reasons: ['worker_dispatch_error'],
+      no_parallel_explanation: 'tier 1 attempted parallel execution but worker dispatch failed; fell back to sequential retry',
+    });
+    const r = runHook();
+    assert.equal(r.continue, true);
+  });
+
+  it('does not enforce the scheduler MUST when decomposition declares no parallel tier', () => {
+    writeArtifacts();
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'decomposition.yaml'), `
+phases:
+  - id: phase-1
+execution_tiers:
+  - tier: 1
+    phases: [phase-1]
+    parallel: false
+`);
+    // Even with no scheduler block in run-summary, finalize must pass when
+    // nothing requested parallelism.
+    const r = runHook();
+    assert.equal(r.continue, true);
+  });
 });

--- a/hooks/__tests__/mpl-require-finalize-artifacts.test.mjs
+++ b/hooks/__tests__/mpl-require-finalize-artifacts.test.mjs
@@ -361,6 +361,43 @@ execution_tiers:
     assert.match(r.reason, /scheduler:tiers_parallel_executed_mismatch:computed=0,summary=1/);
   });
 
+  it('parses execution_tiers with YAML line comments and still enforces the MUST', () => {
+    // Codex round-13 review on PR #213: `execution_tiers: # scheduler`
+    // and `parallel: true  # independent` are valid YAML. The previous
+    // peek parsed those as zero tiers / parallel=false and skipped the
+    // MUST. Comments must be stripped before regex matching.
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'audit-report.json'), JSON.stringify({ verdict: 'pass' }));
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'RUNBOOK.md'), '# MPL Pipeline RUNBOOK\n\n## Pipeline Complete\n');
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'decomposition.yaml'), `
+recompose_count: 0  # initial decomposition
+phases:
+  - id: phase-1
+  - id: phase-2
+execution_tiers: # scheduler
+  - tier: 1   # tier of order
+    phases: [phase-1, phase-2]
+    parallel: true   # independent
+`);
+    writeSummaryScheduler({
+      tiers_total: 1,
+      tiers_parallel_requested: 1,
+      tiers_parallel_executed: 0,
+      tiers_parallel_rejected: 1,
+      tiers_with_missing_telemetry: [1],
+      waves_parallel_rejected: 0,
+      waves_parallel_failed: 0,
+      tiers_with_partial_rejection: [],
+      rejection_reasons: [],
+      no_parallel_explanation: null,
+    });
+    const r = runHook();
+    assert.equal(r.decision, 'block');
+    // Either the missing-explanation or a contents check should trip; what
+    // matters is that the comment-bearing YAML did NOT silently disable
+    // enforcement.
+    assert.match(r.reason, /scheduler:no_parallel_explanation_required_but_missing/);
+  });
+
   it('parses inline-map execution_tiers and still enforces the MUST', () => {
     // Codex round-11 review on PR #213: the YAML peek only recognized the
     // block form. Inline-map `- { tier: 4, parallel: true, ... }` (a valid

--- a/hooks/__tests__/mpl-require-finalize-artifacts.test.mjs
+++ b/hooks/__tests__/mpl-require-finalize-artifacts.test.mjs
@@ -564,6 +564,37 @@ execution_tiers:
     assert.match(r.reason, /scheduler:decomposition_execution_tiers_unparseable/);
   });
 
+  it('collects rejection_reasons from sequential/skipped events on parallel-requested tiers', () => {
+    // Codex round-15 review on PR #213: the executor emits
+    // rejection_reasons (e.g. ["single_ready_phase"]) on sequential
+    // events for parallel:true tiers. The aggregator must collect those
+    // too — otherwise a correctly-generated summary listing
+    // ["single_ready_phase"] gets blocked by a rejection_reasons set
+    // mismatch.
+    writeArtifacts();
+    writeDecompositionWithParallelTier();
+    writeSchedulerEvents([
+      // parallel:true tier reduced to 1 ready phase → sequential branch
+      // with rejection_reasons: ["single_ready_phase"].
+      { tier: 1, selected_mode: 'sequential',
+        rejection_reasons: ['single_ready_phase'] },
+    ]);
+    writeSummaryScheduler({
+      tiers_total: 1,
+      tiers_parallel_requested: 1,
+      tiers_parallel_executed: 0,
+      tiers_parallel_rejected: 1,
+      tiers_with_missing_telemetry: [],
+      waves_parallel_rejected: 0,
+      waves_parallel_failed: 0,
+      tiers_with_partial_rejection: [],
+      rejection_reasons: ['single_ready_phase'],
+      no_parallel_explanation: 'tier 1 ran sequentially: only one phase ready in the wave',
+    });
+    const r = runHook();
+    assert.equal(r.continue, true);
+  });
+
   it('preserves two same-tier rejected waves through dedupe via wave_index', () => {
     // Codex round-12 review on PR #213: dedupe-by-timestamp let same-tier
     // rejected waves collapse onto one event. wave_index is the per-tier

--- a/hooks/__tests__/mpl-require-finalize-artifacts.test.mjs
+++ b/hooks/__tests__/mpl-require-finalize-artifacts.test.mjs
@@ -230,10 +230,14 @@ execution_tiers:
   // current-run scope keys (pipeline_id, run_started_at, recompose_count)
   // so the aggregator includes it.
   function writeSchedulerEvents(events) {
-    const stamped = events.map((e) => ({
+    const stamped = events.map((e, i) => ({
       pipeline_id: TEST_PIPELINE_ID,
       run_started_at: TEST_STARTED_AT,
       recompose_count: 0,
+      wave_index: i,
+      // Distinct ISO timestamps so the dedupe key cannot collapse
+      // multiple events sharing the same coarse time.
+      timestamp: `2026-05-27T00:00:${String(10 + i).padStart(2, '0')}.000Z`,
       ...e,
     }));
     // patch state.phase_scheduler_history
@@ -263,7 +267,8 @@ execution_tiers:
     // Real evidence: a parallel_rejected event for tier 1 (planning could
     // not split into a parallel wave). The hook recomputes from this.
     writeSchedulerEvents([
-      { tier: 1, selected_mode: 'parallel_rejected', timestamp: '2026-05-27T00:00:01Z' },
+      { tier: 1, selected_mode: 'parallel_rejected',
+        rejection_reasons_by_phase: { 'phase-1': ['file_overlap'] } },
     ]);
     writeSummaryScheduler({
       tiers_total: 1,
@@ -473,6 +478,96 @@ execution_tiers:
     const r = runHook();
     assert.equal(r.decision, 'block');
     assert.match(r.reason, /scheduler:decomposition_execution_tiers_unparseable/);
+  });
+
+  it('preserves two same-tier rejected waves through dedupe via wave_index', () => {
+    // Codex round-12 review on PR #213: dedupe-by-timestamp let same-tier
+    // rejected waves collapse onto one event. wave_index is the per-tier
+    // counter that guarantees distinct dedupe keys.
+    writeArtifacts();
+    writeDecompositionWithParallelTier();
+    writeSchedulerEvents([
+      { tier: 1, selected_mode: 'parallel_rejected',
+        rejection_reasons_by_phase: { 'phase-1': ['file_overlap'] } },
+      { tier: 1, selected_mode: 'parallel_rejected',
+        rejection_reasons_by_phase: { 'phase-2': ['resource_lock'] } },
+    ]);
+    writeSummaryScheduler({
+      tiers_total: 1,
+      tiers_parallel_requested: 1,
+      tiers_parallel_executed: 0,
+      tiers_parallel_rejected: 1,
+      tiers_with_missing_telemetry: [],
+      waves_parallel_rejected: 2,
+      waves_parallel_failed: 0,
+      tiers_with_partial_rejection: [],
+      rejection_reasons: ['file_overlap', 'resource_lock'],
+      no_parallel_explanation: 'tier 1: both waves rejected by file_overlap and resource_lock; fell back to sequential',
+    });
+    const r = runHook();
+    assert.equal(r.continue, true);
+  });
+
+  it('blocks finalize when no_parallel_explanation is non-empty but fails to reference the affected tier ids', () => {
+    // Codex round-12 review on PR #213: a non-empty string is not enough.
+    // The explanation must name each affected tier id by number so an
+    // operator can find which tiers lost parallelism.
+    writeArtifacts();
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'decomposition.yaml'), `
+recompose_count: 0
+phases:
+  - id: phase-1
+  - id: phase-2
+execution_tiers:
+  - tier: 5
+    phases: [phase-1, phase-2]
+    parallel: true
+`);
+    writeSchedulerEvents([
+      { tier: 5, selected_mode: 'parallel_rejected',
+        rejection_reasons_by_phase: { 'phase-1': ['file_overlap'] } },
+    ]);
+    writeSummaryScheduler({
+      tiers_total: 1,
+      tiers_parallel_requested: 1,
+      tiers_parallel_executed: 0,
+      tiers_parallel_rejected: 1,
+      tiers_with_missing_telemetry: [],
+      waves_parallel_rejected: 1,
+      waves_parallel_failed: 0,
+      tiers_with_partial_rejection: [],
+      rejection_reasons: ['file_overlap'],
+      no_parallel_explanation: 'n/a',
+    });
+    const r = runHook();
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason, /scheduler:no_parallel_explanation_missing_tier_refs:\[5\]/);
+  });
+
+  it('blocks finalize when summary.scheduler.rejection_reasons disagrees with the computed set', () => {
+    writeArtifacts();
+    writeDecompositionWithParallelTier();
+    writeSchedulerEvents([
+      { tier: 1, selected_mode: 'parallel_rejected',
+        rejection_reasons_by_phase: { 'phase-1': ['file_overlap'] } },
+    ]);
+    writeSummaryScheduler({
+      tiers_total: 1,
+      tiers_parallel_requested: 1,
+      tiers_parallel_executed: 0,
+      tiers_parallel_rejected: 1,
+      tiers_with_missing_telemetry: [],
+      waves_parallel_rejected: 1,
+      waves_parallel_failed: 0,
+      tiers_with_partial_rejection: [],
+      rejection_reasons: ['something_unrelated'],   // drift
+      no_parallel_explanation: 'tier 1 rejected',
+    });
+    const r = runHook();
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason, /scheduler:rejection_reasons_mismatch/);
+    assert.match(r.reason, /file_overlap/);
+    assert.match(r.reason, /something_unrelated/);
   });
 
   it('does not enforce the scheduler MUST when decomposition declares no parallel tier', () => {

--- a/hooks/__tests__/mpl-require-finalize-artifacts.test.mjs
+++ b/hooks/__tests__/mpl-require-finalize-artifacts.test.mjs
@@ -1,7 +1,7 @@
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'fs';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { tmpdir } from 'os';
@@ -13,6 +13,9 @@ const __filename = fileURLToPath(import.meta.url);
 const HOOK_PATH = join(dirname(__filename), '..', 'mpl-require-finalize-artifacts.mjs');
 const SCHEMA_V = CURRENT_SCHEMA_VERSION;
 
+const TEST_PIPELINE_ID = 'mpl-test-205';
+const TEST_STARTED_AT = '2026-05-27T00:00:00.000Z';
+
 let tmp;
 beforeEach(() => {
   tmp = mkdtempSync(join(tmpdir(), 'mpl-finalize-art-'));
@@ -20,6 +23,9 @@ beforeEach(() => {
   writeFileSync(join(tmp, '.mpl', 'state.json'), JSON.stringify({
     schema_version: SCHEMA_V,
     current_phase: 'phase5-finalize',
+    pipeline_id: TEST_PIPELINE_ID,
+    started_at: TEST_STARTED_AT,
+    phase_scheduler_history: [],
     security_results: {
       dependency_audit: { command: 'npm audit --omit=dev', exit_code: 0 },
     },
@@ -200,8 +206,9 @@ artifacts:
 
   /* ───────── Exp22 R6 / #205: scheduler observability guard ───────── */
 
-  function writeDecompositionWithParallelTier() {
+  function writeDecompositionWithParallelTier({ recompose_count = 0 } = {}) {
     writeFileSync(join(tmp, '.mpl', 'mpl', 'decomposition.yaml'), `
+recompose_count: ${recompose_count}
 phases:
   - id: phase-1
   - id: phase-2
@@ -215,6 +222,28 @@ execution_tiers:
   function writeSummaryScheduler(scheduler) {
     writeFileSync(join(tmp, '.mpl', 'mpl', 'profile', 'run-summary.json'),
       JSON.stringify({ run_id: 'r1', scheduler }));
+  }
+
+  // Write phase-scheduler events into BOTH state.phase_scheduler_history
+  // (the ring-buffered mirror that hooks/lib/mpl-scheduler-aggregate reads)
+  // and the persistent JSONL profile file. Each event carries the
+  // current-run scope keys (pipeline_id, run_started_at, recompose_count)
+  // so the aggregator includes it.
+  function writeSchedulerEvents(events) {
+    const stamped = events.map((e) => ({
+      pipeline_id: TEST_PIPELINE_ID,
+      run_started_at: TEST_STARTED_AT,
+      recompose_count: 0,
+      ...e,
+    }));
+    // patch state.phase_scheduler_history
+    const statePath = join(tmp, '.mpl', 'state.json');
+    const state = JSON.parse(readFileSync(statePath, 'utf-8'));
+    state.phase_scheduler_history = stamped;
+    writeFileSync(statePath, JSON.stringify(state));
+    // mirror to persistent JSONL
+    const jsonlPath = join(tmp, '.mpl', 'mpl', 'profile', 'phase-scheduler.jsonl');
+    writeFileSync(jsonlPath, stamped.map((e) => JSON.stringify(e)).join('\n') + '\n');
   }
 
   it('blocks finalize when decomposition declares a parallel tier but run-summary.scheduler is missing', () => {
@@ -231,6 +260,11 @@ execution_tiers:
     writeFileSync(join(tmp, '.mpl', 'mpl', 'audit-report.json'), JSON.stringify({ verdict: 'pass' }));
     writeFileSync(join(tmp, '.mpl', 'mpl', 'RUNBOOK.md'), '# MPL Pipeline RUNBOOK\n\n## Pipeline Complete\n');
     writeDecompositionWithParallelTier();
+    // Real evidence: a parallel_rejected event for tier 1 (planning could
+    // not split into a parallel wave). The hook recomputes from this.
+    writeSchedulerEvents([
+      { tier: 1, selected_mode: 'parallel_rejected', timestamp: '2026-05-27T00:00:01Z' },
+    ]);
     writeSummaryScheduler({
       tiers_total: 1,
       tiers_parallel_requested: 1,
@@ -251,11 +285,14 @@ execution_tiers:
   it('allows finalize when parallel-requested tier failed at runtime but no_parallel_explanation is filled', () => {
     writeArtifacts();
     writeDecompositionWithParallelTier();
+    writeSchedulerEvents([
+      { tier: 1, selected_mode: 'parallel_failed', timestamp: '2026-05-27T00:00:02Z', failure_reason: 'worker_dispatch_error' },
+    ]);
     writeSummaryScheduler({
       tiers_total: 1,
       tiers_parallel_requested: 1,
       tiers_parallel_executed: 0,
-      tiers_parallel_rejected: 0,
+      tiers_parallel_rejected: 1,
       tiers_with_missing_telemetry: [],
       waves_parallel_rejected: 0,
       waves_parallel_failed: 1,
@@ -268,11 +305,9 @@ execution_tiers:
   });
 
   it('blocks finalize when summary.scheduler.tiers_parallel_requested is lower than decomposition truth (drift/spoof guard)', () => {
-    // Codex round-9 review on PR #213: the original guard used the summary's
-    // self-reported tiers_parallel_requested as the denominator. A prompt-
-    // drifted or hand-edited summary could set requested=0/executed=0 with
-    // explanation=null to vacuously pass. decomposition.yaml is the
-    // authority; the summary's count must match it.
+    // Codex round-9 review on PR #213: a prompt-drifted or hand-edited
+    // summary that reports requested=0 must be rejected because the
+    // hook now computes that count from decomposition.yaml itself.
     writeFileSync(join(tmp, '.mpl', 'mpl', 'audit-report.json'), JSON.stringify({ verdict: 'pass' }));
     writeFileSync(join(tmp, '.mpl', 'mpl', 'RUNBOOK.md'), '# MPL Pipeline RUNBOOK\n\n## Pipeline Complete\n');
     writeDecompositionWithParallelTier();
@@ -291,13 +326,40 @@ execution_tiers:
     const r = runHook();
     assert.equal(r.decision, 'block');
     assert.match(r.reason, /scheduler:tiers_parallel_requested_mismatch/);
-    assert.match(r.reason, /decomp=1/);
+    assert.match(r.reason, /computed=1/);
     assert.match(r.reason, /summary=0/);
+  });
+
+  it('blocks finalize when run-summary falsely claims executed parallelism but no current-run event exists', () => {
+    // Codex round-10 review on PR #213: the hook must not trust
+    // summary.scheduler.tiers_parallel_executed. Re-derive it from the
+    // event stream. A summary that lies (executed=1) with no actual
+    // selected_mode:"parallel" event in JSONL/state must be blocked.
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'audit-report.json'), JSON.stringify({ verdict: 'pass' }));
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'RUNBOOK.md'), '# MPL Pipeline RUNBOOK\n\n## Pipeline Complete\n');
+    writeDecompositionWithParallelTier();
+    // Intentionally no scheduler events written — telemetry is missing.
+    writeSummaryScheduler({
+      tiers_total: 1,
+      tiers_parallel_requested: 1,
+      tiers_parallel_executed: 1,   // lie — there is no parallel event
+      tiers_parallel_rejected: 0,
+      tiers_with_missing_telemetry: [],   // lie — tier 1 is missing
+      waves_parallel_rejected: 0,
+      waves_parallel_failed: 0,
+      tiers_with_partial_rejection: [],
+      rejection_reasons: [],
+      no_parallel_explanation: null,
+    });
+    const r = runHook();
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason, /scheduler:tiers_parallel_executed_mismatch:computed=0,summary=1/);
   });
 
   it('does not enforce the scheduler MUST when decomposition declares no parallel tier', () => {
     writeArtifacts();
     writeFileSync(join(tmp, '.mpl', 'mpl', 'decomposition.yaml'), `
+recompose_count: 0
 phases:
   - id: phase-1
 execution_tiers:

--- a/hooks/__tests__/mpl-require-finalize-artifacts.test.mjs
+++ b/hooks/__tests__/mpl-require-finalize-artifacts.test.mjs
@@ -267,6 +267,34 @@ execution_tiers:
     assert.equal(r.continue, true);
   });
 
+  it('blocks finalize when summary.scheduler.tiers_parallel_requested is lower than decomposition truth (drift/spoof guard)', () => {
+    // Codex round-9 review on PR #213: the original guard used the summary's
+    // self-reported tiers_parallel_requested as the denominator. A prompt-
+    // drifted or hand-edited summary could set requested=0/executed=0 with
+    // explanation=null to vacuously pass. decomposition.yaml is the
+    // authority; the summary's count must match it.
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'audit-report.json'), JSON.stringify({ verdict: 'pass' }));
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'RUNBOOK.md'), '# MPL Pipeline RUNBOOK\n\n## Pipeline Complete\n');
+    writeDecompositionWithParallelTier();
+    writeSummaryScheduler({
+      tiers_total: 1,
+      tiers_parallel_requested: 0,   // drift — decomposition says 1
+      tiers_parallel_executed: 0,
+      tiers_parallel_rejected: 0,
+      tiers_with_missing_telemetry: [],
+      waves_parallel_rejected: 0,
+      waves_parallel_failed: 0,
+      tiers_with_partial_rejection: [],
+      rejection_reasons: [],
+      no_parallel_explanation: null,
+    });
+    const r = runHook();
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason, /scheduler:tiers_parallel_requested_mismatch/);
+    assert.match(r.reason, /decomp=1/);
+    assert.match(r.reason, /summary=0/);
+  });
+
   it('does not enforce the scheduler MUST when decomposition declares no parallel tier', () => {
     writeArtifacts();
     writeFileSync(join(tmp, '.mpl', 'mpl', 'decomposition.yaml'), `

--- a/hooks/lib/migrations/index.mjs
+++ b/hooks/lib/migrations/index.mjs
@@ -22,6 +22,7 @@ import v2ToV3 from './v2-to-v3.mjs';
 import v3ToV4 from './v3-to-v4.mjs';
 import v4ToV5 from './v4-to-v5.mjs';
 import v5ToV6 from './v5-to-v6.mjs';
+import v6ToV7 from './v6-to-v7.mjs';
 
 /**
  * Ordered registry. Add new entries here when bumping
@@ -33,6 +34,7 @@ export const MIGRATIONS = Object.freeze([
   v3ToV4,
   v4ToV5,
   v5ToV6,
+  v6ToV7,
 ]);
 
 /**

--- a/hooks/lib/migrations/v6-to-v7.mjs
+++ b/hooks/lib/migrations/v6-to-v7.mjs
@@ -1,0 +1,41 @@
+/**
+ * v6 → v7: Exp22 R6 scheduler observability state.
+ *
+ * Adds two ring-buffered arrays consumed by the parallel scheduler in
+ * `commands/mpl-run-execute.md`:
+ *  - `phase_scheduler_history` — mirrors the latest 50
+ *    `record_scheduler_event` rows that also append to
+ *    `.mpl/mpl/profile/phase-scheduler.jsonl`. Lets runs prove whether each
+ *    `execution_tiers[]` decision was parallelized or why it was rejected.
+ *  - `worktree_pool_history` — slot lifecycle for the parallel-tier worktree
+ *    pool. Distinct from `worktree_history` (HIGH-risk isolation lifecycle in
+ *    `commands/mpl-run-execute-context.md` §5). Two writers with
+ *    non-overlapping shapes; keeping them on separate fields stops any reader
+ *    from having to discriminate by schema-shape inspection.
+ *
+ * Same backfill pattern as v5→v6 (PR #213 codex/claude review): adding fields
+ * to DEFAULT_STATE without a migration would let legacy v6 state.json read
+ * with `state.phase_scheduler_history === undefined`, then any reader doing
+ * `state.phase_scheduler_history.length` would throw. The migration removes
+ * that ambiguity at read time.
+ */
+
+export default {
+  from: 6,
+  to: 7,
+  description:
+    'Additive backfill — Exp22 R6 scheduler observability (phase_scheduler_history, worktree_pool_history)',
+  migrate(state, _cwd) {
+    const merged = { ...state };
+
+    if (!Array.isArray(merged.phase_scheduler_history)) {
+      merged.phase_scheduler_history = [];
+    }
+    if (!Array.isArray(merged.worktree_pool_history)) {
+      merged.worktree_pool_history = [];
+    }
+
+    merged.schema_version = 7;
+    return merged;
+  },
+};

--- a/hooks/lib/mpl-scheduler-aggregate.mjs
+++ b/hooks/lib/mpl-scheduler-aggregate.mjs
@@ -20,7 +20,18 @@ import { join } from 'path';
  * Minimal YAML peek over `execution_tiers:` and top-level
  * `recompose_count:` in decomposition.yaml. We only need the parallel
  * boolean per tier and recompose_count — no need to pull in a full YAML
- * parser for this hook. If the file is missing or malformed, returns null.
+ * parser for this hook. Supports:
+ *  - Block form with arbitrary key order:
+ *      - tier: 4
+ *        parallel: true
+ *        phases: [...]
+ *  - Inline-map form:
+ *      - { tier: 4, parallel: true, phases: [...] }
+ * Returns null when the file is missing. Returns
+ * `{ tiers: [], recompose_count, parse_error }` when execution_tiers is
+ * present but cannot be parsed; the caller treats parse_error as fail-
+ * closed because a present-but-unparseable execution_tiers block must not
+ * vacuously skip the scheduler MUST.
  */
 export function readDecompositionScope(cwd) {
   const path = join(cwd, '.mpl', 'mpl', 'decomposition.yaml');
@@ -31,23 +42,79 @@ export function readDecompositionScope(cwd) {
   const recomposeMatch = text.match(/(^|\n)recompose_count:\s*(\d+)/);
   const recompose_count = recomposeMatch ? Number(recomposeMatch[2]) : 0;
 
-  const block = text.match(/(^|\n)execution_tiers:\s*\n([\s\S]*?)(\n[a-zA-Z_]+:|\n*$)/);
+  const blockMatch = text.match(/(^|\n)execution_tiers:\s*\n([\s\S]*?)(?=\n[a-zA-Z_][a-zA-Z0-9_]*:|\n*$)/);
+  if (!blockMatch) return { tiers: [], recompose_count };
+
+  const items = splitYamlListItems(blockMatch[2]);
   const tiers = [];
-  if (block) {
-    let currentTier = null;
-    for (const line of block[2].split('\n')) {
-      const tierIdMatch = line.match(/^\s*-\s*tier:\s*(\d+)/);
-      const parallelMatch = line.match(/^\s*parallel:\s*(true|false)/i);
-      if (tierIdMatch) {
-        if (currentTier) tiers.push(currentTier);
-        currentTier = { tier: Number(tierIdMatch[1]), parallel: false };
-      } else if (parallelMatch && currentTier) {
-        currentTier.parallel = parallelMatch[1].toLowerCase() === 'true';
+  let parseError = false;
+  for (const item of items) {
+    const tier = extractField(item, 'tier');
+    const parallel = extractField(item, 'parallel');
+    if (tier === null) {
+      // List item present but no tier field recognized — fail closed.
+      parseError = true;
+      continue;
+    }
+    const tierNum = Number(tier);
+    if (!Number.isInteger(tierNum)) {
+      parseError = true;
+      continue;
+    }
+    const parallelBool = parallel !== null && /^true$/i.test(String(parallel).trim());
+    tiers.push({ tier: tierNum, parallel: parallelBool });
+  }
+  return { tiers, recompose_count, parse_error: parseError };
+}
+
+/**
+ * Split an indented YAML list block into raw item strings. Each item
+ * starts at a line beginning with the list-item marker `- ` at the same
+ * indentation, and ends at the next item marker (or end of block).
+ * Inline-map items (`- { ... }`) come back as a single line; block-form
+ * items come back as multiple lines.
+ */
+function splitYamlListItems(text) {
+  const lines = text.split('\n');
+  let markerIndent = null;
+  const items = [];
+  let current = null;
+  for (const line of lines) {
+    const itemMatch = line.match(/^(\s*)-\s+(.*)$/);
+    if (itemMatch) {
+      if (markerIndent === null) markerIndent = itemMatch[1].length;
+      if (itemMatch[1].length === markerIndent) {
+        if (current !== null) items.push(current);
+        current = itemMatch[2];
+        continue;
       }
     }
-    if (currentTier) tiers.push(currentTier);
+    if (current !== null) current += '\n' + line;
   }
-  return { tiers, recompose_count };
+  if (current !== null) items.push(current);
+  return items;
+}
+
+/**
+ * Extract a scalar field from a YAML list item that may be block-form
+ * (newline-separated key: value) or inline-map form (`{ k: v, k2: v2 }`).
+ * Returns the raw string value or null if not found.
+ */
+function extractField(item, key) {
+  // Block form first: key on its own line (or the start of the item),
+  // possibly indented. Works for both reordered-key block items and
+  // straight block items.
+  const blockMatch = item.match(new RegExp(`(^|\\n)\\s*${key}\\s*:\\s*([^\\n,}]+)`, 'i'));
+  if (blockMatch) return blockMatch[2].trim();
+  // Inline map form fallback: `{ k: v, k2: v2 }` on one line. Strip
+  // surrounding braces. The character class excludes newlines and the
+  // map terminators so the lazy quantifier stops at the next field.
+  const inlineCandidate = item.trim().replace(/^\{\s*/, '').replace(/\s*\}$/, '');
+  const inlineMatch = inlineCandidate.match(
+    new RegExp(`(^|,)\\s*${key}\\s*:\\s*([^,\\n}]+?)(?=\\s*[,\\n}]|$)`, 'i')
+  );
+  if (inlineMatch) return inlineMatch[2].trim();
+  return null;
 }
 
 function readJsonl(cwd) {
@@ -85,6 +152,13 @@ function eventKey(e) {
 export function aggregateScheduler(cwd, state) {
   const decomp = readDecompositionScope(cwd);
   if (!decomp) return null;
+
+  // If execution_tiers exists but items could not be parsed, fail closed:
+  // the caller treats this as a guard violation rather than vacuously
+  // skipping the MUST.
+  if (decomp.parse_error) {
+    return { __decomposition_unparseable__: true };
+  }
 
   const expectedParallel = new Set(
     decomp.tiers.filter((t) => t.parallel).map((t) => t.tier)

--- a/hooks/lib/mpl-scheduler-aggregate.mjs
+++ b/hooks/lib/mpl-scheduler-aggregate.mjs
@@ -39,9 +39,18 @@ export function readDecompositionScope(cwd) {
   let text;
   try { text = readFileSync(path, 'utf-8'); } catch { return null; }
 
+  // Strip YAML line comments before regex parsing so `key: # comment` and
+  // `parallel: true # note` are recognized. Quoted-string-aware: `#`
+  // inside double or single quotes does NOT start a comment. Decomposition
+  // values are simple scalars; this is sufficient.
+  text = stripYamlComments(text);
+
   const recomposeMatch = text.match(/(^|\n)recompose_count:\s*(\d+)/);
   const recompose_count = recomposeMatch ? Number(recomposeMatch[2]) : 0;
 
+  // Allow optional trailing whitespace and an optional same-line value
+  // marker (e.g. `execution_tiers: |` or just a newline). Block ends at
+  // the next top-level YAML key.
   const blockMatch = text.match(/(^|\n)execution_tiers:\s*\n([\s\S]*?)(?=\n[a-zA-Z_][a-zA-Z0-9_]*:|\n*$)/);
   if (!blockMatch) return { tiers: [], recompose_count };
 
@@ -61,8 +70,21 @@ export function readDecompositionScope(cwd) {
       parseError = true;
       continue;
     }
-    const parallelBool = parallel !== null && /^true$/i.test(String(parallel).trim());
-    tiers.push({ tier: tierNum, parallel: parallelBool });
+    // Normalize the parallel value. A missing parallel field is an
+    // explicit failure rather than an implicit false — `parallel:` is
+    // required on every execution_tiers item by the decomposer schema,
+    // and silently treating absence as false would let a malformed
+    // decomposition vacuously skip the MUST.
+    if (parallel === null) {
+      parseError = true;
+      continue;
+    }
+    const raw = String(parallel).trim().toLowerCase();
+    if (raw !== 'true' && raw !== 'false') {
+      parseError = true;
+      continue;
+    }
+    tiers.push({ tier: tierNum, parallel: raw === 'true' });
   }
   return { tiers, recompose_count, parse_error: parseError };
 }
@@ -100,6 +122,32 @@ function splitYamlListItems(text) {
  * (newline-separated key: value) or inline-map form (`{ k: v, k2: v2 }`).
  * Returns the raw string value or null if not found.
  */
+/**
+ * Strip YAML `# comment` segments from each line, except when the `#` is
+ * inside a single- or double-quoted string. Keeps escape behavior simple
+ * (no backslash handling) — decomposition.yaml scalars are plain enough
+ * that this matches js-yaml's behavior for the cases we parse.
+ */
+function stripYamlComments(text) {
+  const out = [];
+  for (const line of text.split('\n')) {
+    let inSingle = false;
+    let inDouble = false;
+    let cut = -1;
+    for (let i = 0; i < line.length; i++) {
+      const c = line[i];
+      if (c === "'" && !inDouble) inSingle = !inSingle;
+      else if (c === '"' && !inSingle) inDouble = !inDouble;
+      else if (c === '#' && !inSingle && !inDouble) {
+        const prev = i === 0 ? ' ' : line[i - 1];
+        if (/\s/.test(prev)) { cut = i; break; }
+      }
+    }
+    out.push(cut === -1 ? line : line.slice(0, cut).replace(/\s+$/, ''));
+  }
+  return out.join('\n');
+}
+
 function extractField(item, key) {
   // Block form first: key on its own line (or the start of the item),
   // possibly indented. Works for both reordered-key block items and

--- a/hooks/lib/mpl-scheduler-aggregate.mjs
+++ b/hooks/lib/mpl-scheduler-aggregate.mjs
@@ -1,0 +1,165 @@
+/**
+ * Exp22 R6 / #205 — scheduler telemetry aggregator.
+ *
+ * Reads phase-scheduler events from `.mpl/mpl/profile/phase-scheduler.jsonl`
+ * (persistent across pipelines) AND `state.phase_scheduler_history`
+ * (ring-buffered last-50 mirror), unions+deduplicates them, filters to the
+ * current run scope (pipeline_id + run_started_at + recompose_count), then
+ * computes the same fields documented in `commands/mpl-run-finalize.md`
+ * Step 5.4. The finalize-artifacts hook calls this to recompute the gates
+ * itself rather than trusting `run-summary.json`'s self-reported counts.
+ *
+ * Returns null when the raw decomposition cannot be read or the
+ * state/decomposition is empty (caller decides whether that's fail-open).
+ */
+
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+
+/**
+ * Minimal YAML peek over `execution_tiers:` and top-level
+ * `recompose_count:` in decomposition.yaml. We only need the parallel
+ * boolean per tier and recompose_count — no need to pull in a full YAML
+ * parser for this hook. If the file is missing or malformed, returns null.
+ */
+export function readDecompositionScope(cwd) {
+  const path = join(cwd, '.mpl', 'mpl', 'decomposition.yaml');
+  if (!existsSync(path)) return null;
+  let text;
+  try { text = readFileSync(path, 'utf-8'); } catch { return null; }
+
+  const recomposeMatch = text.match(/(^|\n)recompose_count:\s*(\d+)/);
+  const recompose_count = recomposeMatch ? Number(recomposeMatch[2]) : 0;
+
+  const block = text.match(/(^|\n)execution_tiers:\s*\n([\s\S]*?)(\n[a-zA-Z_]+:|\n*$)/);
+  const tiers = [];
+  if (block) {
+    let currentTier = null;
+    for (const line of block[2].split('\n')) {
+      const tierIdMatch = line.match(/^\s*-\s*tier:\s*(\d+)/);
+      const parallelMatch = line.match(/^\s*parallel:\s*(true|false)/i);
+      if (tierIdMatch) {
+        if (currentTier) tiers.push(currentTier);
+        currentTier = { tier: Number(tierIdMatch[1]), parallel: false };
+      } else if (parallelMatch && currentTier) {
+        currentTier.parallel = parallelMatch[1].toLowerCase() === 'true';
+      }
+    }
+    if (currentTier) tiers.push(currentTier);
+  }
+  return { tiers, recompose_count };
+}
+
+function readJsonl(cwd) {
+  const path = join(cwd, '.mpl', 'mpl', 'profile', 'phase-scheduler.jsonl');
+  if (!existsSync(path)) return [];
+  let text;
+  try { text = readFileSync(path, 'utf-8'); } catch { return []; }
+  const out = [];
+  for (const line of text.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try { out.push(JSON.parse(trimmed)); } catch { /* skip malformed line */ }
+  }
+  return out;
+}
+
+function eventKey(e) {
+  return `${e?.pipeline_id ?? ''}|${e?.run_started_at ?? ''}|${e?.recompose_count ?? ''}|${e?.tier ?? ''}|${e?.timestamp ?? ''}|${e?.selected_mode ?? ''}`;
+}
+
+/**
+ * Compute the scheduler block as documented in `commands/mpl-run-finalize.md`
+ * Step 5.4. The returned shape mirrors the schema in
+ * `commands/schemas/run-summary.json`.
+ *
+ * @param {string} cwd
+ * @param {object} state - parsed .mpl/state.json
+ * @returns {object|null} {
+ *   tiers_total, tiers_parallel_requested, tiers_parallel_executed,
+ *   tiers_parallel_rejected, tiers_with_missing_telemetry,
+ *   waves_parallel_rejected, waves_parallel_failed,
+ *   tiers_with_partial_rejection,
+ * } — or null when decomposition is missing.
+ */
+export function aggregateScheduler(cwd, state) {
+  const decomp = readDecompositionScope(cwd);
+  if (!decomp) return null;
+
+  const expectedParallel = new Set(
+    decomp.tiers.filter((t) => t.parallel).map((t) => t.tier)
+  );
+
+  const jsonlEvents = readJsonl(cwd);
+  const stateEvents = Array.isArray(state?.phase_scheduler_history)
+    ? state.phase_scheduler_history : [];
+  const merged = jsonlEvents.concat(stateEvents);
+
+  const seen = new Set();
+  const raw = [];
+  for (const e of merged) {
+    const k = eventKey(e);
+    if (seen.has(k)) continue;
+    seen.add(k);
+    raw.push(e);
+  }
+
+  const events = raw.filter((e) =>
+    e &&
+    e.pipeline_id === state?.pipeline_id &&
+    e.run_started_at === state?.started_at &&
+    Number(e.recompose_count) === Number(decomp.recompose_count)
+  );
+
+  const tiersWithParallelEvent = new Set();
+  const tiersWithRejectedEvent = new Set();
+  const tiersSeen = new Set();
+  let wavesParallelRejected = 0;
+  let wavesParallelFailed = 0;
+
+  for (const e of events) {
+    tiersSeen.add(Number(e.tier));
+    if (e.selected_mode === 'parallel') tiersWithParallelEvent.add(Number(e.tier));
+    if (e.selected_mode === 'parallel_rejected') {
+      tiersWithRejectedEvent.add(Number(e.tier));
+      wavesParallelRejected += 1;
+    }
+    if (e.selected_mode === 'parallel_failed') wavesParallelFailed += 1;
+  }
+
+  const tiersParallelExecuted = [...expectedParallel].filter((t) =>
+    tiersWithParallelEvent.has(t)
+  ).length;
+  const tiersWithMissingTelemetry = [...expectedParallel].filter((t) =>
+    !tiersSeen.has(t)
+  );
+  const tiersWithPartialRejection = [...expectedParallel].filter((t) =>
+    tiersWithParallelEvent.has(t) && tiersWithRejectedEvent.has(t)
+  );
+
+  return {
+    tiers_total: decomp.tiers.length,
+    tiers_parallel_requested: expectedParallel.size,
+    tiers_parallel_executed: tiersParallelExecuted,
+    tiers_parallel_rejected: expectedParallel.size - tiersParallelExecuted,
+    tiers_with_missing_telemetry: tiersWithMissingTelemetry,
+    waves_parallel_rejected: wavesParallelRejected,
+    waves_parallel_failed: wavesParallelFailed,
+    tiers_with_partial_rejection: tiersWithPartialRejection,
+  };
+}
+
+/**
+ * Whether the computed scheduler aggregate requires a
+ * `no_parallel_explanation`.
+ */
+export function explanationRequiredFromAggregate(agg) {
+  if (!agg) return false;
+  if (agg.tiers_parallel_requested === 0) return false;
+  return (
+    agg.tiers_parallel_executed < agg.tiers_parallel_requested ||
+    agg.tiers_with_missing_telemetry.length > 0 ||
+    agg.tiers_with_partial_rejection.length > 0 ||
+    agg.waves_parallel_failed > 0
+  );
+}

--- a/hooks/lib/mpl-scheduler-aggregate.mjs
+++ b/hooks/lib/mpl-scheduler-aggregate.mjs
@@ -361,6 +361,15 @@ export function aggregateScheduler(cwd, state) {
       wavesParallelFailed += 1;
       collectRejectionReasons(e);
     }
+    // Sequential / skipped events for a parallel-requested tier also carry
+    // rejection reasons (e.g. `single_ready_phase`, `tier_parallel_false`,
+    // `all_phases_already_completed`). The finalize prompt's
+    // `rejection_reasons` union is supposed to include those, so the hook
+    // must collect them too — otherwise a correctly-generated summary
+    // gets blocked by a rejection_reasons set mismatch.
+    if (e.selected_mode === 'sequential' || e.selected_mode === 'skipped') {
+      collectRejectionReasons(e);
+    }
   }
 
   const tiersParallelExecuted = [...expectedParallel].filter((t) =>

--- a/hooks/lib/mpl-scheduler-aggregate.mjs
+++ b/hooks/lib/mpl-scheduler-aggregate.mjs
@@ -355,21 +355,16 @@ export function aggregateScheduler(cwd, state) {
     if (e.selected_mode === 'parallel_rejected') {
       tiersWithRejectedEvent.add(Number(e.tier));
       wavesParallelRejected += 1;
-      collectRejectionReasons(e);
     }
     if (e.selected_mode === 'parallel_failed') {
       wavesParallelFailed += 1;
-      collectRejectionReasons(e);
     }
-    // Sequential / skipped events for a parallel-requested tier also carry
-    // rejection reasons (e.g. `single_ready_phase`, `tier_parallel_false`,
-    // `all_phases_already_completed`). The finalize prompt's
-    // `rejection_reasons` union is supposed to include those, so the hook
-    // must collect them too — otherwise a correctly-generated summary
-    // gets blocked by a rejection_reasons set mismatch.
-    if (e.selected_mode === 'sequential' || e.selected_mode === 'skipped') {
-      collectRejectionReasons(e);
-    }
+    // Collect rejection reasons from EVERY event — the finalize prompt's
+    // rejection_reasons rule is "union across all events", including
+    // successful parallel events that record ready_but_blocked_reason on
+    // deferred phases. Limiting this to non-parallel events would wedge a
+    // correctly generated summary that mentions wave-split block reasons.
+    collectRejectionReasons(e);
   }
 
   const tiersParallelExecuted = [...expectedParallel].filter((t) =>

--- a/hooks/lib/mpl-scheduler-aggregate.mjs
+++ b/hooks/lib/mpl-scheduler-aggregate.mjs
@@ -132,7 +132,18 @@ function readJsonl(cwd) {
 }
 
 function eventKey(e) {
-  return `${e?.pipeline_id ?? ''}|${e?.run_started_at ?? ''}|${e?.recompose_count ?? ''}|${e?.tier ?? ''}|${e?.timestamp ?? ''}|${e?.selected_mode ?? ''}`;
+  // wave_index is the per-tier wave counter and prevents two same-tier
+  // rejected/failed waves from collapsing onto the same dedupe key when
+  // the timestamps happen to share the same coarse value.
+  return [
+    e?.pipeline_id ?? '',
+    e?.run_started_at ?? '',
+    e?.recompose_count ?? '',
+    e?.tier ?? '',
+    e?.wave_index ?? '',
+    e?.timestamp ?? '',
+    e?.selected_mode ?? '',
+  ].join('|');
 }
 
 /**
@@ -188,8 +199,25 @@ export function aggregateScheduler(cwd, state) {
   const tiersWithParallelEvent = new Set();
   const tiersWithRejectedEvent = new Set();
   const tiersSeen = new Set();
+  const rejectionReasonSet = new Set();
   let wavesParallelRejected = 0;
   let wavesParallelFailed = 0;
+
+  function collectRejectionReasons(e) {
+    if (Array.isArray(e?.rejection_reasons)) {
+      for (const r of e.rejection_reasons) if (typeof r === 'string' && r) rejectionReasonSet.add(r);
+    }
+    const byPhase = e?.rejection_reasons_by_phase;
+    if (byPhase && typeof byPhase === 'object') {
+      for (const v of Object.values(byPhase)) {
+        if (typeof v === 'string' && v) rejectionReasonSet.add(v);
+        else if (Array.isArray(v)) for (const r of v) if (typeof r === 'string' && r) rejectionReasonSet.add(r);
+      }
+    }
+    if (typeof e?.failure_reason === 'string' && e.failure_reason) {
+      rejectionReasonSet.add(e.failure_reason);
+    }
+  }
 
   for (const e of events) {
     tiersSeen.add(Number(e.tier));
@@ -197,8 +225,12 @@ export function aggregateScheduler(cwd, state) {
     if (e.selected_mode === 'parallel_rejected') {
       tiersWithRejectedEvent.add(Number(e.tier));
       wavesParallelRejected += 1;
+      collectRejectionReasons(e);
     }
-    if (e.selected_mode === 'parallel_failed') wavesParallelFailed += 1;
+    if (e.selected_mode === 'parallel_failed') {
+      wavesParallelFailed += 1;
+      collectRejectionReasons(e);
+    }
   }
 
   const tiersParallelExecuted = [...expectedParallel].filter((t) =>
@@ -211,6 +243,18 @@ export function aggregateScheduler(cwd, state) {
     tiersWithParallelEvent.has(t) && tiersWithRejectedEvent.has(t)
   );
 
+  // Tiers for which the run-summary's no_parallel_explanation MUST name an
+  // affected tier id. The union of: missing telemetry, partial rejection,
+  // and any expected parallel tier where the only event(s) were rejected or
+  // failed (no successful parallel event).
+  const affectedTierSet = new Set();
+  for (const t of tiersWithMissingTelemetry) affectedTierSet.add(t);
+  for (const t of tiersWithPartialRejection) affectedTierSet.add(t);
+  for (const t of expectedParallel) {
+    if (!tiersWithParallelEvent.has(t) && tiersSeen.has(t)) affectedTierSet.add(t);
+  }
+  const affected_tier_ids = [...affectedTierSet].sort((a, b) => a - b);
+
   return {
     tiers_total: decomp.tiers.length,
     tiers_parallel_requested: expectedParallel.size,
@@ -220,6 +264,8 @@ export function aggregateScheduler(cwd, state) {
     waves_parallel_rejected: wavesParallelRejected,
     waves_parallel_failed: wavesParallelFailed,
     tiers_with_partial_rejection: tiersWithPartialRejection,
+    rejection_reasons: [...rejectionReasonSet].sort(),
+    affected_tier_ids,
   };
 }
 

--- a/hooks/lib/mpl-scheduler-aggregate.mjs
+++ b/hooks/lib/mpl-scheduler-aggregate.mjs
@@ -48,13 +48,40 @@ export function readDecompositionScope(cwd) {
   const recomposeMatch = text.match(/(^|\n)recompose_count:\s*(\d+)/);
   const recompose_count = recomposeMatch ? Number(recomposeMatch[2]) : 0;
 
-  // Allow optional trailing whitespace and an optional same-line value
-  // marker (e.g. `execution_tiers: |` or just a newline). Block ends at
-  // the next top-level YAML key.
-  const blockMatch = text.match(/(^|\n)execution_tiers:\s*\n([\s\S]*?)(?=\n[a-zA-Z_][a-zA-Z0-9_]*:|\n*$)/);
-  if (!blockMatch) return { tiers: [], recompose_count };
+  // Two supported forms for the execution_tiers value:
+  //   (a) block list — `execution_tiers:` on its own line, items indented
+  //       below as `- ...`
+  //   (b) top-level inline list — `execution_tiers: [{...}, {...}]` on the
+  //       same line (still valid YAML)
+  // The previous parser only recognized (a), so form (b) silently returned
+  // zero tiers and bypassed enforcement.
+  const headerMatch = text.match(/(^|\n)execution_tiers:[ \t]*(.*)$/m);
+  if (!headerMatch) return { tiers: [], recompose_count };
+  const sameLineValue = headerMatch[2].trim();
 
-  const items = splitYamlListItems(blockMatch[2]);
+  let items;
+  if (sameLineValue.startsWith('[')) {
+    // Inline list form. Find the matching closing `]` (nesting-aware) so
+    // multi-line inline lists are handled too.
+    const headerEnd = headerMatch.index + headerMatch[0].length - headerMatch[2].length + (headerMatch[2].indexOf('[') >= 0 ? headerMatch[2].indexOf('[') : 0);
+    const startBracket = text.indexOf('[', headerEnd);
+    const endBracket = matchClosingBracket(text, startBracket);
+    if (endBracket === -1) {
+      return { tiers: [], recompose_count, parse_error: true };
+    }
+    const inner = text.slice(startBracket + 1, endBracket);
+    items = splitTopLevelCommaItems(inner);
+  } else if (sameLineValue === '' || sameLineValue.startsWith('#')) {
+    // Block list form. Block ends at the next top-level YAML key.
+    const blockMatch = text.match(/(^|\n)execution_tiers:[ \t]*(?:#[^\n]*)?\n([\s\S]*?)(?=\n[a-zA-Z_][a-zA-Z0-9_]*:|\n*$)/);
+    if (!blockMatch) return { tiers: [], recompose_count };
+    items = splitYamlListItems(blockMatch[2]);
+  } else {
+    // Same-line non-list value (e.g. `execution_tiers: null`). Treat as
+    // unparseable — fail closed rather than pretending zero tiers.
+    return { tiers: [], recompose_count, parse_error: true };
+  }
+
   const tiers = [];
   let parseError = false;
   for (const item of items) {
@@ -122,6 +149,61 @@ function splitYamlListItems(text) {
  * (newline-separated key: value) or inline-map form (`{ k: v, k2: v2 }`).
  * Returns the raw string value or null if not found.
  */
+/**
+ * Find the closing `]` matching the opening `[` at `start`, ignoring
+ * brackets inside single/double quotes. Returns -1 if unmatched.
+ */
+function matchClosingBracket(text, start) {
+  let depth = 0;
+  let inSingle = false;
+  let inDouble = false;
+  let pairs = { '[': ']', '{': '}' };
+  let opens = new Set(['[', '{']);
+  let closes = new Set([']', '}']);
+  for (let i = start; i < text.length; i++) {
+    const c = text[i];
+    if (c === "'" && !inDouble) inSingle = !inSingle;
+    else if (c === '"' && !inSingle) inDouble = !inDouble;
+    else if (!inSingle && !inDouble) {
+      if (opens.has(c)) depth++;
+      else if (closes.has(c)) {
+        depth--;
+        if (depth === 0 && c === ']') return i;
+      }
+    }
+  }
+  return -1;
+}
+
+/**
+ * Split an inline-list body on top-level commas (not inside nested
+ * brackets or quotes). Returns each item as a raw string. For our parse
+ * needs, items are either inline maps `{ ... }` or bare YAML values.
+ */
+function splitTopLevelCommaItems(text) {
+  const out = [];
+  let buf = '';
+  let depth = 0;
+  let inSingle = false;
+  let inDouble = false;
+  for (const c of text) {
+    if (c === "'" && !inDouble) inSingle = !inSingle;
+    else if (c === '"' && !inSingle) inDouble = !inDouble;
+    if (!inSingle && !inDouble) {
+      if (c === '[' || c === '{') depth++;
+      else if (c === ']' || c === '}') depth--;
+      if (c === ',' && depth === 0) {
+        if (buf.trim().length > 0) out.push(buf.trim());
+        buf = '';
+        continue;
+      }
+    }
+    buf += c;
+  }
+  if (buf.trim().length > 0) out.push(buf.trim());
+  return out;
+}
+
 /**
  * Strip YAML `# comment` segments from each line, except when the `#` is
  * inside a single- or double-quoted string. Keeps escape behavior simple

--- a/hooks/lib/mpl-state.mjs
+++ b/hooks/lib/mpl-state.mjs
@@ -127,6 +127,10 @@ const DEFAULT_STATE = {
   // command_exit_codes) before Hard 2 / phase evidence latches treat them as
   // satisfying independent verification. A dispatch timestamp alone is not enough.
   test_agent_dispatched: {},
+  // Exp22 R6: prompt-level scheduler telemetry. The executor records one row
+  // per execution_tiers[] decision so runs can prove whether phase-level
+  // parallelism was used or why it was rejected.
+  phase_scheduler_history: [],
   // AD-0006: verification contract captured by Phase 0 Enhanced Step 4.
   // "verify_script" | "explicit" | "heuristic" | null (pre-Phase-0 default).
   verification_strategy: null,
@@ -535,6 +539,10 @@ export function writeState(cwd, patch) {
     const dropped = merged.ambiguity_history.length - MAX_AMBIGUITY_HISTORY;
     merged.ambiguity_history = merged.ambiguity_history.slice(-MAX_AMBIGUITY_HISTORY);
     process.stderr.write(`[mpl-state] ambiguity_history ring-buffer truncated ${dropped} oldest entries (cap=${MAX_AMBIGUITY_HISTORY})\n`);
+  }
+
+  if (Array.isArray(merged.phase_scheduler_history) && merged.phase_scheduler_history.length > 50) {
+    merged.phase_scheduler_history = merged.phase_scheduler_history.slice(-50);
   }
 
   // G5 (#114): mirror fix_loop_count increments into fix_loop_history.

--- a/hooks/lib/mpl-state.mjs
+++ b/hooks/lib/mpl-state.mjs
@@ -56,7 +56,7 @@ export const MAX_AMBIGUITY_HISTORY = 10;
  * bump this constant, register a new migration entry; see
  * `docs/schemas/migration-policy.md`.
  */
-export const CURRENT_SCHEMA_VERSION = 6;
+export const CURRENT_SCHEMA_VERSION = 7;
 
 /**
  * Legacy execution state file. Pre-P2-6 orchestrator prompts wrote to this
@@ -127,10 +127,16 @@ const DEFAULT_STATE = {
   // command_exit_codes) before Hard 2 / phase evidence latches treat them as
   // satisfying independent verification. A dispatch timestamp alone is not enough.
   test_agent_dispatched: {},
-  // Exp22 R6: prompt-level scheduler telemetry. The executor records one row
-  // per execution_tiers[] decision so runs can prove whether phase-level
-  // parallelism was used or why it was rejected.
+  // Exp22 R6 (schema v7): prompt-level scheduler telemetry. The executor
+  // records one row per execution_tiers[] decision so runs can prove whether
+  // phase-level parallelism was used or why it was rejected.
   phase_scheduler_history: [],
+  // Exp22 R6 (schema v7): worktree slot lifecycle for the parallel-tier pool.
+  // Distinct from worktree_history (HIGH-risk isolation: phase_id/branch/
+  // path/risk_level/result/timestamp). Entries here come from the parallel
+  // pool: { tier, phase_id, slot_id, worktree_path, base_ref, started_at,
+  // completed_at }.
+  worktree_pool_history: [],
   // AD-0006: verification contract captured by Phase 0 Enhanced Step 4.
   // "verify_script" | "explicit" | "heuristic" | null (pre-Phase-0 default).
   verification_strategy: null,
@@ -543,6 +549,9 @@ export function writeState(cwd, patch) {
 
   if (Array.isArray(merged.phase_scheduler_history) && merged.phase_scheduler_history.length > 50) {
     merged.phase_scheduler_history = merged.phase_scheduler_history.slice(-50);
+  }
+  if (Array.isArray(merged.worktree_pool_history) && merged.worktree_pool_history.length > 50) {
+    merged.worktree_pool_history = merged.worktree_pool_history.slice(-50);
   }
 
   // G5 (#114): mirror fix_loop_count increments into fix_loop_history.

--- a/hooks/mpl-require-finalize-artifacts.mjs
+++ b/hooks/mpl-require-finalize-artifacts.mjs
@@ -164,6 +164,63 @@ function hasCommitSinceBaseline(cwd) {
   }
 }
 
+function readDecompositionTiers(cwd) {
+  // Minimal YAML peek: we only need execution_tiers[].parallel bool flags.
+  // Parsing the whole decomposition.yaml here would couple this hook to
+  // every decomposer field. Use a regex over the execution_tiers block.
+  const path = join(cwd, '.mpl', 'mpl', 'decomposition.yaml');
+  if (!existsSync(path)) return null;
+  let text;
+  try { text = readFileSync(path, 'utf-8'); } catch { return null; }
+  const block = text.match(/(^|\n)execution_tiers:\s*\n([\s\S]*?)(\n[a-zA-Z_]+:|\n*$)/);
+  if (!block) return { tiers: [], parallelTierCount: 0 };
+  const tiers = [];
+  for (const line of block[2].split('\n')) {
+    const parallelMatch = line.match(/^\s*parallel:\s*(true|false)/i);
+    if (parallelMatch) tiers.push({ parallel: parallelMatch[1].toLowerCase() === 'true' });
+  }
+  const parallelTierCount = tiers.filter((t) => t.parallel).length;
+  return { tiers, parallelTierCount };
+}
+
+function schedulerExplanationMissing(cwd) {
+  // Exp22 R6 / #205: when decomposition.yaml declares any
+  // execution_tiers[].parallel:true, the run-summary scheduler block must
+  // either show full execution or carry a non-null no_parallel_explanation.
+  // The prompt in commands/mpl-run-finalize.md already documents this MUST;
+  // this guard makes it machine-enforceable so prompt drift cannot ship a
+  // completed run with rejected/missing parallelism and no explanation.
+  const decomp = readDecompositionTiers(cwd);
+  if (!decomp || decomp.parallelTierCount === 0) return null;
+
+  const summary = readJsonIfExists(cwd, '.mpl/mpl/profile/run-summary.json');
+  if (!summary) return 'scheduler:run_summary_missing';
+  const sched = summary.scheduler;
+  if (!sched || typeof sched !== 'object') return 'scheduler:block_missing';
+
+  const requested = Number(sched.tiers_parallel_requested) || 0;
+  const executed = Number(sched.tiers_parallel_executed) || 0;
+  const missingTelemetry = Array.isArray(sched.tiers_with_missing_telemetry)
+    ? sched.tiers_with_missing_telemetry.length : 0;
+  const partial = Array.isArray(sched.tiers_with_partial_rejection)
+    ? sched.tiers_with_partial_rejection.length : 0;
+  const wavesFailed = Number(sched.waves_parallel_failed) || 0;
+  const explanation = sched.no_parallel_explanation;
+  const explanationFilled = typeof explanation === 'string' && explanation.trim().length > 0;
+
+  const explanationRequired = requested > 0 && (
+    executed < requested ||
+    missingTelemetry > 0 ||
+    partial > 0 ||
+    wavesFailed > 0
+  );
+
+  if (explanationRequired && !explanationFilled) {
+    return 'scheduler:no_parallel_explanation_required_but_missing';
+  }
+  return null;
+}
+
 function runbookFinalized(cwd) {
   const path = join(cwd, '.mpl', 'mpl', 'RUNBOOK.md');
   if (!existsSync(path)) return false;
@@ -253,6 +310,13 @@ async function main() {
     const commit = hasCommitSinceBaseline(cwd);
     if (!commit.ok) missing.push(`git:${commit.reason}`);
   }
+
+  // Exp22 R6 / #205: machine-enforce the scheduler observability MUST.
+  // Independent of contract.completion_evidence so even runs without an
+  // explicit completion contract still satisfy the no-parallel
+  // explanation rule when decomposition declared parallel tiers.
+  const schedulerProblem = schedulerExplanationMissing(cwd);
+  if (schedulerProblem) missing.push(schedulerProblem);
 
   if (missing.length > 0) {
     block(

--- a/hooks/mpl-require-finalize-artifacts.mjs
+++ b/hooks/mpl-require-finalize-artifacts.mjs
@@ -29,6 +29,9 @@ const { readGoalContract, readBaselineGoalContractHash, defaultRequiredArtifacts
 const { readStdin } = await import(
   pathToFileURL(join(__dirname, 'lib', 'stdin.mjs')).href
 );
+const { aggregateScheduler, explanationRequiredFromAggregate } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-scheduler-aggregate.mjs')).href
+);
 
 function ok() {
   console.log(JSON.stringify({ continue: true, suppressOutput: true }));
@@ -164,69 +167,49 @@ function hasCommitSinceBaseline(cwd) {
   }
 }
 
-function readDecompositionTiers(cwd) {
-  // Minimal YAML peek: we only need execution_tiers[].parallel bool flags.
-  // Parsing the whole decomposition.yaml here would couple this hook to
-  // every decomposer field. Use a regex over the execution_tiers block.
-  const path = join(cwd, '.mpl', 'mpl', 'decomposition.yaml');
-  if (!existsSync(path)) return null;
-  let text;
-  try { text = readFileSync(path, 'utf-8'); } catch { return null; }
-  const block = text.match(/(^|\n)execution_tiers:\s*\n([\s\S]*?)(\n[a-zA-Z_]+:|\n*$)/);
-  if (!block) return { tiers: [], parallelTierCount: 0 };
-  const tiers = [];
-  for (const line of block[2].split('\n')) {
-    const parallelMatch = line.match(/^\s*parallel:\s*(true|false)/i);
-    if (parallelMatch) tiers.push({ parallel: parallelMatch[1].toLowerCase() === 'true' });
-  }
-  const parallelTierCount = tiers.filter((t) => t.parallel).length;
-  return { tiers, parallelTierCount };
-}
-
-function schedulerExplanationMissing(cwd) {
+function schedulerExplanationMissing(cwd, state) {
   // Exp22 R6 / #205: when decomposition.yaml declares any
   // execution_tiers[].parallel:true, the run-summary scheduler block must
   // either show full execution or carry a non-null no_parallel_explanation.
-  // The prompt in commands/mpl-run-finalize.md already documents this MUST;
-  // this guard makes it machine-enforceable so prompt drift cannot ship a
+  // The prompt in commands/mpl-run-finalize.md documents this MUST; the
+  // hook makes it machine-enforceable so prompt drift cannot ship a
   // completed run with rejected/missing parallelism and no explanation.
-  const decomp = readDecompositionTiers(cwd);
-  if (!decomp || decomp.parallelTierCount === 0) return null;
+  //
+  // The hook re-derives the aggregation itself from phase-scheduler.jsonl
+  // and state.phase_scheduler_history (see hooks/lib/mpl-scheduler-aggregate.mjs).
+  // A drifted or hand-edited run-summary can self-report a clean state, so
+  // the summary cannot be trusted as the source of truth — only as an
+  // informational mirror that must MATCH the computed evidence.
+  const computed = aggregateScheduler(cwd, state);
+  if (!computed) return null;
+  if (computed.tiers_parallel_requested === 0) return null;
 
   const summary = readJsonIfExists(cwd, '.mpl/mpl/profile/run-summary.json');
   if (!summary) return 'scheduler:run_summary_missing';
   const sched = summary.scheduler;
   if (!sched || typeof sched !== 'object') return 'scheduler:block_missing';
 
-  // decomposition.yaml is the truth for "did this run request parallelism".
-  // The summary self-reports tiers_parallel_requested — if the finalizer
-  // prompt drifted or someone hand-edited run-summary.json, that field can
-  // be set to 0 to vacuously satisfy "executed >= requested". Use the
-  // decomposition-derived count instead, and additionally require the
-  // summary's self-reported count to match it.
-  const requestedFromDecomp = decomp.parallelTierCount;
-  const requestedFromSummary = Number(sched.tiers_parallel_requested);
-  if (!Number.isInteger(requestedFromSummary) || requestedFromSummary !== requestedFromDecomp) {
-    return `scheduler:tiers_parallel_requested_mismatch:decomp=${requestedFromDecomp},summary=${sched.tiers_parallel_requested ?? 'null'}`;
+  // The summary's self-report must match what we just recomputed from the
+  // raw event stream. Mismatches indicate prompt drift, hand-edits, or
+  // missing telemetry that the finalizer prompt failed to surface.
+  for (const k of ['tiers_parallel_requested', 'tiers_parallel_executed', 'waves_parallel_failed']) {
+    const a = Number(computed[k]);
+    const b = Number(sched[k]);
+    if (!Number.isInteger(b) || a !== b) {
+      return `scheduler:${k}_mismatch:computed=${a},summary=${sched[k] ?? 'null'}`;
+    }
+  }
+  for (const k of ['tiers_with_missing_telemetry', 'tiers_with_partial_rejection']) {
+    const a = Array.isArray(computed[k]) ? computed[k].length : 0;
+    const b = Array.isArray(sched[k]) ? sched[k].length : -1;
+    if (a !== b) {
+      return `scheduler:${k}_length_mismatch:computed=${a},summary=${b === -1 ? 'not_array' : b}`;
+    }
   }
 
-  const executed = Number(sched.tiers_parallel_executed) || 0;
-  const missingTelemetry = Array.isArray(sched.tiers_with_missing_telemetry)
-    ? sched.tiers_with_missing_telemetry.length : 0;
-  const partial = Array.isArray(sched.tiers_with_partial_rejection)
-    ? sched.tiers_with_partial_rejection.length : 0;
-  const wavesFailed = Number(sched.waves_parallel_failed) || 0;
   const explanation = sched.no_parallel_explanation;
   const explanationFilled = typeof explanation === 'string' && explanation.trim().length > 0;
-
-  const explanationRequired = (
-    executed < requestedFromDecomp ||
-    missingTelemetry > 0 ||
-    partial > 0 ||
-    wavesFailed > 0
-  );
-
-  if (explanationRequired && !explanationFilled) {
+  if (explanationRequiredFromAggregate(computed) && !explanationFilled) {
     return 'scheduler:no_parallel_explanation_required_but_missing';
   }
   return null;
@@ -326,7 +309,7 @@ async function main() {
   // Independent of contract.completion_evidence so even runs without an
   // explicit completion contract still satisfy the no-parallel
   // explanation rule when decomposition declared parallel tiers.
-  const schedulerProblem = schedulerExplanationMissing(cwd);
+  const schedulerProblem = schedulerExplanationMissing(cwd, state);
   if (schedulerProblem) missing.push(schedulerProblem);
 
   if (missing.length > 0) {

--- a/hooks/mpl-require-finalize-artifacts.mjs
+++ b/hooks/mpl-require-finalize-artifacts.mjs
@@ -182,6 +182,9 @@ function schedulerExplanationMissing(cwd, state) {
   // informational mirror that must MATCH the computed evidence.
   const computed = aggregateScheduler(cwd, state);
   if (!computed) return null;
+  if (computed.__decomposition_unparseable__) {
+    return 'scheduler:decomposition_execution_tiers_unparseable';
+  }
   if (computed.tiers_parallel_requested === 0) return null;
 
   const summary = readJsonIfExists(cwd, '.mpl/mpl/profile/run-summary.json');
@@ -191,8 +194,19 @@ function schedulerExplanationMissing(cwd, state) {
 
   // The summary's self-report must match what we just recomputed from the
   // raw event stream. Mismatches indicate prompt drift, hand-edits, or
-  // missing telemetry that the finalizer prompt failed to surface.
-  for (const k of ['tiers_parallel_requested', 'tiers_parallel_executed', 'waves_parallel_failed']) {
+  // missing telemetry that the finalizer prompt failed to surface. Compare
+  // every aggregate field, not just a sentinel subset — codex r11 noted a
+  // narrow subset still let drift through (mis-named missing tier ids,
+  // under-reported rejected waves).
+  const scalarKeys = [
+    'tiers_total',
+    'tiers_parallel_requested',
+    'tiers_parallel_executed',
+    'tiers_parallel_rejected',
+    'waves_parallel_rejected',
+    'waves_parallel_failed',
+  ];
+  for (const k of scalarKeys) {
     const a = Number(computed[k]);
     const b = Number(sched[k]);
     if (!Number.isInteger(b) || a !== b) {
@@ -200,10 +214,16 @@ function schedulerExplanationMissing(cwd, state) {
     }
   }
   for (const k of ['tiers_with_missing_telemetry', 'tiers_with_partial_rejection']) {
-    const a = Array.isArray(computed[k]) ? computed[k].length : 0;
-    const b = Array.isArray(sched[k]) ? sched[k].length : -1;
-    if (a !== b) {
-      return `scheduler:${k}_length_mismatch:computed=${a},summary=${b === -1 ? 'not_array' : b}`;
+    const computedSorted = Array.isArray(computed[k])
+      ? [...computed[k]].map(Number).sort((x, y) => x - y) : [];
+    const summarySorted = Array.isArray(sched[k])
+      ? [...sched[k]].map(Number).sort((x, y) => x - y) : null;
+    if (summarySorted === null) {
+      return `scheduler:${k}_not_array_in_summary`;
+    }
+    if (computedSorted.length !== summarySorted.length ||
+        computedSorted.some((v, i) => v !== summarySorted[i])) {
+      return `scheduler:${k}_contents_mismatch:computed=[${computedSorted.join(',')}],summary=[${summarySorted.join(',')}]`;
     }
   }
 

--- a/hooks/mpl-require-finalize-artifacts.mjs
+++ b/hooks/mpl-require-finalize-artifacts.mjs
@@ -227,10 +227,42 @@ function schedulerExplanationMissing(cwd, state) {
     }
   }
 
+  // rejection_reasons set must match what we observed in events.
+  const computedReasons = [...(computed.rejection_reasons || [])].sort();
+  const summaryReasons = Array.isArray(sched.rejection_reasons)
+    ? [...sched.rejection_reasons].filter((r) => typeof r === 'string' && r).sort()
+    : null;
+  if (summaryReasons === null) {
+    return 'scheduler:rejection_reasons_not_array_in_summary';
+  }
+  // Set equality (order-independent, deduplicated).
+  const computedReasonSet = new Set(computedReasons);
+  const summaryReasonSet = new Set(summaryReasons);
+  const reasonsMatch =
+    computedReasonSet.size === summaryReasonSet.size &&
+    [...computedReasonSet].every((r) => summaryReasonSet.has(r));
+  if (!reasonsMatch) {
+    return `scheduler:rejection_reasons_mismatch:computed=[${[...computedReasonSet].sort().join(',')}],summary=[${[...summaryReasonSet].sort().join(',')}]`;
+  }
+
   const explanation = sched.no_parallel_explanation;
   const explanationFilled = typeof explanation === 'string' && explanation.trim().length > 0;
   if (explanationRequiredFromAggregate(computed) && !explanationFilled) {
     return 'scheduler:no_parallel_explanation_required_but_missing';
+  }
+  // The explanation must reference each affected tier id by number, so an
+  // operator reading the summary can find which tiers lost parallelism.
+  // `n/a`-style placeholders fail this check.
+  if (explanationFilled && Array.isArray(computed.affected_tier_ids) && computed.affected_tier_ids.length > 0) {
+    const missingMentions = computed.affected_tier_ids.filter((tid) => {
+      // Match the tier id as a standalone integer (not embedded in another
+      // number). Accept both "tier 1" and bare "1" anywhere in the text.
+      const re = new RegExp(`(^|[^\\d])${tid}(?=[^\\d]|$)`);
+      return !re.test(explanation);
+    });
+    if (missingMentions.length > 0) {
+      return `scheduler:no_parallel_explanation_missing_tier_refs:[${missingMentions.join(',')}]`;
+    }
   }
   return null;
 }

--- a/hooks/mpl-require-finalize-artifacts.mjs
+++ b/hooks/mpl-require-finalize-artifacts.mjs
@@ -198,7 +198,18 @@ function schedulerExplanationMissing(cwd) {
   const sched = summary.scheduler;
   if (!sched || typeof sched !== 'object') return 'scheduler:block_missing';
 
-  const requested = Number(sched.tiers_parallel_requested) || 0;
+  // decomposition.yaml is the truth for "did this run request parallelism".
+  // The summary self-reports tiers_parallel_requested — if the finalizer
+  // prompt drifted or someone hand-edited run-summary.json, that field can
+  // be set to 0 to vacuously satisfy "executed >= requested". Use the
+  // decomposition-derived count instead, and additionally require the
+  // summary's self-reported count to match it.
+  const requestedFromDecomp = decomp.parallelTierCount;
+  const requestedFromSummary = Number(sched.tiers_parallel_requested);
+  if (!Number.isInteger(requestedFromSummary) || requestedFromSummary !== requestedFromDecomp) {
+    return `scheduler:tiers_parallel_requested_mismatch:decomp=${requestedFromDecomp},summary=${sched.tiers_parallel_requested ?? 'null'}`;
+  }
+
   const executed = Number(sched.tiers_parallel_executed) || 0;
   const missingTelemetry = Array.isArray(sched.tiers_with_missing_telemetry)
     ? sched.tiers_with_missing_telemetry.length : 0;
@@ -208,8 +219,8 @@ function schedulerExplanationMissing(cwd) {
   const explanation = sched.no_parallel_explanation;
   const explanationFilled = typeof explanation === 'string' && explanation.trim().length > 0;
 
-  const explanationRequired = requested > 0 && (
-    executed < requested ||
+  const explanationRequired = (
+    executed < requestedFromDecomp ||
     missingTelemetry > 0 ||
     partial > 0 ||
     wavesFailed > 0


### PR DESCRIPTION
## What

- `commands/mpl-run-execute.md`: every `execution_tiers[]` decision must `record_scheduler_event` with tier, phases, `selected_mode` (`skipped|sequential|parallel|parallel_rejected`), `parallel_requested`, `worker_cap`, `worktree_slots`, and per-phase rejection reasons. Telemetry appends to `.mpl/mpl/profile/phase-scheduler.jsonl` and mirrors the latest 50 rows in `state.phase_scheduler_history`. Parallel waves also append `state.worktree_history` slot entries.
- `hooks/lib/mpl-state.mjs`: initialize `phase_scheduler_history` and cap to 50 entries on `writeState`, matching `ambiguity_history`/`fix_loop_history` ring-buffer patterns.
- `hooks/__tests__/mpl-execution-tiers-observability.test.mjs`: pin the executor contract so the telemetry literals cannot regress out of the run prompt.

## Why

Exp22 R6 observed a 22-phase run that stayed fully sequential — `state.json.worktree_history` was empty, only one subagent line was ever active, and the run spent ~14h wall vs ~2h30m phase-runner activity. The current `execution_tiers` scheduler contract already covers fields needed for parallelism, so the gap is not field design — it's **reachability and observability**: artifacts gave no evidence whether a parallel-eligible tier reached the parallel branch or why it was rejected.

After this change, a future exp run can answer **from artifacts alone** whether each tier was parallelized or why it was not.

## Design

N/A — small prompt + state-init change. Full motivation, scope, and acceptance criteria live in issue #205 (ygg-exp22 V1 execution analysis, R6).

Explicit non-goal called out in the executor prompt: **do not** add a separate `phase_dependencies` field. Dependency safety still comes from existing `depends_on` / `interface_contract.requires[].from_phase` plus `execution_tiers`.

## Agent Review Status

This PR is gated on **2 unique agent reviews** (footers \`— from <agent>\`).

- [ ] from claude
- [ ] from codex

Closes #205.

---
_Awaiting reviews. Merge once the gate is satisfied._