### PR TITLE
Enforce Phase 0 artifact invariant in mcp_state_write (#223)

### DIFF
--- a/mcp-server/__tests__/state-manager.test.mjs
+++ b/mcp-server/__tests__/state-manager.test.mjs
@@ -132,11 +132,33 @@ describe('writeState Phase 0 artifact invariant (#223)', () => {
     assert.match(result.reason, /contracts/);
   });
 
-  it('non-current_phase patches pass through without Phase 0 check', async () => {
+  it('non-current_phase patches pass through when existing current_phase is not protected', async () => {
     const mod = await loadModule();
-    // No Phase 0 artifacts. Patch is unrelated to current_phase.
+    // No Phase 0 artifacts, no existing state — current_phase defaults
+    // to phase1-plan (not protected). The patch updates an unrelated key.
     const result = mod.writeState(tmpDir, { run_mode: 'auto' });
     assert.strictEqual(result.success, true);
     assert.deepEqual(result.updated_keys, ['run_mode']);
+  });
+
+  it('codex r1 [data-integrity]: non-current_phase patch BLOCKED when merged current_phase is protected and artifacts missing', async () => {
+    const mod = await loadModule();
+    // Step 1: set up the chicken (Phase 0 artifacts present), transition to protected, then remove the artifacts.
+    setupPhase0(tmpDir);
+    const ok = mod.writeState(tmpDir, { current_phase: 'phase2-sprint' });
+    assert.strictEqual(ok.success, true);
+    rmSync(join(tmpDir, '.mpl', 'mpl', 'phase0'), { recursive: true, force: true });
+    rmSync(join(tmpDir, '.mpl', 'contracts'), { recursive: true, force: true });
+    // Step 2: a non-current_phase patch must NOT succeed while the merged
+    // state is in a protected phase without artifacts. Hook-side I13
+    // validates the full proposed state on every STATE_WRITE; this
+    // mirrors that behavior on the MCP path.
+    const result = mod.writeState(tmpDir, { run_mode: 'auto' });
+    assert.strictEqual(result.success, false);
+    assert.match(result.reason, /\[MPL I13\]/);
+    assert.match(result.reason, /phase2-sprint/);
+    // run_mode was NOT written.
+    const raw = JSON.parse(readFileSync(join(tmpDir, '.mpl', 'state.json'), 'utf-8'));
+    assert.notStrictEqual(raw.run_mode, 'auto');
   });
 });

--- a/mcp-server/__tests__/state-manager.test.mjs
+++ b/mcp-server/__tests__/state-manager.test.mjs
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, rmSync, readFileSync } from 'fs';
+import { mkdtempSync, rmSync, readFileSync, mkdirSync, writeFileSync, existsSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 
@@ -60,5 +60,83 @@ describe('state-manager ring buffer (P1-3a)', () => {
     const raw = JSON.parse(readFileSync(join(tmpDir, '.mpl', 'state.json'), 'utf-8'));
     assert.strictEqual(raw.ambiguity_history.length, mod.MAX_AMBIGUITY_HISTORY);
     assert.strictEqual(stderrCaptured, '');
+  });
+});
+
+describe('writeState Phase 0 artifact invariant (#223)', () => {
+  let tmpDir;
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'mpl-state-mgr-i13-'));
+  });
+  afterEach(() => {
+    if (tmpDir) rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function setupPhase0(dir, { rawScan = true, designIntent = true, contracts = true } = {}) {
+    const phase0 = join(dir, '.mpl', 'mpl', 'phase0');
+    mkdirSync(phase0, { recursive: true });
+    if (rawScan) writeFileSync(join(phase0, 'raw-scan.md'), '# raw-scan');
+    if (designIntent) writeFileSync(join(phase0, 'design-intent.yaml'), 'invariants: []');
+    if (contracts) {
+      mkdirSync(join(dir, '.mpl', 'contracts'), { recursive: true });
+      writeFileSync(join(dir, '.mpl', 'contracts', '_no-boundaries.json'), '{}');
+    }
+  }
+
+  it('rejects a state-write proposing a protected current_phase when Phase 0 artifacts are missing', async () => {
+    const mod = await loadModule();
+    // No Phase 0 artifacts at all.
+    const result = mod.writeState(tmpDir, { current_phase: 'phase2-sprint' });
+    assert.strictEqual(result.success, false);
+    assert.deepEqual(result.updated_keys, []);
+    assert.match(result.reason, /\[MPL I13\]/);
+    assert.match(result.reason, /phase2-sprint/);
+    assert.match(result.reason, /raw-scan\.md/);
+    // CRITICAL: no .mpl/state.json should have been written.
+    assert.strictEqual(existsSync(join(tmpDir, '.mpl', 'state.json')), false);
+  });
+
+  for (const phase of ['phase3-gate', 'phase4-fix', 'phase5-finalize', 'release-gate', 'release-finalize', 'completed']) {
+    it(`rejects transition to ${phase} when artifacts missing`, async () => {
+      const mod = await loadModule();
+      const result = mod.writeState(tmpDir, { current_phase: phase });
+      assert.strictEqual(result.success, false);
+      assert.match(result.reason, new RegExp(phase));
+    });
+  }
+
+  it('allows transition to a protected phase when Phase 0 artifacts are present', async () => {
+    const mod = await loadModule();
+    setupPhase0(tmpDir);
+    const result = mod.writeState(tmpDir, { current_phase: 'phase2-sprint' });
+    assert.strictEqual(result.success, true);
+    assert.deepEqual(result.updated_keys, ['current_phase']);
+    const raw = JSON.parse(readFileSync(join(tmpDir, '.mpl', 'state.json'), 'utf-8'));
+    assert.strictEqual(raw.current_phase, 'phase2-sprint');
+  });
+
+  it('allows transition to an EXEMPT phase (phase1b-plan) with no Phase 0 artifacts', async () => {
+    const mod = await loadModule();
+    // No setupPhase0 — chicken-and-egg, phase1b-plan is where artifacts get made.
+    const result = mod.writeState(tmpDir, { current_phase: 'phase1b-plan' });
+    assert.strictEqual(result.success, true);
+  });
+
+  it('rejects when contracts directory exists but contains no .json (only e.g. README)', async () => {
+    const mod = await loadModule();
+    setupPhase0(tmpDir, { contracts: false });
+    mkdirSync(join(tmpDir, '.mpl', 'contracts'), { recursive: true });
+    writeFileSync(join(tmpDir, '.mpl', 'contracts', 'README.md'), '# placeholder');
+    const result = mod.writeState(tmpDir, { current_phase: 'phase2-sprint' });
+    assert.strictEqual(result.success, false);
+    assert.match(result.reason, /contracts/);
+  });
+
+  it('non-current_phase patches pass through without Phase 0 check', async () => {
+    const mod = await loadModule();
+    // No Phase 0 artifacts. Patch is unrelated to current_phase.
+    const result = mod.writeState(tmpDir, { run_mode: 'auto' });
+    assert.strictEqual(result.success, true);
+    assert.deepEqual(result.updated_keys, ['run_mode']);
   });
 });

--- a/mcp-server/src/lib/state-manager.ts
+++ b/mcp-server/src/lib/state-manager.ts
@@ -265,21 +265,23 @@ export function writeState(cwd: string, patch: Record<string, unknown>): { succe
   const filePath = join(cwd, STATE_PATH);
   const dir = dirname(filePath);
 
-  // #223: enforce I13 BEFORE any disk write. A patch that proposes a
-  // protected phase without Phase 0 artifacts is rejected up-front;
-  // partial application (write succeeds, invariant violated) would
-  // leak state through the MCP layer that no other write path allows.
-  if (typeof patch?.current_phase === 'string') {
-    const blockedReason = blockedPhaseTransitionReason(cwd, patch.current_phase);
+  // #223 + codex r1 [data-integrity]: enforce I13 against the
+  // POST-MERGE current_phase, not the patch alone. Hook-side I13
+  // validates the full proposed state on every STATE_WRITE; mirror
+  // that here so non-`current_phase` patches against an already-
+  // protected-phase state with missing artifacts cannot persist
+  // execution/gate metadata while leaving the invariant violated.
+  const current = readState(cwd) ?? { ...DEFAULT_STATE };
+  const merged = deepMerge(current as unknown as Record<string, unknown>, patch);
+  const mergedPhase = typeof merged.current_phase === 'string' ? merged.current_phase : '';
+  if (mergedPhase) {
+    const blockedReason = blockedPhaseTransitionReason(cwd, mergedPhase);
     if (blockedReason) {
       return { success: false, updated_keys: [], reason: blockedReason };
     }
   }
 
   mkdirSync(dir, { recursive: true });
-
-  const current = readState(cwd) ?? { ...DEFAULT_STATE };
-  const merged = deepMerge(current as unknown as Record<string, unknown>, patch);
 
   // Ring-buffer cap for ambiguity_history (mirrors hooks/lib/mpl-state.mjs).
   // deepMerge replaces arrays wholesale, so the patch either set or preserved

--- a/mcp-server/src/lib/state-manager.ts
+++ b/mcp-server/src/lib/state-manager.ts
@@ -3,7 +3,7 @@
  * Provides deterministic state read/write with atomic file operations.
  */
 
-import { readFileSync, writeFileSync, mkdirSync, existsSync, renameSync } from 'fs';
+import { readFileSync, writeFileSync, mkdirSync, existsSync, renameSync, readdirSync } from 'fs';
 import { join, dirname } from 'path';
 import { randomUUID } from 'crypto';
 
@@ -209,9 +209,73 @@ export function readState(cwd: string): MplState | null {
   }
 }
 
-export function writeState(cwd: string, patch: Record<string, unknown>): { success: boolean; updated_keys: string[] } {
+// #223: Phase 0 artifact invariant enforcement (mirrors I13 in
+// hooks/lib/mpl-state-invariant.mjs + phase-controller's pre-transition
+// check). The hooks-side enforcement is intercepted by Claude Code's
+// PreToolUse pipeline; MCP `mpl_state_write` writes through the
+// state-manager directly, bypassing PreToolUse. Keep the lists in sync
+// with hooks/lib/mpl-phase0-artifacts.mjs.
+const REQUIRES_PHASE0_ARTIFACTS = new Set<string>([
+  'phase2-sprint',
+  'phase3-gate',
+  'phase4-fix',
+  'phase5-finalize',
+  'release-gate',
+  'release-finalize',
+  'completed',
+]);
+
+function missingPhase0Artifacts(cwd: string): string[] {
+  const missing: string[] = [];
+  if (!existsSync(join(cwd, '.mpl', 'mpl', 'phase0', 'raw-scan.md'))) {
+    missing.push('.mpl/mpl/phase0/raw-scan.md');
+  }
+  if (!existsSync(join(cwd, '.mpl', 'mpl', 'phase0', 'design-intent.yaml'))) {
+    missing.push('.mpl/mpl/phase0/design-intent.yaml');
+  }
+  const contractsDir = join(cwd, '.mpl', 'contracts');
+  let hasContract = false;
+  try {
+    if (existsSync(contractsDir)) {
+      hasContract = readdirSync(contractsDir).some((n) => n.endsWith('.json'));
+    }
+  } catch {
+    hasContract = false;
+  }
+  if (!hasContract) {
+    missing.push('.mpl/contracts/*.json (or _no-boundaries.json)');
+  }
+  return missing;
+}
+
+function blockedPhaseTransitionReason(cwd: string, nextPhase: string): string | null {
+  if (!REQUIRES_PHASE0_ARTIFACTS.has(nextPhase)) return null;
+  const missing = missingPhase0Artifacts(cwd);
+  if (missing.length === 0) return null;
+  return (
+    `[MPL I13] Cannot transition to ${nextPhase} — Phase 0 boundary/runtime ` +
+    `artifacts missing: ${missing.join(', ')}. Fast-track (run_mode=auto) ` +
+    `may shorten user interviews but MUST NOT skip these artifacts. Re-run ` +
+    `Phase 0 to produce them, or write .mpl/contracts/_no-boundaries.json ` +
+    `as the explicit opt-out for non-boundary tasks.`
+  );
+}
+
+export function writeState(cwd: string, patch: Record<string, unknown>): { success: boolean; updated_keys: string[]; reason?: string } {
   const filePath = join(cwd, STATE_PATH);
   const dir = dirname(filePath);
+
+  // #223: enforce I13 BEFORE any disk write. A patch that proposes a
+  // protected phase without Phase 0 artifacts is rejected up-front;
+  // partial application (write succeeds, invariant violated) would
+  // leak state through the MCP layer that no other write path allows.
+  if (typeof patch?.current_phase === 'string') {
+    const blockedReason = blockedPhaseTransitionReason(cwd, patch.current_phase);
+    if (blockedReason) {
+      return { success: false, updated_keys: [], reason: blockedReason };
+    }
+  }
+
   mkdirSync(dir, { recursive: true });
 
   const current = readState(cwd) ?? { ...DEFAULT_STATE };

--- a/mcp-server/src/tools/state.ts
+++ b/mcp-server/src/tools/state.ts
@@ -49,5 +49,9 @@ export const stateWriteTool = {
 
 export async function handleStateWrite(args: { cwd: string; patch: Record<string, unknown> }) {
   const result = writeState(args.cwd, args.patch);
+  // #223: when writeState rejects on I13 (Phase 0 artifacts missing for
+  // a protected current_phase), surface the reason verbatim. Existing
+  // success/failure shape is preserved; only the optional `reason`
+  // field is new.
   return { content: [{ type: 'text' as const, text: JSON.stringify(result) }] };
 }


### PR DESCRIPTION
## Summary

- Closes #223 — the I13 invariant from PR #222 is now also enforced in `mcp-server/src/lib/state-manager.ts::writeState`, plugging the MCP-tool bypass.
- Adds 11 regression tests covering each protected phase, exempt phases, no-json contracts dir, and non-current_phase patches.

## Why

I13 (FAST_TRACK_PHASE0_ARTIFACTS_MISSING) was enforced in two places after #222:
- `hooks/lib/mpl-state-invariant.mjs` (PreToolUse on STATE_WRITE)
- `hooks/mpl-phase-controller.mjs` (Stop hook pre-transition check)

The MCP tool `mpl_state_write` calls `writeState` directly and bypasses both. A caller could patch `current_phase` to `phase2-sprint` / `phase3-gate` / ... / `completed` with no Phase 0 artifacts and receive `{success: true}`. Same invariant; new write path.

## Approach

Mirror `REQUIRES_PHASE0_ARTIFACTS` + `missingPhase0Artifacts` + `blockedPhaseTransitionReason` into the MCP TS layer (the canonical lib is .mjs in `hooks/lib/mpl-phase0-artifacts.mjs` and the MCP server runs compiled .js — a small duplicated set vs a cross-package import). Check fires BEFORE any disk write, returns `{ success: false, reason }` and leaves `.mpl/state.json` untouched on rejection.

`writeState` return type adds an optional `reason?: string`; existing callers continue to work without changes. The MCP tool handler passes the new field through to the JSON response so MCP clients see the structured reason.

## Test plan

- [x] `cd mcp-server && npm test` — 90/90 pass, including 11 new tests under "writeState Phase 0 artifact invariant (#223)".
- [x] Full hook suite `node --test "hooks/__tests__/*.test.mjs"` — 1261/1261 pass (no regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)