### PR TITLE
Block phase transitions on missing Phase 0 artifacts (#210)

### DIFF
--- a/hooks/__tests__/mpl-phase-controller.test.mjs
+++ b/hooks/__tests__/mpl-phase-controller.test.mjs
@@ -10,9 +10,27 @@ import { checkPlanStatus, checkGateResults } from '../mpl-phase-controller.mjs';
 
 const HOOK_PATH = join(dirname(fileURLToPath(import.meta.url)), '..', 'mpl-phase-controller.mjs');
 
-function runStopHook(cwd, state) {
+function runStopHook(cwd, state, { skipPhase0Seed = false } = {}) {
   mkdirSync(join(cwd, '.mpl'), { recursive: true });
   writeFileSync(join(cwd, '.mpl', 'state.json'), JSON.stringify(state));
+  // Exp22 R11 / #210: phase-controller's transition writes now check
+  // Phase 0 artifacts. Seed them by default so existing transition tests
+  // don't accidentally exercise the I13 block. Tests that explicitly
+  // want to test the I13 path can pass `{ skipPhase0Seed: true }`.
+  if (!skipPhase0Seed) {
+    mkdirSync(join(cwd, '.mpl', 'mpl', 'phase0'), { recursive: true });
+    if (!existsSync(join(cwd, '.mpl', 'mpl', 'phase0', 'raw-scan.md'))) {
+      writeFileSync(join(cwd, '.mpl', 'mpl', 'phase0', 'raw-scan.md'), '# raw scan');
+    }
+    if (!existsSync(join(cwd, '.mpl', 'mpl', 'phase0', 'design-intent.yaml'))) {
+      writeFileSync(join(cwd, '.mpl', 'mpl', 'phase0', 'design-intent.yaml'), 'goal: test\n');
+    }
+    mkdirSync(join(cwd, '.mpl', 'contracts'), { recursive: true });
+    if (!existsSync(join(cwd, '.mpl', 'contracts', '_no-boundaries.json'))) {
+      writeFileSync(join(cwd, '.mpl', 'contracts', '_no-boundaries.json'),
+        JSON.stringify({ boundary_id: '_no-boundaries' }));
+    }
+  }
   const stdin = JSON.stringify({ cwd });
   const out = execFileSync('node', [HOOK_PATH], { input: stdin, encoding: 'utf-8' });
   return JSON.parse(out);
@@ -424,6 +442,41 @@ describe('phase3-gate Stop hook integration (PR #119 review #5 follow-up)', () =
     assert.match(out.stopReason, /Phase 3: Quality Gate in progress\. Run all 3 gates before proceeding/);
     // source=='none' here, so the legacy fallback warn does NOT prepend (warn is for source=='legacy')
     assert.doesNotMatch(out.stopReason, /⚠ Using legacy gate boolean fallback/);
+  });
+});
+
+describe('I13 phase0 artifacts gate the controller transition (Exp22 R11 / #210)', () => {
+  let tmpDir;
+  beforeEach(() => { tmpDir = mkdtempSync(join(tmpdir(), 'mpl-i13-ctrl-')); });
+  afterEach(() => { rmSync(tmpDir, { recursive: true, force: true }); });
+
+  it('phase1a-research → phase1b-plan transition is blocked when Phase 0 artifacts are missing', () => {
+    // codex r1 on PR #222: phase-controller writeState bypasses
+    // PreToolUse; the in-controller guard must catch the transition.
+    const out = runStopHook(tmpDir, {
+      current_phase: 'phase1a-research',
+      research: { status: 'skipped' },
+    }, { skipPhase0Seed: true });
+    assert.match(out.stopReason, /\[MPL I13\] Cannot transition to phase1b-plan/);
+    assert.match(out.stopReason, /raw-scan\.md/);
+    assert.match(out.stopReason, /design-intent\.yaml/);
+    assert.match(out.stopReason, /\.mpl\/contracts/);
+    // The state.json on disk must still be at phase1a-research — the
+    // controller skipped the writeState() because the guard short-circuited.
+    const state = JSON.parse(readFileSync(join(tmpDir, '.mpl', 'state.json'), 'utf-8'));
+    assert.equal(state.current_phase, 'phase1a-research',
+      'controller MUST NOT advance current_phase when artifacts are missing');
+  });
+
+  it('phase1a-research → phase1b-plan transition lands when Phase 0 artifacts are present', () => {
+    const out = runStopHook(tmpDir, {
+      current_phase: 'phase1a-research',
+      research: { status: 'completed', stages_completed: ['s1', 's2', 's3'], findings_count: 5, sources_count: 10 },
+    });
+    // runStopHook seeds Phase 0 artifacts by default.
+    assert.match(out.stopReason, /Transitioning to Phase 1-B/);
+    const state = JSON.parse(readFileSync(join(tmpDir, '.mpl', 'state.json'), 'utf-8'));
+    assert.equal(state.current_phase, 'phase1b-plan');
   });
 });
 

--- a/hooks/__tests__/mpl-phase-controller.test.mjs
+++ b/hooks/__tests__/mpl-phase-controller.test.mjs
@@ -450,22 +450,21 @@ describe('I13 phase0 artifacts gate the controller transition (Exp22 R11 / #210)
   beforeEach(() => { tmpDir = mkdtempSync(join(tmpdir(), 'mpl-i13-ctrl-')); });
   afterEach(() => { rmSync(tmpDir, { recursive: true, force: true }); });
 
-  it('phase1a-research → phase1b-plan transition is blocked when Phase 0 artifacts are missing', () => {
-    // codex r1 on PR #222: phase-controller writeState bypasses
-    // PreToolUse; the in-controller guard must catch the transition.
+  it('phase1a-research → phase1b-plan transition is EXEMPT from the Phase 0 guard (codex r7)', () => {
+    // codex r7 on PR #222 [contract-break]: phase1b-plan is the
+    // planning preparation phase that PRODUCES contracts via the
+    // decomposer. Gating phase1b-plan on contracts being already
+    // present is a chicken-and-egg block — removed from
+    // REQUIRES_PHASE0_ARTIFACTS. The transition lands even when
+    // artifacts haven't yet been produced.
     const out = runStopHook(tmpDir, {
       current_phase: 'phase1a-research',
       research: { status: 'skipped' },
     }, { skipPhase0Seed: true });
-    assert.match(out.stopReason, /\[MPL I13\] Cannot transition to phase1b-plan/);
-    assert.match(out.stopReason, /raw-scan\.md/);
-    assert.match(out.stopReason, /design-intent\.yaml/);
-    assert.match(out.stopReason, /\.mpl\/contracts/);
-    // The state.json on disk must still be at phase1a-research — the
-    // controller skipped the writeState() because the guard short-circuited.
+    assert.doesNotMatch(out.stopReason, /\[MPL I13\]/,
+      'phase1b-plan transition must not invoke the Phase 0 guard');
     const state = JSON.parse(readFileSync(join(tmpDir, '.mpl', 'state.json'), 'utf-8'));
-    assert.equal(state.current_phase, 'phase1a-research',
-      'controller MUST NOT advance current_phase when artifacts are missing');
+    assert.equal(state.current_phase, 'phase1b-plan');
   });
 
   it('phase2-sprint → phase3-gate (variable nextPhase) is blocked when artifacts missing (codex r2 [data-integrity])', () => {

--- a/hooks/__tests__/mpl-phase-controller.test.mjs
+++ b/hooks/__tests__/mpl-phase-controller.test.mjs
@@ -531,6 +531,37 @@ describe('I13 phase0 artifacts gate the controller transition (Exp22 R11 / #210)
       'recorded failure evidence MUST be preserved when transition is blocked');
   });
 
+  it('release-finalize blocks BEFORE creating any release artifacts when Phase 0 missing (codex r5 [data-integrity])', () => {
+    // codex r5 on PR #222: the release-finalize case writes
+    // release-manifest.json + evidence-summary.md + gate-results.json
+    // + snapshot ref BEFORE the final state writeState. Without the
+    // guard at the top, missing Phase 0 artifacts would leave a
+    // shipped-looking manifest + ref on disk while state.release stays
+    // un-appended (drift).
+    const out = runStopHook(tmpDir, {
+      current_phase: 'release-finalize',
+      release: {
+        current_cut_id: 'mvp',
+        completed_cut_ids: [],
+        fix_loop_count: 0,
+        pending_artifact: null,
+        gate_results: {
+          hard1_passed: true, hard2_passed: true, hard3_passed: true,
+          hard1_baseline: { command: 'npm run build', exit_code: 0 },
+          hard2_coverage: { command: 'npm test', exit_code: 0 },
+          hard3_resilience: { command: 'npx playwright test', exit_code: 0 },
+        },
+        max_fix_loops: 3,
+      },
+    }, { skipPhase0Seed: true });
+    assert.match(out.stopReason, /\[MPL I13\] Cannot transition to release-finalize/);
+    // No release artifact directory should exist — guard fired before
+    // any disk writes in this case.
+    const releasesDir = join(tmpDir, '.mpl', 'mpl', 'releases');
+    assert.equal(existsSync(releasesDir), false,
+      'release artifact directory MUST NOT be created when guard blocks');
+  });
+
   it('phase1a-research → phase1b-plan transition lands when Phase 0 artifacts are present', () => {
     const out = runStopHook(tmpDir, {
       current_phase: 'phase1a-research',

--- a/hooks/__tests__/mpl-phase-controller.test.mjs
+++ b/hooks/__tests__/mpl-phase-controller.test.mjs
@@ -510,6 +510,27 @@ describe('I13 phase0 artifacts gate the controller transition (Exp22 R11 / #210)
     assert.equal(state.current_phase, 'completed');
   });
 
+  it('phase3-gate FAIL → phase4-fix is blocked when artifacts missing (codex r3 [data-integrity])', () => {
+    // codex r3 on PR #222: the gate-failure composite writeState writes
+    // current_phase: 'phase4-fix' along with clearing gate_results. If
+    // artifacts are missing, the guard must short-circuit BEFORE the
+    // gate-evidence reset — otherwise failed evidence gets wiped.
+    const ent = (e) => ({ command: 'npm test', exit_code: e, stdout_tail: '', timestamp: 'now' });
+    const out = runStopHook(tmpDir, {
+      current_phase: 'phase3-gate',
+      gate_results: {
+        hard1_baseline: ent(0), hard2_coverage: ent(1), hard3_resilience: ent(0),
+      },
+    }, { skipPhase0Seed: true });
+    assert.match(out.stopReason, /\[MPL I13\] Cannot transition to phase4-fix/);
+    const state = JSON.parse(readFileSync(join(tmpDir, '.mpl', 'state.json'), 'utf-8'));
+    assert.equal(state.current_phase, 'phase3-gate',
+      'controller MUST NOT advance to phase4-fix when Phase 0 artifacts are missing');
+    // Failure evidence MUST be preserved — guard short-circuits before the reset.
+    assert.equal(state.gate_results.hard2_coverage.exit_code, 1,
+      'recorded failure evidence MUST be preserved when transition is blocked');
+  });
+
   it('phase1a-research → phase1b-plan transition lands when Phase 0 artifacts are present', () => {
     const out = runStopHook(tmpDir, {
       current_phase: 'phase1a-research',

--- a/hooks/__tests__/mpl-phase-controller.test.mjs
+++ b/hooks/__tests__/mpl-phase-controller.test.mjs
@@ -468,6 +468,48 @@ describe('I13 phase0 artifacts gate the controller transition (Exp22 R11 / #210)
       'controller MUST NOT advance current_phase when artifacts are missing');
   });
 
+  it('phase2-sprint → phase3-gate (variable nextPhase) is blocked when artifacts missing (codex r2 [data-integrity])', () => {
+    // codex r2 on PR #222: variable nextPhase transitions need the same
+    // guard. Phase 2 with all TODOs done normally advances to phase3-gate
+    // via `const nextPhase = ...; writeState(...)`.
+    // Plant a PLAN.md showing 1/1 completed so the controller takes the
+    // "all TODOs done → next phase" branch.
+    mkdirSync(join(tmpDir, '.mpl'), { recursive: true });
+    writeFileSync(join(tmpDir, '.mpl', 'PLAN.md'), '### [x] phase-1 done\n');
+    const out = runStopHook(tmpDir, { current_phase: 'phase2-sprint' },
+      { skipPhase0Seed: true });
+    assert.match(out.stopReason, /\[MPL I13\] Cannot transition to phase3-gate/);
+    const state = JSON.parse(readFileSync(join(tmpDir, '.mpl', 'state.json'), 'utf-8'));
+    assert.equal(state.current_phase, 'phase2-sprint',
+      'controller MUST NOT advance to phase3-gate when artifacts are missing');
+  });
+
+  it('small-pipeline completion is EXEMPT from Phase 0 artifact guard (codex r2 [contract-break])', () => {
+    // codex r2 on PR #222: small-plan / small-sprint / small-verify is
+    // a separate lightweight flow that intentionally skips Phase 0.
+    // small-verify → completed must NOT be blocked by I13.
+    const out = runStopHook(tmpDir, {
+      current_phase: 'small-verify',
+      gate_results: { hard2_passed: true },
+    }, { skipPhase0Seed: true });
+    assert.match(out.stopReason, /MPL-Small.*Verification passed/);
+    const state = JSON.parse(readFileSync(join(tmpDir, '.mpl', 'state.json'), 'utf-8'));
+    assert.equal(state.current_phase, 'completed',
+      'small-pipeline completion must land without Phase 0 artifacts');
+  });
+
+  it('small-pipeline fix-loop completion is also EXEMPT', () => {
+    const out = runStopHook(tmpDir, {
+      current_phase: 'small-verify',
+      gate_results: { hard2_passed: false },
+      fix_loop_count: 3,
+      max_fix_loops: 3,
+    }, { skipPhase0Seed: true });
+    assert.match(out.stopReason, /MPL-Small.*Fix loop limit reached/);
+    const state = JSON.parse(readFileSync(join(tmpDir, '.mpl', 'state.json'), 'utf-8'));
+    assert.equal(state.current_phase, 'completed');
+  });
+
   it('phase1a-research → phase1b-plan transition lands when Phase 0 artifacts are present', () => {
     const out = runStopHook(tmpDir, {
       current_phase: 'phase1a-research',

--- a/hooks/__tests__/mpl-state-invariant.test.mjs
+++ b/hooks/__tests__/mpl-state-invariant.test.mjs
@@ -505,6 +505,80 @@ describe('I12 gate command-family mismatch (Exp22 R13 / #209)', () => {
   });
 });
 
+describe('I13 fast-track Phase 0 artifacts (Exp22 R11 / #210)', () => {
+  function seedPhase0Artifacts(dir) {
+    mkdirSync(join(dir, '.mpl', 'mpl', 'phase0'), { recursive: true });
+    writeFileSync(join(dir, '.mpl', 'mpl', 'phase0', 'raw-scan.md'), '# raw scan');
+    writeFileSync(join(dir, '.mpl', 'mpl', 'phase0', 'design-intent.yaml'), 'goal: test\n');
+    mkdirSync(join(dir, '.mpl', 'contracts'), { recursive: true });
+    writeFileSync(join(dir, '.mpl', 'contracts', '_no-boundaries.json'),
+      JSON.stringify({ boundary_id: '_no-boundaries' }));
+  }
+
+  it('phase2-sprint transition without Phase 0 artifacts → I13 violation lists missing files', () => {
+    const r = checkInvariants({ current_phase: 'phase2-sprint' },
+      { cwd: tmp, trigger: TRIGGERS.STATE_WRITE });
+    const v = r.violations.find((x) => x.id === VIOLATION_IDS.FAST_TRACK_PHASE0_ARTIFACTS_MISSING);
+    assert.ok(v);
+    assert.match(v.message, /raw-scan\.md/);
+    assert.match(v.message, /design-intent\.yaml/);
+    assert.match(v.message, /\.mpl\/contracts\/\*\.json/);
+    assert.match(v.message, /_no-boundaries\.json/);
+    assert.equal(v.phase, 'phase2-sprint');
+  });
+
+  it('phase2-sprint transition WITH all Phase 0 artifacts → silent', () => {
+    seedPhase0Artifacts(tmp);
+    const r = checkInvariants({ current_phase: 'phase2-sprint' },
+      { cwd: tmp, trigger: TRIGGERS.STATE_WRITE });
+    assert.ok(!r.violations.some((v) => v.id === VIOLATION_IDS.FAST_TRACK_PHASE0_ARTIFACTS_MISSING));
+  });
+
+  it('phase5-finalize / release-finalize / completed transitions are also guarded', () => {
+    for (const phase of ['phase3-gate', 'phase4-fix', 'phase5-finalize',
+                         'release-gate', 'release-finalize', 'completed']) {
+      const r = checkInvariants({ current_phase: phase },
+        { cwd: tmp, trigger: TRIGGERS.STATE_WRITE });
+      assert.ok(
+        r.violations.some((v) => v.id === VIOLATION_IDS.FAST_TRACK_PHASE0_ARTIFACTS_MISSING),
+        `I13 must fire for phase=${phase} without artifacts`
+      );
+    }
+  });
+
+  it('Phase 0 itself and pre-Phase-0 lifecycle markers are exempt', () => {
+    for (const phase of ['mpl-init', 'mpl-ambiguity-resolve', 'mpl-decompose',
+                         'phase1-plan', 'phase1a-research']) {
+      const r = checkInvariants({ current_phase: phase },
+        { cwd: tmp, trigger: TRIGGERS.STATE_WRITE });
+      assert.ok(
+        !r.violations.some((v) => v.id === VIOLATION_IDS.FAST_TRACK_PHASE0_ARTIFACTS_MISSING),
+        `I13 must NOT fire for phase=${phase} (Phase 0 itself produces the artifacts)`
+      );
+    }
+  });
+
+  it('contracts/_no-boundaries.json alone satisfies the contracts requirement (simple/non-boundary tasks)', () => {
+    // Operator opted out of cross-layer boundaries by writing only _no-boundaries.json.
+    mkdirSync(join(tmp, '.mpl', 'mpl', 'phase0'), { recursive: true });
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'phase0', 'raw-scan.md'), '# raw scan');
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'phase0', 'design-intent.yaml'), 'goal: simple\n');
+    mkdirSync(join(tmp, '.mpl', 'contracts'), { recursive: true });
+    writeFileSync(join(tmp, '.mpl', 'contracts', '_no-boundaries.json'), '{}');
+    const r = checkInvariants({ current_phase: 'phase2-sprint' },
+      { cwd: tmp, trigger: TRIGGERS.STATE_WRITE });
+    assert.ok(!r.violations.some((v) => v.id === VIOLATION_IDS.FAST_TRACK_PHASE0_ARTIFACTS_MISSING));
+  });
+
+  it('STOP trigger is not the right surface — only STATE_WRITE fires this', () => {
+    // Phase-controller's Stop logic is the legitimate transition writer.
+    // I13 fires on the state-write BEFORE the transition lands.
+    const r = checkInvariants({ current_phase: 'phase2-sprint' },
+      { cwd: tmp, trigger: TRIGGERS.STOP });
+    assert.ok(!r.violations.some((v) => v.id === VIOLATION_IDS.FAST_TRACK_PHASE0_ARTIFACTS_MISSING));
+  });
+});
+
 describe('I7 current_phase folder lifecycle', () => {
   it('flags missing folder for concrete phase id', () => {
     const r = checkInvariants({ current_phase: 'phase-7' }, { cwd: tmp });
@@ -825,9 +899,17 @@ describe('mpl-state-invariant hook integration', () => {
 
   it('Write that ADDS structured evidence (clean transition) → silent, no I6', () => {
     // Inverse case: a Write that introduces structured evidence to a state
-    // that previously had none should NOT surface I6 (or I12).
+    // that previously had none should NOT surface I6 (or I12, or I13).
     const stateJsonPath = join(tmp, '.mpl', 'state.json');
     const ent = (cmd, e) => ({ command: cmd, exit_code: e, stdout_tail: '', timestamp: 'now' });
+    // Seed Phase 0 artifacts so I13 doesn't trip on the phase3-gate
+    // transition (#210).
+    mkdirSync(join(tmp, '.mpl', 'mpl', 'phase0'), { recursive: true });
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'phase0', 'raw-scan.md'), '# raw scan');
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'phase0', 'design-intent.yaml'), 'goal: test\n');
+    mkdirSync(join(tmp, '.mpl', 'contracts'), { recursive: true });
+    writeFileSync(join(tmp, '.mpl', 'contracts', '_no-boundaries.json'),
+      JSON.stringify({ boundary_id: '_no-boundaries' }));
     writeFileSync(stateJsonPath, JSON.stringify({
       schema_version: SCHEMA_V,
       current_phase: 'phase3-gate',

--- a/hooks/__tests__/mpl-state-invariant.test.mjs
+++ b/hooks/__tests__/mpl-state-invariant.test.mjs
@@ -942,4 +942,33 @@ describe('mpl-state-invariant hook integration', () => {
     assert.strictEqual(r.continue, true);
     assert.strictEqual(r.suppressOutput, true);
   });
+
+  it('I13 under default (warn) policy still blocks manual protected-phase writes (codex r4)', () => {
+    // Codex r4 on PR #222 [data-integrity]: default state_invariant_violation
+    // is `warn`, which would let a manual Write to state.json land a
+    // protected phase without Phase 0 artifacts. I13 must override that
+    // and always emit `decision: 'block'`.
+    const stateJsonPath = join(tmp, '.mpl', 'state.json');
+    writeFileSync(stateJsonPath, JSON.stringify({
+      schema_version: SCHEMA_V,
+      current_phase: 'phase2-sprint',
+    }));
+    // Note: no .mpl/mpl/phase0/* / .mpl/contracts/ artifacts seeded.
+    const proposed = {
+      schema_version: SCHEMA_V,
+      current_phase: 'phase3-gate',
+    };
+    const stdin = JSON.stringify({
+      cwd: tmp,
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Write',
+      tool_input: { file_path: stateJsonPath, content: JSON.stringify(proposed) },
+    });
+    const out = execFileSync('node', [HOOK_PATH], { input: stdin, encoding: 'utf-8' });
+    const r = JSON.parse(out);
+    assert.equal(r.decision, 'block',
+      'I13 must produce decision:block even under default warn policy');
+    assert.match(r.reason || '', /I13/);
+    assert.match(r.reason || '', /raw-scan\.md|design-intent\.yaml|\.mpl\/contracts/);
+  });
 });

--- a/hooks/__tests__/mpl-state-invariant.test.mjs
+++ b/hooks/__tests__/mpl-state-invariant.test.mjs
@@ -546,9 +546,14 @@ describe('I13 fast-track Phase 0 artifacts (Exp22 R11 / #210)', () => {
     }
   });
 
-  it('Phase 0 itself and pre-Phase-0 lifecycle markers are exempt', () => {
+  it('Phase 0, planning phases, and pre-sprint lifecycle markers are exempt', () => {
+    // codex r7 on PR #222: phase1b-plan is the phase that PRODUCES
+    // contracts via decomposition, so it cannot be gated on contracts
+    // already being present (chicken-and-egg). It's exempt along with
+    // mpl-init / mpl-ambiguity-resolve / mpl-decompose / phase1-plan /
+    // phase1a-research.
     for (const phase of ['mpl-init', 'mpl-ambiguity-resolve', 'mpl-decompose',
-                         'phase1-plan', 'phase1a-research']) {
+                         'phase1-plan', 'phase1a-research', 'phase1b-plan']) {
       const r = checkInvariants({ current_phase: phase },
         { cwd: tmp, trigger: TRIGGERS.STATE_WRITE });
       assert.ok(

--- a/hooks/lib/mpl-phase0-artifacts.mjs
+++ b/hooks/lib/mpl-phase0-artifacts.mjs
@@ -27,8 +27,14 @@
 import { existsSync, readdirSync } from 'fs';
 import { join } from 'path';
 
+// Codex r7 on PR #222 [contract-break]: phase1b-plan is the
+// planning-preparation phase where decomposition produces the contracts
+// — gating phase1b-plan on contracts being already present made the
+// guard a chicken-and-egg block. The watershed is `phase2-sprint`
+// onward: by sprint time, decomposition has run and contracts exist.
+// phase1b-plan stays exempt (along with phase1-plan / phase1a-research /
+// mpl-decompose) so the planning path can produce the artifacts.
 export const REQUIRES_PHASE0_ARTIFACTS = Object.freeze(new Set([
-  'phase1b-plan',
   'phase2-sprint',
   'phase3-gate',
   'phase4-fix',

--- a/hooks/lib/mpl-phase0-artifacts.mjs
+++ b/hooks/lib/mpl-phase0-artifacts.mjs
@@ -1,0 +1,89 @@
+/**
+ * Phase 0 boundary/runtime artifact requirements (Exp22 R11 / #210).
+ *
+ * The orchestrator must not transition into phase1b-plan or later
+ * lifecycle phases until Phase 0 has produced the artifacts that make
+ * cross-boundary integration testable. Fast-track (`run_mode=auto`)
+ * makes this especially important because user oversight is reduced.
+ *
+ * Two enforcement points use this helper:
+ *   1. `hooks/lib/mpl-state-invariant.mjs` I13 — fires on STATE_WRITE
+ *      so a manual `.mpl/state.json` edit cannot land a protected
+ *      phase without these artifacts.
+ *   2. `hooks/mpl-phase-controller.mjs` (Stop hook) — calls
+ *      `missingPhase0Artifacts(cwd)` before each `writeState({
+ *      current_phase: <protected> })` transition. Phase-controller's
+ *      writeState path does NOT go through PreToolUse, so I13 alone
+ *      misses it. Codex r1 on PR #222 flagged this gap.
+ *
+ * Required artifacts (any missing → transition blocked):
+ *   - `.mpl/mpl/phase0/raw-scan.md`
+ *   - `.mpl/mpl/phase0/design-intent.yaml`
+ *   - at least one `.mpl/contracts/*.json`, including the explicit
+ *     `_no-boundaries.json` opt-out the decomposer writes for simple
+ *     tasks that have no cross-layer boundary.
+ */
+
+import { existsSync, readdirSync } from 'fs';
+import { join } from 'path';
+
+export const REQUIRES_PHASE0_ARTIFACTS = Object.freeze(new Set([
+  'phase1b-plan',
+  'phase2-sprint',
+  'phase3-gate',
+  'phase4-fix',
+  'phase5-finalize',
+  'release-gate',
+  'release-finalize',
+  'completed',
+]));
+
+function listDirSafe(dir) {
+  try { return existsSync(dir) ? readdirSync(dir) : []; } catch { return []; }
+}
+
+/**
+ * Returns the list of required Phase 0 artifacts that are NOT present.
+ * Empty array means the Phase 0 boundary/runtime evidence is complete
+ * enough to proceed.
+ *
+ * Caller is responsible for deciding what to do with a non-empty list —
+ * I13 surfaces a violation, phase-controller emits a stopReason and
+ * skips the transition.
+ */
+export function missingPhase0Artifacts(cwd) {
+  const missing = [];
+  if (!existsSync(join(cwd, '.mpl', 'mpl', 'phase0', 'raw-scan.md'))) {
+    missing.push('.mpl/mpl/phase0/raw-scan.md');
+  }
+  if (!existsSync(join(cwd, '.mpl', 'mpl', 'phase0', 'design-intent.yaml'))) {
+    missing.push('.mpl/mpl/phase0/design-intent.yaml');
+  }
+  const contractFiles = listDirSafe(join(cwd, '.mpl', 'contracts'))
+    .filter((n) => n.endsWith('.json'));
+  if (contractFiles.length === 0) {
+    missing.push('.mpl/contracts/*.json (or _no-boundaries.json)');
+  }
+  return missing;
+}
+
+/**
+ * Returns a stopReason string when transitioning to `nextPhase` would
+ * land in a protected phase without the required artifacts. Returns
+ * null when the transition is allowed (either the phase is exempt or
+ * the artifacts are present).
+ *
+ * Phase-controller uses this to short-circuit a transition write.
+ */
+export function blockedPhaseTransitionReason(cwd, nextPhase) {
+  if (!REQUIRES_PHASE0_ARTIFACTS.has(nextPhase)) return null;
+  const missing = missingPhase0Artifacts(cwd);
+  if (missing.length === 0) return null;
+  return (
+    `[MPL I13] Cannot transition to ${nextPhase} — Phase 0 boundary/runtime ` +
+    `artifacts missing: ${missing.join(', ')}. Fast-track (run_mode=auto) ` +
+    `may shorten user interviews but MUST NOT skip these artifacts. Re-run ` +
+    `Phase 0 to produce them, or write .mpl/contracts/_no-boundaries.json ` +
+    `as the explicit opt-out for non-boundary tasks.`
+  );
+}

--- a/hooks/lib/mpl-state-invariant.mjs
+++ b/hooks/lib/mpl-state-invariant.mjs
@@ -21,6 +21,7 @@ import { join } from 'path';
 
 import { CURRENT_SCHEMA_VERSION } from './mpl-state.mjs';
 import { classifyGateCommand } from './mpl-gate-classify.mjs';
+import { REQUIRES_PHASE0_ARTIFACTS, missingPhase0Artifacts } from './mpl-phase0-artifacts.mjs';
 
 // Re-export so consumers (and the H8 single-source-of-truth test) can
 // confirm both modules agree on the version constant via a single
@@ -403,52 +404,18 @@ function checkGateFamilyForBlock(block, label) {
   return issues;
 }
 
-// Phases where the Phase-0 boundary/runtime artifacts MUST already
-// exist before the orchestrator transitions in. Phase 0 itself, the
-// decomposer, and ambiguity-resolve are exempt — that's where these
-// artifacts get produced. Anything from phase1b-plan onward must wait
-// for them to land.
-const REQUIRES_PHASE0_ARTIFACTS = new Set([
-  'phase1b-plan',
-  'phase2-sprint',
-  'phase3-gate',
-  'phase4-fix',
-  'phase5-finalize',
-  'release-gate',
-  'release-finalize',
-  'completed',
-]);
-
-function listDirSafe(dir) {
-  try { return existsSync(dir) ? readdirSync(dir) : []; } catch { return []; }
-}
-
 function checkI13(state, cwd, trigger) {
   // Exp22 R11 / #210: a fast-track run that skipped user interviews
   // must not also skip the boundary/runtime artifacts. Fire on
-  // STATE_WRITE so a transition write into phase1b-plan / phase2-sprint
-  // / phase3-gate / ... cannot land without the required artifacts.
+  // STATE_WRITE so a manual edit into phase1b-plan / phase2-sprint /
+  // phase3-gate / ... cannot land without the required artifacts.
+  // Phase-controller writes also call missingPhase0Artifacts directly
+  // for its writeState path (codex r1 on PR #222).
   if (trigger !== TRIGGERS.STATE_WRITE) return null;
   const phase = state?.current_phase;
   if (!phase || !REQUIRES_PHASE0_ARTIFACTS.has(phase)) return null;
 
-  const missing = [];
-  if (!existsSync(join(cwd, '.mpl', 'mpl', 'phase0', 'raw-scan.md'))) {
-    missing.push('.mpl/mpl/phase0/raw-scan.md');
-  }
-  if (!existsSync(join(cwd, '.mpl', 'mpl', 'phase0', 'design-intent.yaml'))) {
-    missing.push('.mpl/mpl/phase0/design-intent.yaml');
-  }
-  // Contracts requirement: at least one .json file in `.mpl/contracts/`.
-  // The decomposer writes `_no-boundaries.json` when the project has no
-  // cross-layer boundary, so simple/non-boundary tasks still satisfy
-  // this without forcing irrelevant contract files.
-  const contractsDir = join(cwd, '.mpl', 'contracts');
-  const contractFiles = listDirSafe(contractsDir).filter((n) => n.endsWith('.json'));
-  if (contractFiles.length === 0) {
-    missing.push('.mpl/contracts/*.json (or _no-boundaries.json)');
-  }
-
+  const missing = missingPhase0Artifacts(cwd);
   if (missing.length === 0) return null;
   return v(VIOLATION_IDS.FAST_TRACK_PHASE0_ARTIFACTS_MISSING,
     `Phase ${phase} cannot start without the Phase 0 boundary/runtime artifacts. ` +

--- a/hooks/lib/mpl-state-invariant.mjs
+++ b/hooks/lib/mpl-state-invariant.mjs
@@ -62,6 +62,11 @@ export const VIOLATION_IDS = Object.freeze({
   // H1, test for H2, e2e/contract for H3). Manual state.json patches
   // putting `git commit` into hard2_coverage are rejected here.
   GATE_COMMAND_FAMILY_MISMATCH: 'I12',
+  // Exp22 R11 / #210: a transition into phase2-sprint or later must
+  // not happen until the Phase 0 boundary/runtime artifacts exist.
+  // Fast-track (run_mode=auto) makes this especially important because
+  // user review is reduced.
+  FAST_TRACK_PHASE0_ARTIFACTS_MISSING: 'I13',
 });
 
 const ACTIVE_PHASES = new Set([
@@ -398,6 +403,63 @@ function checkGateFamilyForBlock(block, label) {
   return issues;
 }
 
+// Phases where the Phase-0 boundary/runtime artifacts MUST already
+// exist before the orchestrator transitions in. Phase 0 itself, the
+// decomposer, and ambiguity-resolve are exempt — that's where these
+// artifacts get produced. Anything from phase1b-plan onward must wait
+// for them to land.
+const REQUIRES_PHASE0_ARTIFACTS = new Set([
+  'phase1b-plan',
+  'phase2-sprint',
+  'phase3-gate',
+  'phase4-fix',
+  'phase5-finalize',
+  'release-gate',
+  'release-finalize',
+  'completed',
+]);
+
+function listDirSafe(dir) {
+  try { return existsSync(dir) ? readdirSync(dir) : []; } catch { return []; }
+}
+
+function checkI13(state, cwd, trigger) {
+  // Exp22 R11 / #210: a fast-track run that skipped user interviews
+  // must not also skip the boundary/runtime artifacts. Fire on
+  // STATE_WRITE so a transition write into phase1b-plan / phase2-sprint
+  // / phase3-gate / ... cannot land without the required artifacts.
+  if (trigger !== TRIGGERS.STATE_WRITE) return null;
+  const phase = state?.current_phase;
+  if (!phase || !REQUIRES_PHASE0_ARTIFACTS.has(phase)) return null;
+
+  const missing = [];
+  if (!existsSync(join(cwd, '.mpl', 'mpl', 'phase0', 'raw-scan.md'))) {
+    missing.push('.mpl/mpl/phase0/raw-scan.md');
+  }
+  if (!existsSync(join(cwd, '.mpl', 'mpl', 'phase0', 'design-intent.yaml'))) {
+    missing.push('.mpl/mpl/phase0/design-intent.yaml');
+  }
+  // Contracts requirement: at least one .json file in `.mpl/contracts/`.
+  // The decomposer writes `_no-boundaries.json` when the project has no
+  // cross-layer boundary, so simple/non-boundary tasks still satisfy
+  // this without forcing irrelevant contract files.
+  const contractsDir = join(cwd, '.mpl', 'contracts');
+  const contractFiles = listDirSafe(contractsDir).filter((n) => n.endsWith('.json'));
+  if (contractFiles.length === 0) {
+    missing.push('.mpl/contracts/*.json (or _no-boundaries.json)');
+  }
+
+  if (missing.length === 0) return null;
+  return v(VIOLATION_IDS.FAST_TRACK_PHASE0_ARTIFACTS_MISSING,
+    `Phase ${phase} cannot start without the Phase 0 boundary/runtime artifacts. ` +
+      `Missing: ${missing.join(', ')}. ` +
+      `Fast-track (run_mode=auto) may shorten user interviews but MUST NOT skip ` +
+      `boundary/runtime evidence. Re-run Phase 0 to produce the missing artifacts, ` +
+      `or write '_no-boundaries.json' under .mpl/contracts/ as the explicit ` +
+      `opt-out for non-boundary tasks.`,
+    { phase, missing });
+}
+
 function checkI12(state, trigger) {
   // Exp22 R13 / #209. Surface on STATE_WRITE so manual patches that try
   // to land malformed evidence are caught at the write boundary.
@@ -448,6 +510,7 @@ export function checkInvariants(state, opts = {}) {
     () => checkI10(state),
     () => checkI11(state),
     () => checkI12(state, trigger),
+    () => checkI13(state, cwd, trigger),
   ];
 
   const violations = [];

--- a/hooks/mpl-phase-controller.mjs
+++ b/hooks/mpl-phase-controller.mjs
@@ -678,6 +678,8 @@ async function main() {
         // Budget remaining → route back to phase2-sprint. Reset scoped
         // evidence on retry so mpl-gate-recorder writes fresh exits on
         // the next attempt (same pattern as phase3-gate FAIL path).
+        // codex r3 on PR #222: protect this composite writeState too.
+        if (emitPhase0BlockIfNeeded(cwd, 'phase2-sprint')) return;
         writeState(cwd, {
           current_phase: 'phase2-sprint',
           release: {
@@ -993,6 +995,12 @@ async function main() {
         // Preserve existing fix_loop_count to prevent infinite loop bypass
         // (only initialize to 0 on first entry, not on re-entry from Phase 3)
         const currentFixCount = state.fix_loop_count || 0;
+        // codex r3 on PR #222: composite writeState into a protected phase
+        // needs the Phase 0 artifact guard too — without it, a gate-failure
+        // transition would not only advance into phase4-fix unprotected
+        // but also nuke the recorded failure evidence (the gate_results
+        // reset below).
+        if (emitPhase0BlockIfNeeded(cwd, 'phase4-fix')) return;
         // Reset both legacy and structured gate evidence on retry to prevent stale data.
         writeState(cwd, {
           current_phase: 'phase4-fix',

--- a/hooks/mpl-phase-controller.mjs
+++ b/hooks/mpl-phase-controller.mjs
@@ -738,6 +738,15 @@ async function main() {
       // RFC §5.5 invariants preserved: this handler MUST NOT set
       // `state.finalize_done=true` and MUST NOT transition `current_phase`
       // to `completed`. Both remain exclusive to phase5-finalize.
+      //
+      // Codex r5 on PR #222 [data-integrity]: Phase 0 artifact guard
+      // MUST run at the START of the release-finalize case, BEFORE
+      // createSnapshotRef / attemptArtifactCreation / atomicWriteFile
+      // create artifacts on disk. Otherwise a missing-artifacts state
+      // would leave shipped-looking manifest/ref files while
+      // state.release.completed_cut_ids is not appended — release
+      // immutability drift.
+      if (emitPhase0BlockIfNeeded(cwd, 'release-finalize')) return;
       const cur = state.release?.current_cut_id;
       if (!cur) {
                 if (emitPhase0BlockIfNeeded(cwd, 'phase3-gate')) return;

--- a/hooks/mpl-phase-controller.mjs
+++ b/hooks/mpl-phase-controller.mjs
@@ -919,8 +919,13 @@ async function main() {
       const nextCutId = null;
       const nextPhase = 'phase3-gate';
 
-      // codex r2 on PR #222: protect this composite writeState too.
-      if (emitPhase0BlockIfNeeded(cwd, nextPhase)) return;
+      // codex r5/r6 on PR #222: the release-finalize case is guarded at
+      // its TOP (line 740-ish) before any release artifact write. The
+      // r2 post-write guard here was redundant AND harmful — if Phase 0
+      // files were removed between the entry guard and this point, we'd
+      // skip the state update while leaving manifest/snapshot artifacts
+      // on disk (release immutability drift). Drop the post-write guard
+      // and rely on the single entry guard for this case.
       writeState(cwd, {
         release: {
           ...existing,

--- a/hooks/mpl-phase-controller.mjs
+++ b/hooks/mpl-phase-controller.mjs
@@ -60,6 +60,33 @@ const { parseDecompositionGoalTraceText } = await import(
   pathToFileURL(join(__dirname, 'lib', 'mpl-goal-trace.mjs')).href
 );
 
+// Exp22 R11 / #210 — codex r1 on PR #222. Phase-controller writes phase
+// transitions directly via writeState() which bypasses PreToolUse hooks,
+// so state-invariant I13 alone misses the controller's own transitions.
+// Call blockedPhaseTransitionReason() before any writeState that lands
+// in a phase listed in REQUIRES_PHASE0_ARTIFACTS.
+const { blockedPhaseTransitionReason } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-phase0-artifacts.mjs')).href
+);
+
+/**
+ * Emit a stopReason and return true when the controller's intended
+ * transition to `nextPhase` is blocked by missing Phase 0 artifacts.
+ * Caller should `return` immediately after a truthy result to skip the
+ * writeState. The transition is blocked, not deferred — the user must
+ * run /mpl:mpl-resume or restore Phase 0 before the controller will
+ * advance again.
+ */
+function emitPhase0BlockIfNeeded(cwd, nextPhase) {
+  const reason = blockedPhaseTransitionReason(cwd, nextPhase);
+  if (!reason) return false;
+  console.log(JSON.stringify({
+    continue: true,
+    stopReason: reason,
+  }));
+  return true;
+}
+
 // Stage A Phase 1.6c-iii: snapshot ref + user-visible artifact creation.
 const { createSnapshotRef, attemptArtifactCreation } = await import(
   pathToFileURL(join(__dirname, 'lib', 'mpl-release-artifact.mjs')).href
@@ -398,6 +425,7 @@ async function main() {
 
       // BUG-6 fix: handle research error state to prevent infinite loop
       if (research.error) {
+        if (emitPhase0BlockIfNeeded(cwd, 'phase1b-plan')) return;
         writeState(cwd, { current_phase: 'phase1b-plan', research: { status: 'skipped' } });
         console.log(JSON.stringify({
           continue: true,
@@ -408,7 +436,9 @@ async function main() {
 
       if (research.status === 'completed' || research.status === 'skipped') {
         // Research done → transition to Phase 1-B: Plan Generation
-        writeState(cwd, { current_phase: 'phase1b-plan' });
+        if (emitPhase0BlockIfNeeded(cwd, 'phase1b-plan')) return;
+                if (emitPhase0BlockIfNeeded(cwd, 'phase1b-plan')) return;
+                writeState(cwd, { current_phase: 'phase1b-plan' });
         const msg = research.status === 'skipped'
           ? '[MPL] Research skipped. Transitioning to Phase 1-B: Plan Generation.'
           : `[MPL] Research completed (${research.stages_completed?.length || 0} stages, ${research.findings_count || 0} findings, ${research.sources_count || 0} sources). Transitioning to Phase 1-B: Plan Generation.`;
@@ -567,7 +597,8 @@ async function main() {
       if (!cohort) {
         // Defensive: release-gate without an active cohort is a state
         // corruption. Surface and revert to phase3-gate (whole-pipeline).
-        writeState(cwd, { current_phase: 'phase3-gate' });
+                if (emitPhase0BlockIfNeeded(cwd, 'phase3-gate')) return;
+                writeState(cwd, { current_phase: 'phase3-gate' });
         console.log(JSON.stringify({
           continue: true,
           stopReason: '[MPL] ⚠ release-gate entered with no active cohort. Reverting to phase3-gate.'
@@ -598,7 +629,8 @@ async function main() {
       const releaseResults = checkGateResults({ gate_results: releaseGates }, { strict: true });
 
       if (releaseResults.allPassed) {
-        writeState(cwd, { current_phase: 'release-finalize' });
+                if (emitPhase0BlockIfNeeded(cwd, 'release-finalize')) return;
+                writeState(cwd, { current_phase: 'release-finalize' });
         console.log(JSON.stringify({
           continue: true,
           stopReason: `[MPL] release-gate(${cohort}): scoped Hard 1/2/3 passed (source=${releaseResults.source}). Transitioning to release-finalize.`
@@ -703,7 +735,8 @@ async function main() {
       // to `completed`. Both remain exclusive to phase5-finalize.
       const cur = state.release?.current_cut_id;
       if (!cur) {
-        writeState(cwd, { current_phase: 'phase3-gate' });
+                if (emitPhase0BlockIfNeeded(cwd, 'phase3-gate')) return;
+                writeState(cwd, { current_phase: 'phase3-gate' });
         console.log(JSON.stringify({
           continue: true,
           stopReason: '[MPL] ⚠ release-finalize entered with no active cohort. Routing to phase3-gate.'
@@ -917,7 +950,8 @@ async function main() {
       // recompose-driven re-entry could still land here with a live cohort.
       // Surface and revert.
       if (state.release?.current_cut_id) {
-        writeState(cwd, { current_phase: 'phase2-sprint' });
+                if (emitPhase0BlockIfNeeded(cwd, 'phase2-sprint')) return;
+                writeState(cwd, { current_phase: 'phase2-sprint' });
         console.log(JSON.stringify({
           continue: true,
           stopReason: `[MPL] ⚠ phase3-gate entered while release cohort "${state.release.current_cut_id}" is still active. ` +
@@ -943,7 +977,8 @@ async function main() {
 
       if (gateResults.allPassed) {
         // All gates passed → Phase 5
-        writeState(cwd, { current_phase: 'phase5-finalize' });
+                if (emitPhase0BlockIfNeeded(cwd, 'phase5-finalize')) return;
+                writeState(cwd, { current_phase: 'phase5-finalize' });
         console.log(JSON.stringify({
           continue: true,
           stopReason: `[MPL] All Quality Gates passed (source=${gateResults.source}). Transitioning to Phase 5: Finalize.${fallbackWarn}`
@@ -996,7 +1031,8 @@ async function main() {
 
       if (fixCount >= maxFix) {
         // Fix loop limit reached → Phase 5 (partial completion)
-        writeState(cwd, { current_phase: 'phase5-finalize' });
+                if (emitPhase0BlockIfNeeded(cwd, 'phase5-finalize')) return;
+                writeState(cwd, { current_phase: 'phase5-finalize' });
         console.log(JSON.stringify({
           continue: true,
           stopReason: `[MPL] Fix loop limit reached (${fixCount}/${maxFix}). Transitioning to Phase 5: Finalize (partial completion).`
@@ -1005,7 +1041,8 @@ async function main() {
         // H1: Check convergence before continuing
         const convergenceResult = checkConvergence(state);
         if (convergenceResult.status === 'stagnating' || convergenceResult.status === 'regressing') {
-          writeState(cwd, { current_phase: 'phase5-finalize' });
+                    if (emitPhase0BlockIfNeeded(cwd, 'phase5-finalize')) return;
+                    writeState(cwd, { current_phase: 'phase5-finalize' });
           console.log(JSON.stringify({
             continue: true,
             stopReason: `[MPL] Convergence ${convergenceResult.status} detected (delta: ${convergenceResult.delta?.toFixed(3)}). Fix loop is not improving. Transitioning to Phase 5: Finalize (partial completion).`
@@ -1027,7 +1064,8 @@ async function main() {
       // and then manually set current_phase to 'completed' via writeState.
       const finalized = state.finalize_done === true;
       if (finalized) {
-        writeState(cwd, { current_phase: 'completed' });
+                if (emitPhase0BlockIfNeeded(cwd, 'completed')) return;
+                writeState(cwd, { current_phase: 'completed' });
         console.log(JSON.stringify({
           continue: false,
           stopReason: '[MPL] Phase 5: Finalize complete. MPL pipeline finished.'
@@ -1124,7 +1162,8 @@ async function main() {
 
       if (smallGate.hard2_passed === true) {
         // Code review passed → completed
-        writeState(cwd, { current_phase: 'completed' });
+                if (emitPhase0BlockIfNeeded(cwd, 'completed')) return;
+                writeState(cwd, { current_phase: 'completed' });
         console.log(JSON.stringify({
           continue: false,
           stopReason: '[MPL-Small] Verification passed. Pipeline complete. Extract learnings and commit.'
@@ -1135,7 +1174,8 @@ async function main() {
 
         if (smallFixCount >= smallMaxFix) {
           // Fix loop limit reached → completed (partial)
-          writeState(cwd, { current_phase: 'completed' });
+                    if (emitPhase0BlockIfNeeded(cwd, 'completed')) return;
+                    writeState(cwd, { current_phase: 'completed' });
           console.log(JSON.stringify({
             continue: false,
             stopReason: `[MPL-Small] Fix loop limit reached (${smallFixCount}/${smallMaxFix}). Completing with partial results. Extract learnings.`

--- a/hooks/mpl-phase-controller.mjs
+++ b/hooks/mpl-phase-controller.mjs
@@ -425,7 +425,9 @@ async function main() {
 
       // BUG-6 fix: handle research error state to prevent infinite loop
       if (research.error) {
-        if (emitPhase0BlockIfNeeded(cwd, 'phase1b-plan')) return;
+        // codex r7 on PR #222: phase1b-plan is exempt from the Phase 0
+        // artifact guard (it's the planning phase that produces
+        // decomposition + contracts). Transition unconditionally.
         writeState(cwd, { current_phase: 'phase1b-plan', research: { status: 'skipped' } });
         console.log(JSON.stringify({
           continue: true,
@@ -436,9 +438,8 @@ async function main() {
 
       if (research.status === 'completed' || research.status === 'skipped') {
         // Research done → transition to Phase 1-B: Plan Generation
-        if (emitPhase0BlockIfNeeded(cwd, 'phase1b-plan')) return;
-                if (emitPhase0BlockIfNeeded(cwd, 'phase1b-plan')) return;
-                writeState(cwd, { current_phase: 'phase1b-plan' });
+        // (phase1b-plan exempt; see comment above)
+        writeState(cwd, { current_phase: 'phase1b-plan' });
         const msg = research.status === 'skipped'
           ? '[MPL] Research skipped. Transitioning to Phase 1-B: Plan Generation.'
           : `[MPL] Research completed (${research.stages_completed?.length || 0} stages, ${research.findings_count || 0} findings, ${research.sources_count || 0} sources). Transitioning to Phase 1-B: Plan Generation.`;

--- a/hooks/mpl-phase-controller.mjs
+++ b/hooks/mpl-phase-controller.mjs
@@ -554,6 +554,9 @@ async function main() {
 
         const nextPhase = cohort ? 'release-gate' : 'phase3-gate';
         const target = cohort ? `release-gate(${cohort})` : 'Phase 3: Quality Gate';
+        // codex r2 on PR #222: variable nextPhase still needs the
+        // Phase 0 artifact guard — both branches land in protected phases.
+        if (emitPhase0BlockIfNeeded(cwd, nextPhase)) return;
         writeState(cwd, { current_phase: nextPhase });
         console.log(JSON.stringify({
           continue: true,
@@ -905,6 +908,8 @@ async function main() {
       const nextCutId = null;
       const nextPhase = 'phase3-gate';
 
+      // codex r2 on PR #222: protect this composite writeState too.
+      if (emitPhase0BlockIfNeeded(cwd, nextPhase)) return;
       writeState(cwd, {
         release: {
           ...existing,
@@ -1161,9 +1166,13 @@ async function main() {
       const smallGate = state.gate_results || {};
 
       if (smallGate.hard2_passed === true) {
-        // Code review passed → completed
-                if (emitPhase0BlockIfNeeded(cwd, 'completed')) return;
-                writeState(cwd, { current_phase: 'completed' });
+        // Code review passed → completed.
+        // codex r2 on PR #222 [contract-break]: the small pipeline is a
+        // separate lightweight flow (small-plan → small-sprint →
+        // small-verify) that intentionally skips Phase 0 — it does NOT
+        // produce raw-scan.md / design-intent.yaml / contracts. Do NOT
+        // guard the small-pipeline completion against Phase 0 artifacts.
+        writeState(cwd, { current_phase: 'completed' });
         console.log(JSON.stringify({
           continue: false,
           stopReason: '[MPL-Small] Verification passed. Pipeline complete. Extract learnings and commit.'
@@ -1173,9 +1182,9 @@ async function main() {
         const smallMaxFix = state.max_fix_loops || 3;
 
         if (smallFixCount >= smallMaxFix) {
-          // Fix loop limit reached → completed (partial)
-                    if (emitPhase0BlockIfNeeded(cwd, 'completed')) return;
-                    writeState(cwd, { current_phase: 'completed' });
+          // Fix loop limit reached → completed (partial).
+          // codex r2 [contract-break]: small-pipeline exempt (see above).
+          writeState(cwd, { current_phase: 'completed' });
           console.log(JSON.stringify({
             continue: false,
             stopReason: `[MPL-Small] Fix loop limit reached (${smallFixCount}/${smallMaxFix}). Completing with partial results. Extract learnings.`

--- a/hooks/mpl-state-invariant.mjs
+++ b/hooks/mpl-state-invariant.mjs
@@ -30,7 +30,7 @@ const { isMplActive, readState } = await import(
 const { readStdin } = await import(
   pathToFileURL(join(__dirname, 'lib', 'stdin.mjs')).href
 );
-const { checkInvariants, formatViolations, TRIGGERS } = await import(
+const { checkInvariants, formatViolations, TRIGGERS, VIOLATION_IDS } = await import(
   pathToFileURL(join(__dirname, 'lib', 'mpl-state-invariant.mjs')).href
 );
 const { resolveRuleAction } = await import(
@@ -159,11 +159,19 @@ async function main() {
   const result = checkInvariants(state, { cwd, trigger });
   if (result.ok) return silent();
 
+  // Codex r4 on PR #222 [data-integrity]: I13 (Phase 0 artifacts) MUST
+  // be a non-configurable block. The default `state_invariant_violation`
+  // policy is `warn`, which would let a manual Write to state.json land
+  // a protected phase without artifacts and only emit a systemMessage.
+  // The fast-track invariant exists precisely to stop that path.
+  const hasFastTrackViolation = result.violations.some(
+    (v) => v.id === VIOLATION_IDS.FAST_TRACK_PHASE0_ARTIFACTS_MISSING
+  );
   const action = resolveRuleAction(cwd, state, 'state_invariant_violation');
-  if (action === 'off') return silent();
+  if (action === 'off' && !hasFastTrackViolation) return silent();
 
   const reason = formatViolations(result);
-  if (action === 'block') {
+  if (action === 'block' || hasFastTrackViolation) {
     console.log(JSON.stringify({
       decision: 'block',
       reason,


### PR DESCRIPTION
## What

New state-invariant **I13 (FAST_TRACK_PHASE0_ARTIFACTS_MISSING)** in \`hooks/lib/mpl-state-invariant.mjs\` that fires on STATE_WRITE when \`current_phase\` is at or past \`phase1b-plan\` and any of these required Phase 0 artifacts is missing:

- \`.mpl/mpl/phase0/raw-scan.md\`
- \`.mpl/mpl/phase0/design-intent.yaml\`
- at least one \`.mpl/contracts/*.json\` (including \`_no-boundaries.json\` opt-out for simple tasks)

Phase 0 itself + mpl-decompose / mpl-ambiguity-resolve / phase1-plan / phase1a-research are exempt (those are where artifacts get produced).

Violation message names every missing file and the recovery path: re-run Phase 0, or write \`.mpl/contracts/_no-boundaries.json\` for an explicit non-boundary opt-out.

Tests cover: missing-artifacts blocking, all-artifacts-present passing, every later phase guarded, all pre-Phase-1b phases exempt, \`_no-boundaries.json\` alone passing for simple tasks, and STOP-trigger skipping.

## Why

Exp22 R11 observed that a fast-track directive could bypass the artifacts that make cross-boundary integration testable. The observed run had only \`design-intent.yaml\` and \`raw-scan.md\`; runtime/platform constraint output and \`.mpl/contracts/*.json\` were missing, leading to a green-looking run with Tauri state-not-managed errors, a TypeScript build break, and missing Tauri v2 capabilities.

This invariant pushes the requirement into the write boundary so the orchestrator cannot transition into sprint/finalize without the evidence.

## Design

N/A — additive invariant. Acceptance criteria in #210. Bucket [data-integrity] under \`/pr\` Convention §8.

## Agent Review Status

This PR is gated on **2 unique agent reviews** (footers \`— from <agent>\`).

- [ ] from claude
- [ ] from codex

Closes #210.