### PR TITLE
Always surface active blocker even with stale envelope (#217)

### DIFF
--- a/hooks/__tests__/mpl-hook-trace.test.mjs
+++ b/hooks/__tests__/mpl-hook-trace.test.mjs
@@ -159,6 +159,64 @@ describe('mpl-hook-trace', () => {
     }
   });
 
+  it('#217: blocked_artifact missing entirely — active blocker still surfaces on an unrelated target', () => {
+    // Codex r8 on PR #216 / #217: prior versions required activeBlockArtifact
+    // to non-empty AND endsWith()-match the target before force-include.
+    // A stale envelope with NO blocked_artifact at all (corrupt state.json
+    // from an aborted hook) plus a target like
+    // `state.test_agent_dispatched.<phase>` would silently filter out
+    // the active blocker via the category check. The diagnostic showed
+    // a clean trace while the run was paused.
+    const tmp = mkdtempSync(join(tmpdir(), 'mpl-hook-trace-217-noartifact-'));
+    try {
+      mkdirSync(join(tmp, '.mpl'), { recursive: true });
+      writeFileSync(join(tmp, '.mpl', 'state.json'), JSON.stringify({
+        schema_version: CURRENT_SCHEMA_VERSION,
+        current_phase: 'phase2-sprint',
+        session_status: 'blocked_hook',
+        blocked_by_hook: 'mpl-require-test-agent',
+        // blocked_artifact intentionally absent
+      }));
+      const trace = traceHookChain({
+        targetPath: 'state.test_agent_dispatched.phase-1',
+        cwd: tmp,
+      });
+      const row = trace.hooks.find((h) => h.hook_id === 'mpl-require-test-agent');
+      assert.ok(row, 'mpl-require-test-agent must appear even with no blocked_artifact');
+      assert.equal(row.status, 'invalid_blocked_envelope');
+      assert.match(formatHookTrace(trace), /INVALID_BLOCKED_ENVELOPE/);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('#217: synthetic row when active blocker not in hooks.json AND envelope missing artifact', () => {
+    // The synthetic-row path also dropped the artifact-match precondition.
+    const tmp = mkdtempSync(join(tmpdir(), 'mpl-hook-trace-217-synthetic-'));
+    try {
+      mkdirSync(join(tmp, '.mpl'), { recursive: true });
+      writeFileSync(join(tmp, '.mpl', 'state.json'), JSON.stringify({
+        schema_version: CURRENT_SCHEMA_VERSION,
+        current_phase: 'phase2-sprint',
+        session_status: 'blocked_hook',
+        blocked_by_hook: 'mpl-imaginary-hook-not-registered',
+        // blocked_artifact intentionally absent
+      }));
+      const trace = traceHookChain({
+        targetPath: 'state.test_agent_dispatched.phase-1',
+        cwd: tmp,
+      });
+      const row = trace.hooks.find((h) => h.hook_id === 'mpl-imaginary-hook-not-registered');
+      assert.ok(row, 'synthetic row must surface even with no artifact');
+      assert.equal(row.event, 'state');
+      assert.equal(row.matcher, 'blocked_by_hook');
+      assert.match(row.purpose, /registry skew/);
+      assert.equal(row.status, 'invalid_blocked_envelope');
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it('always includes the blocked_by_hook entry for an active block, even when the path category would filter it out', () => {
     // Codex r4 on PR #216: a valid mpl-require-test-agent block records
     // blocked_artifact as `state.test_agent_dispatched.<phase>`, which the

--- a/hooks/lib/mpl-hook-trace.mjs
+++ b/hooks/lib/mpl-hook-trace.mjs
@@ -209,26 +209,26 @@ export function traceHookChain({
   // (stale/corrupt envelope); both diagnoses are useful and either is
   // better than silently filtering out the hook that is actually keeping
   // the run blocked.
+  //
+  // Codex r8 / #217: drop the artifact-match precondition entirely. If
+  // the envelope is STALE and missing blocked_artifact, the prior
+  // version silently filtered the active blocker out via category check
+  // — so tracing any non-matching target while paused returned a row
+  // set that looked healthy. Force-include is now triggered by
+  // session_status === 'blocked_hook' + non-empty blocked_by_hook
+  // alone; the missing artifact case shows up as
+  // invalid_blocked_envelope per blockStatusFor.
   const activeBlockHookId = activeState
     && activeState.session_status === 'blocked_hook'
     ? String(activeState.blocked_by_hook || '').trim()
     : null;
-  const activeBlockArtifact = activeBlockHookId
-    ? String(activeState.blocked_artifact || '').trim()
-    : null;
-  const resolvedTargetTrim = String(resolvedTarget).trim();
-  const activeBlockMatchesTarget = activeBlockArtifact && resolvedTargetTrim && (
-    activeBlockArtifact === resolvedTargetTrim ||
-    resolvedTargetTrim.endsWith(activeBlockArtifact) ||
-    activeBlockArtifact.endsWith(resolvedTargetTrim)
-  );
 
   for (const [eventName, registrations] of Object.entries(config.hooks || {})) {
     for (const registration of registrations || []) {
       const matcher = registration.matcher || null;
       for (const hook of registration.hooks || []) {
         const hookId = hookIdFromCommand(hook.command);
-        const isActiveBlocker = activeBlockMatchesTarget && hookId === activeBlockHookId;
+        const isActiveBlocker = activeBlockHookId && hookId === activeBlockHookId;
         if (!isActiveBlocker && !shouldIncludeHook({ eventName, matcher, hookId, category })) continue;
         rows.push({
           event: eventName,
@@ -243,14 +243,12 @@ export function traceHookChain({
     }
   }
 
-  // Codex r7 on PR #216: if hooks.json was changed (upgrade/downgrade /
-  // rename) and the active blocker hook id is no longer registered, the
-  // force-include path above never fires because it iterates the
-  // registry. Append a synthetic row so the diagnostic still surfaces
-  // the active block instead of looking like the run is healthy.
+  // Codex r7 on PR #216 + #217: synthetic row when the active blocker
+  // hook id is no longer registered (hooks.json rename / upgrade).
+  // Same artifact-match relaxation: if there is an active blocker, we
+  // surface it even when the envelope is stale.
   if (
     activeBlockHookId &&
-    activeBlockMatchesTarget &&
     !rows.some((r) => r.hook_id === activeBlockHookId)
   ) {
     rows.push({


### PR DESCRIPTION
## Summary

- Closes #217 — `hooks/lib/mpl-hook-trace.mjs` no longer silently filters the active blocker when the envelope is missing `blocked_artifact`.
- Drops the artifact-match precondition from both the force-include path and the synthetic-row path. `blockStatusFor` continues to distinguish `currently_blocking` vs `invalid_blocked_envelope` so the diagnostic still describes envelope quality accurately.
- Two new regression tests; existing PR #216 tests stay green.

## Why

When the envelope is stale (zombie state from an abrupt hook exit) with only `blocked_by_hook` set, the prior code's `activeBlockMatchesTarget` was always false → force-include skipped → the category check filtered the active blocker out. Tracing a non-decomposition target like `state.test_agent_dispatched.<phase>` returned a healthy-looking row set while the run was paused.

Codex r8 on PR #216 flagged this as a defense-in-depth gap (out of scope for #207, valid follow-up).

## Test plan

- [x] `node --test hooks/__tests__/mpl-hook-trace.test.mjs` — 12/12 pass, includes two new #217 regression tests.
- [x] Full hook suite — 1263/1263 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)