### PR TITLE
Guard gate evidence command families on state writes (#209)

### DIFF
--- a/hooks/__tests__/mpl-gate-recorder.test.mjs
+++ b/hooks/__tests__/mpl-gate-recorder.test.mjs
@@ -932,4 +932,38 @@ describe('mpl-gate-recorder Bash gate routing — release-gate vs whole-pipeline
       rmSync(tmp, { recursive: true, force: true });
     }
   });
+
+  it('recorder accepts legitimate execution wrappers (docker / kubectl / bash) — codex r6 regression guard', () => {
+    // Codex r6 on PR #219: the strict I12 head denylist must NOT apply
+    // to the recorder path. A real `docker compose run app npm test` or
+    // `bash -lc "npx playwright test"` is genuine evidence; rejecting
+    // it would corrupt the gate SSOT (older PASS staying in state, or
+    // required evidence permanently missing).
+    const cases = [
+      { command: 'docker compose run app npm test', exit_code: 0,
+        slot: 'hard2_coverage', expect_pass: true },
+      { command: 'kubectl exec pod -- npm test', exit_code: 0,
+        slot: 'hard2_coverage', expect_pass: true },
+      { command: 'bash -lc "npm test"', exit_code: 0,
+        slot: 'hard2_coverage', expect_pass: true },
+      { command: 'bash -lc "npx playwright test"', exit_code: 0,
+        slot: 'hard3_resilience', expect_pass: true },
+      { command: 'docker compose run app npm run build', exit_code: 0,
+        slot: 'hard1_baseline', expect_pass: true },
+    ];
+    for (const c of cases) {
+      const tmp = mkdtempSync(join(tmpdir(), 'mpl-gr-wrapper-'));
+      try {
+        seedState(tmp, { current_phase: 'phase3-gate' });
+        runBashHook(tmp, { command: c.command, exit_code: c.exit_code });
+        const state = readState(tmp);
+        assert.ok(state.gate_results[c.slot],
+          `command must record into ${c.slot}: ${c.command}`);
+        assert.equal(state.gate_results[c.slot].exit_code, c.exit_code);
+        assert.equal(state.gate_results[c.slot].command, c.command);
+      } finally {
+        rmSync(tmp, { recursive: true, force: true });
+      }
+    }
+  });
 });

--- a/hooks/__tests__/mpl-state-invariant.test.mjs
+++ b/hooks/__tests__/mpl-state-invariant.test.mjs
@@ -325,6 +325,54 @@ describe('I12 gate command-family mismatch (Exp22 R13 / #209)', () => {
     }
   });
 
+  it('script-interpreter eval forms (node -e, python -c) are rejected (codex r7 [data-integrity])', () => {
+    // Codex r7 on PR #219: even with the head denylist + wrapper-flag
+    // guards, a manual write like `node -e "console.log('npm test')"`
+    // would slip past because `node` was not denied AND the full
+    // command string contains the `npm test` keyword. Strict classifier
+    // is now allowlist-based: only known test/build heads.
+    for (const cmd of [
+      'node -e "console.log(\'npm test\')"',
+      'node -e "playwright"',
+      'python -c "print(\'e2e contract\')"',
+      'python3 -c "print(\'npm test\')"',
+      'ruby -e "puts \'jest\'"',
+      'perl -e "print qq{vitest}"',
+      'php -r "echo \'go test\';"',
+      'awk \'BEGIN{print "npm test"}\'',
+    ]) {
+      const r = checkInvariants({
+        gate_results: {
+          hard2_coverage: gateEntry(cmd),
+        },
+      }, { cwd: tmp, trigger: TRIGGERS.STATE_WRITE });
+      const v = r.violations.find((x) => x.id === VIOLATION_IDS.GATE_COMMAND_FAMILY_MISMATCH);
+      assert.ok(v, `script-interpreter eval form must be rejected: ${cmd}`);
+    }
+  });
+
+  it('strict classifier still accepts known gate heads on the allowlist', () => {
+    // Sanity: pnpm/yarn/npx/cargo/go all in allowlist; family regex
+    // narrows them into the right slot.
+    const cases = [
+      { command: 'pnpm test', slot: 'hard2_coverage' },
+      { command: 'yarn run test', slot: 'hard2_coverage' },
+      { command: 'pnpm run build', slot: 'hard1_baseline' },
+      { command: 'cargo test', slot: 'hard2_coverage' },
+      { command: 'cargo build', slot: 'hard1_baseline' },
+      { command: 'go test ./...', slot: 'hard2_coverage' },
+      { command: 'npx playwright test', slot: 'hard3_resilience' },
+      { command: 'tsc --noEmit', slot: 'hard1_baseline' },
+    ];
+    for (const c of cases) {
+      const r = checkInvariants({
+        gate_results: { [c.slot]: gateEntry(c.command) },
+      }, { cwd: tmp, trigger: TRIGGERS.STATE_WRITE });
+      assert.ok(!r.violations.some((v) => v.id === VIOLATION_IDS.GATE_COMMAND_FAMILY_MISMATCH),
+        `allowlisted head should pass: ${c.command}`);
+    }
+  });
+
   it('prefix wrappers with flag options still resolve to inner head (codex r5 [data-integrity])', () => {
     // Codex r5 on PR #219: `sudo -E git`, `env -u FOO git`, `time -p git`,
     // `nice -n 5 git` would all bypass denylist if the head extractor

--- a/hooks/__tests__/mpl-state-invariant.test.mjs
+++ b/hooks/__tests__/mpl-state-invariant.test.mjs
@@ -325,6 +325,29 @@ describe('I12 gate command-family mismatch (Exp22 R13 / #209)', () => {
     }
   });
 
+  it('prefix wrappers with flag options still resolve to inner head (codex r5 [data-integrity])', () => {
+    // Codex r5 on PR #219: `sudo -E git`, `env -u FOO git`, `time -p git`,
+    // `nice -n 5 git` would all bypass denylist if the head extractor
+    // stopped at `-E` / `-u` / `-p` / `-n`. Skip flag tokens after a
+    // wrapper prefix until the real executable is reached.
+    for (const cmd of [
+      'sudo -E git commit -m e2e',
+      'sudo -u root git commit -m e2e',
+      'env -u FOO git commit -m e2e',
+      'env --unset=FOO git commit -m e2e',
+      'time -p git commit -m e2e',
+      'nice -n 5 git commit -m e2e',
+    ]) {
+      const r = checkInvariants({
+        gate_results: {
+          hard3_resilience: gateEntry(cmd),
+        },
+      }, { cwd: tmp, trigger: TRIGGERS.STATE_WRITE });
+      const v = r.violations.find((x) => x.id === VIOLATION_IDS.GATE_COMMAND_FAMILY_MISMATCH);
+      assert.ok(v, `wrapper-with-flags command must be rejected: ${cmd}`);
+    }
+  });
+
   it('eval/subshell-wrapped non-gate commands are rejected (codex+claude r4 [data-integrity])', () => {
     // Codex+claude r4 on PR #219: shell-evaluation primitives (`eval`,
     // subshell `(...)`, backticks, `$(...)`) must not let git commit

--- a/hooks/__tests__/mpl-state-invariant.test.mjs
+++ b/hooks/__tests__/mpl-state-invariant.test.mjs
@@ -303,6 +303,26 @@ describe('I12 gate command-family mismatch (Exp22 R13 / #209)', () => {
     assert.ok(r.violations.some((v) => v.id === VIOLATION_IDS.GATE_COMMAND_FAMILY_MISMATCH));
   });
 
+  it('path-qualified git command still blocks (codex r1 [data-integrity])', () => {
+    // Codex r1 on PR #219: `/usr/bin/git commit -m "e2e"` would bypass
+    // the head denylist if we only matched the literal token. extractCommandHead
+    // now reduces to basename so the denylist catches it.
+    for (const cmd of [
+      '/usr/bin/git commit -m "e2e fix"',
+      '/opt/homebrew/bin/git push origin main',
+      'env VAR=1 /usr/local/bin/git tag',
+      'sudo /usr/bin/git commit -am "release"',
+    ]) {
+      const r = checkInvariants({
+        gate_results: {
+          hard3_resilience: gateEntry(cmd),
+        },
+      }, { cwd: tmp, trigger: TRIGGERS.STATE_WRITE });
+      const v = r.violations.find((x) => x.id === VIOLATION_IDS.GATE_COMMAND_FAMILY_MISMATCH);
+      assert.ok(v, `path-qualified git must still be rejected: ${cmd}`);
+    }
+  });
+
   it('wrong-family classified command also blocks (build in hard2 slot)', () => {
     const r = checkInvariants({
       gate_results: {

--- a/hooks/__tests__/mpl-state-invariant.test.mjs
+++ b/hooks/__tests__/mpl-state-invariant.test.mjs
@@ -237,6 +237,106 @@ describe('I6 phase3-gate state-write missing structured evidence', () => {
   });
 });
 
+describe('I12 gate command-family mismatch (Exp22 R13 / #209)', () => {
+  function gateEntry(command) {
+    return { command, exit_code: 0, stdout_tail: '', timestamp: 'now' };
+  }
+
+  it('valid Hard 1/2/3 commands → no violation', () => {
+    const r = checkInvariants({
+      gate_results: {
+        hard1_baseline: gateEntry('npm run build'),
+        hard2_coverage: gateEntry('npm test'),
+        hard3_resilience: gateEntry('npx playwright test'),
+      },
+    }, { cwd: tmp, trigger: TRIGGERS.STATE_WRITE });
+    assert.ok(!r.violations.some((v) => v.id === VIOLATION_IDS.GATE_COMMAND_FAMILY_MISMATCH));
+  });
+
+  it('git commit in hard2_coverage → violation names offending key+command', () => {
+    const r = checkInvariants({
+      gate_results: {
+        hard2_coverage: gateEntry('git commit -m "tests done"'),
+      },
+    }, { cwd: tmp, trigger: TRIGGERS.STATE_WRITE });
+    const v = r.violations.find((x) => x.id === VIOLATION_IDS.GATE_COMMAND_FAMILY_MISMATCH);
+    assert.ok(v, 'violation must fire');
+    assert.match(v.message, /state\.gate_results\.hard2_coverage/);
+    assert.match(v.message, /git commit/);
+    assert.equal(v.mismatches[0].gate, 'state.gate_results.hard2_coverage');
+    assert.equal(v.mismatches[0].expected_family, 'hard2_coverage');
+  });
+
+  it('git commit in hard3_resilience → violation', () => {
+    const r = checkInvariants({
+      gate_results: {
+        hard3_resilience: gateEntry('git commit -m "e2e"'),
+      },
+    }, { cwd: tmp, trigger: TRIGGERS.STATE_WRITE });
+    const v = r.violations.find((x) => x.id === VIOLATION_IDS.GATE_COMMAND_FAMILY_MISMATCH);
+    assert.ok(v);
+    assert.match(v.message, /hard3_resilience/);
+  });
+
+  it('release-scoped state.release.gate_results is also checked', () => {
+    const r = checkInvariants({
+      release: {
+        gate_results: {
+          hard2_coverage: gateEntry('echo done'),
+        },
+      },
+    }, { cwd: tmp, trigger: TRIGGERS.STATE_WRITE });
+    const v = r.violations.find((x) => x.id === VIOLATION_IDS.GATE_COMMAND_FAMILY_MISMATCH);
+    assert.ok(v);
+    assert.match(v.message, /state\.release\.gate_results\.hard2_coverage/);
+  });
+
+  it('legacy booleans true with invalid structured command still blocks', () => {
+    const r = checkInvariants({
+      gate_results: {
+        hard1_passed: true,
+        hard2_passed: true,
+        hard3_passed: true,
+        hard1_baseline: gateEntry('git commit'),
+      },
+    }, { cwd: tmp, trigger: TRIGGERS.STATE_WRITE });
+    assert.ok(r.violations.some((v) => v.id === VIOLATION_IDS.GATE_COMMAND_FAMILY_MISMATCH));
+  });
+
+  it('wrong-family classified command also blocks (build in hard2 slot)', () => {
+    const r = checkInvariants({
+      gate_results: {
+        hard2_coverage: gateEntry('npm run build'),
+      },
+    }, { cwd: tmp, trigger: TRIGGERS.STATE_WRITE });
+    const v = r.violations.find((x) => x.id === VIOLATION_IDS.GATE_COMMAND_FAMILY_MISMATCH);
+    assert.ok(v);
+    assert.equal(v.mismatches[0].classified_as, 'hard1_baseline');
+    assert.equal(v.mismatches[0].expected_family, 'hard2_coverage');
+  });
+
+  it('STOP trigger → not checked (state-write boundary only)', () => {
+    const r = checkInvariants({
+      gate_results: { hard2_coverage: gateEntry('git commit') },
+    }, { cwd: tmp, trigger: TRIGGERS.STOP });
+    assert.ok(!r.violations.some((v) => v.id === VIOLATION_IDS.GATE_COMMAND_FAMILY_MISMATCH));
+  });
+
+  it('null entry → not flagged', () => {
+    const r = checkInvariants({
+      gate_results: { hard2_coverage: null },
+    }, { cwd: tmp, trigger: TRIGGERS.STATE_WRITE });
+    assert.ok(!r.violations.some((v) => v.id === VIOLATION_IDS.GATE_COMMAND_FAMILY_MISMATCH));
+  });
+
+  it('entry without command → not flagged', () => {
+    const r = checkInvariants({
+      gate_results: { hard2_coverage: { exit_code: 0 } },
+    }, { cwd: tmp, trigger: TRIGGERS.STATE_WRITE });
+    assert.ok(!r.violations.some((v) => v.id === VIOLATION_IDS.GATE_COMMAND_FAMILY_MISMATCH));
+  });
+});
+
 describe('I7 current_phase folder lifecycle', () => {
   it('flags missing folder for concrete phase id', () => {
     const r = checkInvariants({ current_phase: 'phase-7' }, { cwd: tmp });
@@ -557,9 +657,9 @@ describe('mpl-state-invariant hook integration', () => {
 
   it('Write that ADDS structured evidence (clean transition) → silent, no I6', () => {
     // Inverse case: a Write that introduces structured evidence to a state
-    // that previously had none should NOT surface I6.
+    // that previously had none should NOT surface I6 (or I12).
     const stateJsonPath = join(tmp, '.mpl', 'state.json');
-    const ent = (e) => ({ command: 'npm test', exit_code: e, stdout_tail: '', timestamp: 'now' });
+    const ent = (cmd, e) => ({ command: cmd, exit_code: e, stdout_tail: '', timestamp: 'now' });
     writeFileSync(stateJsonPath, JSON.stringify({
       schema_version: SCHEMA_V,
       current_phase: 'phase3-gate',
@@ -569,9 +669,9 @@ describe('mpl-state-invariant hook integration', () => {
       schema_version: SCHEMA_V,
       current_phase: 'phase3-gate',
       gate_results: {
-        hard1_baseline: ent(0),
-        hard2_coverage: ent(0),
-        hard3_resilience: ent(0),
+        hard1_baseline: ent('npm run build', 0),
+        hard2_coverage: ent('npm test', 0),
+        hard3_resilience: ent('npx playwright test', 0),
       },
     };
     const stdin = JSON.stringify({

--- a/hooks/__tests__/mpl-state-invariant.test.mjs
+++ b/hooks/__tests__/mpl-state-invariant.test.mjs
@@ -342,6 +342,37 @@ describe('I12 gate command-family mismatch (Exp22 R13 / #209)', () => {
     assert.ok(!r.violations.some((v) => v.id === VIOLATION_IDS.GATE_COMMAND_FAMILY_MISMATCH));
   });
 
+  it('structured entry without command is rejected (codex r2 [data-integrity])', () => {
+    // Codex r2 on PR #219: `{ exit_code: 0 }` with no command is a valid
+    // structured entry by I6 but must NOT count as gate evidence.
+    const r = checkInvariants({
+      gate_results: {
+        hard1_baseline: { exit_code: 0 },
+        hard2_coverage: { exit_code: 0 },
+        hard3_resilience: { exit_code: 0 },
+      },
+    }, { cwd: tmp, trigger: TRIGGERS.STATE_WRITE });
+    const v = r.violations.find((x) => x.id === VIOLATION_IDS.GATE_COMMAND_FAMILY_MISMATCH);
+    assert.ok(v, 'commandless gate entries must trigger I12');
+    // All three slots must be in the mismatches list.
+    const gates = v.mismatches.map((m) => m.gate).sort();
+    assert.deepStrictEqual(gates, [
+      'state.gate_results.hard1_baseline',
+      'state.gate_results.hard2_coverage',
+      'state.gate_results.hard3_resilience',
+    ]);
+    assert.equal(v.mismatches[0].classified_as, 'missing_command');
+  });
+
+  it('blank-command structured entry is rejected', () => {
+    const r = checkInvariants({
+      gate_results: {
+        hard2_coverage: { command: '   ', exit_code: 0 },
+      },
+    }, { cwd: tmp, trigger: TRIGGERS.STATE_WRITE });
+    assert.ok(r.violations.some((v) => v.id === VIOLATION_IDS.GATE_COMMAND_FAMILY_MISMATCH));
+  });
+
   it('null entry → not flagged', () => {
     const r = checkInvariants({
       gate_results: { hard2_coverage: null },
@@ -349,11 +380,14 @@ describe('I12 gate command-family mismatch (Exp22 R13 / #209)', () => {
     assert.ok(!r.violations.some((v) => v.id === VIOLATION_IDS.GATE_COMMAND_FAMILY_MISMATCH));
   });
 
-  it('entry without command → not flagged', () => {
+  it('entry without command IS flagged (manual exit_code-only writes are not gate evidence — codex r2)', () => {
+    // Replaces the prior "not flagged" expectation. Per codex r2,
+    // commandless entries MUST be rejected — a structured shape alone
+    // without a recognized command does not constitute gate evidence.
     const r = checkInvariants({
       gate_results: { hard2_coverage: { exit_code: 0 } },
     }, { cwd: tmp, trigger: TRIGGERS.STATE_WRITE });
-    assert.ok(!r.violations.some((v) => v.id === VIOLATION_IDS.GATE_COMMAND_FAMILY_MISMATCH));
+    assert.ok(r.violations.some((v) => v.id === VIOLATION_IDS.GATE_COMMAND_FAMILY_MISMATCH));
   });
 });
 

--- a/hooks/__tests__/mpl-state-invariant.test.mjs
+++ b/hooks/__tests__/mpl-state-invariant.test.mjs
@@ -303,6 +303,28 @@ describe('I12 gate command-family mismatch (Exp22 R13 / #209)', () => {
     assert.ok(r.violations.some((v) => v.id === VIOLATION_IDS.GATE_COMMAND_FAMILY_MISMATCH));
   });
 
+  it('shell-wrapped non-gate commands are rejected (codex r3 [data-integrity])', () => {
+    // Codex r3 on PR #219: `bash -lc "git commit -m e2e"` would otherwise
+    // classify as hard3_resilience via the embedded `e2e` keyword. Adding
+    // shell wrappers to the denylist forces the classifier to return null
+    // for any bash/sh/zsh/... -wrapped command.
+    for (const cmd of [
+      'bash -lc "git commit -m e2e"',
+      'bash -lc "echo e2e contract"',
+      'sh -c "git push origin main"',
+      '/bin/zsh -lc "playwright test"',
+      'dash -c "echo skipped"',
+    ]) {
+      const r = checkInvariants({
+        gate_results: {
+          hard3_resilience: gateEntry(cmd),
+        },
+      }, { cwd: tmp, trigger: TRIGGERS.STATE_WRITE });
+      const v = r.violations.find((x) => x.id === VIOLATION_IDS.GATE_COMMAND_FAMILY_MISMATCH);
+      assert.ok(v, `shell-wrapped command must be rejected: ${cmd}`);
+    }
+  });
+
   it('path-qualified git command still blocks (codex r1 [data-integrity])', () => {
     // Codex r1 on PR #219: `/usr/bin/git commit -m "e2e"` would bypass
     // the head denylist if we only matched the literal token. extractCommandHead

--- a/hooks/__tests__/mpl-state-invariant.test.mjs
+++ b/hooks/__tests__/mpl-state-invariant.test.mjs
@@ -325,6 +325,27 @@ describe('I12 gate command-family mismatch (Exp22 R13 / #209)', () => {
     }
   });
 
+  it('eval/subshell-wrapped non-gate commands are rejected (codex+claude r4 [data-integrity])', () => {
+    // Codex+claude r4 on PR #219: shell-evaluation primitives (`eval`,
+    // subshell `(...)`, backticks, `$(...)`) must not let git commit
+    // smuggle the e2e keyword into hard3_resilience.
+    for (const cmd of [
+      'eval "git commit -m e2e"',
+      'eval git push',
+      '(git commit -m e2e)',
+      '`git commit -m e2e`',
+      '$(git commit -m e2e)',
+    ]) {
+      const r = checkInvariants({
+        gate_results: {
+          hard3_resilience: gateEntry(cmd),
+        },
+      }, { cwd: tmp, trigger: TRIGGERS.STATE_WRITE });
+      const v = r.violations.find((x) => x.id === VIOLATION_IDS.GATE_COMMAND_FAMILY_MISMATCH);
+      assert.ok(v, `wrapped command must be rejected: ${cmd}`);
+    }
+  });
+
   it('path-qualified git command still blocks (codex r1 [data-integrity])', () => {
     // Codex r1 on PR #219: `/usr/bin/git commit -m "e2e"` would bypass
     // the head denylist if we only matched the literal token. extractCommandHead

--- a/hooks/lib/mpl-gate-classify.mjs
+++ b/hooks/lib/mpl-gate-classify.mjs
@@ -74,6 +74,11 @@ const NON_GATE_HEAD_COMMANDS = new Set([
   // (it sees the actual command executed); manual writes that go
   // through a wrapper are not credible gate evidence.
   'sh', 'bash', 'zsh', 'fish', 'dash', 'ksh', 'csh', 'tcsh',
+  // Shell-evaluation primitives — codex+claude r4 on PR #219. `eval`
+  // takes a string and evaluates it as a shell command, the same
+  // bypass shape as r3's `bash -c`. Subshell openers `(` are normalized
+  // out by extractCommandHead so they reach this set as the inner head.
+  'eval',
 ]);
 
 // Tokens commonly used as prefixes that should be peeled before the
@@ -87,6 +92,14 @@ function extractCommandHead(command) {
   // `/usr/bin/git` are recognized as `git` against the denylist.
   // Codex r1 on PR #219: without basename reduction, an absolute-path
   // git invocation would bypass the gate-family invariant.
+  //
+  // Codex+claude r4 on PR #219: subshell/eval prefixes (`(git ...)`,
+  // `` `git ...` ``, `$(git ...)`) must also be normalized so the inner
+  // head reaches the denylist check. Strip any leading shell-opener
+  // characters from the first significant token before basename
+  // reduction. This is a heuristic — full shell parsing is out of
+  // scope, and the right answer for "command i don't understand" is
+  // null (classifier returns null → I12 rejects unclassified entries).
   const tokens = command.trim().split(/\s+/);
   let i = 0;
   while (i < tokens.length) {
@@ -96,9 +109,13 @@ function extractCommandHead(command) {
     if (/^[A-Z_][A-Z0-9_]*=/i.test(t)) { i++; continue; }
     const lower = t.toLowerCase();
     if (COMMAND_PREFIX_TOKENS.has(lower)) { i++; continue; }
-    // Take basename: last `/`-separated component. Strip leading `./`
-    // first so `./scripts/run.sh` reduces to `run.sh`.
-    const stripped = lower.replace(/^\.\//, '');
+    // Strip leading subshell / eval-opener chars: `(`, `` ` ``, `$(`,
+    // and any trailing `;` from a previous statement.
+    const stripped = lower
+      .replace(/^[`(]+/, '')
+      .replace(/^\$\(/, '')
+      .replace(/^\.\//, '');
+    if (!stripped) { i++; continue; }
     const lastSlash = stripped.lastIndexOf('/');
     return lastSlash === -1 ? stripped : stripped.slice(lastSlash + 1);
   }

--- a/hooks/lib/mpl-gate-classify.mjs
+++ b/hooks/lib/mpl-gate-classify.mjs
@@ -139,15 +139,46 @@ function extractCommandHead(command) {
   return '';
 }
 
+/**
+ * Strict classifier — used by the I12 state-invariant on manual
+ * `state.gate_results` writes. Rejects head-denylisted, empty-head, and
+ * wrapper-with-flag forms (codex r1/r3/r4/r5 on PR #219).
+ *
+ * Recorder events should NOT use this — they need to accept legitimate
+ * execution wrappers (`docker compose run app npm test`, `kubectl exec
+ * pod -- npm test`, `bash -lc "npm test"`) that the strict path denies.
+ * Codex r6 on PR #219 caught the recorder regression. Use
+ * `classifyRecordedCommand` for that path.
+ */
 export function classifyGateCommand(command) {
   if (typeof command !== 'string' || !command.trim()) return null;
   const head = extractCommandHead(command);
-  // Fail closed if extractCommandHead couldn't resolve a real head —
-  // either nothing significant was found OR it explicitly returned ''
-  // to signal a wrapper-with-flag form (codex r5). Empty head must
-  // NOT fall through to the full-string family regex.
   if (!head) return null;
   if (NON_GATE_HEAD_COMMANDS.has(head)) return null;
+  return matchFamilyRegex(command);
+}
+
+/**
+ * Loose classifier — used by `mpl-gate-recorder` on real Bash
+ * PostToolUse events. Matches family regexes against the full command
+ * regardless of head. Recovers the pre-refactor behavior of the
+ * recorder: a `docker compose run app npm test` invocation records as
+ * hard2_coverage; a `bash -lc "npx playwright test"` records as
+ * hard3_resilience. Commands that mention no family keyword at all
+ * (e.g. `git commit`) still classify as null — the recorder didn't
+ * record those either, so no regression.
+ *
+ * The strict head-denylist intentionally does NOT apply here because
+ * an operator running a real test inside a wrapper is legitimate
+ * coverage evidence; the strict denylist exists only to stop manual
+ * `state.json` patches from masquerading as evidence.
+ */
+export function classifyRecordedCommand(command) {
+  if (typeof command !== 'string' || !command.trim()) return null;
+  return matchFamilyRegex(command);
+}
+
+function matchFamilyRegex(command) {
   const c = command.trim().toLowerCase();
   if (HARD3_PATTERNS.some((re) => re.test(c))) return 'hard3_resilience';
   if (HARD2_PATTERNS.some((re) => re.test(c))) return 'hard2_coverage';

--- a/hooks/lib/mpl-gate-classify.mjs
+++ b/hooks/lib/mpl-gate-classify.mjs
@@ -74,10 +74,12 @@ const NON_GATE_HEAD_COMMANDS = new Set([
 const COMMAND_PREFIX_TOKENS = new Set(['sudo', 'time', 'nice', 'env', 'exec']);
 
 function extractCommandHead(command) {
-  // First, strip the command up to the first real shell word. We don't
-  // try to parse full shell syntax — just enough to find the head
-  // program name. Leading env-var assignments (FOO=bar npm test) and
-  // common prefix tokens (sudo, time) are skipped.
+  // Find the head program after skipping env-var assignments
+  // (FOO=bar npm test) and common prefix tokens (sudo, time). Reduce
+  // the head to its BASENAME so path-qualified invocations like
+  // `/usr/bin/git` are recognized as `git` against the denylist.
+  // Codex r1 on PR #219: without basename reduction, an absolute-path
+  // git invocation would bypass the gate-family invariant.
   const tokens = command.trim().split(/\s+/);
   let i = 0;
   while (i < tokens.length) {
@@ -85,8 +87,13 @@ function extractCommandHead(command) {
     if (!t) { i++; continue; }
     // env assignment "VAR=value"
     if (/^[A-Z_][A-Z0-9_]*=/i.test(t)) { i++; continue; }
-    if (COMMAND_PREFIX_TOKENS.has(t.toLowerCase())) { i++; continue; }
-    return t.toLowerCase().replace(/^\.\//, '');
+    const lower = t.toLowerCase();
+    if (COMMAND_PREFIX_TOKENS.has(lower)) { i++; continue; }
+    // Take basename: last `/`-separated component. Strip leading `./`
+    // first so `./scripts/run.sh` reduces to `run.sh`.
+    const stripped = lower.replace(/^\.\//, '');
+    const lastSlash = stripped.lastIndexOf('/');
+    return lastSlash === -1 ? stripped : stripped.slice(lastSlash + 1);
   }
   return '';
 }

--- a/hooks/lib/mpl-gate-classify.mjs
+++ b/hooks/lib/mpl-gate-classify.mjs
@@ -97,20 +97,37 @@ function extractCommandHead(command) {
   // `` `git ...` ``, `$(git ...)`) must also be normalized so the inner
   // head reaches the denylist check. Strip any leading shell-opener
   // characters from the first significant token before basename
-  // reduction. This is a heuristic — full shell parsing is out of
-  // scope, and the right answer for "command i don't understand" is
-  // null (classifier returns null → I12 rejects unclassified entries).
+  // reduction.
+  //
+  // Codex r5 on PR #219: after consuming a wrapper prefix token, the
+  // next token may be a flag (`sudo -E`, `env -u FOO`, `time -p`,
+  // `nice -n 5`). Skip flag tokens (starting with `-`) until we reach
+  // a real executable head.
+  //
+  // This is a heuristic — full shell parsing is out of scope, and the
+  // right answer for "command i don't understand" is null (classifier
+  // returns null → I12 rejects unclassified entries).
   const tokens = command.trim().split(/\s+/);
   let i = 0;
+  let sawPrefix = false;
   while (i < tokens.length) {
     const t = tokens[i];
     if (!t) { i++; continue; }
     // env assignment "VAR=value"
     if (/^[A-Z_][A-Z0-9_]*=/i.test(t)) { i++; continue; }
     const lower = t.toLowerCase();
-    if (COMMAND_PREFIX_TOKENS.has(lower)) { i++; continue; }
-    // Strip leading subshell / eval-opener chars: `(`, `` ` ``, `$(`,
-    // and any trailing `;` from a previous statement.
+    if (COMMAND_PREFIX_TOKENS.has(lower)) { sawPrefix = true; i++; continue; }
+    // Codex r5: after a wrapper prefix (sudo, env, time, nice, ...),
+    // any `-`-prefixed flag token is ambiguous — `-E` takes no value,
+    // `-u` takes one, etc. Heuristic flag-value consumption is wrong in
+    // both directions. Fail closed: return empty head so the classifier
+    // returns null and I12 rejects the entry. Manual gate evidence
+    // doesn't need wrapper flags; recorder-produced commands never
+    // wrap with flags either, so this denial is safe.
+    if (sawPrefix && t.startsWith('-')) {
+      return '';
+    }
+    // Strip leading subshell / eval-opener chars: `(`, `` ` ``, `$(`.
     const stripped = lower
       .replace(/^[`(]+/, '')
       .replace(/^\$\(/, '')
@@ -125,6 +142,11 @@ function extractCommandHead(command) {
 export function classifyGateCommand(command) {
   if (typeof command !== 'string' || !command.trim()) return null;
   const head = extractCommandHead(command);
+  // Fail closed if extractCommandHead couldn't resolve a real head —
+  // either nothing significant was found OR it explicitly returned ''
+  // to signal a wrapper-with-flag form (codex r5). Empty head must
+  // NOT fall through to the full-string family regex.
+  if (!head) return null;
   if (NON_GATE_HEAD_COMMANDS.has(head)) return null;
   const c = command.trim().toLowerCase();
   if (HARD3_PATTERNS.some((re) => re.test(c))) return 'hard3_resilience';

--- a/hooks/lib/mpl-gate-classify.mjs
+++ b/hooks/lib/mpl-gate-classify.mjs
@@ -139,10 +139,35 @@ function extractCommandHead(command) {
   return '';
 }
 
+// Strict-mode head allowlist — codex r7 on PR #219 [data-integrity].
+// Manual `state.gate_results` writes must use a command whose HEAD is a
+// recognized test runner / build tool. Anything else — even with a
+// matching family keyword inside an argument (`node -e "npm test"`,
+// `python -c "print('e2e')"`) — fails closed. This is much tighter than
+// a denylist; it explicitly enumerates the only heads we accept as
+// manual gate evidence. The recorder path (`classifyRecordedCommand`)
+// still uses regex-only matching to keep wrapper invocations working.
+const STRICT_GATE_HEAD_ALLOWLIST = new Set([
+  // Hard 1 — lint / typecheck / build / compile
+  'tsc', 'eslint', 'ruff', 'mypy',
+  // Hard 2 — unit / integration test runners
+  'vitest', 'jest', 'pytest', 'mocha',
+  // Hard 3 — e2e / contract
+  'playwright', 'cypress', 'wdio',
+  // Package-manager invocations cover most build+test+e2e cases.
+  // The family regex still narrows: `npm test` → hard2, `npm run build`
+  // → hard1, `npm run test:e2e` → hard3.
+  'npm', 'pnpm', 'yarn', 'npx', 'pnpx',
+  // Compiled / system languages
+  'cargo', 'go',
+]);
+
 /**
  * Strict classifier — used by the I12 state-invariant on manual
- * `state.gate_results` writes. Rejects head-denylisted, empty-head, and
- * wrapper-with-flag forms (codex r1/r3/r4/r5 on PR #219).
+ * `state.gate_results` writes. The command's HEAD must be in the
+ * strict allowlist of recognized gate-evidence binaries; rejects
+ * head-denylisted, empty-head, and wrapper-with-flag forms (codex
+ * r1/r3/r4/r5/r7 on PR #219).
  *
  * Recorder events should NOT use this — they need to accept legitimate
  * execution wrappers (`docker compose run app npm test`, `kubectl exec
@@ -155,6 +180,12 @@ export function classifyGateCommand(command) {
   const head = extractCommandHead(command);
   if (!head) return null;
   if (NON_GATE_HEAD_COMMANDS.has(head)) return null;
+  // Codex r7: even with a non-denied head, the head MUST be in the
+  // explicit allowlist. `node`, `python`, `ruby`, `perl`, etc. are NOT
+  // accepted manual gate evidence because their `-e`/`-c` forms can
+  // contain arbitrary text that the family regex would erroneously
+  // match.
+  if (!STRICT_GATE_HEAD_ALLOWLIST.has(head)) return null;
   return matchFamilyRegex(command);
 }
 

--- a/hooks/lib/mpl-gate-classify.mjs
+++ b/hooks/lib/mpl-gate-classify.mjs
@@ -1,0 +1,115 @@
+/**
+ * Shared Bash command → gate-family classifier.
+ *
+ * AD-0006 / P0-1 (#102): the Hard 1/2/3 gates each expect a specific kind
+ * of evidence. We need to know whether a command belongs to:
+ *   hard1_baseline   — lint / typecheck / build / compile
+ *   hard2_coverage   — unit / integration test runners
+ *   hard3_resilience — E2E / contract / a11y / runtime resilience
+ *
+ * Two consumers use this:
+ *  1. `hooks/mpl-gate-recorder.mjs` — to route observed Bash completions
+ *     into the matching `gate_results.hardN_*` slot.
+ *  2. `hooks/lib/mpl-state-invariant.mjs` (I12 — Exp22 R13 / #209) — to
+ *     reject manual state.json writes that put e.g. `git commit ...` into
+ *     `hard2_coverage.command`.
+ *
+ * Returns one of `'hard1_baseline'`, `'hard2_coverage'`,
+ * `'hard3_resilience'`, or `null` when no family matches.
+ */
+
+const HARD3_PATTERNS = [
+  /\bplaywright\b/,
+  /\bcypress\b/,
+  /\be2e\b/,
+  /\bcontract\b/,
+  /jest.*\be2e\b/,
+  /wdio/,
+];
+
+const HARD2_PATTERNS = [
+  /\bpnpm\s+(run\s+)?test\b/,
+  /\bnpm\s+(run\s+)?test\b/,
+  /\byarn\s+(run\s+)?test\b/,
+  /\bvitest\b/,
+  /\bjest\b/,
+  /\bcargo\s+test\b/,
+  /\bpytest\b/,
+  /\bgo\s+test\b/,
+  /\bmocha\b/,
+];
+
+const HARD1_PATTERNS = [
+  /\bpnpm\s+(run\s+)?lint\b/,
+  /\bnpm\s+(run\s+)?lint\b/,
+  /\bpnpm\s+(run\s+)?build\b/,
+  /\bnpm\s+(run\s+)?build\b/,
+  /\bpnpm\s+(run\s+)?typecheck\b/,
+  /\btsc\b/,
+  /\beslint\b/,
+  /\bcargo\s+clippy\b/,
+  /\bcargo\s+build\b/,
+  /\bcargo\s+check\b/,
+  /\bruff\b/,
+  /\bmypy\b/,
+  /\bgo\s+build\b/,
+  /\bgo\s+vet\b/,
+];
+
+// Commands whose HEAD (first non-prefix word) is never gate evidence.
+// Without this, a `git commit -m "e2e tests done"` would match the
+// hard3 `\be2e\b` keyword by accident and slip past I12. We reject the
+// command at the head before falling through to family patterns.
+const NON_GATE_HEAD_COMMANDS = new Set([
+  'git', 'gh', 'echo', 'printf', 'cat', 'ls', 'cd', 'pwd', 'mkdir',
+  'rm', 'mv', 'cp', 'touch', 'chmod', 'chown', 'ln',
+  'curl', 'wget', 'ping', 'ssh', 'scp', 'rsync',
+  'sleep', 'true', 'false',
+  'docker', 'kubectl', 'helm',
+  'open',
+]);
+
+// Tokens commonly used as prefixes that should be peeled before the
+// "head command" check — `sudo npm test` is still a test command.
+const COMMAND_PREFIX_TOKENS = new Set(['sudo', 'time', 'nice', 'env', 'exec']);
+
+function extractCommandHead(command) {
+  // First, strip the command up to the first real shell word. We don't
+  // try to parse full shell syntax — just enough to find the head
+  // program name. Leading env-var assignments (FOO=bar npm test) and
+  // common prefix tokens (sudo, time) are skipped.
+  const tokens = command.trim().split(/\s+/);
+  let i = 0;
+  while (i < tokens.length) {
+    const t = tokens[i];
+    if (!t) { i++; continue; }
+    // env assignment "VAR=value"
+    if (/^[A-Z_][A-Z0-9_]*=/i.test(t)) { i++; continue; }
+    if (COMMAND_PREFIX_TOKENS.has(t.toLowerCase())) { i++; continue; }
+    return t.toLowerCase().replace(/^\.\//, '');
+  }
+  return '';
+}
+
+export function classifyGateCommand(command) {
+  if (typeof command !== 'string' || !command.trim()) return null;
+  const head = extractCommandHead(command);
+  if (NON_GATE_HEAD_COMMANDS.has(head)) return null;
+  const c = command.trim().toLowerCase();
+  if (HARD3_PATTERNS.some((re) => re.test(c))) return 'hard3_resilience';
+  if (HARD2_PATTERNS.some((re) => re.test(c))) return 'hard2_coverage';
+  if (HARD1_PATTERNS.some((re) => re.test(c))) return 'hard1_baseline';
+  return null;
+}
+
+/**
+ * Return `true` when `command` is in the family expected by `gateKey`.
+ * Unclassified commands (classifier returns null) are NOT accepted —
+ * Exp22 R13 specifically caught `git commit` masquerading as coverage
+ * evidence. Manual writers MUST use a recognized command family or
+ * record evidence through the recorder hook itself.
+ */
+export function commandMatchesGate(gateKey, command) {
+  const family = classifyGateCommand(command);
+  return family !== null && family === gateKey;
+}

--- a/hooks/lib/mpl-gate-classify.mjs
+++ b/hooks/lib/mpl-gate-classify.mjs
@@ -67,6 +67,13 @@ const NON_GATE_HEAD_COMMANDS = new Set([
   'sleep', 'true', 'false',
   'docker', 'kubectl', 'helm',
   'open',
+  // Shell wrappers — codex r3 on PR #219 [data-integrity]. A manual
+  // gate-evidence write like `bash -lc "git commit -m e2e"` would
+  // otherwise classify as hard3_resilience via the embedded `e2e`
+  // keyword. The recorder hook never records shell-wrapped commands
+  // (it sees the actual command executed); manual writes that go
+  // through a wrapper are not credible gate evidence.
+  'sh', 'bash', 'zsh', 'fish', 'dash', 'ksh', 'csh', 'tcsh',
 ]);
 
 // Tokens commonly used as prefixes that should be peeled before the

--- a/hooks/lib/mpl-state-invariant.mjs
+++ b/hooks/lib/mpl-state-invariant.mjs
@@ -20,6 +20,7 @@ import { existsSync, readdirSync, statSync } from 'fs';
 import { join } from 'path';
 
 import { CURRENT_SCHEMA_VERSION } from './mpl-state.mjs';
+import { classifyGateCommand } from './mpl-gate-classify.mjs';
 
 // Re-export so consumers (and the H8 single-source-of-truth test) can
 // confirm both modules agree on the version constant via a single
@@ -56,6 +57,11 @@ export const VIOLATION_IDS = Object.freeze({
   SESSION_STATUS_INVALID: 'I9',
   COMPLETION_EXECUTION_STALE: 'I10',
   BLOCKED_HOOK_STALE: 'I11',
+  // Exp22 R13 / #209: a hard{1,2,3}_baseline/coverage/resilience entry's
+  // `command` must belong to the matching gate family (lint/build for
+  // H1, test for H2, e2e/contract for H3). Manual state.json patches
+  // putting `git commit` into hard2_coverage are rejected here.
+  GATE_COMMAND_FAMILY_MISMATCH: 'I12',
 });
 
 const ACTIVE_PHASES = new Set([
@@ -348,6 +354,57 @@ function checkI11(state) {
     { missing });
 }
 
+function checkGateFamilyForBlock(block, label) {
+  // A "structured gate entry" carries { command, exit_code, ... }. Check
+  // that the recorded `command` belongs to the family this slot expects.
+  // mpl-gate-recorder produces commands the classifier recognizes; manual
+  // patches that put unrelated commands here (Exp22 R13: `git commit` in
+  // hard2_coverage) are rejected.
+  if (!block || typeof block !== 'object') return [];
+  const slots = [
+    ['hard1_baseline', 'hard1_baseline'],
+    ['hard2_coverage', 'hard2_coverage'],
+    ['hard3_resilience', 'hard3_resilience'],
+  ];
+  const issues = [];
+  for (const [slot, expectedFamily] of slots) {
+    const entry = block[slot];
+    if (!entry || typeof entry !== 'object') continue;
+    const command = entry.command;
+    if (typeof command !== 'string' || !command.trim()) continue;
+    const family = classifyGateCommand(command);
+    if (family !== expectedFamily) {
+      issues.push({
+        gate: `${label}.${slot}`,
+        command,
+        classified_as: family ?? 'unclassified',
+        expected_family: expectedFamily,
+      });
+    }
+  }
+  return issues;
+}
+
+function checkI12(state, trigger) {
+  // Exp22 R13 / #209. Surface on STATE_WRITE so manual patches that try
+  // to land malformed evidence are caught at the write boundary.
+  if (trigger !== TRIGGERS.STATE_WRITE) return null;
+  const issues = [
+    ...checkGateFamilyForBlock(state?.gate_results, 'state.gate_results'),
+    ...checkGateFamilyForBlock(state?.release?.gate_results, 'state.release.gate_results'),
+  ];
+  if (issues.length === 0) return null;
+  const messages = issues
+    .map((x) => `${x.gate}.command='${x.command}' (classified as ${x.classified_as}, expected ${x.expected_family})`);
+  return v(VIOLATION_IDS.GATE_COMMAND_FAMILY_MISMATCH,
+    `Gate evidence command family mismatch: ${messages.join('; ')}. ` +
+      `Hard 1 expects lint/typecheck/build/compile; Hard 2 expects test runner; ` +
+      `Hard 3 expects e2e/contract/a11y. Manual state.json patches MUST use a ` +
+      `recognized command, or record evidence by running the verification command ` +
+      `(mpl-gate-recorder hook auto-routes).`,
+    { mismatches: issues });
+}
+
 /* ────────────────────────── aggregator ──────────────────────────────────── */
 
 /**
@@ -377,6 +434,7 @@ export function checkInvariants(state, opts = {}) {
     () => checkI9(state),
     () => checkI10(state),
     () => checkI11(state),
+    () => checkI12(state, trigger),
   ];
 
   const violations = [];

--- a/hooks/lib/mpl-state-invariant.mjs
+++ b/hooks/lib/mpl-state-invariant.mjs
@@ -360,6 +360,11 @@ function checkGateFamilyForBlock(block, label) {
   // mpl-gate-recorder produces commands the classifier recognizes; manual
   // patches that put unrelated commands here (Exp22 R13: `git commit` in
   // hard2_coverage) are rejected.
+  //
+  // Codex r2 on PR #219: a structured entry with a numeric exit_code but
+  // NO command is also a violation — manual `{exit_code: 0}` writes can
+  // otherwise claim a verified gate without any recorded command family.
+  // Treat missing/blank command as the strongest mismatch ("absent").
   if (!block || typeof block !== 'object') return [];
   const slots = [
     ['hard1_baseline', 'hard1_baseline'],
@@ -371,7 +376,15 @@ function checkGateFamilyForBlock(block, label) {
     const entry = block[slot];
     if (!entry || typeof entry !== 'object') continue;
     const command = entry.command;
-    if (typeof command !== 'string' || !command.trim()) continue;
+    if (typeof command !== 'string' || !command.trim()) {
+      issues.push({
+        gate: `${label}.${slot}`,
+        command: command === undefined ? '(missing)' : String(command),
+        classified_as: 'missing_command',
+        expected_family: expectedFamily,
+      });
+      continue;
+    }
     const family = classifyGateCommand(command);
     if (family !== expectedFamily) {
       issues.push({

--- a/hooks/mpl-gate-recorder.mjs
+++ b/hooks/mpl-gate-recorder.mjs
@@ -55,6 +55,9 @@ const {
 const { buildBlockedHookPatch } = await import(
   pathToFileURL(join(__dirname, 'lib', 'mpl-blocked-hook.mjs')).href
 );
+const { classifyGateCommand } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-gate-classify.mjs')).href
+);
 
 function ok(systemMessage = null) {
   if (systemMessage) {
@@ -72,57 +75,16 @@ function ok(systemMessage = null) {
  *   hard2_coverage  — unit/integration test commands
  *   hard3_resilience — e2e/playwright/contract/a11y test commands
  *
+ * The actual pattern lists live in hooks/lib/mpl-gate-classify.mjs so the
+ * state-invariant (I12) can apply the SAME family check on proposed
+ * manual writes to state.gate_results.
+ *
  * Users can override by putting a `.mpl/verify.sh` that emits exit codes tagged
  * via the `MPL_GATE=<name>` environment variable; this heuristic is the fallback
  * when no verify.sh is in use.
  */
-function classifyGate(command) {
-  if (typeof command !== 'string' || !command.trim()) return null;
-  const c = command.trim().toLowerCase();
-
-  const hard3Patterns = [
-    /\bplaywright\b/,
-    /\bcypress\b/,
-    /\be2e\b/,
-    /\bcontract\b/,
-    /jest.*\be2e\b/,
-    /wdio/,
-  ];
-  if (hard3Patterns.some((re) => re.test(c))) return 'hard3_resilience';
-
-  const hard2Patterns = [
-    /\bpnpm\s+(run\s+)?test\b/,
-    /\bnpm\s+(run\s+)?test\b/,
-    /\byarn\s+(run\s+)?test\b/,
-    /\bvitest\b/,
-    /\bjest\b/,
-    /\bcargo\s+test\b/,
-    /\bpytest\b/,
-    /\bgo\s+test\b/,
-    /\bmocha\b/,
-  ];
-  if (hard2Patterns.some((re) => re.test(c))) return 'hard2_coverage';
-
-  const hard1Patterns = [
-    /\bpnpm\s+(run\s+)?lint\b/,
-    /\bnpm\s+(run\s+)?lint\b/,
-    /\bpnpm\s+(run\s+)?build\b/,
-    /\bnpm\s+(run\s+)?build\b/,
-    /\bpnpm\s+(run\s+)?typecheck\b/,
-    /\btsc\b/,
-    /\beslint\b/,
-    /\bcargo\s+clippy\b/,
-    /\bcargo\s+build\b/,
-    /\bcargo\s+check\b/,
-    /\bruff\b/,
-    /\bmypy\b/,
-    /\bgo\s+build\b/,
-    /\bgo\s+vet\b/,
-  ];
-  if (hard1Patterns.some((re) => re.test(c))) return 'hard1_baseline';
-
-  return null;
-}
+// Re-exported as classifyGateCommand from hooks/lib/mpl-gate-classify.mjs.
+const classifyGate = (command) => classifyGateCommand(command);
 
 function tailOf(text, n = 500) {
   const s = typeof text === 'string' ? text : JSON.stringify(text || '');

--- a/hooks/mpl-gate-recorder.mjs
+++ b/hooks/mpl-gate-recorder.mjs
@@ -55,7 +55,7 @@ const {
 const { buildBlockedHookPatch } = await import(
   pathToFileURL(join(__dirname, 'lib', 'mpl-blocked-hook.mjs')).href
 );
-const { classifyGateCommand } = await import(
+const { classifyRecordedCommand } = await import(
   pathToFileURL(join(__dirname, 'lib', 'mpl-gate-classify.mjs')).href
 );
 
@@ -83,8 +83,13 @@ function ok(systemMessage = null) {
  * via the `MPL_GATE=<name>` environment variable; this heuristic is the fallback
  * when no verify.sh is in use.
  */
-// Re-exported as classifyGateCommand from hooks/lib/mpl-gate-classify.mjs.
-const classifyGate = (command) => classifyGateCommand(command);
+// Re-exported as classifyRecordedCommand from hooks/lib/mpl-gate-classify.mjs.
+// Recorder path uses the LOOSE classifier (no head denylist) so legitimate
+// execution wrappers (`docker compose run app npm test`, `kubectl exec ...
+// npm test`, `bash -lc "playwright test"`) still record coverage evidence
+// — codex r6 on PR #219 regression. The strict denylist applies only to
+// manual `state.gate_results` writes via the I12 invariant.
+const classifyGate = (command) => classifyRecordedCommand(command);
 
 function tailOf(text, n = 500) {
   const s = typeof text === 'string' ? text : JSON.stringify(text || '');


### PR DESCRIPTION
## What

- `hooks/lib/mpl-gate-classify.mjs` (new): shared Bash→gate-family classifier, extracted from `mpl-gate-recorder` so the state invariant uses the same pattern lists. Adds a head-command denylist (`git`, `gh`, `echo`, `cat`, `docker`, ...) so commands whose head is never gate evidence get classified as null even when arguments happen to contain a family keyword.
- `hooks/lib/mpl-state-invariant.mjs`: new `VIOLATION_IDS.GATE_COMMAND_FAMILY_MISMATCH` (\`I12\`). Fires on STATE_WRITE; walks `state.gate_results` + `state.release.gate_results` and rejects entries whose `command` doesn't belong to the slot's family. Violation message names the offending key + command verbatim.
- `hooks/mpl-gate-recorder.mjs`: refactored to import the shared `classifyGateCommand`. Same patterns, now also rejects head-denylist commands at the recorder level.
- Tests cover valid Hard 1/2/3 commands, `git commit` in H2/H3, release-scoped writes, legacy-booleans-true with invalid structured command, wrong-family commands (build in H2 slot), STOP-trigger skip, and the null-entry edge cases.

## Why

Exp22 R13 (V1 harness coverage gap analysis) found post-run state with structured-looking gate entries whose commands were the wrong evidence: `hard2_coverage.command` and `hard3_resilience.command` held `git commit ...`. Legacy `hard{1,2,3}_passed: true` booleans made the state appear complete despite the family mismatch.

This guard closes that gap on the write boundary so manual `.mpl/state.json` patches cannot pass unrelated commands as gate evidence; existing recorder-produced evidence remains valid because the classifier patterns are unchanged.

## Design

Implements all of the #209 acceptance criteria. Bucket [data-integrity] under \`/pr\` Convention §8.

## Agent Review Status

This PR is gated on **2 unique agent reviews** (footers \`— from <agent>\`).

- [ ] from claude
- [ ] from codex

Closes #209.