### PR TITLE
Add mpl-hook-trace for hook chain visibility (#207)

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,9 @@ mpl small add retry logic                     # → forces Standard
 
 # Hook-block recovery after resume reports blocked_hook
 /mpl:mpl-recover
+
+# Hook-chain visibility for a canonical artifact
+node hooks/lib/mpl-hook-trace.mjs .mpl/mpl/decomposition.yaml
 ```
 
 Codex also discovers the same MPL skills from the plugin. Use `mpl ...` in a Codex session, or invoke the installed MPL skill by name from the skills menu.

--- a/hooks/__tests__/mpl-hook-trace.test.mjs
+++ b/hooks/__tests__/mpl-hook-trace.test.mjs
@@ -68,6 +68,35 @@ describe('mpl-hook-trace', () => {
     }
   });
 
+  it('surfaces incomplete blocked_hook envelopes as invalid instead of currently_blocking', () => {
+    // Codex r2 on PR #216: a zombie state with blocked_by_hook set but
+    // empty/missing blocked_artifact must not be reported as actively
+    // blocking — that would point recovery at the wrong artifact and
+    // hide the real state-invariant failure.
+    const tmp = mkdtempSync(join(tmpdir(), 'mpl-hook-trace-invalid-'));
+    try {
+      mkdirSync(join(tmp, '.mpl'), { recursive: true });
+      writeFileSync(join(tmp, '.mpl', 'state.json'), JSON.stringify({
+        schema_version: CURRENT_SCHEMA_VERSION,
+        current_phase: 'mpl-decompose',
+        session_status: 'blocked_hook',
+        blocked_by_hook: 'mpl-require-goal-trace',
+        // blocked_artifact intentionally absent
+      }));
+      const trace = traceHookChain({
+        targetPath: '.mpl/mpl/decomposition.yaml',
+        cwd: tmp,
+      });
+      const row = trace.hooks.find((h) => h.hook_id === 'mpl-require-goal-trace');
+      assert.equal(row.status, 'invalid_blocked_envelope');
+      assert.match(formatHookTrace(trace), /INVALID_BLOCKED_ENVELOPE/);
+      assert.doesNotMatch(formatHookTrace(trace), /\[BLOCKING\]/,
+        'must not surface an incomplete envelope as actively blocking');
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it('marks the active blocked_hook as currently_blocking', () => {
     const tmp = mkdtempSync(join(tmpdir(), 'mpl-hook-trace-'));
     try {

--- a/hooks/__tests__/mpl-hook-trace.test.mjs
+++ b/hooks/__tests__/mpl-hook-trace.test.mjs
@@ -1,0 +1,54 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+import { formatHookTrace, traceHookChain } from '../lib/mpl-hook-trace.mjs';
+import { CURRENT_SCHEMA_VERSION } from '../lib/mpl-state.mjs';
+
+describe('mpl-hook-trace', () => {
+  it('lists the decomposition hook chain without manual grep', () => {
+    const trace = traceHookChain({
+      targetPath: '.mpl/mpl/decomposition.yaml',
+      cwd: process.cwd(),
+    });
+    const ids = trace.hooks.map((h) => h.hook_id);
+    for (const expected of [
+      'mpl-require-goal-trace',
+      'mpl-baseline-guard',
+      'mpl-artifact-schema',
+      'mpl-discovery-scanner',
+      'mpl-require-chain-assignment',
+      'mpl-phase-controller',
+      'mpl-require-test-agent',
+    ]) {
+      assert.ok(ids.includes(expected), `missing ${expected}`);
+    }
+    assert.match(formatHookTrace(trace), /MPL Hook Trace/);
+    assert.match(formatHookTrace(trace), /registered/);
+  });
+
+  it('marks the active blocked_hook as currently_blocking', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'mpl-hook-trace-'));
+    try {
+      mkdirSync(join(tmp, '.mpl'), { recursive: true });
+      writeFileSync(join(tmp, '.mpl', 'state.json'), JSON.stringify({
+        schema_version: CURRENT_SCHEMA_VERSION,
+        current_phase: 'mpl-decompose',
+        session_status: 'blocked_hook',
+        blocked_by_hook: 'mpl-require-goal-trace',
+        blocked_artifact: '.mpl/mpl/decomposition.yaml',
+      }));
+      const trace = traceHookChain({
+        targetPath: '.mpl/mpl/decomposition.yaml',
+        cwd: tmp,
+      });
+      const row = trace.hooks.find((h) => h.hook_id === 'mpl-require-goal-trace');
+      assert.equal(row.status, 'currently_blocking');
+      assert.match(formatHookTrace(trace), /BLOCKING/);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/hooks/__tests__/mpl-hook-trace.test.mjs
+++ b/hooks/__tests__/mpl-hook-trace.test.mjs
@@ -129,6 +129,36 @@ describe('mpl-hook-trace', () => {
     }
   });
 
+  it('surfaces a stale/invalid block on a non-decomposition path as invalid_blocked_envelope (does not silently filter)', () => {
+    // Codex r5 on PR #216: a stale envelope (missing retry_context etc.)
+    // pointing at state.test_agent_dispatched.<phase> would otherwise be
+    // filtered out by the category check and disappear from the trace.
+    // The offending hook id is still meaningful to the operator and must
+    // appear, just with an invalid_blocked_envelope status.
+    const tmp = mkdtempSync(join(tmpdir(), 'mpl-hook-trace-stale-task-'));
+    try {
+      mkdirSync(join(tmp, '.mpl'), { recursive: true });
+      writeFileSync(join(tmp, '.mpl', 'state.json'), JSON.stringify({
+        schema_version: CURRENT_SCHEMA_VERSION,
+        current_phase: 'phase2-sprint',
+        session_status: 'blocked_hook',
+        blocked_by_hook: 'mpl-require-test-agent',
+        blocked_artifact: 'state.test_agent_dispatched.phase-1',
+        // retry_context, block_code, blocked_at intentionally absent
+      }));
+      const trace = traceHookChain({
+        targetPath: 'state.test_agent_dispatched.phase-1',
+        cwd: tmp,
+      });
+      const row = trace.hooks.find((h) => h.hook_id === 'mpl-require-test-agent');
+      assert.ok(row, 'mpl-require-test-agent must appear even with a stale envelope');
+      assert.equal(row.status, 'invalid_blocked_envelope');
+      assert.match(formatHookTrace(trace), /INVALID_BLOCKED_ENVELOPE/);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it('always includes the blocked_by_hook entry for an active block, even when the path category would filter it out', () => {
     // Codex r4 on PR #216: a valid mpl-require-test-agent block records
     // blocked_artifact as `state.test_agent_dispatched.<phase>`, which the

--- a/hooks/__tests__/mpl-hook-trace.test.mjs
+++ b/hooks/__tests__/mpl-hook-trace.test.mjs
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 
@@ -27,6 +27,45 @@ describe('mpl-hook-trace', () => {
     }
     assert.match(formatHookTrace(trace), /MPL Hook Trace/);
     assert.match(formatHookTrace(trace), /registered/);
+  });
+
+  it('does not mutate state.json (no migration, no archive) when tracing a legacy or unversioned state', () => {
+    // Codex r1 on PR #216: readState() persists schema migrations and can
+    // archive .mpl/mpl/state.json — a diagnostic command must never do that.
+    // Use a pre-v6 state with no schema_version to exercise the migration
+    // path, then assert the on-disk bytes are unchanged after tracing.
+    const tmp = mkdtempSync(join(tmpdir(), 'mpl-hook-trace-readonly-'));
+    try {
+      mkdirSync(join(tmp, '.mpl'), { recursive: true });
+      mkdirSync(join(tmp, '.mpl', 'mpl'), { recursive: true });
+      const stateBefore = JSON.stringify({
+        // intentionally no schema_version — would trigger v1→v2 migration
+        current_phase: 'mpl-decompose',
+        session_status: 'blocked_hook',
+        blocked_by_hook: 'mpl-require-goal-trace',
+        blocked_artifact: '.mpl/mpl/decomposition.yaml',
+      });
+      writeFileSync(join(tmp, '.mpl', 'state.json'), stateBefore);
+      const legacyPath = join(tmp, '.mpl', 'mpl', 'state.json');
+      writeFileSync(legacyPath, '{"legacy":true}');
+
+      const trace = traceHookChain({
+        targetPath: '.mpl/mpl/decomposition.yaml',
+        cwd: tmp,
+      });
+      // The legacy blocked state should still surface via the raw read.
+      const row = trace.hooks.find((h) => h.hook_id === 'mpl-require-goal-trace');
+      assert.equal(row.status, 'currently_blocking');
+
+      // Critical: on-disk state files must be unchanged.
+      const stateAfter = readFileSync(join(tmp, '.mpl', 'state.json'), 'utf-8');
+      assert.equal(stateAfter, stateBefore, 'state.json must not be rewritten by tracing');
+      assert.ok(existsSync(legacyPath), 'legacy .mpl/mpl/state.json must not be archived/removed by tracing');
+      assert.equal(readFileSync(legacyPath, 'utf-8'), '{"legacy":true}',
+        'legacy state.json content must be byte-for-byte unchanged');
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
   });
 
   it('marks the active blocked_hook as currently_blocking', () => {

--- a/hooks/__tests__/mpl-hook-trace.test.mjs
+++ b/hooks/__tests__/mpl-hook-trace.test.mjs
@@ -129,6 +129,42 @@ describe('mpl-hook-trace', () => {
     }
   });
 
+  it('always includes the blocked_by_hook entry for an active block, even when the path category would filter it out', () => {
+    // Codex r4 on PR #216: a valid mpl-require-test-agent block records
+    // blocked_artifact as `state.test_agent_dispatched.<phase>`, which the
+    // path category considers a generic file. shouldIncludeHook then drops
+    // the Task|Agent PostToolUse hook and BLOCKING is never surfaced.
+    // When state has an active block matching the target, the offending
+    // hook MUST appear in the trace regardless of filter.
+    const tmp = mkdtempSync(join(tmpdir(), 'mpl-hook-trace-active-block-'));
+    try {
+      mkdirSync(join(tmp, '.mpl'), { recursive: true });
+      writeFileSync(join(tmp, '.mpl', 'state.json'), JSON.stringify({
+        schema_version: CURRENT_SCHEMA_VERSION,
+        current_phase: 'phase2-sprint',
+        session_status: 'blocked_hook',
+        blocked_by_hook: 'mpl-require-test-agent',
+        blocked_phase: 'phase-1',
+        blocked_artifact: 'state.test_agent_dispatched.phase-1',
+        block_code: 'missing_or_invalid_test_agent_evidence',
+        block_reason: 'phase-1 has no valid test-agent dispatch evidence',
+        resume_instruction: 'Dispatch mpl-test-agent for phase-1 and retry.',
+        blocked_at: '2026-05-27T00:00:00.000Z',
+        retry_context: { phase_id: 'phase-1' },
+      }));
+      const trace = traceHookChain({
+        targetPath: 'state.test_agent_dispatched.phase-1',
+        cwd: tmp,
+      });
+      const row = trace.hooks.find((h) => h.hook_id === 'mpl-require-test-agent');
+      assert.ok(row, 'mpl-require-test-agent must be included when it is the active blocker');
+      assert.equal(row.status, 'currently_blocking');
+      assert.match(formatHookTrace(trace), /BLOCKING/);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it('marks the active blocked_hook as currently_blocking', () => {
     const tmp = mkdtempSync(join(tmpdir(), 'mpl-hook-trace-'));
     try {

--- a/hooks/__tests__/mpl-hook-trace.test.mjs
+++ b/hooks/__tests__/mpl-hook-trace.test.mjs
@@ -195,6 +195,57 @@ describe('mpl-hook-trace', () => {
     }
   });
 
+  it('fail-closes on a future schema_version: no BLOCKING line, explicit unsupported_schema warning', () => {
+    // Codex r6 on PR #216: a downgraded plugin must not classify a future
+    // state.json envelope as actively blocking — that would point recovery
+    // at the wrong artifact instead of surfacing the schema mismatch.
+    const tmp = mkdtempSync(join(tmpdir(), 'mpl-hook-trace-future-schema-'));
+    try {
+      mkdirSync(join(tmp, '.mpl'), { recursive: true });
+      writeFileSync(join(tmp, '.mpl', 'state.json'), JSON.stringify({
+        schema_version: CURRENT_SCHEMA_VERSION + 1,
+        current_phase: 'mpl-decompose',
+        session_status: 'blocked_hook',
+        blocked_by_hook: 'mpl-require-goal-trace',
+        blocked_phase: 'mpl-decompose',
+        blocked_artifact: '.mpl/mpl/decomposition.yaml',
+        block_code: 'goal_trace_drift',
+        block_reason: 'goal_contract_hash drift detected',
+        resume_instruction: 'Refresh the goal contract hash and retry.',
+        blocked_at: '2026-05-27T00:00:00.000Z',
+        retry_context: { hook: 'mpl-require-goal-trace' },
+      }));
+      const trace = traceHookChain({
+        targetPath: '.mpl/mpl/decomposition.yaml',
+        cwd: tmp,
+      });
+      assert.equal(trace.state_error?.error, 'unsupported_schema');
+      assert.equal(trace.state_error.schemaVersion, CURRENT_SCHEMA_VERSION + 1);
+      // The future envelope must not bleed into a BLOCKING marker.
+      assert.doesNotMatch(formatHookTrace(trace), /\[BLOCKING\]/);
+      assert.match(formatHookTrace(trace), /schema_version=\d+ is newer than the installed plugin supports/);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('fail-closes on malformed JSON: explicit unparseable warning, no block status', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'mpl-hook-trace-malformed-'));
+    try {
+      mkdirSync(join(tmp, '.mpl'), { recursive: true });
+      writeFileSync(join(tmp, '.mpl', 'state.json'), '{ this is not valid json');
+      const trace = traceHookChain({
+        targetPath: '.mpl/mpl/decomposition.yaml',
+        cwd: tmp,
+      });
+      assert.equal(trace.state_error?.error, 'unparseable');
+      assert.doesNotMatch(formatHookTrace(trace), /\[BLOCKING\]/);
+      assert.match(formatHookTrace(trace), /not valid JSON/);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it('marks the active blocked_hook as currently_blocking', () => {
     const tmp = mkdtempSync(join(tmpdir(), 'mpl-hook-trace-'));
     try {

--- a/hooks/__tests__/mpl-hook-trace.test.mjs
+++ b/hooks/__tests__/mpl-hook-trace.test.mjs
@@ -43,7 +43,13 @@ describe('mpl-hook-trace', () => {
         current_phase: 'mpl-decompose',
         session_status: 'blocked_hook',
         blocked_by_hook: 'mpl-require-goal-trace',
+        blocked_phase: 'mpl-decompose',
         blocked_artifact: '.mpl/mpl/decomposition.yaml',
+        block_code: 'goal_trace_drift',
+        block_reason: 'goal_contract_hash drift detected',
+        resume_instruction: 'Refresh the goal contract hash and retry.',
+        blocked_at: '2026-05-27T00:00:00.000Z',
+        retry_context: { hook: 'mpl-require-goal-trace' },
       });
       writeFileSync(join(tmp, '.mpl', 'state.json'), stateBefore);
       const legacyPath = join(tmp, '.mpl', 'mpl', 'state.json');
@@ -69,10 +75,11 @@ describe('mpl-hook-trace', () => {
   });
 
   it('surfaces incomplete blocked_hook envelopes as invalid instead of currently_blocking', () => {
-    // Codex r2 on PR #216: a zombie state with blocked_by_hook set but
-    // empty/missing blocked_artifact must not be reported as actively
-    // blocking — that would point recovery at the wrong artifact and
-    // hide the real state-invariant failure.
+    // Codex r2/r3 on PR #216: any stale/zombie state missing a required
+    // companion field (artifact, block_code, retry_context, etc.) must
+    // not be reported as actively blocking — that would send the operator
+    // toward editing the wrong artifact and hide the real state-invariant
+    // failure. Validation reuses the BLOCKED_HOOK_STALE invariant.
     const tmp = mkdtempSync(join(tmpdir(), 'mpl-hook-trace-invalid-'));
     try {
       mkdirSync(join(tmp, '.mpl'), { recursive: true });
@@ -81,7 +88,7 @@ describe('mpl-hook-trace', () => {
         current_phase: 'mpl-decompose',
         session_status: 'blocked_hook',
         blocked_by_hook: 'mpl-require-goal-trace',
-        // blocked_artifact intentionally absent
+        // blocked_artifact + block_code + retry_context all intentionally absent
       }));
       const trace = traceHookChain({
         targetPath: '.mpl/mpl/decomposition.yaml',
@@ -97,6 +104,31 @@ describe('mpl-hook-trace', () => {
     }
   });
 
+  it('surfaces a blocked_hook missing block_code/retry_context as invalid (matches BLOCKED_HOOK_STALE invariant)', () => {
+    // Codex r3 on PR #216: blocked_artifact alone is not enough.
+    const tmp = mkdtempSync(join(tmpdir(), 'mpl-hook-trace-partial-'));
+    try {
+      mkdirSync(join(tmp, '.mpl'), { recursive: true });
+      writeFileSync(join(tmp, '.mpl', 'state.json'), JSON.stringify({
+        schema_version: CURRENT_SCHEMA_VERSION,
+        current_phase: 'mpl-decompose',
+        session_status: 'blocked_hook',
+        blocked_by_hook: 'mpl-require-goal-trace',
+        blocked_artifact: '.mpl/mpl/decomposition.yaml',
+        // block_code, block_reason, resume_instruction, blocked_at, retry_context all absent
+      }));
+      const trace = traceHookChain({
+        targetPath: '.mpl/mpl/decomposition.yaml',
+        cwd: tmp,
+      });
+      const row = trace.hooks.find((h) => h.hook_id === 'mpl-require-goal-trace');
+      assert.equal(row.status, 'invalid_blocked_envelope');
+      assert.doesNotMatch(formatHookTrace(trace), /\[BLOCKING\]/);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it('marks the active blocked_hook as currently_blocking', () => {
     const tmp = mkdtempSync(join(tmpdir(), 'mpl-hook-trace-'));
     try {
@@ -106,7 +138,13 @@ describe('mpl-hook-trace', () => {
         current_phase: 'mpl-decompose',
         session_status: 'blocked_hook',
         blocked_by_hook: 'mpl-require-goal-trace',
+        blocked_phase: 'mpl-decompose',
         blocked_artifact: '.mpl/mpl/decomposition.yaml',
+        block_code: 'goal_trace_drift',
+        block_reason: 'goal_contract_hash drift detected',
+        resume_instruction: 'Refresh the goal contract hash and retry.',
+        blocked_at: '2026-05-27T00:00:00.000Z',
+        retry_context: { hook: 'mpl-require-goal-trace' },
       }));
       const trace = traceHookChain({
         targetPath: '.mpl/mpl/decomposition.yaml',

--- a/hooks/__tests__/mpl-hook-trace.test.mjs
+++ b/hooks/__tests__/mpl-hook-trace.test.mjs
@@ -246,6 +246,41 @@ describe('mpl-hook-trace', () => {
     }
   });
 
+  it('emits a synthetic row when the active blocked_by_hook is no longer in hooks.json (registry skew)', () => {
+    // Codex r7 on PR #216: if the hook chain changed (rename, removal,
+    // downgrade) and state.blocked_by_hook points at a hook id that no
+    // longer exists in hooks.json, the iteration-based force-include
+    // never runs. A synthetic row must still surface the active block.
+    const tmp = mkdtempSync(join(tmpdir(), 'mpl-hook-trace-skew-'));
+    try {
+      mkdirSync(join(tmp, '.mpl'), { recursive: true });
+      writeFileSync(join(tmp, '.mpl', 'state.json'), JSON.stringify({
+        schema_version: CURRENT_SCHEMA_VERSION,
+        current_phase: 'mpl-decompose',
+        session_status: 'blocked_hook',
+        blocked_by_hook: 'mpl-removed-or-renamed-hook',
+        blocked_phase: 'mpl-decompose',
+        blocked_artifact: '.mpl/mpl/decomposition.yaml',
+        block_code: 'unknown_block',
+        block_reason: 'hook ran but is no longer registered',
+        resume_instruction: 'Reinstall the expected plugin version, then retry.',
+        blocked_at: '2026-05-27T00:00:00.000Z',
+        retry_context: { stale_hook: true },
+      }));
+      const trace = traceHookChain({
+        targetPath: '.mpl/mpl/decomposition.yaml',
+        cwd: tmp,
+      });
+      const row = trace.hooks.find((h) => h.hook_id === 'mpl-removed-or-renamed-hook');
+      assert.ok(row, 'synthetic row for unregistered active blocker must exist');
+      assert.equal(row.status, 'currently_blocking');
+      assert.match(row.purpose, /not registered in current hooks\.json/);
+      assert.match(formatHookTrace(trace), /BLOCKING/);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it('marks the active blocked_hook as currently_blocking', () => {
     const tmp = mkdtempSync(join(tmpdir(), 'mpl-hook-trace-'));
     try {

--- a/hooks/lib/mpl-blocked-hook.mjs
+++ b/hooks/lib/mpl-blocked-hook.mjs
@@ -1,5 +1,40 @@
 import { readState, writeState } from './mpl-state.mjs';
 
+/**
+ * The set of string companion fields a `session_status === 'blocked_hook'`
+ * envelope MUST carry to be considered actionable. Same list mpl-state-invariant
+ * uses for the BLOCKED_HOOK_STALE violation. Exported so diagnostic tools
+ * (e.g. mpl-hook-trace) can validate envelopes without duplicating the rule.
+ */
+export const BLOCKED_HOOK_REQUIRED_STRING_FIELDS = Object.freeze([
+  'blocked_by_hook',
+  'blocked_phase',
+  'blocked_artifact',
+  'block_code',
+  'block_reason',
+  'resume_instruction',
+  'blocked_at',
+]);
+
+/**
+ * Return the list of missing required fields from a `state` object whose
+ * session_status is `blocked_hook`. An empty list means the envelope is
+ * complete enough to be acted on. `retry_context` is required as a plain
+ * object (not null, not an array).
+ */
+export function missingBlockedHookFields(state) {
+  if (!state || state.session_status !== 'blocked_hook') return [];
+  const missing = BLOCKED_HOOK_REQUIRED_STRING_FIELDS.filter((key) => {
+    const v = state[key];
+    return typeof v !== 'string' || v.trim() === '';
+  });
+  const rc = state.retry_context;
+  if (!rc || typeof rc !== 'object' || Array.isArray(rc)) {
+    missing.push('retry_context');
+  }
+  return missing;
+}
+
 export function buildBlockedHookPatch({
   hookId = 'unknown',
   phaseId = 'unknown',

--- a/hooks/lib/mpl-hook-trace.mjs
+++ b/hooks/lib/mpl-hook-trace.mjs
@@ -174,15 +174,16 @@ export function traceHookChain({
   const category = pathCategory(resolvedTarget);
   const rows = [];
 
-  // Codex r4 on PR #216: when there is an active blocked_hook envelope
-  // that matches the queried target, the offending hook MUST appear in
-  // the trace regardless of the category/matcher filter — otherwise a
-  // valid block on e.g. `state.test_agent_dispatched.<phase>` (not a
-  // decomposition path) would have `mpl-require-test-agent` filtered out
-  // and never reach blockStatusFor.
+  // Codex r4/r5 on PR #216: when there is an active blocked_hook envelope
+  // that names the queried target, the offending hook MUST appear in the
+  // trace regardless of the category/matcher filter AND regardless of
+  // whether the envelope is complete. blockStatusFor decides between
+  // currently_blocking (complete envelope) and invalid_blocked_envelope
+  // (stale/corrupt envelope); both diagnoses are useful and either is
+  // better than silently filtering out the hook that is actually keeping
+  // the run blocked.
   const activeBlockHookId = activeState
     && activeState.session_status === 'blocked_hook'
-    && missingBlockedHookFields(activeState).length === 0
     ? String(activeState.blocked_by_hook || '').trim()
     : null;
   const activeBlockArtifact = activeBlockHookId

--- a/hooks/lib/mpl-hook-trace.mjs
+++ b/hooks/lib/mpl-hook-trace.mjs
@@ -4,21 +4,35 @@ import { basename, dirname, join, resolve } from 'path';
 import { fileURLToPath } from 'url';
 
 import { missingBlockedHookFields } from './mpl-blocked-hook.mjs';
+import { CURRENT_SCHEMA_VERSION } from './mpl-state.mjs';
 
 // Read .mpl/state.json byte-for-byte without invoking readState() — that
 // helper persists schema migrations and can archive/remove the legacy
 // `.mpl/mpl/state.json`. A diagnostic command must never mutate run state
 // just by being run; codex r1 on PR #216 flagged this as a state-forensics
-// hazard. Return null when the file is missing or unparseable; callers
-// treat null as "no active blocked_hook info available".
+// hazard. Return value: either { state } when the parsed object passes
+// minimal shape/version checks, { error: 'unparseable' } / { error:
+// 'unsupported_schema', schemaVersion } when not, or null when no file
+// exists. Codex r6: a future schema_version must fail closed rather than
+// being treated as a valid block envelope and pointing recovery at the
+// wrong artifact.
 function readStateRaw(cwd) {
   const path = join(cwd, '.mpl', 'state.json');
   if (!existsSync(path)) return null;
+  let parsed;
   try {
-    return JSON.parse(readFileSync(path, 'utf-8'));
+    parsed = JSON.parse(readFileSync(path, 'utf-8'));
   } catch {
-    return null;
+    return { error: 'unparseable' };
   }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return { error: 'unparseable' };
+  }
+  const sv = parsed.schema_version;
+  if (typeof sv === 'number' && sv > CURRENT_SCHEMA_VERSION) {
+    return { error: 'unsupported_schema', schemaVersion: sv };
+  }
+  return { state: parsed };
 }
 
 const __filename = fileURLToPath(import.meta.url);
@@ -170,7 +184,20 @@ export function traceHookChain({
 } = {}) {
   const resolvedTarget = targetPath || DECOMPOSITION_PATH;
   const config = hooksConfig || readHooksConfig(pluginRoot);
-  const activeState = state || readStateRaw(cwd);
+  // state can be either a parsed state object (when caller injects one)
+  // or null / { error, ... } / { state } from readStateRaw.
+  let activeState = null;
+  let stateError = null;
+  if (state) {
+    activeState = state;
+  } else {
+    const raw = readStateRaw(cwd);
+    if (raw && raw.error) {
+      stateError = raw;
+    } else if (raw && raw.state) {
+      activeState = raw.state;
+    }
+  }
   const category = pathCategory(resolvedTarget);
   const rows = [];
 
@@ -221,6 +248,7 @@ export function traceHookChain({
     category,
     cwd,
     plugin_root: pluginRoot,
+    state_error: stateError,
     hooks: rows,
   };
 }
@@ -231,6 +259,14 @@ export function formatHookTrace(trace) {
     `category: ${trace.category}`,
     '',
   ];
+  if (trace.state_error) {
+    if (trace.state_error.error === 'unsupported_schema') {
+      lines.push(`WARNING: state.json schema_version=${trace.state_error.schemaVersion} is newer than the installed plugin supports — upgrade the plugin or restore a compatible state before relying on this trace.`);
+    } else if (trace.state_error.error === 'unparseable') {
+      lines.push('WARNING: .mpl/state.json is unreadable / not valid JSON — block status cannot be computed for this trace.');
+    }
+    lines.push('');
+  }
   if (!trace.hooks.length) {
     lines.push('No matching hooks registered.');
     return lines.join('\n');

--- a/hooks/lib/mpl-hook-trace.mjs
+++ b/hooks/lib/mpl-hook-trace.mjs
@@ -2,7 +2,22 @@
 import { existsSync, readFileSync } from 'fs';
 import { basename, dirname, join, resolve } from 'path';
 import { fileURLToPath } from 'url';
-import { readState } from './mpl-state.mjs';
+
+// Read .mpl/state.json byte-for-byte without invoking readState() — that
+// helper persists schema migrations and can archive/remove the legacy
+// `.mpl/mpl/state.json`. A diagnostic command must never mutate run state
+// just by being run; codex r1 on PR #216 flagged this as a state-forensics
+// hazard. Return null when the file is missing or unparseable; callers
+// treat null as "no active blocked_hook info available".
+function readStateRaw(cwd) {
+  const path = join(cwd, '.mpl', 'state.json');
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, 'utf-8'));
+  } catch {
+    return null;
+  }
+}
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -139,7 +154,7 @@ export function traceHookChain({
 } = {}) {
   const resolvedTarget = targetPath || DECOMPOSITION_PATH;
   const config = hooksConfig || readHooksConfig(pluginRoot);
-  const activeState = state || (existsSync(join(cwd, '.mpl', 'state.json')) ? readState(cwd) : null);
+  const activeState = state || readStateRaw(cwd);
   const category = pathCategory(resolvedTarget);
   const rows = [];
 

--- a/hooks/lib/mpl-hook-trace.mjs
+++ b/hooks/lib/mpl-hook-trace.mjs
@@ -1,0 +1,220 @@
+#!/usr/bin/env node
+import { existsSync, readFileSync } from 'fs';
+import { basename, dirname, join, resolve } from 'path';
+import { fileURLToPath } from 'url';
+import { readState } from './mpl-state.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const DEFAULT_PLUGIN_ROOT = resolve(__dirname, '..', '..');
+
+const PURPOSES = {
+  'mpl-auto-permit': 'learned safe permission preflight',
+  'mpl-write-guard': 'direct write/delegation guard',
+  'mpl-bash-timeout': 'bash timeout enforcement',
+  'mpl-state-invariant': 'state schema and lifecycle invariants',
+  'mpl-require-e2e': 'required E2E artifact guard',
+  'mpl-require-e2e-authenticity': 'E2E authenticity guard',
+  'mpl-require-finalize-artifacts': 'finalization artifact guard',
+  'mpl-require-whole-goal-closure': 'whole-goal closure guard',
+  'mpl-validate-pp-schema': 'PP schema validation',
+  'mpl-require-covers': 'phase coverage guard',
+  'mpl-require-goal-trace': 'goal_contract_hash and goal-trace drift check',
+  'mpl-require-phase-contract-graph': 'decomposition graph/schema validation',
+  'mpl-require-decomposition-delta': 'controlled decomposition delta guard',
+  'mpl-require-completed-phase-immutability': 'completed phase immutability guard',
+  'mpl-require-phase-evidence': 'phase evidence guard',
+  'mpl-baseline-guard': 'baseline immutability/hash guard',
+  'mpl-ambiguity-gate': 'ambiguity score gate before decomposer dispatch',
+  'mpl-require-chain-assignment': 'chain assignment guard before seed generation',
+  'mpl-tool-tracker': 'last-tool telemetry',
+  'mpl-gate-recorder': 'gate/test-agent evidence recorder',
+  'mpl-fallback-grep': 'anti-pattern fallback scanner',
+  'mpl-artifact-schema': 'canonical artifact schema validation',
+  'mpl-decomposition-postprocess': 'decomposition normalization/postprocess',
+  'mpl-require-test-agent': 'independent test-agent continuation gate',
+  'mpl-quality-gate': 'adversarial quality gate',
+  'mpl-validate-output': 'agent output validation/token tracking',
+  'mpl-validate-seed': 'phase seed validation',
+  'mpl-sentinel-s0': 'sentinel S0 guard',
+  'mpl-sentinel-s1': 'sentinel S1 guard',
+  'mpl-sentinel-s3': 'sentinel S3 guard',
+  'mpl-permit-learner': 'permission learning telemetry',
+  'mpl-sentinel-pp-file': 'PP file sentinel',
+  'mpl-context-monitor': 'chain context usage monitor',
+  'mpl-discovery-scanner': 'discovery sentinel scanner',
+  'mpl-phase-controller': 'Stop hook phase routing and hang/block handling',
+  'mpl-compaction-tracker': 'compaction telemetry',
+  'mpl-session-init': 'session initialization',
+  'mpl-keyword-detector': 'MPL keyword/slash command detection',
+};
+
+const DECOMPOSITION_PATH = '.mpl/mpl/decomposition.yaml';
+const DECOMPOSITION_FOCUS = new Set([
+  'mpl-require-goal-trace',
+  'mpl-baseline-guard',
+  'mpl-artifact-schema',
+  'mpl-discovery-scanner',
+  'mpl-require-chain-assignment',
+  'mpl-phase-controller',
+  'mpl-require-test-agent',
+]);
+
+function readHooksConfig(pluginRoot = DEFAULT_PLUGIN_ROOT) {
+  const path = join(pluginRoot, 'hooks', 'hooks.json');
+  return JSON.parse(readFileSync(path, 'utf-8'));
+}
+
+function hookIdFromCommand(command) {
+  if (typeof command !== 'string') return 'unknown';
+  const match = command.match(/\/([^/\s"']+\.mjs)\b/);
+  const file = match ? match[1] : basename(command.trim().split(/\s+/).pop() || 'unknown');
+  return file.replace(/\.mjs$/, '');
+}
+
+function matcherTools(matcher) {
+  if (!matcher) return ['*'];
+  return String(matcher)
+    .split('|')
+    .map((p) => p.trim())
+    .filter(Boolean);
+}
+
+function matcherIncludes(matcher, tools) {
+  const patterns = matcherTools(matcher);
+  if (patterns.includes('*')) return true;
+  return patterns.some((pattern) => {
+    if (pattern === 'mcp__.*') return tools.some((t) => t.startsWith('mcp__'));
+    if (pattern.includes('.*')) {
+      const re = new RegExp(`^${pattern.replace(/\./g, '\\.').replace(/\*/g, '.*')}$`);
+      return tools.some((tool) => re.test(tool));
+    }
+    return tools.includes(pattern);
+  });
+}
+
+function pathCategory(targetPath) {
+  const normalized = String(targetPath || '').replace(/\\/g, '/');
+  if (normalized.endsWith(DECOMPOSITION_PATH) || normalized === DECOMPOSITION_PATH) {
+    return 'decomposition';
+  }
+  if (normalized.endsWith('.mpl/state.json')) return 'state';
+  return 'file';
+}
+
+function shouldIncludeHook({ eventName, matcher, hookId, category }) {
+  const fileWriteTools = ['Edit', 'Write', 'MultiEdit'];
+  if (eventName === 'PreToolUse') {
+    if (matcherIncludes(matcher, fileWriteTools)) return true;
+    if (category === 'decomposition' && matcherIncludes(matcher, ['Task', 'Agent'])) return true;
+    return !matcher;
+  }
+  if (eventName === 'PostToolUse') {
+    if (matcherIncludes(matcher, fileWriteTools)) return true;
+    if (category === 'decomposition' && matcherIncludes(matcher, ['Task', 'Agent'])) return true;
+    return !matcher;
+  }
+  if (eventName === 'Stop') return true;
+  if (category === 'decomposition') return DECOMPOSITION_FOCUS.has(hookId);
+  return false;
+}
+
+function blockStatusFor(hookId, state, targetPath) {
+  if (!state || state.session_status !== 'blocked_hook') return 'registered';
+  if (state.blocked_by_hook !== hookId) return 'registered';
+  const artifact = String(state.blocked_artifact || '');
+  const target = String(targetPath || '');
+  if (!artifact || !target || artifact === target || target.endsWith(artifact) || artifact.endsWith(target)) {
+    return 'currently_blocking';
+  }
+  return 'registered_blocking_other_artifact';
+}
+
+export function traceHookChain({
+  targetPath,
+  cwd = process.cwd(),
+  pluginRoot = DEFAULT_PLUGIN_ROOT,
+  hooksConfig = null,
+  state = null,
+} = {}) {
+  const resolvedTarget = targetPath || DECOMPOSITION_PATH;
+  const config = hooksConfig || readHooksConfig(pluginRoot);
+  const activeState = state || (existsSync(join(cwd, '.mpl', 'state.json')) ? readState(cwd) : null);
+  const category = pathCategory(resolvedTarget);
+  const rows = [];
+
+  for (const [eventName, registrations] of Object.entries(config.hooks || {})) {
+    for (const registration of registrations || []) {
+      const matcher = registration.matcher || null;
+      for (const hook of registration.hooks || []) {
+        const hookId = hookIdFromCommand(hook.command);
+        if (!shouldIncludeHook({ eventName, matcher, hookId, category })) continue;
+        rows.push({
+          event: eventName,
+          matcher: matcher || '*',
+          hook_id: hookId,
+          command: hook.command,
+          timeout: hook.timeout ?? null,
+          purpose: PURPOSES[hookId] || 'registered hook',
+          status: blockStatusFor(hookId, activeState, resolvedTarget),
+        });
+      }
+    }
+  }
+
+  return {
+    target_path: resolvedTarget,
+    category,
+    cwd,
+    plugin_root: pluginRoot,
+    hooks: rows,
+  };
+}
+
+export function formatHookTrace(trace) {
+  const lines = [
+    `MPL Hook Trace: ${trace.target_path}`,
+    `category: ${trace.category}`,
+    '',
+  ];
+  if (!trace.hooks.length) {
+    lines.push('No matching hooks registered.');
+    return lines.join('\n');
+  }
+
+  let currentEvent = null;
+  for (const hook of trace.hooks) {
+    if (hook.event !== currentEvent) {
+      currentEvent = hook.event;
+      lines.push(`${currentEvent}:`);
+    }
+    const marker = hook.status === 'currently_blocking' ? 'BLOCKING' : hook.status;
+    lines.push(`  - ${hook.hook_id} [${marker}] matcher=${hook.matcher} :: ${hook.purpose}`);
+  }
+  return lines.join('\n');
+}
+
+function parseArgs(argv) {
+  const args = { cwd: process.cwd(), pluginRoot: DEFAULT_PLUGIN_ROOT, json: false, targetPath: null };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--cwd') args.cwd = argv[++i] || args.cwd;
+    else if (arg === '--plugin-root') args.pluginRoot = argv[++i] || args.pluginRoot;
+    else if (arg === '--json') args.json = true;
+    else if (!args.targetPath) args.targetPath = arg;
+  }
+  return args;
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === __filename) {
+  const args = parseArgs(process.argv.slice(2));
+  const target = args.targetPath || DECOMPOSITION_PATH;
+  const trace = traceHookChain({
+    targetPath: target,
+    cwd: args.cwd,
+    pluginRoot: args.pluginRoot,
+  });
+  process.stdout.write(args.json
+    ? `${JSON.stringify(trace, null, 2)}\n`
+    : `${formatHookTrace(trace)}\n`);
+}

--- a/hooks/lib/mpl-hook-trace.mjs
+++ b/hooks/lib/mpl-hook-trace.mjs
@@ -243,6 +243,27 @@ export function traceHookChain({
     }
   }
 
+  // Codex r7 on PR #216: if hooks.json was changed (upgrade/downgrade /
+  // rename) and the active blocker hook id is no longer registered, the
+  // force-include path above never fires because it iterates the
+  // registry. Append a synthetic row so the diagnostic still surfaces
+  // the active block instead of looking like the run is healthy.
+  if (
+    activeBlockHookId &&
+    activeBlockMatchesTarget &&
+    !rows.some((r) => r.hook_id === activeBlockHookId)
+  ) {
+    rows.push({
+      event: 'state',
+      matcher: 'blocked_by_hook',
+      hook_id: activeBlockHookId,
+      command: null,
+      timeout: null,
+      purpose: 'active blocker not registered in current hooks.json (registry skew)',
+      status: blockStatusFor(activeBlockHookId, activeState, resolvedTarget),
+    });
+  }
+
   return {
     target_path: resolvedTarget,
     category,

--- a/hooks/lib/mpl-hook-trace.mjs
+++ b/hooks/lib/mpl-hook-trace.mjs
@@ -3,6 +3,8 @@ import { existsSync, readFileSync } from 'fs';
 import { basename, dirname, join, resolve } from 'path';
 import { fileURLToPath } from 'url';
 
+import { missingBlockedHookFields } from './mpl-blocked-hook.mjs';
+
 // Read .mpl/state.json byte-for-byte without invoking readState() — that
 // helper persists schema migrations and can archive/remove the legacy
 // `.mpl/mpl/state.json`. A diagnostic command must never mutate run state
@@ -137,15 +139,20 @@ function shouldIncludeHook({ eventName, matcher, hookId, category }) {
 function blockStatusFor(hookId, state, targetPath) {
   if (!state || state.session_status !== 'blocked_hook') return 'registered';
   if (state.blocked_by_hook !== hookId) return 'registered';
-  // Codex r2 on PR #216: a blocked_hook envelope without blocked_artifact
-  // (or without a target the tracer was asked about) is a corrupt /
-  // zombie state — surfacing it as `currently_blocking` would point the
-  // operator at the wrong artifact and hide the real invariant failure.
-  // Demand a non-empty artifact field AND a non-empty target, then match
-  // them; otherwise report the envelope as invalid.
+  // Codex r2/r3 on PR #216: a blocked_hook envelope is only actionable
+  // when ALL companion fields required by the state-invariant are present
+  // (blocked_phase, block_code, block_reason, resume_instruction,
+  // blocked_at, retry_context object — same list as
+  // mpl-state-invariant BLOCKED_HOOK_STALE). A stale or partially-cleared
+  // zombie state would otherwise print BLOCKING for the requested target
+  // and hide the real state-invariant failure. Reuse the shared validator.
+  const missing = missingBlockedHookFields(state);
+  if (missing.length > 0) {
+    return 'invalid_blocked_envelope';
+  }
   const artifact = String(state.blocked_artifact || '').trim();
   const target = String(targetPath || '').trim();
-  if (!artifact || !target) {
+  if (!target) {
     return 'invalid_blocked_envelope';
   }
   if (artifact === target || target.endsWith(artifact) || artifact.endsWith(target)) {

--- a/hooks/lib/mpl-hook-trace.mjs
+++ b/hooks/lib/mpl-hook-trace.mjs
@@ -174,12 +174,34 @@ export function traceHookChain({
   const category = pathCategory(resolvedTarget);
   const rows = [];
 
+  // Codex r4 on PR #216: when there is an active blocked_hook envelope
+  // that matches the queried target, the offending hook MUST appear in
+  // the trace regardless of the category/matcher filter — otherwise a
+  // valid block on e.g. `state.test_agent_dispatched.<phase>` (not a
+  // decomposition path) would have `mpl-require-test-agent` filtered out
+  // and never reach blockStatusFor.
+  const activeBlockHookId = activeState
+    && activeState.session_status === 'blocked_hook'
+    && missingBlockedHookFields(activeState).length === 0
+    ? String(activeState.blocked_by_hook || '').trim()
+    : null;
+  const activeBlockArtifact = activeBlockHookId
+    ? String(activeState.blocked_artifact || '').trim()
+    : null;
+  const resolvedTargetTrim = String(resolvedTarget).trim();
+  const activeBlockMatchesTarget = activeBlockArtifact && resolvedTargetTrim && (
+    activeBlockArtifact === resolvedTargetTrim ||
+    resolvedTargetTrim.endsWith(activeBlockArtifact) ||
+    activeBlockArtifact.endsWith(resolvedTargetTrim)
+  );
+
   for (const [eventName, registrations] of Object.entries(config.hooks || {})) {
     for (const registration of registrations || []) {
       const matcher = registration.matcher || null;
       for (const hook of registration.hooks || []) {
         const hookId = hookIdFromCommand(hook.command);
-        if (!shouldIncludeHook({ eventName, matcher, hookId, category })) continue;
+        const isActiveBlocker = activeBlockMatchesTarget && hookId === activeBlockHookId;
+        if (!isActiveBlocker && !shouldIncludeHook({ eventName, matcher, hookId, category })) continue;
         rows.push({
           event: eventName,
           matcher: matcher || '*',

--- a/hooks/lib/mpl-hook-trace.mjs
+++ b/hooks/lib/mpl-hook-trace.mjs
@@ -137,9 +137,18 @@ function shouldIncludeHook({ eventName, matcher, hookId, category }) {
 function blockStatusFor(hookId, state, targetPath) {
   if (!state || state.session_status !== 'blocked_hook') return 'registered';
   if (state.blocked_by_hook !== hookId) return 'registered';
-  const artifact = String(state.blocked_artifact || '');
-  const target = String(targetPath || '');
-  if (!artifact || !target || artifact === target || target.endsWith(artifact) || artifact.endsWith(target)) {
+  // Codex r2 on PR #216: a blocked_hook envelope without blocked_artifact
+  // (or without a target the tracer was asked about) is a corrupt /
+  // zombie state — surfacing it as `currently_blocking` would point the
+  // operator at the wrong artifact and hide the real invariant failure.
+  // Demand a non-empty artifact field AND a non-empty target, then match
+  // them; otherwise report the envelope as invalid.
+  const artifact = String(state.blocked_artifact || '').trim();
+  const target = String(targetPath || '').trim();
+  if (!artifact || !target) {
+    return 'invalid_blocked_envelope';
+  }
+  if (artifact === target || target.endsWith(artifact) || artifact.endsWith(target)) {
     return 'currently_blocking';
   }
   return 'registered_blocking_other_artifact';
@@ -203,7 +212,10 @@ export function formatHookTrace(trace) {
       currentEvent = hook.event;
       lines.push(`${currentEvent}:`);
     }
-    const marker = hook.status === 'currently_blocking' ? 'BLOCKING' : hook.status;
+    let marker;
+    if (hook.status === 'currently_blocking') marker = 'BLOCKING';
+    else if (hook.status === 'invalid_blocked_envelope') marker = 'INVALID_BLOCKED_ENVELOPE';
+    else marker = hook.status;
     lines.push(`  - ${hook.hook_id} [${marker}] matcher=${hook.matcher} :: ${hook.purpose}`);
   }
   return lines.join('\n');


### PR DESCRIPTION
## What

- `hooks/lib/mpl-hook-trace.mjs`: traces the MPL hook chain for a given path, listing PreToolUse / PostToolUse hooks that can block writes, their event/matcher, purpose summary, and current block status when state/config/context allows it. Loads the registered chain from `hooks/hooks.json` so the output stays aligned with the real registry. Distinguishes "registered hook" from "currently blocking" by reading `state.blocked_hook`.
- `hooks/__tests__/mpl-hook-trace.test.mjs`: pins the `.mpl/mpl/decomposition.yaml` trace (canonical artifact for the feature) and asserts that an active `blocked_hook` envelope flips the `currently_blocking` flag for the relevant entry.
- `README.md`: adds the invocation line `node hooks/lib/mpl-hook-trace.mjs .mpl/mpl/decomposition.yaml` alongside the existing recovery commands.

## Why

Exp22 R10 spent ~10 minutes manually enumerating which hooks could block writes to `.mpl/mpl/decomposition.yaml`. With the tracer, the same investigation completes in seconds and stays aligned with the registry as it evolves.

## Design

N/A — small additive tool. Motivation, scope, and acceptance criteria live in issue #207 (ygg-exp22 V1 execution analysis, R10).

## Agent Review Status

This PR is gated on **2 unique agent reviews** (footers \`— from <agent>\`).

- [ ] from claude
- [ ] from codex

Closes #207.

---
_Awaiting reviews. Merge once the gate is satisfied._