### PR TITLE
Add test-agent brief schema + validation gate (#212 MVP)

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -450,7 +450,7 @@ All Discoveries are recorded in `.mpl/discoveries.md`.
 
 ## 7. Hook System
 
-`hooks/hooks.json` is the live SSOT for hook registration. MPL maintains pipeline integrity with 38 registered hook commands:
+`hooks/hooks.json` is the live SSOT for hook registration. MPL maintains pipeline integrity with 39 registered hook commands:
 
 | Hook | Event / matcher | Purpose | Introduced |
 |----|--------|------|------------|
@@ -479,6 +479,7 @@ All Discoveries are recorded in `.mpl/discoveries.md`.
 | `mpl-artifact-schema` | PostToolUse: Edit/Write/MultiEdit/mcp__.*__write.* | Validate MPL artifacts against required markdown headings and YAML key schemas. | v0.18.1 |
 | `mpl-decomposition-postprocess` | PostToolUse: Edit/Write/MultiEdit | Regenerate `.mpl/mpl/decomposition-derived.json` immediately after derived source artifacts change. | v0.18 Phase 5 diet |
 | `mpl-require-test-agent` | PostToolUse: Task/Agent | Block phase-runner completion until required test-agent PASS evidence or override exists. | v0.15.1; structured PASS hardening v0.18.3 |
+| `mpl-require-test-agent-brief` | PreToolUse: Task/Agent | Block `mpl-test-agent` dispatch when `test_agent_required: true` phase has no valid `test-agent-brief.yaml` runbook artifact. | #212 |
 | `mpl-quality-gate` | PostToolUse: Task/Agent | Consume adversarial reviewer quality scores and trigger retry/escalation decisions. | v0.18.1 |
 | `mpl-validate-output` | PostToolUse: Task/Agent | Validate required sections of agent output and track token usage. | v0.13.x baseline |
 | `mpl-validate-seed` | PostToolUse: Task/Agent/Write/Edit/MultiEdit | Validate phase and chain seed YAML, contract snippets, TODO dependencies, files, and resource locks. | v0.10.0; registered v0.11.3; scheduling metadata v0.18.6 |

--- a/docs/schemas/test-agent-brief.md
+++ b/docs/schemas/test-agent-brief.md
@@ -106,9 +106,32 @@ PreToolUse on `Task|Agent`. When `tool_input.subagent_type` matches
 1. Read `.mpl/mpl/decomposition.yaml` to confirm the phase has
    `test_agent_required: true`. If `false`, no brief required — pass.
 2. Read `.mpl/mpl/phases/{phase_id}/test-agent-brief.yaml`. Missing →
-   block with a recovery hint pointing at the brief artifact path.
-3. Run the validator. Any violations → block with the structured list.
+   surface diagnostic (per enforcement mode below).
+3. Run the validator. Any violations → surface diagnostic with the
+   structured list.
 4. Otherwise pass.
+
+### Enforcement mode (`.mpl/config/test-agent-brief-enforcement.json`)
+
+Codex r2 on PR #224 [contract-break]: until the brief producer
+(follow-up issue) lands, blocking every existing required
+mpl-test-agent dispatch would break the only mandatory independent
+verification path. The MVP defaults to `warn` mode.
+
+```json
+{ "mode": "warn" }
+```
+
+Recognized values:
+
+- `"warn"` (default) — emit the diagnostic as a `systemMessage` so
+  operators see the missing-brief gap, but allow the dispatch to
+  proceed.
+- `"block"` — emit `decision: block`. Flip to this once the producer
+  ships (follow-up issue) so every required phase MUST have a brief.
+- `"off"` — silent skip; use only for transitional debugging.
+
+The config file is optional; absence means `warn`.
 
 ## Non-goal (deferred to follow-up)
 

--- a/docs/schemas/test-agent-brief.md
+++ b/docs/schemas/test-agent-brief.md
@@ -1,0 +1,128 @@
+# `test-agent-brief.yaml` schema
+
+**Path**: `.mpl/mpl/phases/{phase_id}/test-agent-brief.yaml` (one per
+phase where `test_agent_required: true`).
+
+**Purpose**: Separate the `mpl-test-agent` execution contract from the
+decomposer's responsibility surface (#212). The decomposer keeps its
+existing focus — phase graph, interface contracts, success criteria,
+probing hints. The brief turns those hints into concrete, executable
+runbook fields the test agent consumes directly, without re-inferring
+intent from the full decomposition.
+
+A future "brief generator" responsibility (new agent OR extension of
+`mpl-seed-generator`) writes this file; the MVP shipped with #212
+defines the schema, validates it on `mpl-test-agent` dispatch, and
+documents the contract. The brief generator itself is a follow-up.
+
+## Required shape
+
+```yaml
+phase_id: phase-1                 # MUST match the directory phase id
+phase_domain: api                 # e.g. api / data / ui / cli
+phase_name: "Create widget"       # human-readable
+
+# files the implementation phase is expected to touch — empty for
+# documentation-only phases, required non-empty for code-bearing
+# phases (the validator infers code-bearing from interface_contracts
+# being non-empty).
+target_implementation_files:
+  - src/api/widgets.ts
+
+# interface contracts the brief is verifying. References the phase's
+# interface_contract.produces[] symbols from decomposition.yaml.
+interface_contracts:
+  - symbol: createWidget
+    path: src/api/widgets.ts
+
+# A/S item coverage map — every acceptance / success item the phase
+# committed to in decomposition.yaml.verification_plan must appear here
+# with a concrete test target.
+a_item_coverage:
+  - id: A-1
+    test_target: "POST /widgets returns 201 with valid body"
+s_item_coverage:
+  - id: S-1
+    test_target: "POST /widgets returns 422 on missing field"
+
+# real commands the test-agent must run (non-empty list of non-trivial
+# command strings). placeholder/echo/no-op commands are rejected.
+required_test_commands:
+  - "npm test -- src/api/widgets.test.ts"
+
+# contract assertions (optional; if present, each must be a concrete
+# expression, not a placeholder).
+contract_assertions:
+  - "createWidget(body) returns Promise<Widget>"
+
+# probing hints converted to concrete adversarial test targets
+# (optional list; reuses decomposition.yaml.phase.probing_hints).
+probing_targets:
+  - "retry on transient 5xx returns Result.failure"
+
+# forbidden patterns inside test files — the test-agent must not
+# satisfy verification with these shapes.
+forbidden_conditions:
+  - "Mock / stub of createWidget itself"
+  - "Placeholder assertions (expect(true).toBe(true))"
+
+# the final JSON shape mpl-test-agent must produce
+expected_evidence_shape:
+  phase_id: phase-1
+  verdict: PASS|FAIL|INVALID
+  test_results: { total, passed, failed, skipped }
+  commands_run: [{command, exit_code}]
+  test_files_created: [path, ...]
+  a_item_coverage: [{id, status}]
+  s_item_coverage: [{id, status}]
+  bugs_found: []
+```
+
+## Validator (`hooks/lib/mpl-test-agent-brief.mjs`)
+
+Exports `validateBrief(text)` returning `{ valid, errors }`. Required
+checks for a code-bearing phase:
+
+- `phase_id` non-empty string
+- `target_implementation_files` non-empty array of strings (skipped for
+  documentation-only briefs where `interface_contracts` is empty)
+- `a_item_coverage` and `s_item_coverage` are arrays where every item
+  has an `id` and a non-trivial `test_target` (rejects empty,
+  placeholder strings like "TODO", "n/a")
+- `required_test_commands` non-empty array of strings, each at least 5
+  characters and not in a placeholder denylist (`echo`, `true`,
+  `false`, `:`, `# todo`)
+- `contract_assertions` (if present) — no placeholder-only strings
+  (`expect(true)`, `TODO`, `n/a`)
+
+Returns the structured violation list so the hook can surface a
+copy-ready resume hint.
+
+## Hook gate (`hooks/mpl-require-test-agent-brief.mjs`)
+
+PreToolUse on `Task|Agent`. When `tool_input.subagent_type` matches
+`mpl-test-agent` and the prompt names a `phase_id`:
+
+1. Read `.mpl/mpl/decomposition.yaml` to confirm the phase has
+   `test_agent_required: true`. If `false`, no brief required — pass.
+2. Read `.mpl/mpl/phases/{phase_id}/test-agent-brief.yaml`. Missing →
+   block with a recovery hint pointing at the brief artifact path.
+3. Run the validator. Any violations → block with the structured list.
+4. Otherwise pass.
+
+## Non-goal (deferred to follow-up)
+
+The MVP shipped with #212 does NOT include:
+
+- A `mpl-verification-brief-generator` agent (or `mpl-seed-generator`
+  extension that writes the brief) — the brief is currently expected
+  to land manually or via an out-of-band orchestrator step. The
+  follow-up issue tracks adding the producer.
+- Updates to `mpl-test-agent`'s system prompt to declare the brief as
+  its primary execution contract.
+- Executor dispatch path changes that pre-load the brief into the
+  test-agent prompt instead of assembling scattered decomposition
+  fields ad hoc.
+
+The MVP closes the schema + validation + enforcement gap so the
+generator and consumer can land independently.

--- a/hooks/__tests__/mpl-require-test-agent-brief.test.mjs
+++ b/hooks/__tests__/mpl-require-test-agent-brief.test.mjs
@@ -51,6 +51,14 @@ function runHook(toolInput) {
   }));
 }
 
+function setBlockMode() {
+  mkdirSync(join(tmp, '.mpl', 'config'), { recursive: true });
+  writeFileSync(
+    join(tmp, '.mpl', 'config', 'test-agent-brief-enforcement.json'),
+    JSON.stringify({ mode: 'block' }),
+  );
+}
+
 function writeValidBrief(phaseId) {
   mkdirSync(join(tmp, '.mpl', 'mpl', 'phases', phaseId), { recursive: true });
   writeFileSync(join(tmp, '.mpl', 'mpl', 'phases', phaseId, 'test-agent-brief.yaml'), `
@@ -161,20 +169,34 @@ describe('validateBrief (#212 MVP)', () => {
 /* ──────────────── hook integration tests ──────────────── */
 
 describe('mpl-require-test-agent-brief hook (#212)', () => {
-  it('SCENARIO 1: missing brief for test_agent_required:true → block', () => {
+  it('SCENARIO 1 (warn default): missing brief for test_agent_required:true → warn systemMessage', () => {
+    // Default mode is `warn` per #224 r2 [contract-break]: ship the
+    // gate without breaking existing dispatches before the producer
+    // lands.
+    const r = runHook({
+      subagent_type: 'mpl-test-agent',
+      prompt: 'Verify phase-1 from the contract.',
+    });
+    assert.equal(r.continue, true);
+    assert.match(r.systemMessage, /\[MPL #212\]/);
+    assert.match(r.systemMessage, /phase-1/);
+    assert.match(r.systemMessage, /brief artifact missing/);
+  });
+
+  it('SCENARIO 1 (block mode): same scenario in block mode → block', () => {
+    setBlockMode();
     const r = runHook({
       subagent_type: 'mpl-test-agent',
       prompt: 'Verify phase-1 from the contract.',
     });
     assert.equal(r.continue, false);
     assert.equal(r.decision, 'block');
-    assert.match(r.reason, /\[MPL #212\]/);
-    assert.match(r.reason, /phase-1/);
     assert.match(r.reason, /brief artifact missing/);
     assert.match(r.reason, /test-agent-brief\.yaml/);
   });
 
-  it('SCENARIO 2: invalid brief missing A/S coverage → block with errors', () => {
+  it('SCENARIO 2: invalid brief missing A/S coverage → block with errors (block mode)', () => {
+    setBlockMode();
     mkdirSync(join(tmp, '.mpl', 'mpl', 'phases', 'phase-1'), { recursive: true });
     writeFileSync(join(tmp, '.mpl', 'mpl', 'phases', 'phase-1', 'test-agent-brief.yaml'), `
 phase_id: phase-1
@@ -194,7 +216,8 @@ required_test_commands:
     assert.match(r.reason, /missing_s_item_coverage/);
   });
 
-  it('SCENARIO 3: invalid brief with placeholder command → block', () => {
+  it('SCENARIO 3: invalid brief with placeholder command → block (block mode)', () => {
+    setBlockMode();
     mkdirSync(join(tmp, '.mpl', 'mpl', 'phases', 'phase-1'), { recursive: true });
     writeFileSync(join(tmp, '.mpl', 'mpl', 'phases', 'phase-1', 'test-agent-brief.yaml'), `
 phase_id: phase-1
@@ -217,6 +240,20 @@ required_test_commands:
     });
     assert.equal(r.decision, 'block');
     assert.match(r.reason, /required_test_commands.*placeholder/);
+  });
+
+  it('enforcement mode off → silent even with missing brief (transitional debug)', () => {
+    mkdirSync(join(tmp, '.mpl', 'config'), { recursive: true });
+    writeFileSync(
+      join(tmp, '.mpl', 'config', 'test-agent-brief-enforcement.json'),
+      JSON.stringify({ mode: 'off' }),
+    );
+    const r = runHook({
+      subagent_type: 'mpl-test-agent',
+      prompt: 'Verify phase-1 from the contract.',
+    });
+    assert.equal(r.continue, true);
+    assert.equal(r.suppressOutput, true);
   });
 
   it('SCENARIO 4: valid brief → pass', () => {
@@ -252,6 +289,9 @@ required_test_commands:
     // codex r1 on PR #224: PreToolUse must NOT skip on run_in_background.
     // The brief precondition has to fire BEFORE the background dispatch
     // launches; no later PreToolUse event can stop an already-started run.
+    // In block mode it blocks; in default warn mode it surfaces a
+    // systemMessage. Either way the diagnostic fires (not silent).
+    setBlockMode();
     const r = runHook({
       subagent_type: 'mpl-test-agent',
       prompt: 'Verify phase-1.',

--- a/hooks/__tests__/mpl-require-test-agent-brief.test.mjs
+++ b/hooks/__tests__/mpl-require-test-agent-brief.test.mjs
@@ -1,0 +1,267 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { tmpdir } from 'os';
+
+import { CURRENT_SCHEMA_VERSION } from '../lib/mpl-state.mjs';
+import { validateBrief } from '../lib/mpl-test-agent-brief.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const HOOK_PATH = join(dirname(__filename), '..', 'mpl-require-test-agent-brief.mjs');
+
+let tmp;
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'mpl-brief-'));
+  mkdirSync(join(tmp, '.mpl', 'mpl'), { recursive: true });
+  writeFileSync(join(tmp, '.mpl', 'state.json'), JSON.stringify({
+    schema_version: CURRENT_SCHEMA_VERSION,
+    current_phase: 'phase2-sprint',
+  }));
+  writeFileSync(join(tmp, '.mpl', 'mpl', 'decomposition.yaml'), `
+phases:
+  - id: phase-1
+    phase_domain: api
+    test_agent_required: true
+    test_agent_rationale: "touches a boundary"
+    interface_contract:
+      requires: []
+      produces:
+        - symbol: createWidget
+          path: src/api/widgets.ts
+  - id: phase-2
+    phase_domain: docs
+    test_agent_required: false
+    test_agent_rationale: "documentation only"
+`);
+});
+afterEach(() => rmSync(tmp, { recursive: true, force: true }));
+
+function runHook(toolInput) {
+  const input = {
+    cwd: tmp,
+    tool_name: 'Task',
+    tool_input: toolInput,
+  };
+  return JSON.parse(execFileSync('node', [HOOK_PATH], {
+    input: JSON.stringify(input),
+    encoding: 'utf-8',
+  }));
+}
+
+function writeValidBrief(phaseId) {
+  mkdirSync(join(tmp, '.mpl', 'mpl', 'phases', phaseId), { recursive: true });
+  writeFileSync(join(tmp, '.mpl', 'mpl', 'phases', phaseId, 'test-agent-brief.yaml'), `
+phase_id: ${phaseId}
+phase_domain: api
+phase_name: "Create widget"
+target_implementation_files:
+  - src/api/widgets.ts
+interface_contracts:
+  - symbol: createWidget
+    path: src/api/widgets.ts
+a_item_coverage:
+  - id: A-1
+    test_target: "POST /widgets returns 201 with valid body"
+s_item_coverage:
+  - id: S-1
+    test_target: "POST /widgets returns 422 on missing field"
+required_test_commands:
+  - "npm test -- src/api/widgets.test.ts"
+`);
+}
+
+/* ──────────────── validator unit tests ──────────────── */
+
+describe('validateBrief (#212 MVP)', () => {
+  function freshBrief(overrides = {}) {
+    return {
+      phase_id: 'phase-1',
+      phase_domain: 'api',
+      target_implementation_files: ['src/api/widgets.ts'],
+      interface_contracts: [{ symbol: 'createWidget', path: 'src/api/widgets.ts' }],
+      a_item_coverage: [{ id: 'A-1', test_target: 'POST /widgets returns 201' }],
+      s_item_coverage: [{ id: 'S-1', test_target: 'POST /widgets returns 422' }],
+      required_test_commands: ['npm test -- src/api/widgets.test.ts'],
+      ...overrides,
+    };
+  }
+  function toYaml(brief) {
+    let out = '';
+    for (const [k, v] of Object.entries(brief)) {
+      if (Array.isArray(v)) {
+        out += `${k}:\n`;
+        for (const item of v) {
+          if (item && typeof item === 'object') {
+            const keys = Object.keys(item);
+            out += `  - ${keys[0]}: "${String(item[keys[0]])}"\n`;
+            for (const k2 of keys.slice(1)) {
+              out += `    ${k2}: "${String(item[k2])}"\n`;
+            }
+          } else {
+            out += `  - "${String(item)}"\n`;
+          }
+        }
+      } else {
+        out += `${k}: "${String(v)}"\n`;
+      }
+    }
+    return out;
+  }
+
+  it('accepts a fully valid brief', () => {
+    const r = validateBrief(toYaml(freshBrief()), { phaseId: 'phase-1' });
+    assert.equal(r.valid, true);
+    assert.deepEqual(r.errors, []);
+  });
+
+  it('rejects missing A/S coverage', () => {
+    const r = validateBrief(toYaml(freshBrief({ a_item_coverage: [] })), { phaseId: 'phase-1' });
+    assert.equal(r.valid, false);
+    assert.ok(r.errors.includes('missing_a_item_coverage'));
+  });
+
+  it('rejects placeholder test_target', () => {
+    const r = validateBrief(toYaml(freshBrief({
+      a_item_coverage: [{ id: 'A-1', test_target: 'TODO' }],
+    })), { phaseId: 'phase-1' });
+    assert.equal(r.valid, false);
+    assert.ok(r.errors.some((e) => /a_item_coverage.*placeholder/.test(e)));
+  });
+
+  it('rejects placeholder required_test_commands (echo / true / too short)', () => {
+    for (const cmd of ['echo done', 'true', ':', 'tbd']) {
+      const r = validateBrief(toYaml(freshBrief({ required_test_commands: [cmd] })), { phaseId: 'phase-1' });
+      assert.equal(r.valid, false, `must reject command: ${cmd}`);
+    }
+  });
+
+  it('rejects phase_id mismatch when phaseId is supplied', () => {
+    const r = validateBrief(toYaml(freshBrief({ phase_id: 'phase-9' })), { phaseId: 'phase-1' });
+    assert.ok(r.errors.some((e) => /phase_id_mismatch/.test(e)));
+  });
+
+  it('rejects empty required_test_commands', () => {
+    const r = validateBrief(toYaml(freshBrief({ required_test_commands: [] })), { phaseId: 'phase-1' });
+    assert.ok(r.errors.includes('missing_required_test_commands'));
+  });
+
+  it('skips target_implementation_files requirement for documentation-only briefs (no interface_contracts)', () => {
+    const r = validateBrief(toYaml(freshBrief({
+      interface_contracts: [],
+      target_implementation_files: [],
+    })), { phaseId: 'phase-1' });
+    // missing_target_implementation_files should NOT fire (no interface contracts)
+    assert.ok(!r.errors.includes('missing_target_implementation_files'));
+  });
+});
+
+/* ──────────────── hook integration tests ──────────────── */
+
+describe('mpl-require-test-agent-brief hook (#212)', () => {
+  it('SCENARIO 1: missing brief for test_agent_required:true → block', () => {
+    const r = runHook({
+      subagent_type: 'mpl-test-agent',
+      prompt: 'Verify phase-1 from the contract.',
+    });
+    assert.equal(r.continue, false);
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason, /\[MPL #212\]/);
+    assert.match(r.reason, /phase-1/);
+    assert.match(r.reason, /brief artifact missing/);
+    assert.match(r.reason, /test-agent-brief\.yaml/);
+  });
+
+  it('SCENARIO 2: invalid brief missing A/S coverage → block with errors', () => {
+    mkdirSync(join(tmp, '.mpl', 'mpl', 'phases', 'phase-1'), { recursive: true });
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'phases', 'phase-1', 'test-agent-brief.yaml'), `
+phase_id: phase-1
+target_implementation_files:
+  - src/api/widgets.ts
+interface_contracts:
+  - symbol: createWidget
+required_test_commands:
+  - "npm test"
+`);
+    const r = runHook({
+      subagent_type: 'mpl-test-agent',
+      prompt: 'Verify phase-1 from the contract.',
+    });
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason, /missing_a_item_coverage/);
+    assert.match(r.reason, /missing_s_item_coverage/);
+  });
+
+  it('SCENARIO 3: invalid brief with placeholder command → block', () => {
+    mkdirSync(join(tmp, '.mpl', 'mpl', 'phases', 'phase-1'), { recursive: true });
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'phases', 'phase-1', 'test-agent-brief.yaml'), `
+phase_id: phase-1
+target_implementation_files:
+  - src/api/widgets.ts
+interface_contracts:
+  - symbol: createWidget
+a_item_coverage:
+  - id: A-1
+    test_target: "POST /widgets returns 201"
+s_item_coverage:
+  - id: S-1
+    test_target: "POST /widgets returns 422"
+required_test_commands:
+  - echo done
+`);
+    const r = runHook({
+      subagent_type: 'mpl-test-agent',
+      prompt: 'Verify phase-1 from the contract.',
+    });
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason, /required_test_commands.*placeholder/);
+  });
+
+  it('SCENARIO 4: valid brief → pass', () => {
+    writeValidBrief('phase-1');
+    const r = runHook({
+      subagent_type: 'mpl-test-agent',
+      prompt: 'Verify phase-1 from the contract.',
+    });
+    assert.equal(r.continue, true);
+    assert.equal(r.suppressOutput, true);
+  });
+
+  it('SCENARIO 5: decomposer does NOT need to ship runbook directly — phase with test_agent_required:false passes without a brief', () => {
+    const r = runHook({
+      subagent_type: 'mpl-test-agent',
+      prompt: 'Verify phase-2 from the contract.',
+    });
+    // phase-2 has test_agent_required: false; the brief gate must not fire.
+    assert.equal(r.continue, true);
+  });
+
+  /* extra coverage */
+
+  it('non-test-agent Task dispatch passes through', () => {
+    const r = runHook({
+      subagent_type: 'mpl-phase-runner',
+      prompt: 'Execute phase-1.',
+    });
+    assert.equal(r.continue, true);
+  });
+
+  it('background test-agent dispatch (handle stub) passes through', () => {
+    const r = runHook({
+      subagent_type: 'mpl-test-agent',
+      prompt: 'Verify phase-1.',
+      run_in_background: true,
+    });
+    assert.equal(r.continue, true);
+  });
+
+  it('prompt with no phase id passes through', () => {
+    const r = runHook({
+      subagent_type: 'mpl-test-agent',
+      prompt: 'Generic test-agent task.',
+    });
+    assert.equal(r.continue, true);
+  });
+});

--- a/hooks/__tests__/mpl-require-test-agent-brief.test.mjs
+++ b/hooks/__tests__/mpl-require-test-agent-brief.test.mjs
@@ -248,7 +248,22 @@ required_test_commands:
     assert.equal(r.continue, true);
   });
 
-  it('background test-agent dispatch (handle stub) passes through', () => {
+  it('background test-agent dispatch is ALSO gated — codex r1 [logic]', () => {
+    // codex r1 on PR #224: PreToolUse must NOT skip on run_in_background.
+    // The brief precondition has to fire BEFORE the background dispatch
+    // launches; no later PreToolUse event can stop an already-started run.
+    const r = runHook({
+      subagent_type: 'mpl-test-agent',
+      prompt: 'Verify phase-1.',
+      run_in_background: true,
+    });
+    assert.equal(r.continue, false);
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason, /brief artifact missing/);
+  });
+
+  it('background test-agent dispatch passes when brief IS valid', () => {
+    writeValidBrief('phase-1');
     const r = runHook({
       subagent_type: 'mpl-test-agent',
       prompt: 'Verify phase-1.',

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -190,6 +190,16 @@
             "timeout": 3
           }
         ]
+      },
+      {
+        "matcher": "Task|Agent",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/mpl-require-test-agent-brief.mjs\"",
+            "timeout": 3
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/hooks/lib/mpl-test-agent-brief.mjs
+++ b/hooks/lib/mpl-test-agent-brief.mjs
@@ -1,0 +1,182 @@
+/**
+ * test-agent-brief.yaml validator (#212 MVP).
+ *
+ * Parses the brief YAML (using the same regex-style minimal peek
+ * pattern other MPL hook libs use — no js-yaml dependency) and
+ * surfaces the structured violation list so
+ * `hooks/mpl-require-test-agent-brief.mjs` can block dispatch with a
+ * copy-ready recovery hint. See `docs/schemas/test-agent-brief.md`
+ * for the canonical schema.
+ */
+
+const PLACEHOLDER_COMMANDS = new Set([
+  'echo', 'true', 'false', ':', 'noop', 'pass',
+]);
+
+const PLACEHOLDER_TARGETS = new Set([
+  '', 'todo', 'tbd', 'n/a', 'na', '-', '...',
+  'expect(true)', 'expect(true).tobe(true)', 'pass',
+]);
+
+function isPlaceholderTarget(s) {
+  if (typeof s !== 'string') return true;
+  const norm = s.trim().toLowerCase();
+  if (norm.length === 0) return true;
+  return PLACEHOLDER_TARGETS.has(norm);
+}
+
+function isPlaceholderCommand(s) {
+  if (typeof s !== 'string') return true;
+  const trimmed = s.trim();
+  if (trimmed.length < 5) return true;
+  // first word check
+  const head = trimmed.split(/\s+/)[0].toLowerCase();
+  if (PLACEHOLDER_COMMANDS.has(head)) return true;
+  return false;
+}
+
+/**
+ * Minimal YAML peek. Recognizes top-level scalars + named blocks +
+ * `- ` list items at one indent. Good enough for the brief schema;
+ * malformed YAML lands the same as missing required fields.
+ */
+function parseBriefText(text) {
+  const out = {};
+  const lines = String(text || '').split('\n');
+  let currentKey = null;
+  let currentList = null;
+  let currentObj = null;
+  for (const raw of lines) {
+    const line = raw.replace(/^﻿/, '');
+    if (/^\s*#/.test(line) || /^\s*$/.test(line)) continue;
+    // Top-level scalar: key: value
+    const scalar = line.match(/^([a-z_][a-z0-9_]*)\s*:\s*(.*)$/i);
+    if (scalar && !line.startsWith(' ')) {
+      const key = scalar[1];
+      const val = scalar[2].trim();
+      if (val === '' || val.startsWith('#')) {
+        // start of nested block
+        currentKey = key;
+        currentList = [];
+        currentObj = null;
+        out[key] = currentList;
+        continue;
+      }
+      out[key] = stripQuotes(val);
+      currentKey = null;
+      currentList = null;
+      currentObj = null;
+      continue;
+    }
+    // List item under currentKey
+    const item = line.match(/^\s+-\s+(.*)$/);
+    if (item && currentList) {
+      const body = item[1].trim();
+      const m = body.match(/^([a-z_][a-z0-9_]*)\s*:\s*(.*)$/i);
+      if (m) {
+        currentObj = { [m[1]]: stripQuotes(m[2].trim()) };
+        currentList.push(currentObj);
+      } else {
+        currentList.push(stripQuotes(body));
+        currentObj = null;
+      }
+      continue;
+    }
+    // key: value under currentObj
+    const sub = line.match(/^\s+([a-z_][a-z0-9_]*)\s*:\s*(.*)$/i);
+    if (sub && currentObj) {
+      currentObj[sub[1]] = stripQuotes(sub[2].trim());
+      continue;
+    }
+  }
+  return out;
+}
+
+function stripQuotes(s) {
+  if (typeof s !== 'string') return s;
+  const t = s.trim();
+  if ((t.startsWith('"') && t.endsWith('"')) || (t.startsWith("'") && t.endsWith("'"))) {
+    return t.slice(1, -1);
+  }
+  return t;
+}
+
+/**
+ * Validate the parsed brief. Caller may pass `phaseId` to also assert
+ * the `phase_id` field matches.
+ *
+ * Returns { valid: boolean, errors: string[] }.
+ */
+export function validateBrief(text, { phaseId = null } = {}) {
+  const errors = [];
+  let brief;
+  try {
+    brief = parseBriefText(text);
+  } catch (e) {
+    return { valid: false, errors: [`unparseable_yaml:${e?.message || 'unknown'}`] };
+  }
+  if (!brief || typeof brief !== 'object') {
+    return { valid: false, errors: ['empty_or_invalid_brief'] };
+  }
+
+  if (typeof brief.phase_id !== 'string' || !brief.phase_id.trim()) {
+    errors.push('missing_phase_id');
+  } else if (phaseId && brief.phase_id !== phaseId) {
+    errors.push(`phase_id_mismatch:expected=${phaseId},actual=${brief.phase_id}`);
+  }
+
+  const interfaceContracts = Array.isArray(brief.interface_contracts)
+    ? brief.interface_contracts : [];
+  const codeBearing = interfaceContracts.length > 0;
+
+  const targets = Array.isArray(brief.target_implementation_files)
+    ? brief.target_implementation_files : [];
+  if (codeBearing && targets.length === 0) {
+    errors.push('missing_target_implementation_files');
+  }
+
+  // A/S coverage
+  for (const fld of ['a_item_coverage', 's_item_coverage']) {
+    const cov = Array.isArray(brief[fld]) ? brief[fld] : [];
+    if (cov.length === 0) {
+      errors.push(`missing_${fld}`);
+      continue;
+    }
+    cov.forEach((entry, idx) => {
+      if (!entry || typeof entry !== 'object') {
+        errors.push(`${fld}[${idx}]_malformed`);
+        return;
+      }
+      if (typeof entry.id !== 'string' || !entry.id.trim()) {
+        errors.push(`${fld}[${idx}]_missing_id`);
+      }
+      if (isPlaceholderTarget(entry.test_target)) {
+        errors.push(`${fld}[${idx}]_placeholder_or_missing_test_target`);
+      }
+    });
+  }
+
+  // Required test commands — non-empty, real commands
+  const cmds = Array.isArray(brief.required_test_commands)
+    ? brief.required_test_commands : [];
+  if (cmds.length === 0) {
+    errors.push('missing_required_test_commands');
+  } else {
+    cmds.forEach((c, idx) => {
+      if (isPlaceholderCommand(c)) {
+        errors.push(`required_test_commands[${idx}]_placeholder_or_too_short`);
+      }
+    });
+  }
+
+  // Contract assertions (optional; if present, no placeholder-only)
+  if (Array.isArray(brief.contract_assertions)) {
+    brief.contract_assertions.forEach((a, idx) => {
+      if (isPlaceholderTarget(a)) {
+        errors.push(`contract_assertions[${idx}]_placeholder`);
+      }
+    });
+  }
+
+  return { valid: errors.length === 0, errors };
+}

--- a/hooks/mpl-require-test-agent-brief.mjs
+++ b/hooks/mpl-require-test-agent-brief.mjs
@@ -105,12 +105,14 @@ async function main() {
   const subagent = String(toolInput.subagent_type || toolInput.subagentType || '');
   if (!/mpl-test-agent$/.test(subagent)) return silent();
 
-  // Background dispatches (handle stubs) bypass — same heuristic as the
-  // require-test-agent hook (#218 r9). The real completion fires this
-  // hook again with a non-handle response.
-  if (toolInput.run_in_background === true || toolInput.runInBackground === true) {
-    return silent();
-  }
+  // No background bypass here — codex r1 on PR #224. This hook is
+  // PreToolUse; if we skipped on `run_in_background`, the background
+  // dispatch would launch without a brief check and no later PreToolUse
+  // event can stop the already-started run. The brief precondition
+  // must be enforced for foreground AND background dispatches.
+  // (The PostToolUse mpl-require-test-agent hook has its own handle-stub
+  // heuristic — that's separate, because it's reasoning about a
+  // tool_response that doesn't exist at this point in the lifecycle.)
 
   const phaseId = extractPhaseId(toolInput.prompt || toolInput.description || '');
   if (!phaseId) return silent(); // non-phase task, conservative allow

--- a/hooks/mpl-require-test-agent-brief.mjs
+++ b/hooks/mpl-require-test-agent-brief.mjs
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+/**
+ * Exp22 R12 / #212 MVP — block `Task(subagent_type='mpl-test-agent')`
+ * dispatches when the phase is marked `test_agent_required: true` and
+ * `.mpl/mpl/phases/{phase_id}/test-agent-brief.yaml` is missing or
+ * fails the brief schema validation.
+ *
+ * The brief contract (`docs/schemas/test-agent-brief.md`) decouples
+ * the test-agent execution runbook from the decomposer's
+ * responsibility surface. The brief generator (a new agent or a
+ * mpl-seed-generator extension) is deferred to a follow-up — the MVP
+ * just enforces the validated artifact must be present before the
+ * test-agent can be dispatched.
+ *
+ * Wired in `hooks/hooks.json` as PreToolUse on Task|Agent. Returns
+ * `{ continue: false, decision: 'block', reason }` when the brief is
+ * missing/invalid. All other paths (non-test-agent dispatch,
+ * test_agent_required:false phase, valid brief) pass silently.
+ */
+
+import { dirname, join } from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+import { existsSync, readFileSync } from 'fs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const isMain = import.meta.url === pathToFileURL(process.argv[1] || '').href;
+
+const { readState, isMplActive } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-state.mjs')).href
+);
+const { readStdin } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'stdin.mjs')).href
+);
+const { validateBrief } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-test-agent-brief.mjs')).href
+);
+
+function silent() {
+  console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+}
+
+function block(reason) {
+  console.log(JSON.stringify({ continue: false, decision: 'block', reason }));
+}
+
+function extractPhaseId(text) {
+  if (typeof text !== 'string') return null;
+  const m = text.match(/\bphase-(\d+)\b/);
+  return m ? `phase-${m[1]}` : null;
+}
+
+/**
+ * Minimal decomposition.yaml peek: find the entry for `phaseId` and
+ * return its `test_agent_required` boolean (default `true` per AD-0007
+ * — Decomposer must actively mark `false` with rationale).
+ */
+function readTestAgentRequired(cwd, phaseId) {
+  const path = join(cwd, '.mpl', 'mpl', 'decomposition.yaml');
+  if (!existsSync(path)) return null;
+  let text;
+  try { text = readFileSync(path, 'utf-8'); } catch { return null; }
+
+  const idMatch = new RegExp(`(^|\\n)\\s*-\\s*id\\s*:\\s*${phaseId}\\b`).exec(text);
+  if (!idMatch) return null;
+  // Walk forward from the phase id line until we hit the next sibling
+  // `- id:` or the end of the file.
+  const tail = text.slice(idMatch.index);
+  const nextSibling = tail.slice(1).search(/\n\s*-\s*id\s*:/);
+  const phaseBlock = nextSibling === -1 ? tail : tail.slice(0, nextSibling + 1);
+  const flagMatch = phaseBlock.match(/^\s*test_agent_required\s*:\s*(true|false)/im);
+  if (!flagMatch) return true; // default: required
+  return flagMatch[1].toLowerCase() === 'true';
+}
+
+function briefPath(cwd, phaseId) {
+  return join(cwd, '.mpl', 'mpl', 'phases', phaseId, 'test-agent-brief.yaml');
+}
+
+function buildReason(phaseId, reason, errors) {
+  const path = `.mpl/mpl/phases/${phaseId}/test-agent-brief.yaml`;
+  const errs = (errors && errors.length) ? `\n  - ${errors.join('\n  - ')}` : '';
+  return (
+    `[MPL #212] mpl-test-agent dispatch for ${phaseId} blocked: ${reason}. ` +
+    `Phase has \`test_agent_required: true\` per decomposition.yaml; ` +
+    `\`${path}\` is the required execution runbook (see ` +
+    `docs/schemas/test-agent-brief.md).${errs}`
+  );
+}
+
+async function main() {
+  const raw = await readStdin();
+  if (!raw.trim()) return silent();
+
+  let data;
+  try { data = JSON.parse(raw); } catch { return silent(); }
+
+  const cwd = data.cwd || data.directory || process.cwd();
+  if (!isMplActive(cwd)) return silent();
+
+  const toolName = String(data.tool_name || data.toolName || '');
+  if (!['Task', 'Agent'].includes(toolName)) return silent();
+
+  const toolInput = data.tool_input || data.toolInput || {};
+  const subagent = String(toolInput.subagent_type || toolInput.subagentType || '');
+  if (!/mpl-test-agent$/.test(subagent)) return silent();
+
+  // Background dispatches (handle stubs) bypass — same heuristic as the
+  // require-test-agent hook (#218 r9). The real completion fires this
+  // hook again with a non-handle response.
+  if (toolInput.run_in_background === true || toolInput.runInBackground === true) {
+    return silent();
+  }
+
+  const phaseId = extractPhaseId(toolInput.prompt || toolInput.description || '');
+  if (!phaseId) return silent(); // non-phase task, conservative allow
+
+  const required = readTestAgentRequired(cwd, phaseId);
+  if (required === false) return silent(); // explicit opt-out path
+  // null (decomposition not yet available) also passes — defer to
+  // existing require-test-agent hook to handle that case.
+  if (required === null) return silent();
+
+  const path = briefPath(cwd, phaseId);
+  if (!existsSync(path)) {
+    block(buildReason(phaseId, 'brief artifact missing'));
+    return;
+  }
+  let text;
+  try { text = readFileSync(path, 'utf-8'); } catch (e) {
+    block(buildReason(phaseId, `brief artifact unreadable: ${e?.message || 'unknown'}`));
+    return;
+  }
+  const { valid, errors } = validateBrief(text, { phaseId });
+  if (!valid) {
+    block(buildReason(phaseId, 'brief failed schema validation', errors));
+    return;
+  }
+  silent();
+}
+
+if (isMain) {
+  await main().catch(() => silent());
+}

--- a/hooks/mpl-require-test-agent-brief.mjs
+++ b/hooks/mpl-require-test-agent-brief.mjs
@@ -40,8 +40,40 @@ function silent() {
   console.log(JSON.stringify({ continue: true, suppressOutput: true }));
 }
 
+function warn(reason) {
+  console.log(JSON.stringify({ continue: true, systemMessage: reason }));
+}
+
 function block(reason) {
   console.log(JSON.stringify({ continue: false, decision: 'block', reason }));
+}
+
+/**
+ * Codex r2 on PR #224 [contract-break]: the MVP ships the schema +
+ * validator + gate but defers the brief producer (follow-up). Until
+ * the producer lands, blocking every existing required mpl-test-agent
+ * dispatch would break the only mandatory independent verification
+ * path. Default to WARN mode so existing pipelines surface the
+ * missing-brief diagnostic without losing the gate; flip to BLOCK
+ * by writing `.mpl/config/test-agent-brief-enforcement.json` with
+ * `{ "mode": "block" }` (which the follow-up that adds the producer
+ * will do as part of the cutover).
+ */
+function resolveEnforcementMode(cwd) {
+  const cfgPath = join(cwd, '.mpl', 'config', 'test-agent-brief-enforcement.json');
+  if (!existsSync(cfgPath)) return 'warn';
+  try {
+    const parsed = JSON.parse(readFileSync(cfgPath, 'utf-8'));
+    const mode = String(parsed?.mode || '').toLowerCase();
+    if (mode === 'block' || mode === 'warn' || mode === 'off') return mode;
+  } catch { /* fall through */ }
+  return 'warn';
+}
+
+function surface(mode, reason) {
+  if (mode === 'off') return silent();
+  if (mode === 'block') return block(reason);
+  warn(reason);
 }
 
 function extractPhaseId(text) {
@@ -123,19 +155,22 @@ async function main() {
   // existing require-test-agent hook to handle that case.
   if (required === null) return silent();
 
+  const mode = resolveEnforcementMode(cwd);
+  if (mode === 'off') return silent();
+
   const path = briefPath(cwd, phaseId);
   if (!existsSync(path)) {
-    block(buildReason(phaseId, 'brief artifact missing'));
+    surface(mode, buildReason(phaseId, 'brief artifact missing'));
     return;
   }
   let text;
   try { text = readFileSync(path, 'utf-8'); } catch (e) {
-    block(buildReason(phaseId, `brief artifact unreadable: ${e?.message || 'unknown'}`));
+    surface(mode, buildReason(phaseId, `brief artifact unreadable: ${e?.message || 'unknown'}`));
     return;
   }
   const { valid, errors } = validateBrief(text, { phaseId });
   if (!valid) {
-    block(buildReason(phaseId, 'brief failed schema validation', errors));
+    surface(mode, buildReason(phaseId, 'brief failed schema validation', errors));
     return;
   }
   silent();


### PR DESCRIPTION
## What

- **\`docs/schemas/test-agent-brief.md\`** (new): canonical schema for \`.mpl/mpl/phases/{phase_id}/test-agent-brief.yaml\` — the per-phase test-agent execution runbook. Required fields: \`phase_id\`, \`target_implementation_files\` (for code-bearing phases), A/S item coverage maps with concrete \`test_target\`, \`required_test_commands\`. Placeholder/echo/true commands and TODO/n/a targets are rejected.
- **\`hooks/lib/mpl-test-agent-brief.mjs\`** (new): \`validateBrief(text, { phaseId })\` with structured violation list. Minimal YAML peek (same style as \`mpl-gate-classify\`/\`mpl-phase0-artifacts\`).
- **\`hooks/mpl-require-test-agent-brief.mjs\`** (new): PreToolUse Task|Agent. Fires for \`subagent_type=mpl-test-agent\`. Reads decomposition.yaml for \`test_agent_required\`; reads brief; blocks dispatch on missing/invalid brief with copy-ready recovery hint.
- **\`hooks/hooks.json\`**: register the new hook.
- **\`docs/design.md\`**: hook table entry + count bump.

Tests in \`hooks/__tests__/mpl-require-test-agent-brief.test.mjs\` cover the validator + 5 integration scenarios:
1. missing brief for \`test_agent_required:true\` → block
2. invalid brief missing A/S coverage → block
3. invalid brief with placeholder command → block
4. valid brief → pass
5. \`test_agent_required:false\` phase → pass without a brief

## Why

Exp22 R12 / #212: decomposer responsibility concentration — it would have to ship full test-agent runbook context (commands, coverage, adversarial targets) on top of phase graph + contracts + type policy + E2E + probing hints. Splitting the brief out as its own artifact gives the role boundary a concrete schema-checked artifact instead of prose.

## Non-goal (follow-up)

This PR ships the schema + validator + enforcement gate. The brief PRODUCER — a new \`mpl-verification-brief-generator\` agent OR a \`mpl-seed-generator\` extension that writes the artifact — is intentionally deferred so producer and consumer can land independently. \`mpl-test-agent\` prompt updates that declare the brief as the primary contract, and executor dispatch changes that pre-load the brief, are also follow-ups.

## Design

Acceptance criteria from #212:
- ✅ A schema exists for \`test-agent-brief.yaml\`
- ✅ Required phases cannot advance to test-agent dispatch without a valid brief
- 🟡 Executor dispatch prompt uses the brief — deferred to follow-up
- 🟡 \`mpl-test-agent\` prompt documents brief as primary contract — deferred to follow-up
- ✅ All 5 regression scenarios covered
- ✅ Decomposer NOT required to emit detailed runbook content directly (non-goal in issue body respected)

Bucket [data-integrity] under \`/pr\` Convention §8.

## Agent Review Status

This PR is gated on **2 unique agent reviews** (footers \`— from <agent>\`).

- [ ] from claude
- [ ] from codex

Closes #212.