### PR TITLE
Detect subagent anomalies + harden test-agent recovery (#206, #208)

### DIFF
--- a/agents/mpl-test-agent.md
+++ b/agents/mpl-test-agent.md
@@ -84,7 +84,12 @@ disallowedTools: Task
   </Execution_Flow>
 
   <Output_Schema>
-    Your final output MUST be a valid JSON block wrapped in ```json fences.
+    FINAL OUTPUT RULE:
+    - Your final assistant message MUST start with a ```json fence.
+    - Your final assistant message MUST end with the closing ``` fence.
+    - Do NOT put prose, headings, bullets, or commentary before or after the JSON block.
+    - Put any human-readable summary inside JSON fields only.
+    - A natural-language final report is INVALID even when tests passed.
 
     ```json
     {

--- a/hooks/__tests__/mpl-gate-recorder.test.mjs
+++ b/hooks/__tests__/mpl-gate-recorder.test.mjs
@@ -392,6 +392,50 @@ describe('mpl-gate-recorder test-agent evidence', () => {
     assert.equal(ev.valid_json, false);
     assert.equal(ev.invalid_reason, 'missing_json_block');
   });
+
+  it('phase-runner anomaly does not advance sprint_status.completed_todos (codex r3)', () => {
+    // Codex r3 on PR #218: when the phase-runner returns anomalous output
+    // (empty / zero tokens after substantial tool work), the hook must not
+    // count a possibly-stale state-summary.md as a completed phase.
+    const tmp = mkdtempSync(join(tmpdir(), 'mpl-gate-recorder-phase-runner-anomaly-'));
+    try {
+      seedState(tmp, { sprint_status: { completed_todos: 0, in_progress_todos: 0, failed_todos: 0, total_todos: 1 } });
+      // Plant a stale on-disk state-summary.md so countCompletedPhases would
+      // otherwise increment to 1.
+      mkdirSync(join(tmp, '.mpl', 'mpl', 'phases', 'phase-1'), { recursive: true });
+      writeFileSync(
+        join(tmp, '.mpl', 'mpl', 'phases', 'phase-1', 'state-summary.md'),
+        '# phase-1 state summary\nstatus: COMPLETED\n'
+      );
+      const input = {
+        cwd: tmp,
+        tool_name: 'Task',
+        tool_input: {
+          subagent_type: 'mpl-phase-runner',
+          prompt: 'Execute phase-1.',
+        },
+        tool_response: '',  // empty final response after tool work
+        usage: { output_tokens: 0 },
+        metrics: { tools_used: 40, duration_ms: 28 * 60 * 1000 },
+      };
+      const r = JSON.parse(execFileSync('node', [HOOK_PATH], {
+        input: JSON.stringify(input),
+        encoding: 'utf-8',
+      }));
+      assert.equal(r.continue, true);
+      assert.match(r.systemMessage, /SUBAGENT RETURN ANOMALY/);
+      const state = readState(tmp);
+      // The anomaly is recorded …
+      assert.equal(state.subagent_return_anomalies.length, 1);
+      assert.equal(state.subagent_return_anomalies[0].agent_type, 'mpl-phase-runner');
+      // … but completed_todos must STAY at 0 — not auto-advance from the
+      // stale state-summary.md.
+      assert.equal(state.sprint_status.completed_todos, 0,
+        'phase-runner anomaly must NOT advance completed_todos');
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
 });
 
 /* ─── Stage A Phase 1.6c-i (PR #186 review fix): Bash gate routing ─── */

--- a/hooks/__tests__/mpl-gate-recorder.test.mjs
+++ b/hooks/__tests__/mpl-gate-recorder.test.mjs
@@ -393,6 +393,108 @@ describe('mpl-gate-recorder test-agent evidence', () => {
     assert.equal(ev.invalid_reason, 'missing_json_block');
   });
 
+  it('test-agent valid PASS JSON with anomaly is INVALID, not PASS (codex r4)', () => {
+    // Codex r4 on PR #218: a syntactically valid PASS JSON paired with a
+    // recorded subagent anomaly must NOT clear the verifier trust
+    // boundary. The anomaly is added to the issues list so invalid_reason
+    // stays non-null and isPassingTestAgentEvidence returns false.
+    const fenced = '```json\n' + JSON.stringify({
+      phase_id: 'phase-1',
+      verdict: 'PASS',
+      test_results: { total: 3, passed: 3, failed: 0, skipped: 0, pass_rate: 100 },
+      test_files_created: ['tests/phase-1.test.ts'],
+      commands_run: [{ command: 'npm test', exit_code: 0 }],
+      bugs_found: [],
+      a_item_coverage: [{ id: 'A-1', status: 'PASS' }],
+      s_item_coverage: [{ id: 'S-1', status: 'PASS' }],
+    }) + '\n```';
+    const ev = parseTestAgentEvidence({
+      phaseId: 'phase-1',
+      response: fenced,
+      anomaly: { type: 'zero_token_after_tools' },
+    });
+    assert.equal(ev.valid_json, true);
+    assert.equal(ev.verdict, 'INVALID');
+    assert.match(ev.invalid_reason, /subagent_anomaly:zero_token_after_tools/);
+    assert.equal(ev.subagent_anomaly_type, 'zero_token_after_tools');
+    assert.equal(isPassingTestAgentEvidence(ev), false);
+  });
+
+  it('phase-runner anomaly installs blocked_hook envelope (codex r4)', () => {
+    // Codex r4 on PR #218: phase-runner anomaly must structurally block
+    // progression — the orchestrator advances from PLAN.md state, not
+    // sprint_status, so a non-blocking systemMessage is insufficient.
+    const tmp = mkdtempSync(join(tmpdir(), 'mpl-gate-recorder-phase-runner-block-'));
+    try {
+      seedState(tmp);
+      const input = {
+        cwd: tmp,
+        tool_name: 'Task',
+        tool_input: {
+          subagent_type: 'mpl-phase-runner',
+          prompt: 'Execute phase-3.',
+        },
+        tool_response: '',
+        usage: { output_tokens: 0 },
+        metrics: { tools_used: 40, duration_ms: 28 * 60 * 1000 },
+      };
+      const r = JSON.parse(execFileSync('node', [HOOK_PATH], {
+        input: JSON.stringify(input),
+        encoding: 'utf-8',
+      }));
+      assert.equal(r.continue, true);
+      const state = readState(tmp);
+      assert.equal(state.session_status, 'blocked_hook',
+        'phase-runner anomaly must install a blocked_hook envelope');
+      assert.equal(state.blocked_by_hook, 'mpl-gate-recorder');
+      assert.match(state.block_code, /^phase_runner_/);
+      assert.equal(typeof state.retry_context, 'object');
+      assert.equal(state.retry_context.agent_type, 'mpl-phase-runner');
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('phase-runner anomaly does NOT clobber a pre-existing blocked_hook (codex r4)', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'mpl-gate-recorder-phase-runner-noclobber-'));
+    try {
+      seedState(tmp, {
+        session_status: 'blocked_hook',
+        blocked_by_hook: 'mpl-require-test-agent',
+        blocked_phase: 'phase-1',
+        blocked_artifact: 'state.test_agent_dispatched.phase-1',
+        block_code: 'missing_or_invalid_test_agent_evidence',
+        block_reason: 'pre-existing more specific block',
+        resume_instruction: 'follow existing recovery',
+        blocked_at: '2026-05-27T00:00:00.000Z',
+        retry_context: { from: 'earlier' },
+      });
+      const input = {
+        cwd: tmp,
+        tool_name: 'Task',
+        tool_input: {
+          subagent_type: 'mpl-phase-runner',
+          prompt: 'Execute phase-3.',
+        },
+        tool_response: '',
+        usage: { output_tokens: 0 },
+        metrics: { tools_used: 40, duration_ms: 28 * 60 * 1000 },
+      };
+      execFileSync('node', [HOOK_PATH], {
+        input: JSON.stringify(input),
+        encoding: 'utf-8',
+      });
+      const state = readState(tmp);
+      // The pre-existing more-specific block must survive.
+      assert.equal(state.blocked_by_hook, 'mpl-require-test-agent');
+      assert.equal(state.block_code, 'missing_or_invalid_test_agent_evidence');
+      // Anomaly is still recorded for visibility.
+      assert.equal(state.subagent_return_anomalies.length, 1);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it('phase-runner anomaly does not advance sprint_status.completed_todos (codex r3)', () => {
     // Codex r3 on PR #218: when the phase-runner returns anomalous output
     // (empty / zero tokens after substantial tool work), the hook must not

--- a/hooks/__tests__/mpl-gate-recorder.test.mjs
+++ b/hooks/__tests__/mpl-gate-recorder.test.mjs
@@ -10,6 +10,7 @@ import {
   isPassingTestAgentEvidence,
   parseTestAgentEvidence,
   TEST_AGENT_EVIDENCE_PREVIEW_LIMIT,
+  TEST_AGENT_RESPONSE_PREVIEW_LIMIT,
 } from '../lib/mpl-test-agent-evidence.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -235,6 +236,66 @@ describe('mpl-gate-recorder test-agent evidence', () => {
     assert.equal(ev.valid_json, false);
     assert.equal(ev.verdict, 'INVALID');
     assert.equal(ev.invalid_reason, 'missing_test_agent_fields');
+    assert.match(ev.response_preview, /completed without structured payload/);
+  });
+
+  it('records prose-only test-agent diagnostics without accepting PASS', () => {
+    const prose = `Tests passed.\n${'x'.repeat(TEST_AGENT_RESPONSE_PREVIEW_LIMIT + 30)}`;
+    const ev = parseTestAgentEvidence({
+      phaseId: 'phase-1',
+      response: prose,
+    });
+    assert.equal(ev.valid_json, false);
+    assert.equal(ev.verdict, 'INVALID');
+    assert.equal(ev.invalid_reason, 'missing_json_block');
+    assert.ok(ev.response_preview.length <= TEST_AGENT_RESPONSE_PREVIEW_LIMIT);
+    assert.match(ev.response_preview, /\[truncated\]/);
+    assert.equal(isPassingTestAgentEvidence(ev), false);
+  });
+
+  it('marks empty test-agent returns with an explicit anomaly reason', () => {
+    const ev = parseTestAgentEvidence({
+      phaseId: 'phase-1',
+      response: '',
+      anomaly: { type: 'zero_token_after_tools' },
+    });
+    assert.equal(ev.valid_json, false);
+    assert.equal(ev.verdict, 'INVALID');
+    assert.equal(ev.invalid_reason, 'empty_response_anomaly');
+    assert.equal(ev.subagent_anomaly_type, 'zero_token_after_tools');
+  });
+
+  it('records empty test-agent Task returns as anomalies without rewriting response_len', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'mpl-gate-recorder-anomaly-'));
+    try {
+      seedState(tmp);
+      const input = {
+        cwd: tmp,
+        tool_name: 'Task',
+        tool_input: {
+          subagent_type: 'mpl-test-agent',
+          prompt: 'Verify phase-1 from the contract.',
+        },
+        tool_response: '',
+        usage: { output_tokens: 0 },
+        metrics: { tools_used: 32, duration_ms: 34 * 60 * 1000 },
+      };
+      const r = JSON.parse(execFileSync('node', [HOOK_PATH], {
+        input: JSON.stringify(input),
+        encoding: 'utf-8',
+      }));
+      assert.equal(r.continue, true);
+      assert.match(r.systemMessage, /SUBAGENT RETURN ANOMALY/);
+      const state = readState(tmp);
+      assert.equal(state.subagent_return_anomalies.length, 1);
+      assert.equal(state.subagent_return_anomalies[0].type, 'zero_token_after_tools');
+      const ev = state.test_agent_dispatched['phase-1'];
+      assert.equal(ev.response_len, 0);
+      assert.equal(ev.invalid_reason, 'empty_response_anomaly');
+      assert.equal(ev.subagent_anomaly_type, 'zero_token_after_tools');
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
   });
 
   it('requires the full evidence contract, not verdict alone, for PASS consumption', () => {

--- a/hooks/__tests__/mpl-gate-recorder.test.mjs
+++ b/hooks/__tests__/mpl-gate-recorder.test.mjs
@@ -496,6 +496,49 @@ describe('mpl-gate-recorder test-agent evidence', () => {
     }
   });
 
+  it('phase-runner clean re-dispatch self-clears a prior phase_runner_* block (codex r6)', () => {
+    // Codex r6 on PR #218: after a phase-runner anomaly installs a
+    // phase_runner_* block, a subsequent non-anomalous phase-runner
+    // completion must clear that block; otherwise transient anomalies
+    // permanently pause the pipeline with no recovery path.
+    const tmp = mkdtempSync(join(tmpdir(), 'mpl-gate-recorder-phase-runner-self-clear-'));
+    try {
+      seedState(tmp, {
+        session_status: 'blocked_hook',
+        blocked_by_hook: 'mpl-gate-recorder',
+        blocked_phase: 'phase-1',
+        blocked_artifact: 'state.subagent_return_anomalies[empty_response]',
+        block_code: 'phase_runner_empty_response',
+        block_reason: 'prior anomaly',
+        resume_instruction: 'rerun',
+        blocked_at: '2026-05-27T00:00:00.000Z',
+        retry_context: { agent_type: 'mpl-phase-runner' },
+      });
+      const input = {
+        cwd: tmp,
+        tool_name: 'Task',
+        tool_input: {
+          subagent_type: 'mpl-phase-runner',
+          prompt: 'Re-execute phase-1.',
+        },
+        tool_response: 'Phase 1 completed successfully.',
+        usage: { output_tokens: 1500 },
+        metrics: { tools_used: 12, duration_ms: 5 * 60 * 1000 },
+      };
+      execFileSync('node', [HOOK_PATH], {
+        input: JSON.stringify(input),
+        encoding: 'utf-8',
+      });
+      const state = readState(tmp);
+      assert.equal(state.session_status, null,
+        'clean phase-runner re-dispatch must clear its own phase_runner_* block');
+      assert.equal(state.blocked_by_hook, null);
+      assert.equal(state.block_code, null);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it('phase-runner anomaly does NOT clobber a pre-existing blocked_hook (codex r4)', () => {
     const tmp = mkdtempSync(join(tmpdir(), 'mpl-gate-recorder-phase-runner-noclobber-'));
     try {

--- a/hooks/__tests__/mpl-gate-recorder.test.mjs
+++ b/hooks/__tests__/mpl-gate-recorder.test.mjs
@@ -319,6 +319,56 @@ describe('mpl-gate-recorder test-agent evidence', () => {
       bugs_found_count: 0,
     }), false);
   });
+
+  it('accepts content-array Task responses by extracting the text payload (codex r1)', () => {
+    // Real Task tool responses arrive shaped as
+    // { content: [{ type: 'text', text: '<assistant message>' }, ...] }
+    // The parser must extract that text and parse the fenced JSON inside.
+    const fenced = '```json\n' + JSON.stringify({
+      phase_id: 'phase-1',
+      verdict: 'PASS',
+      test_results: { total: 3, passed: 3, failed: 0, skipped: 0, pass_rate: 100 },
+      test_files_created: ['tests/phase-1.test.ts'],
+      commands_run: [{ command: 'npm test', exit_code: 0 }],
+      bugs_found: [],
+      a_item_coverage: [{ id: 'A-1', status: 'PASS' }],
+      s_item_coverage: [{ id: 'S-1', status: 'PASS' }],
+    }) + '\n```';
+    const ev = parseTestAgentEvidence({
+      phaseId: 'phase-1',
+      response: { content: [{ type: 'text', text: fenced }] },
+    });
+    assert.equal(ev.valid_json, true);
+    assert.equal(ev.verdict, 'PASS');
+    assert.equal(ev.invalid_reason, null);
+  });
+
+  it('rejects prose-before-fence outputs with prose_outside_json_fence (codex r1)', () => {
+    // The test-agent prompt requires the final message to start with the
+    // fence and have no prose outside. A response with leading prose must
+    // not slip through to PASS even when the fenced JSON itself is valid.
+    const promiseProse = 'Tests passed. Summary follows.\n\n```json\n' + JSON.stringify({
+      phase_id: 'phase-1', verdict: 'PASS',
+      test_results: { total: 1, passed: 1, failed: 0, skipped: 0 },
+    }) + '\n```';
+    const ev = parseTestAgentEvidence({
+      phaseId: 'phase-1',
+      response: promiseProse,
+    });
+    assert.equal(ev.valid_json, false);
+    assert.equal(ev.verdict, 'INVALID');
+    assert.equal(ev.invalid_reason, 'prose_outside_json_fence');
+  });
+
+  it('rejects bare JSON (no fence) with missing_json_block (codex r1)', () => {
+    const bare = JSON.stringify({ phase_id: 'phase-1', verdict: 'PASS' });
+    const ev = parseTestAgentEvidence({
+      phaseId: 'phase-1',
+      response: bare,
+    });
+    assert.equal(ev.valid_json, false);
+    assert.equal(ev.invalid_reason, 'missing_json_block');
+  });
 });
 
 /* ─── Stage A Phase 1.6c-i (PR #186 review fix): Bash gate routing ─── */

--- a/hooks/__tests__/mpl-gate-recorder.test.mjs
+++ b/hooks/__tests__/mpl-gate-recorder.test.mjs
@@ -539,6 +539,50 @@ describe('mpl-gate-recorder test-agent evidence', () => {
     }
   });
 
+  it('background dispatch with substantive content still records test-agent evidence (codex r11 [data-integrity])', () => {
+    // Codex r11 on PR #218: skipping on run_in_background alone was too
+    // coarse — if the hook later sees the actual completion with
+    // substantive content, evidence must still be recorded. Only
+    // handle-stub shapes (object with handle id but no text payload) are
+    // skipped.
+    const tmp = mkdtempSync(join(tmpdir(), 'mpl-gate-recorder-bg-substantive-'));
+    try {
+      seedState(tmp);
+      const fenced = '```json\n' + JSON.stringify({
+        phase_id: 'phase-1',
+        verdict: 'PASS',
+        test_results: { total: 3, passed: 3, failed: 0, skipped: 0, pass_rate: 100 },
+        test_files_created: ['tests/phase-1.test.ts'],
+        commands_run: [{ command: 'npm test', exit_code: 0 }],
+        bugs_found: [],
+        a_item_coverage: [{ id: 'A-1', status: 'PASS' }],
+        s_item_coverage: [{ id: 'S-1', status: 'PASS' }],
+      }) + '\n```';
+      const input = {
+        cwd: tmp,
+        tool_name: 'Task',
+        tool_input: {
+          subagent_type: 'mpl-test-agent',
+          prompt: 'Verify phase-1 from the contract.',
+          run_in_background: true,
+        },
+        // Real completion content (not a handle stub) — must be processed.
+        tool_response: fenced,
+      };
+      execFileSync('node', [HOOK_PATH], {
+        input: JSON.stringify(input),
+        encoding: 'utf-8',
+      });
+      const state = readState(tmp);
+      // Evidence must be recorded even though run_in_background=true.
+      assert.ok(state.test_agent_dispatched['phase-1'],
+        'substantive background completion must still record test_agent_dispatched');
+      assert.equal(state.test_agent_dispatched['phase-1'].verdict, 'PASS');
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it('background phase-runner Task dispatch does NOT record anomaly or install block (codex r8)', () => {
     // Codex r8 on PR #218: a background Task dispatch returns a handle
     // stub, not the final assistant text. Recording it as empty_response

--- a/hooks/__tests__/mpl-gate-recorder.test.mjs
+++ b/hooks/__tests__/mpl-gate-recorder.test.mjs
@@ -539,6 +539,48 @@ describe('mpl-gate-recorder test-agent evidence', () => {
     }
   });
 
+  it('phase-runner clean completion for a DIFFERENT phase does NOT clear an anomaly block (codex r7)', () => {
+    // Codex r7 on PR #218: self-clear must match the blocked phase id.
+    // A clean phase-runner completion for phase-2 must not clear a
+    // phase-1 anomaly block.
+    const tmp = mkdtempSync(join(tmpdir(), 'mpl-gate-recorder-phase-runner-cross-phase-'));
+    try {
+      seedState(tmp, {
+        session_status: 'blocked_hook',
+        blocked_by_hook: 'mpl-gate-recorder',
+        blocked_phase: 'phase-1',
+        blocked_artifact: 'state.subagent_return_anomalies[empty_response]',
+        block_code: 'phase_runner_empty_response',
+        block_reason: 'phase-1 anomaly',
+        resume_instruction: 'rerun phase-1',
+        blocked_at: '2026-05-27T00:00:00.000Z',
+        retry_context: { agent_type: 'mpl-phase-runner', phase_id: 'phase-1' },
+      });
+      const input = {
+        cwd: tmp,
+        tool_name: 'Task',
+        tool_input: {
+          subagent_type: 'mpl-phase-runner',
+          prompt: 'Re-execute phase-2.',
+        },
+        tool_response: 'Phase 2 completed successfully.',
+        usage: { output_tokens: 1500 },
+        metrics: { tools_used: 12, duration_ms: 5 * 60 * 1000 },
+      };
+      execFileSync('node', [HOOK_PATH], {
+        input: JSON.stringify(input),
+        encoding: 'utf-8',
+      });
+      const state = readState(tmp);
+      // Phase-1 anomaly block must STILL be active.
+      assert.equal(state.session_status, 'blocked_hook');
+      assert.equal(state.blocked_phase, 'phase-1');
+      assert.equal(state.block_code, 'phase_runner_empty_response');
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it('phase-runner anomaly does NOT clobber a pre-existing blocked_hook (codex r4)', () => {
     const tmp = mkdtempSync(join(tmpdir(), 'mpl-gate-recorder-phase-runner-noclobber-'));
     try {

--- a/hooks/__tests__/mpl-gate-recorder.test.mjs
+++ b/hooks/__tests__/mpl-gate-recorder.test.mjs
@@ -640,6 +640,41 @@ describe('mpl-gate-recorder test-agent evidence', () => {
     }
   });
 
+  it('phase-runner anomaly does NOT overwrite paused_budget / verification_hang / cancelled session states (codex r10)', () => {
+    // Codex r10 bounded review [logic]: !== 'blocked_hook' would overwrite
+    // any non-blocked-hook status, including the global pause/hang/cancel
+    // states. Anomaly block must only install when session is null/active.
+    for (const status of ['paused_budget', 'paused_checkpoint', 'verification_hang', 'cancelled']) {
+      const tmp = mkdtempSync(join(tmpdir(), `mpl-gate-recorder-status-${status}-`));
+      try {
+        seedState(tmp, { session_status: status });
+        const input = {
+          cwd: tmp,
+          tool_name: 'Task',
+          tool_input: {
+            subagent_type: 'mpl-phase-runner',
+            prompt: 'Execute phase-3.',
+          },
+          tool_response: '',
+          usage: { output_tokens: 0 },
+          metrics: { tools_used: 40, duration_ms: 28 * 60 * 1000 },
+        };
+        execFileSync('node', [HOOK_PATH], {
+          input: JSON.stringify(input),
+          encoding: 'utf-8',
+        });
+        const state = readState(tmp);
+        assert.equal(state.session_status, status,
+          `session_status=${status} must NOT be overwritten by anomaly block`);
+        // The anomaly is still recorded for visibility.
+        assert.equal(state.subagent_return_anomalies.length, 1,
+          `anomaly should still be recorded even when block install is skipped (status=${status})`);
+      } finally {
+        rmSync(tmp, { recursive: true, force: true });
+      }
+    }
+  });
+
   it('phase-runner anomaly does NOT clobber a pre-existing blocked_hook (codex r4)', () => {
     const tmp = mkdtempSync(join(tmpdir(), 'mpl-gate-recorder-phase-runner-noclobber-'));
     try {

--- a/hooks/__tests__/mpl-gate-recorder.test.mjs
+++ b/hooks/__tests__/mpl-gate-recorder.test.mjs
@@ -360,6 +360,29 @@ describe('mpl-gate-recorder test-agent evidence', () => {
     assert.equal(ev.invalid_reason, 'prose_outside_json_fence');
   });
 
+  it('rejects bare objects bypassing strict-fence even with test-agent fields (codex r2)', () => {
+    // Codex r2 on PR #218: a bare object with test_results/phase_id used
+    // to short-circuit and become valid PASS evidence, defeating the new
+    // strict-fence rule. All payloads must pass through text extraction
+    // and the fenced-JSON gate.
+    const bareObject = {
+      phase_id: 'phase-1',
+      verdict: 'PASS',
+      test_results: { total: 1, passed: 1, failed: 0, skipped: 0, pass_rate: 100 },
+      test_files_created: ['tests/phase-1.test.ts'],
+      commands_run: [{ command: 'npm test', exit_code: 0 }],
+      bugs_found: [],
+    };
+    const ev = parseTestAgentEvidence({
+      phaseId: 'phase-1',
+      response: bareObject,
+    });
+    assert.equal(ev.valid_json, false);
+    assert.equal(ev.verdict, 'INVALID');
+    assert.equal(ev.invalid_reason, 'missing_test_agent_fields');
+    assert.equal(isPassingTestAgentEvidence(ev), false);
+  });
+
   it('rejects bare JSON (no fence) with missing_json_block (codex r1)', () => {
     const bare = JSON.stringify({ phase_id: 'phase-1', verdict: 'PASS' });
     const ev = parseTestAgentEvidence({

--- a/hooks/__tests__/mpl-gate-recorder.test.mjs
+++ b/hooks/__tests__/mpl-gate-recorder.test.mjs
@@ -455,6 +455,47 @@ describe('mpl-gate-recorder test-agent evidence', () => {
     }
   });
 
+  it('test-agent PASS does not clear a phase_runner_* block (codex r5 hook-order regression)', () => {
+    // Codex r5 on PR #218: when mpl-gate-recorder installs a
+    // phase_runner_<anomaly> block, a later test-agent PASS in the same
+    // gate-recorder pass must NOT clear the structural anomaly block.
+    // The clear-on-PASS branch only nulls session_status when
+    // blocked_by_hook === 'mpl-require-test-agent'.
+    const tmp = mkdtempSync(join(tmpdir(), 'mpl-gate-recorder-block-survive-'));
+    try {
+      seedState(tmp, {
+        session_status: 'blocked_hook',
+        blocked_by_hook: 'mpl-gate-recorder',
+        blocked_phase: 'phase-1',
+        blocked_artifact: 'state.subagent_return_anomalies[empty_response]',
+        block_code: 'phase_runner_empty_response',
+        block_reason: 'phase-runner returned empty after substantial tool work',
+        resume_instruction: 'Verify phase artifacts; re-dispatch the runner.',
+        blocked_at: '2026-05-27T00:00:00.000Z',
+        retry_context: { agent_type: 'mpl-phase-runner', anomaly_type: 'empty_response' },
+      });
+      // Now a test-agent PASS arrives.
+      const fenced = '```json\n' + JSON.stringify({
+        phase_id: 'phase-1',
+        verdict: 'PASS',
+        test_results: { total: 3, passed: 3, failed: 0, skipped: 0, pass_rate: 100 },
+        test_files_created: ['tests/phase-1.test.ts'],
+        commands_run: [{ command: 'npm test', exit_code: 0 }],
+        bugs_found: [],
+        a_item_coverage: [{ id: 'A-1', status: 'PASS' }],
+        s_item_coverage: [{ id: 'S-1', status: 'PASS' }],
+      }) + '\n```';
+      runHook(tmp, fenced);
+      const state = readState(tmp);
+      // Phase-runner anomaly block survives.
+      assert.equal(state.session_status, 'blocked_hook');
+      assert.equal(state.blocked_by_hook, 'mpl-gate-recorder');
+      assert.equal(state.block_code, 'phase_runner_empty_response');
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it('phase-runner anomaly does NOT clobber a pre-existing blocked_hook (codex r4)', () => {
     const tmp = mkdtempSync(join(tmpdir(), 'mpl-gate-recorder-phase-runner-noclobber-'));
     try {

--- a/hooks/__tests__/mpl-gate-recorder.test.mjs
+++ b/hooks/__tests__/mpl-gate-recorder.test.mjs
@@ -539,6 +539,65 @@ describe('mpl-gate-recorder test-agent evidence', () => {
     }
   });
 
+  it('background phase-runner Task dispatch does NOT record anomaly or install block (codex r8)', () => {
+    // Codex r8 on PR #218: a background Task dispatch returns a handle
+    // stub, not the final assistant text. Recording it as empty_response
+    // would freeze the pipeline before the real completion is joined.
+    const tmp = mkdtempSync(join(tmpdir(), 'mpl-gate-recorder-bg-phase-runner-'));
+    try {
+      seedState(tmp);
+      const input = {
+        cwd: tmp,
+        tool_name: 'Task',
+        tool_input: {
+          subagent_type: 'mpl-phase-runner',
+          prompt: 'Execute phase-1.',
+          run_in_background: true,
+        },
+        tool_response: { handle: 'task-bg-abc123' },
+        usage: { output_tokens: 0 },
+        metrics: { tools_used: 0, duration_ms: 100 },
+      };
+      execFileSync('node', [HOOK_PATH], {
+        input: JSON.stringify(input),
+        encoding: 'utf-8',
+      });
+      const state = readState(tmp);
+      assert.equal(Array.isArray(state.subagent_return_anomalies) ? state.subagent_return_anomalies.length : 0, 0,
+        'background dispatch must NOT create anomaly entries');
+      assert.notEqual(state.session_status, 'blocked_hook',
+        'background dispatch must NOT install a block');
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('background test-agent Task dispatch does NOT record dispatched evidence (codex r8)', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'mpl-gate-recorder-bg-test-agent-'));
+    try {
+      seedState(tmp);
+      const input = {
+        cwd: tmp,
+        tool_name: 'Task',
+        tool_input: {
+          subagent_type: 'mpl-test-agent',
+          prompt: 'Verify phase-1 from the contract.',
+          run_in_background: true,
+        },
+        tool_response: { handle: 'task-bg-xyz' },
+      };
+      execFileSync('node', [HOOK_PATH], {
+        input: JSON.stringify(input),
+        encoding: 'utf-8',
+      });
+      const state = readState(tmp);
+      assert.deepEqual(state.test_agent_dispatched, {},
+        'background dispatch must NOT write evidence');
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it('phase-runner clean completion for a DIFFERENT phase does NOT clear an anomaly block (codex r7)', () => {
     // Codex r7 on PR #218: self-clear must match the blocked phase id.
     // A clean phase-runner completion for phase-2 must not clear a

--- a/hooks/__tests__/mpl-require-test-agent.test.mjs
+++ b/hooks/__tests__/mpl-require-test-agent.test.mjs
@@ -103,6 +103,60 @@ phases:
     }
   });
 
+  it('passes through background phase-runner dispatch without installing a block (codex r9 bundle)', () => {
+    // Codex r9 on PR #218: gate-recorder learned to skip background Task
+    // dispatches but require-test-agent did not, so a required phase
+    // dispatched with run_in_background:true would have its handle-stub
+    // event trigger a missing_or_invalid_test_agent_evidence block before
+    // the real completion arrived.
+    const tmp = mkdtempSync(join(tmpdir(), 'mpl-test-agent-bg-'));
+    try {
+      mkdirSync(join(tmp, '.mpl', 'mpl'), { recursive: true });
+      writeFileSync(join(tmp, '.mpl', 'state.json'), JSON.stringify({
+        schema_version: CURRENT_SCHEMA_VERSION,
+        current_phase: 'phase2-sprint',
+        test_agent_dispatched: {},
+      }));
+      writeFileSync(join(tmp, '.mpl', 'mpl', 'decomposition.yaml'), `
+phases:
+  - id: phase-1
+    phase_domain: api
+    impact:
+      modify:
+        - src/api/widgets.ts
+    interface_contract:
+      requires: []
+      produces:
+        - symbol: createWidget
+          path: src/api/widgets.ts
+    test_agent_required: true
+    test_agent_rationale: "touches a boundary"
+`);
+
+      const input = {
+        cwd: tmp,
+        tool_name: 'Task',
+        tool_input: {
+          subagent_type: 'mpl-phase-runner',
+          prompt: 'Run phase-1 and report completion.',
+          run_in_background: true,
+        },
+        tool_response: { handle: 'task-bg-abc123' },
+      };
+      const r = JSON.parse(execFileSync('node', [HOOK_PATH], {
+        input: JSON.stringify(input),
+        encoding: 'utf-8',
+      }));
+      assert.equal(r.continue, true);
+      // No block installed for a background handle.
+      const state = JSON.parse(readFileSync(join(tmp, '.mpl', 'state.json'), 'utf-8'));
+      assert.notEqual(state.session_status, 'blocked_hook',
+        'background phase-runner dispatch must NOT install a block before the real completion fires');
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it('blocks even when phase-runner self-tests have gate evidence but no independent test-agent PASS', () => {
     const tmp = mkdtempSync(join(tmpdir(), 'mpl-test-agent-self-test-'));
     try {

--- a/hooks/__tests__/mpl-require-test-agent.test.mjs
+++ b/hooks/__tests__/mpl-require-test-agent.test.mjs
@@ -103,6 +103,59 @@ phases:
     }
   });
 
+  it('string-form content on background dispatch is treated as completion, not handle stub (codex r12 [logic])', () => {
+    // Codex r12 on PR #218: `{ id: "...", content: "phase complete" }` is
+    // a valid completion shape. The handle-stub predicate must not exit
+    // early on string-form content. Required phase MUST still hit the
+    // missing-evidence gate.
+    const tmp = mkdtempSync(join(tmpdir(), 'mpl-test-agent-bg-string-content-'));
+    try {
+      mkdirSync(join(tmp, '.mpl', 'mpl'), { recursive: true });
+      writeFileSync(join(tmp, '.mpl', 'state.json'), JSON.stringify({
+        schema_version: CURRENT_SCHEMA_VERSION,
+        current_phase: 'phase2-sprint',
+        test_agent_dispatched: {},
+      }));
+      writeFileSync(join(tmp, '.mpl', 'mpl', 'decomposition.yaml'), `
+phases:
+  - id: phase-1
+    phase_domain: api
+    impact:
+      modify:
+        - src/api/widgets.ts
+    interface_contract:
+      requires: []
+      produces:
+        - symbol: createWidget
+          path: src/api/widgets.ts
+    test_agent_required: true
+    test_agent_rationale: "touches a boundary"
+`);
+
+      const input = {
+        cwd: tmp,
+        tool_name: 'Task',
+        tool_input: {
+          subagent_type: 'mpl-phase-runner',
+          prompt: 'Run phase-1.',
+          run_in_background: true,
+        },
+        // id + STRING content — NOT a handle stub, it's a real completion.
+        tool_response: { id: 'task-bg-abc', content: 'phase complete' },
+      };
+      const r = JSON.parse(execFileSync('node', [HOOK_PATH], {
+        input: JSON.stringify(input),
+        encoding: 'utf-8',
+      }));
+      // Required phase with no test-agent evidence must block — not pass through.
+      assert.equal(r.continue, false);
+      assert.equal(r.decision, 'block');
+      assert.match(r.reason, /mpl-test-agent was not dispatched/);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it('passes through background phase-runner dispatch without installing a block (codex r9 bundle)', () => {
     // Codex r9 on PR #218: gate-recorder learned to skip background Task
     // dispatches but require-test-agent did not, so a required phase

--- a/hooks/__tests__/mpl-require-test-agent.test.mjs
+++ b/hooks/__tests__/mpl-require-test-agent.test.mjs
@@ -87,6 +87,8 @@ phases:
       assert.equal(state.retry_context.phase_id, 'phase-1');
       assert.equal(state.retry_context.required_agent, 'mpl-test-agent');
       assert.match(state.resume_instruction, /Dispatch mpl-test-agent for phase-1/);
+      assert.match(state.resume_instruction, /FINAL OUTPUT RULE/);
+      assert.match(state.resume_instruction, /MUST start with ```json/);
       assert.match(state.resume_instruction, /Task\(subagent_type="mpl-test-agent"/);
       assert.match(state.resume_instruction, /Interface Contract:/);
       assert.match(state.resume_instruction, /createWidget/);
@@ -147,6 +149,7 @@ phases:
       assert.deepEqual(state.test_agent_dispatched, {});
       // The hook output stays concise; the executable recovery prompt lives in state.
       assert.match(state.resume_instruction, /independent test author/);
+      assert.match(state.resume_instruction, /No prior mpl-test-agent evidence is recorded/);
       assert.match(state.resume_instruction, /Task\(subagent_type="mpl-test-agent"/);
       assert.match(state.resume_instruction, /N\/A - not declared in decomposition\.yaml/);
     } finally {
@@ -334,6 +337,53 @@ phases:
       assert.equal(state.retry_context.override_path, '.mpl/config/test-agent-override.json');
       assert.match(state.block_reason, /recorded mpl-test-agent evidence is verdict=PASS/);
       assert.match(state.resume_instruction, /Prior evidence status:/);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('surfaces invalid test-agent diagnostics in the recovery prompt', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'mpl-test-agent-invalid-diag-'));
+    try {
+      mkdirSync(join(tmp, '.mpl', 'mpl'), { recursive: true });
+      writeFileSync(join(tmp, '.mpl', 'state.json'), JSON.stringify({
+        schema_version: CURRENT_SCHEMA_VERSION,
+        current_phase: 'phase2-sprint',
+        test_agent_dispatched: {
+          'phase-1': {
+            valid_json: false,
+            verdict: 'INVALID',
+            invalid_reason: 'missing_json_block',
+            response_len: 13426,
+            response_preview: 'Natural-language report that said tests passed.',
+          },
+        },
+      }));
+      writeFileSync(join(tmp, '.mpl', 'mpl', 'decomposition.yaml'), `
+phases:
+  - id: phase-1
+    test_agent_required: true
+`);
+
+      const input = {
+        cwd: tmp,
+        tool_name: 'Task',
+        tool_input: {
+          subagent_type: 'mpl-phase-runner',
+          prompt: 'Run phase-1 and report completion.',
+        },
+      };
+      const r = JSON.parse(execFileSync('node', [HOOK_PATH], {
+        input: JSON.stringify(input),
+        encoding: 'utf-8',
+      }));
+      assert.equal(r.continue, false);
+      const state = JSON.parse(readFileSync(join(tmp, '.mpl', 'state.json'), 'utf-8'));
+      assert.match(r.reason, /response_len=13426/);
+      assert.match(state.resume_instruction, /invalid_reason=missing_json_block/);
+      assert.match(state.resume_instruction, /response_preview=/);
+      assert.match(state.resume_instruction, /no prose outside the fence/);
+      assert.equal(state.retry_context.schema_reminder, 'Final response must be a single fenced ```json block with no prose outside it.');
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }

--- a/hooks/__tests__/mpl-subagent-anomaly.test.mjs
+++ b/hooks/__tests__/mpl-subagent-anomaly.test.mjs
@@ -1,0 +1,96 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+import {
+  appendSubagentReturnAnomaly,
+  detectSubagentReturnAnomaly,
+  extractFinalResponseText,
+  formatSubagentAnomalyMessage,
+} from '../lib/mpl-subagent-anomaly.mjs';
+import { CURRENT_SCHEMA_VERSION } from '../lib/mpl-state.mjs';
+
+function taskPayload({ response = '', toolsUsed = null, outputTokens = null, durationMs = null } = {}) {
+  return {
+    cwd: '/tmp/example',
+    tool_name: 'Task',
+    tool_input: {
+      subagent_type: 'mpl-phase-runner',
+      prompt: 'Run phase-19.',
+    },
+    tool_response: {
+      text: response,
+      usage: { output_tokens: outputTokens },
+      metrics: { tools_used: toolsUsed, duration_ms: durationMs },
+    },
+  };
+}
+
+describe('mpl-subagent-anomaly', () => {
+  it('extracts final text from common Task response shapes', () => {
+    assert.equal(extractFinalResponseText('done'), 'done');
+    assert.equal(extractFinalResponseText({ text: 'done' }), 'done');
+    assert.equal(extractFinalResponseText({ content: [{ type: 'text', text: 'done' }] }), 'done');
+    assert.equal(extractFinalResponseText({ usage: { output_tokens: 0 } }), '');
+  });
+
+  it('detects empty response after substantial tool use', () => {
+    const anomaly = detectSubagentReturnAnomaly({
+      data: taskPayload({ response: '', toolsUsed: 58, outputTokens: 0, durationMs: 55 * 60 * 1000 }),
+    });
+    assert.equal(anomaly.type, 'zero_token_after_tools');
+    assert.equal(anomaly.phase_id, 'phase-19');
+    assert.equal(anomaly.tools_used, 58);
+    assert.equal(anomaly.output_tokens, 0);
+    assert.match(formatSubagentAnomalyMessage(anomaly), /zero_token_after_tools/);
+  });
+
+  it('detects init failure when empty response has zero output and no tool use', () => {
+    const anomaly = detectSubagentReturnAnomaly({
+      data: taskPayload({ response: '', toolsUsed: 0, outputTokens: 0, durationMs: 30_000 }),
+    });
+    assert.equal(anomaly.type, 'agent_init_failure');
+  });
+
+  it('does not flag normal non-empty responses', () => {
+    const anomaly = detectSubagentReturnAnomaly({
+      data: taskPayload({ response: 'phase complete', toolsUsed: 10, outputTokens: 25 }),
+    });
+    assert.equal(anomaly, null);
+  });
+
+  it('records anomalies in state and profile JSONL', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'mpl-anomaly-'));
+    try {
+      mkdirSync(join(tmp, '.mpl'), { recursive: true });
+      writeFileSync(join(tmp, '.mpl', 'state.json'), JSON.stringify({
+        schema_version: CURRENT_SCHEMA_VERSION,
+        current_phase: 'phase2-sprint',
+      }));
+      const anomaly = {
+        timestamp: '2026-05-27T00:00:00.000Z',
+        type: 'zero_token_after_tools',
+        agent_type: 'mpl-phase-runner',
+        phase_id: 'phase-19',
+        response_len: 0,
+        output_tokens: 0,
+        tools_used: 58,
+        duration_ms: 123,
+        recommendation: 'verify',
+      };
+      appendSubagentReturnAnomaly(tmp, anomaly);
+      const state = JSON.parse(readFileSync(join(tmp, '.mpl', 'state.json'), 'utf-8'));
+      assert.equal(state.subagent_return_anomalies.length, 1);
+      assert.equal(state.subagent_return_anomalies[0].type, 'zero_token_after_tools');
+      const profile = readFileSync(
+        join(tmp, '.mpl', 'mpl', 'profile', 'subagent-return-anomalies.jsonl'),
+        'utf-8',
+      );
+      assert.match(profile, /zero_token_after_tools/);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/hooks/__tests__/mpl-subagent-anomaly.test.mjs
+++ b/hooks/__tests__/mpl-subagent-anomaly.test.mjs
@@ -36,6 +36,19 @@ describe('mpl-subagent-anomaly', () => {
     assert.equal(extractFinalResponseText({ usage: { output_tokens: 0 } }), '');
   });
 
+  it('prefers non-empty content array over an empty direct alias field (codex r3)', () => {
+    // Real shape: { text: '', content: [{type:'text', text:'<actual>'}] }
+    // Empty `text` must NOT shadow the real content array.
+    assert.equal(
+      extractFinalResponseText({ text: '', content: [{ type: 'text', text: 'real' }] }),
+      'real'
+    );
+    assert.equal(
+      extractFinalResponseText({ output: '', content: [{ type: 'text', text: 'real' }] }),
+      'real'
+    );
+  });
+
   it('detects empty response after substantial tool use', () => {
     const anomaly = detectSubagentReturnAnomaly({
       data: taskPayload({ response: '', toolsUsed: 58, outputTokens: 0, durationMs: 55 * 60 * 1000 }),

--- a/hooks/lib/mpl-subagent-anomaly.mjs
+++ b/hooks/lib/mpl-subagent-anomaly.mjs
@@ -18,6 +18,10 @@ function stringField(value) {
   return typeof value === 'string' ? value : null;
 }
 
+function nonEmptyStringField(value) {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
 function textFromContentArray(content) {
   if (!Array.isArray(content)) return null;
   const parts = [];
@@ -37,14 +41,19 @@ export function extractFinalResponseText(toolResponse) {
   if (typeof toolResponse === 'string') return toolResponse;
   if (!isPlainObject(toolResponse)) return '';
 
-  const direct = stringField(toolResponse.text)
-    ?? stringField(toolResponse.response)
-    ?? stringField(toolResponse.output)
-    ?? stringField(toolResponse.stdout)
-    ?? stringField(toolResponse.message)
-    ?? stringField(toolResponse.final_response)
-    ?? stringField(toolResponse.finalResponse)
-    ?? stringField(toolResponse.result);
+  // Codex r3 on PR #218: prefer NON-EMPTY direct fields. A response shaped
+  // like { text: '', content: [{type:'text',text:'...'}] } previously
+  // returned '' here, manufacturing a false anomaly for a valid content-
+  // array response. The content array is the canonical Task tool shape,
+  // so check it ahead of any empty direct alias.
+  const direct = nonEmptyStringField(toolResponse.text)
+    ?? nonEmptyStringField(toolResponse.response)
+    ?? nonEmptyStringField(toolResponse.output)
+    ?? nonEmptyStringField(toolResponse.stdout)
+    ?? nonEmptyStringField(toolResponse.message)
+    ?? nonEmptyStringField(toolResponse.final_response)
+    ?? nonEmptyStringField(toolResponse.finalResponse)
+    ?? nonEmptyStringField(toolResponse.result);
   if (direct !== null) return direct;
 
   const contentText = typeof toolResponse.content === 'string'

--- a/hooks/lib/mpl-subagent-anomaly.mjs
+++ b/hooks/lib/mpl-subagent-anomaly.mjs
@@ -1,0 +1,236 @@
+import { appendFileSync, existsSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import { readState, writeState } from './mpl-state.mjs';
+import { recordTelemetryError } from './mpl-profile.mjs';
+
+export const SUBAGENT_RETURN_ANOMALY_LIMIT = 20;
+const PROFILE_FILE = 'subagent-return-anomalies.jsonl';
+
+function numeric(value) {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function isPlainObject(value) {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+}
+
+function stringField(value) {
+  return typeof value === 'string' ? value : null;
+}
+
+function textFromContentArray(content) {
+  if (!Array.isArray(content)) return null;
+  const parts = [];
+  for (const item of content) {
+    if (typeof item === 'string') {
+      parts.push(item);
+      continue;
+    }
+    if (isPlainObject(item) && typeof item.text === 'string') {
+      parts.push(item.text);
+    }
+  }
+  return parts.length > 0 ? parts.join('\n') : null;
+}
+
+export function extractFinalResponseText(toolResponse) {
+  if (typeof toolResponse === 'string') return toolResponse;
+  if (!isPlainObject(toolResponse)) return '';
+
+  const direct = stringField(toolResponse.text)
+    ?? stringField(toolResponse.response)
+    ?? stringField(toolResponse.output)
+    ?? stringField(toolResponse.stdout)
+    ?? stringField(toolResponse.message)
+    ?? stringField(toolResponse.final_response)
+    ?? stringField(toolResponse.finalResponse)
+    ?? stringField(toolResponse.result);
+  if (direct !== null) return direct;
+
+  const contentText = typeof toolResponse.content === 'string'
+    ? toolResponse.content
+    : textFromContentArray(toolResponse.content);
+  if (contentText !== null) return contentText;
+
+  // A structured test-agent object is a real final response. Metadata-only
+  // objects are intentionally not stringified here; they represent "no final
+  // assistant text" for the anomaly detector.
+  if (toolResponse.phase_id || toolResponse.test_results || toolResponse.verdict) {
+    try {
+      return JSON.stringify(toolResponse);
+    } catch {
+      return '';
+    }
+  }
+  return '';
+}
+
+function findNumericByKey(value, keys, depth = 0) {
+  if (!value || depth > 4) return null;
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const found = findNumericByKey(item, keys, depth + 1);
+      if (found !== null) return found;
+    }
+    return null;
+  }
+  if (!isPlainObject(value)) return null;
+
+  for (const key of keys) {
+    const found = numeric(value[key]);
+    if (found !== null) return found;
+  }
+  for (const item of Object.values(value)) {
+    const found = findNumericByKey(item, keys, depth + 1);
+    if (found !== null) return found;
+  }
+  return null;
+}
+
+export function extractPhaseId(text) {
+  if (typeof text !== 'string') return null;
+  const match = text.match(/\bphase[-\s]?(\d+)\b/i);
+  return match ? `phase-${match[1]}` : null;
+}
+
+export function extractSubagentMetrics(data = {}) {
+  const toolResponse = data.tool_response ?? data.toolResponse ?? {};
+  const searchRoot = { data, toolResponse };
+  return {
+    output_tokens: findNumericByKey(searchRoot, [
+      'output_tokens',
+      'outputTokens',
+      'completion_tokens',
+      'completionTokens',
+      'generated_tokens',
+      'generatedTokens',
+    ]),
+    tools_used: findNumericByKey(searchRoot, [
+      'tools_used',
+      'toolsUsed',
+      'tool_count',
+      'toolCount',
+      'tool_calls',
+      'toolCalls',
+      'num_tools',
+      'numTools',
+    ]),
+    duration_ms: findNumericByKey(searchRoot, [
+      'duration_ms',
+      'durationMs',
+      'elapsed_ms',
+      'elapsedMs',
+      'latency_ms',
+      'latencyMs',
+    ]),
+  };
+}
+
+export function detectSubagentReturnAnomaly({
+  data = {},
+  agentType = '',
+  phaseId = null,
+  finalResponseText = null,
+} = {}) {
+  const toolName = String(data.tool_name || data.toolName || '');
+  if (!['Task', 'task', 'Agent', 'agent'].includes(toolName)) return null;
+
+  const toolInput = data.tool_input || data.toolInput || {};
+  const resolvedAgentType = agentType || String(toolInput.subagent_type || toolInput.subagentType || '');
+  const resolvedPhaseId = phaseId || extractPhaseId(toolInput.prompt || toolInput.description || '');
+  const toolResponse = data.tool_response ?? data.toolResponse ?? '';
+  const responseText = finalResponseText === null
+    ? extractFinalResponseText(toolResponse)
+    : String(finalResponseText || '');
+  const responseLen = responseText.length;
+  const responseBlank = responseText.trim().length === 0;
+  const metrics = extractSubagentMetrics(data);
+  const toolsUsed = metrics.tools_used;
+  const outputTokens = metrics.output_tokens;
+  const durationMs = metrics.duration_ms;
+  const substantialToolUse = typeof toolsUsed === 'number' && toolsUsed >= 5;
+  const longDuration = typeof durationMs === 'number' && durationMs >= 5 * 60 * 1000;
+  const zeroOutput = outputTokens === 0;
+
+  let type = null;
+  if (responseBlank && substantialToolUse) {
+    type = zeroOutput ? 'zero_token_after_tools' : 'empty_response_after_tools';
+  } else if (responseBlank && (zeroOutput || longDuration)) {
+    type = 'agent_init_failure';
+  } else if (responseBlank) {
+    type = 'empty_response';
+  } else if (zeroOutput && (substantialToolUse || longDuration)) {
+    type = 'zero_token_after_tools';
+  }
+
+  if (!type) return null;
+
+  return {
+    timestamp: new Date().toISOString(),
+    type,
+    agent_type: resolvedAgentType || null,
+    phase_id: resolvedPhaseId,
+    response_len: responseLen,
+    output_tokens: outputTokens,
+    tools_used: toolsUsed,
+    duration_ms: durationMs,
+    recommendation: recommendationFor(type, resolvedAgentType),
+  };
+}
+
+function recommendationFor(type, agentType) {
+  if (/mpl-test-agent$/.test(agentType || '')) {
+    return 'Re-dispatch mpl-test-agent and require a fenced JSON evidence block.';
+  }
+  if (type === 'agent_init_failure') {
+    return 'Re-dispatch the subagent; no meaningful work was reported.';
+  }
+  return 'Verify on-disk artifacts directly, then re-dispatch the subagent if the phase cannot be proven complete.';
+}
+
+export function appendSubagentReturnAnomaly(cwd, anomaly) {
+  if (!anomaly) return;
+  try {
+    const state = readState(cwd);
+    if (state) {
+      const prior = Array.isArray(state.subagent_return_anomalies)
+        ? state.subagent_return_anomalies
+        : [];
+      writeState(cwd, {
+        subagent_return_anomalies: [...prior, anomaly].slice(-SUBAGENT_RETURN_ANOMALY_LIMIT),
+      });
+    }
+  } catch (err) {
+    recordTelemetryError(cwd, 'mpl-subagent-anomaly:writeState', err, {
+      agent_type: anomaly.agent_type || null,
+      phase_id: anomaly.phase_id || null,
+      type: anomaly.type || null,
+    });
+  }
+
+  try {
+    const profileDir = join(cwd, '.mpl/mpl/profile');
+    if (!existsSync(profileDir)) mkdirSync(profileDir, { recursive: true });
+    appendFileSync(join(profileDir, PROFILE_FILE), JSON.stringify(anomaly) + '\n');
+  } catch (err) {
+    recordTelemetryError(cwd, 'mpl-subagent-anomaly:profile', err, {
+      agent_type: anomaly.agent_type || null,
+      phase_id: anomaly.phase_id || null,
+      type: anomaly.type || null,
+    });
+  }
+}
+
+export function formatSubagentAnomalyMessage(anomaly) {
+  if (!anomaly) return '';
+  const parts = [
+    `[MPL SUBAGENT RETURN ANOMALY] ${anomaly.agent_type || 'subagent'} returned ${anomaly.type}.`,
+    `phase=${anomaly.phase_id || 'unknown'}`,
+    `response_len=${anomaly.response_len}`,
+  ];
+  if (typeof anomaly.output_tokens === 'number') parts.push(`output_tokens=${anomaly.output_tokens}`);
+  if (typeof anomaly.tools_used === 'number') parts.push(`tools_used=${anomaly.tools_used}`);
+  if (typeof anomaly.duration_ms === 'number') parts.push(`duration_ms=${anomaly.duration_ms}`);
+  parts.push(`Recommendation: ${anomaly.recommendation}`);
+  return parts.join(' ');
+}

--- a/hooks/lib/mpl-test-agent-evidence.mjs
+++ b/hooks/lib/mpl-test-agent-evidence.mjs
@@ -14,6 +14,7 @@ function normalizeStatus(value) {
 // Keep enough context for debugging while preventing large sharded verifier
 // responses from bloating .mpl/state.json.
 export const TEST_AGENT_EVIDENCE_PREVIEW_LIMIT = 20;
+export const TEST_AGENT_RESPONSE_PREVIEW_LIMIT = 600;
 
 function firstJsonCandidate(text) {
   if (typeof text !== 'string') return null;
@@ -63,6 +64,12 @@ function boundedPreview(values, limit = TEST_AGENT_EVIDENCE_PREVIEW_LIMIT) {
   };
 }
 
+function responsePreview(text) {
+  const clean = String(text || '').replace(/\s+/g, ' ').trim();
+  if (clean.length <= TEST_AGENT_RESPONSE_PREVIEW_LIMIT) return clean;
+  return `${clean.slice(0, TEST_AGENT_RESPONSE_PREVIEW_LIMIT - 20).trimEnd()}... [truncated]`;
+}
+
 function coverageStatuses(rows) {
   if (!Array.isArray(rows)) return [];
   return rows.map((r) => normalizeStatus(r?.status)).filter(Boolean);
@@ -72,14 +79,17 @@ export function parseTestAgentEvidence({
   phaseId,
   prompt = '',
   response,
+  anomaly = null,
   timestamp = new Date().toISOString(),
 } = {}) {
   const responseText = typeof response === 'string' ? response : JSON.stringify(response || '');
   const parsed = parseResponseJson(response);
+  const anomalyReason = anomaly?.type ? 'empty_response_anomaly' : null;
   const base = {
     timestamp,
     prompt_len: String(prompt || '').length,
     response_len: responseText.length,
+    response_preview: responsePreview(responseText),
     valid_json: parsed.valid,
     verdict: 'INVALID',
     phase_id: phaseId || null,
@@ -96,7 +106,8 @@ export function parseTestAgentEvidence({
     command_exit_codes_nonzero_count: 0,
     command_exit_codes_truncated: false,
     bugs_found_count: null,
-    invalid_reason: parsed.reason || null,
+    invalid_reason: anomalyReason || parsed.reason || null,
+    subagent_anomaly_type: anomaly?.type || null,
   };
 
   if (!parsed.valid) return base;

--- a/hooks/lib/mpl-test-agent-evidence.mjs
+++ b/hooks/lib/mpl-test-agent-evidence.mjs
@@ -198,6 +198,11 @@ export function parseTestAgentEvidence({
   };
 
   const issues = [];
+  // Codex r4 on PR #218: a detector-flagged anomaly (zero_token_after_tools,
+  // empty_response, agent_init_failure) must not yield PASS even when the
+  // JSON parses cleanly. Keep the anomaly visible as a top-priority issue
+  // so isPassingTestAgentEvidence cannot ignore it.
+  if (anomaly?.type) issues.push(`subagent_anomaly:${anomaly.type}`);
   if (phaseId && body.phase_id && body.phase_id !== phaseId) issues.push('phase_id_mismatch');
   if (evidence.tests_total <= 0) issues.push('no_executable_tests');
   if (evidence.tests_failed > 0) issues.push('failed_tests');
@@ -212,7 +217,9 @@ export function parseTestAgentEvidence({
   if (body.verdict && normalizeStatus(body.verdict) !== 'PASS') issues.push('reported_non_pass_verdict');
 
   if (issues.length > 0) {
-    evidence.verdict = issues.includes('phase_id_mismatch') ||
+    const anomalyIssue = issues.find((i) => i.startsWith('subagent_anomaly:'));
+    evidence.verdict = anomalyIssue ||
+      issues.includes('phase_id_mismatch') ||
       issues.includes('missing_command_exit_codes') ||
       issues.includes('missing_verdict')
       ? 'INVALID'

--- a/hooks/lib/mpl-test-agent-evidence.mjs
+++ b/hooks/lib/mpl-test-agent-evidence.mjs
@@ -75,14 +75,16 @@ function hasTextBearingField(obj) {
 }
 
 function parseResponseJson(responseText) {
-  // Already-parsed test-agent body — accept directly.
-  if (responseText && typeof responseText === 'object' && !Array.isArray(responseText)
-      && (responseText.test_results || responseText.phase_id)) {
-    return { valid: true, value: responseText };
-  }
-  // Object payload that carries neither a recognized test-agent field nor
-  // any text-bearing wrapper key is structurally malformed for this hook.
-  // Preserve the historical reason so resume diagnostics keep their label.
+  // Codex r2 on PR #218: a bare object with test_results/phase_id used to
+  // bypass strict-fence enforcement, contradicting the new final-output
+  // contract. The Task tool never produces an already-parsed body; the
+  // test-agent emits a string carrying a fenced JSON block. Route every
+  // payload through extractTextFromResponse + strictFencedJsonCandidate.
+  //
+  // Object payload with no text-bearing wrapper key (no content/output/
+  // response/text in string or array form) is structurally malformed —
+  // preserve the historical reason 'missing_test_agent_fields' so the
+  // resume diagnostics keep their label.
   if (responseText && typeof responseText === 'object' && !Array.isArray(responseText)
       && !hasTextBearingField(responseText)) {
     return { valid: false, value: null, reason: 'missing_test_agent_fields' };

--- a/hooks/lib/mpl-test-agent-evidence.mjs
+++ b/hooks/lib/mpl-test-agent-evidence.mjs
@@ -16,27 +16,80 @@ function normalizeStatus(value) {
 export const TEST_AGENT_EVIDENCE_PREVIEW_LIMIT = 20;
 export const TEST_AGENT_RESPONSE_PREVIEW_LIMIT = 600;
 
-function firstJsonCandidate(text) {
-  if (typeof text !== 'string') return null;
-  const fenced = text.match(/```json\s*([\s\S]*?)```/i);
-  if (fenced) return fenced[1].trim();
-  const start = text.indexOf('{');
-  const end = text.lastIndexOf('}');
-  if (start === -1 || end === -1 || end <= start) return null;
-  return text.slice(start, end + 1);
+/**
+ * The agent prompt requires the final assistant message to be a single
+ * `json` fence with no prose before or after. Codex r1 on PR #218 noted
+ * the previous parser accepted JSON anywhere in the response (and fell
+ * back to bare braces), defeating the strict-output contract.
+ * Reject anything that does not match `\s*```json ... ```\s*` as the
+ * entire trimmed string, with a distinct invalid reason so the recovery
+ * envelope can name the precise violation.
+ */
+function strictFencedJsonCandidate(text) {
+  if (typeof text !== 'string') return { candidate: null, reason: 'missing_json_block' };
+  const trimmed = text.trim();
+  if (!trimmed) return { candidate: null, reason: 'missing_json_block' };
+  const m = trimmed.match(/^```json\s*([\s\S]*?)```$/i);
+  if (m) return { candidate: m[1].trim(), reason: null };
+  if (/```json/i.test(trimmed)) {
+    return { candidate: null, reason: 'prose_outside_json_fence' };
+  }
+  return { candidate: null, reason: 'missing_json_block' };
+}
+
+/**
+ * Extract the final assistant-text payload from a Task tool response.
+ * Codex r1 on PR #218: real Task responses arrive as
+ * `{ content: [{ type: 'text', text: '...' }, ...] }` and the previous
+ * recurse-on-string path rejected that shape as missing_test_agent_fields.
+ * Concatenate every text segment from the array; otherwise fall through
+ * to the legacy string-wrapped fields.
+ */
+function extractTextFromResponse(response) {
+  if (response == null) return '';
+  if (typeof response === 'string') return response;
+  if (Array.isArray(response)) {
+    return response
+      .map((p) => (typeof p === 'string' ? p : (p && typeof p.text === 'string' ? p.text : '')))
+      .join('\n');
+  }
+  if (typeof response === 'object') {
+    if (Array.isArray(response.content)) return extractTextFromResponse(response.content);
+    for (const key of ['content', 'output', 'response', 'text']) {
+      const nested = response[key];
+      if (typeof nested === 'string') return nested;
+      if (Array.isArray(nested)) return extractTextFromResponse(nested);
+    }
+  }
+  return '';
+}
+
+function hasTextBearingField(obj) {
+  if (!obj || typeof obj !== 'object') return false;
+  if (Array.isArray(obj.content)) return true;
+  for (const key of ['content', 'output', 'response', 'text']) {
+    const v = obj[key];
+    if (typeof v === 'string' || Array.isArray(v)) return true;
+  }
+  return false;
 }
 
 function parseResponseJson(responseText) {
-  if (responseText && typeof responseText === 'object' && !Array.isArray(responseText)) {
-    if (responseText.test_results || responseText.phase_id) {
-      return { valid: true, value: responseText };
-    }
-    const nested = responseText.content ?? responseText.output ?? responseText.response ?? responseText.text;
-    if (typeof nested === 'string') return parseResponseJson(nested);
+  // Already-parsed test-agent body — accept directly.
+  if (responseText && typeof responseText === 'object' && !Array.isArray(responseText)
+      && (responseText.test_results || responseText.phase_id)) {
+    return { valid: true, value: responseText };
+  }
+  // Object payload that carries neither a recognized test-agent field nor
+  // any text-bearing wrapper key is structurally malformed for this hook.
+  // Preserve the historical reason so resume diagnostics keep their label.
+  if (responseText && typeof responseText === 'object' && !Array.isArray(responseText)
+      && !hasTextBearingField(responseText)) {
     return { valid: false, value: null, reason: 'missing_test_agent_fields' };
   }
-  const candidate = firstJsonCandidate(String(responseText || ''));
-  if (!candidate) return { valid: false, value: null, reason: 'missing_json_block' };
+  const text = extractTextFromResponse(responseText);
+  const { candidate, reason } = strictFencedJsonCandidate(text);
+  if (!candidate) return { valid: false, value: null, reason };
   try {
     return { valid: true, value: JSON.parse(candidate) };
   } catch {

--- a/hooks/mpl-gate-recorder.mjs
+++ b/hooks/mpl-gate-recorder.mjs
@@ -393,8 +393,14 @@ try {
       }
     }
 
-    // Branch 3: phase-runner completion → sync completed_todos with disk truth
-    if (/mpl-phase-runner$/.test(agentType)) {
+    // Branch 3: phase-runner completion → sync completed_todos with disk
+    // truth. Codex r3 on PR #218: when the phase-runner returned anomalous
+    // output (empty response, zero-token-after-tools, init failure), the
+    // hook MUST NOT advance completed_todos based on a possibly-stale
+    // state-summary.md file. The anomaly is already persisted in
+    // state.subagent_return_anomalies; let the operator verify and either
+    // re-dispatch the runner or fix state by hand before counts advance.
+    if (/mpl-phase-runner$/.test(agentType) && !anomaly) {
       const diskCount = countCompletedPhases(cwd);
       const prior = state.sprint_status || {};
       if (prior.completed_todos !== diskCount) {

--- a/hooks/mpl-gate-recorder.mjs
+++ b/hooks/mpl-gate-recorder.mjs
@@ -415,10 +415,18 @@ try {
     // The anomaly is also persisted in state.subagent_return_anomalies.
     if (/mpl-phase-runner$/.test(agentType) && !isBackgroundDispatch) {
       if (anomaly) {
-        // Only install the block if there isn't already an active one we
-        // could clobber. Operators may have a more specific block already
-        // recorded (e.g. mpl-require-test-agent) — don't overwrite it.
-        if (state.session_status !== 'blocked_hook') {
+        // Only install the block when no stronger session state is
+        // already in effect. Codex r5/r10 on PR #218: do not clobber
+        // - blocked_hook (operator may have a more specific block)
+        // - paused_budget / paused_checkpoint (budget guard)
+        // - verification_hang (verification gate)
+        // - cancelled (user-cancelled run)
+        // The anomaly is still recorded in state.subagent_return_anomalies
+        // for visibility, but the session status takes precedence.
+        const installableFromStatus = state.session_status === null
+          || state.session_status === undefined
+          || state.session_status === 'active';
+        if (installableFromStatus) {
           Object.assign(patch, buildBlockedHookPatch({
             hookId: 'mpl-gate-recorder',
             phaseId: anomaly.phase_id || state.current_phase || 'unknown',

--- a/hooks/mpl-gate-recorder.mjs
+++ b/hooks/mpl-gate-recorder.mjs
@@ -45,8 +45,19 @@ const { readStdin } = await import(
 const { parseTestAgentEvidence, isPassingTestAgentEvidence } = await import(
   pathToFileURL(join(__dirname, 'lib', 'mpl-test-agent-evidence.mjs')).href
 );
+const {
+  appendSubagentReturnAnomaly,
+  detectSubagentReturnAnomaly,
+  formatSubagentAnomalyMessage,
+} = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-subagent-anomaly.mjs')).href
+);
 
-function ok() {
+function ok(systemMessage = null) {
+  if (systemMessage) {
+    console.log(JSON.stringify({ continue: true, systemMessage }));
+    return;
+  }
   console.log(JSON.stringify({ continue: true, suppressOutput: true }));
 }
 
@@ -220,7 +231,7 @@ try {
 
   const toolName = String(data.tool_name || data.toolName || '');
   const toolInput = data.tool_input || data.toolInput || {};
-  const toolResponse = data.tool_response || data.toolResponse || {};
+  const toolResponse = data.tool_response ?? data.toolResponse ?? {};
 
   // Tool response may be string or object — normalize
   const exitCode =
@@ -345,16 +356,24 @@ try {
     }
 
     const patch = {};
+    const phaseIdFromPrompt = extractPhaseId(toolInput.prompt || toolInput.description || '');
+    const anomaly = detectSubagentReturnAnomaly({
+      data,
+      agentType,
+      phaseId: phaseIdFromPrompt,
+    });
+    if (anomaly) appendSubagentReturnAnomaly(cwd, anomaly);
 
     // Branch 2: test-agent dispatch record (AD-0004 empirical gap)
     if (/mpl-test-agent$/.test(agentType)) {
-      const phaseId = extractPhaseId(toolInput.prompt || toolInput.description || '');
+      const phaseId = phaseIdFromPrompt;
       if (phaseId) {
         const dispatched = state.test_agent_dispatched || {};
         const evidence = parseTestAgentEvidence({
           phaseId,
           prompt: toolInput.prompt || toolInput.description || '',
           response: toolResponse,
+          anomaly,
         });
         dispatched[phaseId] = evidence;
         patch.test_agent_dispatched = dispatched;
@@ -386,7 +405,7 @@ try {
     if (Object.keys(patch).length > 0) {
       writeState(cwd, patch);
     }
-    ok();
+    ok(formatSubagentAnomalyMessage(anomaly));
     process.exit(0);
   }
 

--- a/hooks/mpl-gate-recorder.mjs
+++ b/hooks/mpl-gate-recorder.mjs
@@ -423,24 +423,33 @@ try {
           }));
         }
       } else {
-        // Codex r6 on PR #218: a clean re-dispatch must self-clear our
-        // own phase_runner_* block, otherwise transient anomalies leave
-        // the run permanently paused. Only clear an envelope this hook
-        // owns and whose block_code starts with phase_runner_ — never
-        // touch another hook's envelope.
+        // Codex r6/r7 on PR #218: a clean re-dispatch must self-clear
+        // our own phase_runner_* block, otherwise transient anomalies
+        // leave the run permanently paused. Only clear when ALL of:
+        //   - the block is owned by mpl-gate-recorder
+        //   - block_code starts with phase_runner_
+        //   - the clean completion is for the SAME phase that was
+        //     blocked (match state.blocked_phase or
+        //     retry_context.phase_id). A different phase's clean
+        //     completion must NOT clear another phase's anomaly block.
         if (state.session_status === 'blocked_hook'
             && state.blocked_by_hook === 'mpl-gate-recorder'
             && typeof state.block_code === 'string'
             && state.block_code.startsWith('phase_runner_')) {
-          patch.session_status = null;
-          patch.blocked_by_hook = null;
-          patch.blocked_phase = null;
-          patch.blocked_artifact = null;
-          patch.block_code = null;
-          patch.block_reason = null;
-          patch.resume_instruction = null;
-          patch.retry_context = null;
-          patch.blocked_at = null;
+          const blockedPhaseId = state.blocked_phase
+            || (state.retry_context && state.retry_context.phase_id)
+            || null;
+          if (phaseIdFromPrompt && blockedPhaseId && phaseIdFromPrompt === blockedPhaseId) {
+            patch.session_status = null;
+            patch.blocked_by_hook = null;
+            patch.blocked_phase = null;
+            patch.blocked_artifact = null;
+            patch.block_code = null;
+            patch.block_reason = null;
+            patch.resume_instruction = null;
+            patch.retry_context = null;
+            patch.blocked_at = null;
+          }
         }
         const diskCount = countCompletedPhases(cwd);
         const prior = state.sprint_status || {};

--- a/hooks/mpl-gate-recorder.mjs
+++ b/hooks/mpl-gate-recorder.mjs
@@ -423,6 +423,25 @@ try {
           }));
         }
       } else {
+        // Codex r6 on PR #218: a clean re-dispatch must self-clear our
+        // own phase_runner_* block, otherwise transient anomalies leave
+        // the run permanently paused. Only clear an envelope this hook
+        // owns and whose block_code starts with phase_runner_ — never
+        // touch another hook's envelope.
+        if (state.session_status === 'blocked_hook'
+            && state.blocked_by_hook === 'mpl-gate-recorder'
+            && typeof state.block_code === 'string'
+            && state.block_code.startsWith('phase_runner_')) {
+          patch.session_status = null;
+          patch.blocked_by_hook = null;
+          patch.blocked_phase = null;
+          patch.blocked_artifact = null;
+          patch.block_code = null;
+          patch.block_reason = null;
+          patch.resume_instruction = null;
+          patch.retry_context = null;
+          patch.blocked_at = null;
+        }
         const diskCount = countCompletedPhases(cwd);
         const prior = state.sprint_status || {};
         if (prior.completed_todos !== diskCount) {

--- a/hooks/mpl-gate-recorder.mjs
+++ b/hooks/mpl-gate-recorder.mjs
@@ -388,6 +388,7 @@ try {
       && typeof toolResponse.text !== 'string'
       && typeof toolResponse.response !== 'string'
       && typeof toolResponse.output !== 'string'
+      && typeof toolResponse.content !== 'string'
       && !Array.isArray(toolResponse.content)
     );
     const isBackgroundDispatch = isHandleStubShape;

--- a/hooks/mpl-gate-recorder.mjs
+++ b/hooks/mpl-gate-recorder.mjs
@@ -52,6 +52,9 @@ const {
 } = await import(
   pathToFileURL(join(__dirname, 'lib', 'mpl-subagent-anomaly.mjs')).href
 );
+const { buildBlockedHookPatch } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-blocked-hook.mjs')).href
+);
 
 function ok(systemMessage = null) {
   if (systemMessage) {
@@ -394,17 +397,37 @@ try {
     }
 
     // Branch 3: phase-runner completion → sync completed_todos with disk
-    // truth. Codex r3 on PR #218: when the phase-runner returned anomalous
-    // output (empty response, zero-token-after-tools, init failure), the
-    // hook MUST NOT advance completed_todos based on a possibly-stale
-    // state-summary.md file. The anomaly is already persisted in
-    // state.subagent_return_anomalies; let the operator verify and either
-    // re-dispatch the runner or fix state by hand before counts advance.
-    if (/mpl-phase-runner$/.test(agentType) && !anomaly) {
-      const diskCount = countCompletedPhases(cwd);
-      const prior = state.sprint_status || {};
-      if (prior.completed_todos !== diskCount) {
-        patch.sprint_status = { ...prior, completed_todos: diskCount };
+    // truth. Codex r3+r4 on PR #218: when the phase-runner returned
+    // anomalous output, the hook MUST NOT advance completed_todos AND
+    // MUST install a structural block (session_status='blocked_hook')
+    // so the orchestrator pauses regardless of PLAN.md / TODO state.
+    // The anomaly is also persisted in state.subagent_return_anomalies.
+    if (/mpl-phase-runner$/.test(agentType)) {
+      if (anomaly) {
+        // Only install the block if there isn't already an active one we
+        // could clobber. Operators may have a more specific block already
+        // recorded (e.g. mpl-require-test-agent) — don't overwrite it.
+        if (state.session_status !== 'blocked_hook') {
+          Object.assign(patch, buildBlockedHookPatch({
+            hookId: 'mpl-gate-recorder',
+            phaseId: anomaly.phase_id || state.current_phase || 'unknown',
+            artifact: `state.subagent_return_anomalies[${anomaly.type}]`,
+            code: `phase_runner_${anomaly.type}`,
+            reason: `mpl-phase-runner returned ${anomaly.type} (tools=${anomaly.tools_used ?? '?'}, tokens=${anomaly.output_tokens ?? '?'}). Recorded in state.subagent_return_anomalies; cannot advance until verified.`,
+            resumeInstruction: 'Verify on-disk artifacts for the phase, then either re-dispatch mpl-phase-runner or correct state by hand and clear the block.',
+            retryContext: {
+              agent_type: 'mpl-phase-runner',
+              anomaly_type: anomaly.type,
+              phase_id: anomaly.phase_id,
+            },
+          }));
+        }
+      } else {
+        const diskCount = countCompletedPhases(cwd);
+        const prior = state.sprint_status || {};
+        if (prior.completed_todos !== diskCount) {
+          patch.sprint_status = { ...prior, completed_todos: diskCount };
+        }
       }
     }
 

--- a/hooks/mpl-gate-recorder.mjs
+++ b/hooks/mpl-gate-recorder.mjs
@@ -361,15 +361,36 @@ try {
     const patch = {};
     const phaseIdFromPrompt = extractPhaseId(toolInput.prompt || toolInput.description || '');
 
-    // Codex r8 on PR #218: background Task dispatches (run_in_background:
-    // true) return a handle stub on the first PostToolUse event, not the
-    // final assistant text. The anomaly detector would classify that
-    // blank as empty_response and freeze the pipeline before the real
-    // completion is joined. Skip both anomaly recording and test-agent
-    // evidence parsing for background handles — the eventual completion
-    // event will fire this hook again with the real response.
-    const isBackgroundDispatch = toolInput?.run_in_background === true
+    // Codex r8/r11 on PR #218: background Task dispatches can deliver a
+    // handle stub on the first PostToolUse event, not the final assistant
+    // text. The anomaly detector would otherwise classify that blank as
+    // empty_response and freeze the pipeline before the real completion
+    // is joined.
+    //
+    // r11 [data-integrity]: skipping on run_in_background ALONE was too
+    // coarse — if the same hook later sees the actual completion through
+    // PostToolUse with substantive content, we still want to record
+    // test-agent evidence. So skip ONLY when run_in_background is true
+    // AND the response looks like a handle stub (object-shaped, no
+    // usable text payload). Real completion content lands in the normal
+    // anomaly + evidence pipeline.
+    const bgFlag = toolInput?.run_in_background === true
       || toolInput?.runInBackground === true;
+    const isHandleStubShape = (
+      bgFlag
+      && toolResponse !== null
+      && typeof toolResponse === 'object'
+      && !Array.isArray(toolResponse)
+      && (toolResponse.handle !== undefined
+          || toolResponse.taskId !== undefined
+          || toolResponse.task_id !== undefined
+          || toolResponse.id !== undefined)
+      && typeof toolResponse.text !== 'string'
+      && typeof toolResponse.response !== 'string'
+      && typeof toolResponse.output !== 'string'
+      && !Array.isArray(toolResponse.content)
+    );
+    const isBackgroundDispatch = isHandleStubShape;
     const anomaly = isBackgroundDispatch ? null : detectSubagentReturnAnomaly({
       data,
       agentType,

--- a/hooks/mpl-gate-recorder.mjs
+++ b/hooks/mpl-gate-recorder.mjs
@@ -360,15 +360,26 @@ try {
 
     const patch = {};
     const phaseIdFromPrompt = extractPhaseId(toolInput.prompt || toolInput.description || '');
-    const anomaly = detectSubagentReturnAnomaly({
+
+    // Codex r8 on PR #218: background Task dispatches (run_in_background:
+    // true) return a handle stub on the first PostToolUse event, not the
+    // final assistant text. The anomaly detector would classify that
+    // blank as empty_response and freeze the pipeline before the real
+    // completion is joined. Skip both anomaly recording and test-agent
+    // evidence parsing for background handles — the eventual completion
+    // event will fire this hook again with the real response.
+    const isBackgroundDispatch = toolInput?.run_in_background === true
+      || toolInput?.runInBackground === true;
+    const anomaly = isBackgroundDispatch ? null : detectSubagentReturnAnomaly({
       data,
       agentType,
       phaseId: phaseIdFromPrompt,
     });
     if (anomaly) appendSubagentReturnAnomaly(cwd, anomaly);
 
-    // Branch 2: test-agent dispatch record (AD-0004 empirical gap)
-    if (/mpl-test-agent$/.test(agentType)) {
+    // Branch 2: test-agent dispatch record (AD-0004 empirical gap).
+    // Skip background dispatches — same reasoning as the anomaly branch.
+    if (/mpl-test-agent$/.test(agentType) && !isBackgroundDispatch) {
       const phaseId = phaseIdFromPrompt;
       if (phaseId) {
         const dispatched = state.test_agent_dispatched || {};
@@ -402,7 +413,7 @@ try {
     // MUST install a structural block (session_status='blocked_hook')
     // so the orchestrator pauses regardless of PLAN.md / TODO state.
     // The anomaly is also persisted in state.subagent_return_anomalies.
-    if (/mpl-phase-runner$/.test(agentType)) {
+    if (/mpl-phase-runner$/.test(agentType) && !isBackgroundDispatch) {
       if (anomaly) {
         // Only install the block if there isn't already an active one we
         // could clobber. Operators may have a more specific block already

--- a/hooks/mpl-require-test-agent.mjs
+++ b/hooks/mpl-require-test-agent.mjs
@@ -418,6 +418,7 @@ try {
       && typeof toolResponse.text !== 'string'
       && typeof toolResponse.response !== 'string'
       && typeof toolResponse.output !== 'string'
+      && typeof toolResponse.content !== 'string'
       && !Array.isArray(toolResponse.content)
     );
     if (isHandleStubShape) {

--- a/hooks/mpl-require-test-agent.mjs
+++ b/hooks/mpl-require-test-agent.mjs
@@ -394,16 +394,36 @@ try {
     process.exit(0);
   }
 
-  // Background Task dispatches return a handle stub on the first
-  // PostToolUse event, not a real phase completion. Skip the gate until
-  // the eventual completion event arrives with the real response — same
-  // reasoning as mpl-gate-recorder's background guard (codex r8/r9 on
-  // PR #218). Treating a handle as a completed phase would otherwise
-  // install a missing_or_invalid_test_agent_evidence block before the
-  // runner has even produced final output.
-  if (toolInput?.run_in_background === true || toolInput?.runInBackground === true) {
-    ok();
-    process.exit(0);
+  // Background Task dispatches can return a handle stub on the first
+  // PostToolUse event, not a real phase completion. Skip the gate ONLY
+  // when both run_in_background is true AND the response looks like a
+  // handle stub (object with id/handle field and no text payload).
+  // Codex r8/r9 on PR #218 caught the original false-block on the stub;
+  // r11 [data-integrity] sharpened it so that an actual background
+  // completion with substantive content still gets gated. Same heuristic
+  // as mpl-gate-recorder.
+  {
+    const bgFlag = toolInput?.run_in_background === true
+      || toolInput?.runInBackground === true;
+    const toolResponse = data.tool_response ?? data.toolResponse ?? null;
+    const isHandleStubShape = (
+      bgFlag
+      && toolResponse !== null
+      && typeof toolResponse === 'object'
+      && !Array.isArray(toolResponse)
+      && (toolResponse.handle !== undefined
+          || toolResponse.taskId !== undefined
+          || toolResponse.task_id !== undefined
+          || toolResponse.id !== undefined)
+      && typeof toolResponse.text !== 'string'
+      && typeof toolResponse.response !== 'string'
+      && typeof toolResponse.output !== 'string'
+      && !Array.isArray(toolResponse.content)
+    );
+    if (isHandleStubShape) {
+      ok();
+      process.exit(0);
+    }
   }
 
   const phaseId = extractPhaseId(toolInput.prompt || toolInput.description || '');

--- a/hooks/mpl-require-test-agent.mjs
+++ b/hooks/mpl-require-test-agent.mjs
@@ -394,6 +394,18 @@ try {
     process.exit(0);
   }
 
+  // Background Task dispatches return a handle stub on the first
+  // PostToolUse event, not a real phase completion. Skip the gate until
+  // the eventual completion event arrives with the real response — same
+  // reasoning as mpl-gate-recorder's background guard (codex r8/r9 on
+  // PR #218). Treating a handle as a completed phase would otherwise
+  // install a missing_or_invalid_test_agent_evidence block before the
+  // runner has even produced final output.
+  if (toolInput?.run_in_background === true || toolInput?.runInBackground === true) {
+    ok();
+    process.exit(0);
+  }
+
   const phaseId = extractPhaseId(toolInput.prompt || toolInput.description || '');
   if (!phaseId) {
     // Non-phase task — conservatively allow.

--- a/hooks/mpl-require-test-agent.mjs
+++ b/hooks/mpl-require-test-agent.mjs
@@ -63,6 +63,21 @@ function block(reason) {
 const HOOK_ID = 'mpl-require-test-agent';
 
 function recordBlockedHook(cwd, phaseId, reason, resumeInstruction) {
+  // Codex r5 on PR #218: do not clobber an existing blocked_hook owned by
+  // a different hook. mpl-gate-recorder runs ahead of this PreToolUse
+  // hook for the same Task completion event and may have already set a
+  // higher-priority phase_runner_<anomaly> block; overwriting it would
+  // hide the structural anomaly signal and let a later test-agent PASS
+  // clear the only visible block while the anomaly remained un-recovered.
+  try {
+    const existing = readState(cwd);
+    if (existing && existing.session_status === 'blocked_hook'
+        && existing.blocked_by_hook && existing.blocked_by_hook !== HOOK_ID) {
+      return;  // defer to the more-specific existing block
+    }
+  } catch {
+    // Fall through to recordBlockedHookEnvelope, which has its own try/catch.
+  }
   recordBlockedHookEnvelope(cwd, {
     hookId: HOOK_ID,
     phaseId,

--- a/hooks/mpl-require-test-agent.mjs
+++ b/hooks/mpl-require-test-agent.mjs
@@ -74,6 +74,7 @@ function recordBlockedHook(cwd, phaseId, reason, resumeInstruction) {
       phase_id: phaseId,
       required_agent: 'mpl-test-agent',
       override_path: '.mpl/config/test-agent-override.json',
+      schema_reminder: 'Final response must be a single fenced ```json block with no prose outside it.',
     },
   });
 }
@@ -120,13 +121,28 @@ function isLegacyArrayOnlyPassEvidence(evidence) {
 
 function describePriorEvidence(prior, phaseId) {
   if (!prior) return 'but mpl-test-agent was not dispatched';
+  const len = typeof prior.response_len === 'number' ? `, response_len=${prior.response_len}` : '';
+  const anomaly = prior.subagent_anomaly_type ? `, anomaly=${prior.subagent_anomaly_type}` : '';
   const summary = `but the recorded mpl-test-agent evidence is verdict=${prior.verdict || 'UNKNOWN'} ` +
-    `(valid_json=${prior.valid_json === true}, reason=${prior.invalid_reason || 'none'})`;
+    `(valid_json=${prior.valid_json === true}, reason=${prior.invalid_reason || 'none'}${len}${anomaly})`;
   if (!isLegacyArrayOnlyPassEvidence(prior)) return summary;
 
   return `${summary}; missing scalar count fields (${missingScalarCountFields(prior).join(', ')}) ` +
     `in a pre-v0.18.7 legacy record. Re-run mpl-test-agent for ${phaseId} so MPL records ` +
     `lossless scalar counts`;
+}
+
+function formatPriorEvidenceDetails(prior) {
+  if (!prior) return 'No prior mpl-test-agent evidence is recorded.';
+  const lines = [
+    `verdict=${prior.verdict || 'UNKNOWN'}`,
+    `valid_json=${prior.valid_json === true}`,
+    `invalid_reason=${prior.invalid_reason || 'none'}`,
+  ];
+  if (typeof prior.response_len === 'number') lines.push(`response_len=${prior.response_len}`);
+  if (prior.subagent_anomaly_type) lines.push(`subagent_anomaly_type=${prior.subagent_anomaly_type}`);
+  if (prior.response_preview) lines.push(`response_preview=${JSON.stringify(prior.response_preview)}`);
+  return lines.join('\n');
 }
 
 /**
@@ -232,10 +248,19 @@ function finalizePhase(rawPhase) {
   };
 }
 
-function formatTestAgentResumeInstruction(phase, priorDescription) {
+function formatTestAgentResumeInstruction(phase, priorDescription, priorEvidence = null) {
   const domain = phase.phase_domain || 'unknown';
   return [
     `Dispatch mpl-test-agent for ${phase.id}, then retry the blocked phase transition.`,
+    '',
+    'Prior mpl-test-agent evidence diagnostics:',
+    formatPriorEvidenceDetails(priorEvidence),
+    '',
+    'FINAL OUTPUT RULE:',
+    '- The final assistant message MUST start with ```json.',
+    '- The final assistant message MUST end with the closing ``` fence.',
+    '- Do not put prose before or after the JSON block.',
+    '- Put any human-readable summary inside JSON fields only.',
     '',
     'Use this exact recovery shape:',
     'Task(subagent_type="mpl-test-agent", model="sonnet", prompt="""',
@@ -256,6 +281,7 @@ function formatTestAgentResumeInstruction(phase, priorDescription) {
     clampSnippet(phase.verification_plan || phase.success_criteria),
     '',
     'Write and run executable tests for this phase. Return valid JSON with:',
+    '- final response starts with ```json and has no prose outside the fence',
     '- verdict: "PASS" only when all checks pass',
     '- test_results.total > 0',
     '- test_results.failed == 0 and test_results.skipped == 0',
@@ -415,7 +441,7 @@ try {
       `BEFORE proceeding to the next phase. code_author == test_author is a tautology, ` +
       `not a verification (AD-0004). To bypass with user consent, add ${phaseId} to ` +
       `.mpl/config/test-agent-override.json with a reason.`;
-  const resumeInstruction = formatTestAgentResumeInstruction(phase, missingOrBad);
+  const resumeInstruction = formatTestAgentResumeInstruction(phase, missingOrBad, prior);
   recordBlockedHook(cwd, phaseId, reason, resumeInstruction);
   block(reason);
 } catch {

--- a/skills/mpl-recover/SKILL.md
+++ b/skills/mpl-recover/SKILL.md
@@ -19,6 +19,15 @@ Run:
 node hooks/lib/mpl-recover.mjs --plan
 ```
 
+When the blocking hook is unclear, trace the relevant artifact first:
+
+```bash
+node hooks/lib/mpl-hook-trace.mjs .mpl/mpl/decomposition.yaml
+```
+
+The trace distinguishes registered hooks from the hook currently blocking the
+active `blocked_hook` envelope.
+
 If the result is:
 - `no_state` or `not_blocked` → report that there is no hook block to recover.
 - `recoverable` → continue to the matching handler below.


### PR DESCRIPTION
## What

Bundles two coupled Exp22 issues — they share the gate-recorder hook payload, the test-agent evidence parser, and recovery-skill copy.

**#206 — Subagent return anomaly detection**
- `hooks/lib/mpl-subagent-anomaly.mjs` (new): classifies each Task|Agent completion as `empty_response` / `zero_token_after_tools` / `agent_init_failure` based on response length, usage tokens, tool count, duration. Persists structured entries into `state.subagent_return_anomalies` (ring-capped). Returns a formatted operator notice.
- `hooks/mpl-gate-recorder.mjs`: wires the detector + threads anomaly into the evidence parser + propagates a `systemMessage` on continue responses.
- `hooks/__tests__/mpl-subagent-anomaly.test.mjs` (new): detect / append / format across the three anomaly types and a normal run.

**#208 — Test-agent schema compliance recovery**
- `agents/mpl-test-agent.md`: final message MUST start with a `json` fence; natural language only inside JSON fields.
- `hooks/lib/mpl-test-agent-evidence.mjs`: accepts an `anomaly` arg, preserves a truncated `response_preview` (with `[truncated]` marker), and emits `invalid_reason: 'empty_response_anomaly'` for detector-flagged empty returns.
- `hooks/mpl-require-test-agent.mjs`: missing/invalid evidence now produces a resumable `blocked_hook` envelope whose `retry_context` includes the invalid reason, preview, schema reminder, and re-dispatch prompt.
- `skills/mpl-recover/SKILL.md`: documents the surfaced retry path.

Coverage in `hooks/__tests__/mpl-gate-recorder.test.mjs` and `hooks/__tests__/mpl-require-test-agent.test.mjs` (prose-only output, anomaly-flagged empty returns, response_preview truncation, re-dispatch prompt, resumable envelope).

## Why

Exp22 R7/R8 surfaced two failure modes that the current pipeline mishandled:

- Four subagent completions returned 0-token output after substantial tool activity. The hook payload had enough data to flag them, but no detector recorded them and the runs looked cleanly completed.
- 14 INVALID mpl-test-agent verdicts accumulated from prose-only responses. Some runs found real bugs but the evidence-parser dead-ended and `/mpl:mpl-resume` had no concrete retry path.

Bundling them in one PR avoids two passes over `mpl-gate-recorder.mjs` and keeps the evidence-vs-anomaly handoff atomic.

## Design

N/A — additive detector + parser strengthening. Motivation, scope, and acceptance criteria live in issues #206 and #208 (ygg-exp22 V1 execution analysis, R7+R8).

## Agent Review Status

This PR is gated on **2 unique agent reviews** (footers \`— from <agent>\`).

- [ ] from claude
- [ ] from codex

Closes #206, #208.

---
_Awaiting reviews. Merge once the gate is satisfied._