### PR TITLE
Harden Tauri platform constraint profile (#211)

### DIFF
--- a/commands/references/framework-profiles.md
+++ b/commands/references/framework-profiles.md
@@ -97,6 +97,21 @@ Profiles are advisory prompt data. They do not replace hooks or machine checks.
 - `blocked_or_risky_patterns`: browser-native modal/file APIs that are unavailable or constrained inside the WebView runtime.
 - `hint`: verify runtime-safe dialog/file APIs instead of assuming browser APIs work.
 
+- `id`: `tauri-rust-state-manage`
+- `applies_when`: Rust source under the Tauri project root uses `tauri::State<'_, T>` in a `#[tauri::command]`-annotated function.
+- `blocked_or_risky_patterns`: a Rust command accepts `tauri::State<'_, T>` for some resource type `T` while the Tauri app builder never calls `Builder::manage(T)` to register a `T` instance before `.run(...)`. The runtime fails the command at first invocation with a state-not-managed error.
+- `hint`: every `tauri::State<'_, T>` parameter requires a matching `.manage(<T instance>)` registration on the `Builder` chain. Phase 0 raw-scan grep for `tauri::State<` and `.manage(` and surface a mismatch when state types exist without a manage call.
+
+- `id`: `tauri-v2-capability-coverage`
+- `applies_when`: Tauri v2 project where frontend `invoke('<cmd>')` calls map to Rust functions annotated with `#[tauri::command]`.
+- `blocked_or_risky_patterns`: a `#[tauri::command]` exposed to a frontend `invoke()` call has no covering permission entry in any `src-tauri/capabilities/*.json` file. Tauri v2 rejects the call at the IPC boundary with an unauthorized error.
+- `hint`: every command reachable from `invoke(...)` must appear under `permissions` of an active capability JSON. Phase 0 raw-scan grep for `#[tauri::command]`, `invoke(` call sites, and `src-tauri/capabilities/*.json` and require the union of `permissions` to cover the union of invoked command names. `mpl-require-e2e-authenticity.mjs` is the late finalize safety net; this profile pushes the requirement into the decomposer-facing layer.
+
+- `id`: `tauri-conf-csp-null`
+- `applies_when`: `tauri.conf.json` is present.
+- `blocked_or_risky_patterns`: `app.security.csp` is set to `null` (or the field is absent) at release / Phase 5 finalize time. A null CSP allows arbitrary inline scripts and remote resources from the WebView, which is acceptable during development but is a security regression for a release build.
+- `hint`: flag `csp: null` during decomposer / Phase 0 platform scan as a development-only setting. Require either a non-null CSP value or an explicit release rationale recorded against the goal contract before finalize.
+
 `framework_convention_profiles`
 - `id`: `tauri-rust-serde`
 - `type_policy_rules`: keep frontend/Rust boundary keys explicit; account for Serde naming conversion.

--- a/hooks/__tests__/mpl-framework-profile-prompts.test.mjs
+++ b/hooks/__tests__/mpl-framework-profile-prompts.test.mjs
@@ -299,3 +299,43 @@ describe('framework-specific prompt literals', () => {
     assert.deepEqual(parseContractCategories(registry), ['prompt_guard_literals']);
   });
 });
+
+describe('Tauri platform constraint hardening (Exp22 R14 / #211)', () => {
+  it('declares the three new Tauri platform constraint profiles', () => {
+    const registry = readRepoFile(PROFILE_REGISTRY);
+    // Each profile id is a load-bearing literal the decomposer / Phase 0
+    // raw-scan path will look up. These ids must not regress out.
+    assert.match(registry, /`id`: `tauri-rust-state-manage`/,
+      'Tauri profile must declare tauri-rust-state-manage');
+    assert.match(registry, /`id`: `tauri-v2-capability-coverage`/,
+      'Tauri profile must declare tauri-v2-capability-coverage');
+    assert.match(registry, /`id`: `tauri-conf-csp-null`/,
+      'Tauri profile must declare tauri-conf-csp-null');
+  });
+
+  it('names the Builder::manage(T) rule against tauri::State<\'_, T>', () => {
+    const registry = readRepoFile(PROFILE_REGISTRY);
+    // The decomposer-facing constraint MUST mention both literals so the
+    // Phase 0 raw-scan grep pattern stays anchored on the right tokens.
+    assert.match(registry, /tauri::State<'_, T>/);
+    assert.match(registry, /Builder::manage/);
+    assert.match(registry, /\.manage\(/);
+  });
+
+  it('names the capability coverage requirement for #[tauri::command] / invoke()', () => {
+    const registry = readRepoFile(PROFILE_REGISTRY);
+    assert.match(registry, /#\[tauri::command\]/);
+    assert.match(registry, /invoke\(/);
+    assert.match(registry, /src-tauri\/capabilities\/\*\.json/);
+    // The late finalize safety net (mpl-require-e2e-authenticity.mjs)
+    // must still be referenced so the two layers stay coordinated.
+    assert.match(registry, /mpl-require-e2e-authenticity\.mjs/);
+  });
+
+  it('names csp:null as development-only and requires release rationale', () => {
+    const registry = readRepoFile(PROFILE_REGISTRY);
+    assert.match(registry, /tauri\.conf\.json/);
+    assert.match(registry, /csp[^\n]*null/i);
+    assert.match(registry, /release/i);
+  });
+});


### PR DESCRIPTION
## What

Three new platform_constraint_profiles entries under the Tauri section of \`commands/references/framework-profiles.md\`:

- **\`tauri-rust-state-manage\`** — every \`tauri::State<'_, T>\` parameter requires a matching \`.manage(T)\` registration on the Builder chain. Raw-scan grep targets \`tauri::State<\` and \`.manage(\`.
- **\`tauri-v2-capability-coverage\`** — every \`#[tauri::command]\` reachable from \`invoke()\` must be covered by some capability JSON permission. Pushes the requirement from finalize (\`mpl-require-e2e-authenticity\`) up into Phase 0.
- **\`tauri-conf-csp-null\`** — flag \`csp: null\` (or absent) at release time as development-only; require either a real CSP value or an explicit release rationale.

Tests in \`hooks/__tests__/mpl-framework-profile-prompts.test.mjs\` pin every new profile id plus the load-bearing literals (\`tauri::State<'_, T>\`, \`Builder::manage\`, \`#[tauri::command]\`, \`invoke(\`, \`src-tauri/capabilities/*.json\`, \`tauri.conf.json\`, \`csp ... null\`, \`release\`, plus the existing finalize-hook reference) so they cannot regress out of the registry.

## Why

Exp22 R14 left three Tauri runtime blockers that the current profile did not call out strongly enough — a state-not-managed error on first command call, IPC permission denial via missing capabilities, and a release with \`csp: null\`. All three are decomposer-facing constraints, not just finalize-time.

## Design

N/A — additive profile change. Acceptance criteria in #211.

## Agent Review Status

This PR is gated on **2 unique agent reviews** (footers \`— from <agent>\`).

- [ ] from claude
- [ ] from codex

Closes #211.