### PR TITLE
Validate no_parallel_explanation content against computed reasons (#214)

### DIFF
--- a/commands/mpl-run-finalize.md
+++ b/commands/mpl-run-finalize.md
@@ -837,6 +837,27 @@ scheduler = {
     selected modes, and the dominant rejection reasons (or missing
     telemetry tiers, partial-rejection tiers, or failure reasons,
     whichever applies).
+
+    **Canonical-vocabulary requirement (#214)**: the explanation MUST
+    include at least one rejection-reason token VERBATIM (snake_case,
+    or its hyphen-/space-separated variant; case-insensitive). The
+    token list IS the `rejection_reasons` value above — paste a value
+    from that array into the prose. Paraphrases like "conflicting
+    files" / "worker dispatch failed" do NOT satisfy the gate; the
+    summary's structured field and the prose must share vocabulary so
+    operators can grep for cause across runs. Examples:
+
+      OK:    "tier 1 lost parallelism due to file_overlap on phase-1"
+      OK:    "tier 1 hit worker-dispatch-error during the second wave"
+      OK:    "tier 2 ran sequentially: single_ready_phase in the wave"
+      BLOCK: "tier 1"                          (no reason named)
+      BLOCK: "tier 1 had conflicting files"    (paraphrase, not canonical)
+
+    For degraded-telemetry runs where `rejection_reasons` is empty but
+    the explanation is still required (missing-telemetry / unrecorded-
+    reason events), use one of these cause tokens instead:
+    `missing_telemetry`, `parallel_rejected_without_reason`,
+    `parallel_failed_without_reason`, or `no_recorded_reason`.
 }
 ```
 

--- a/commands/mpl-run-finalize.md
+++ b/commands/mpl-run-finalize.md
@@ -853,11 +853,32 @@ scheduler = {
       BLOCK: "tier 1"                          (no reason named)
       BLOCK: "tier 1 had conflicting files"    (paraphrase, not canonical)
 
-    For degraded-telemetry runs where `rejection_reasons` is empty but
-    the explanation is still required (missing-telemetry / unrecorded-
-    reason events), use one of these cause tokens instead:
-    `missing_telemetry`, `parallel_rejected_without_reason`,
-    `parallel_failed_without_reason`, or `no_recorded_reason`.
+    **Degraded-cause tokens — required per-axis regardless of
+    rejection_reasons (#214 / codex r6):** the finalize hook checks
+    each degraded condition INDEPENDENTLY from the concrete-reason
+    axis. A mixed run (e.g. tier 1 has missing telemetry, tier 2
+    has file_overlap) MUST name BOTH the concrete reason AND the
+    degraded-axis token. The degraded tokens are:
+
+    - `missing_telemetry` — required whenever any expected-parallel
+      tier had NO scheduler event recorded.
+    - `parallel_rejected_without_reason` — required whenever at least
+      one `parallel_rejected` wave had no `rejection_reasons` /
+      `rejection_reasons_by_phase`.
+    - `parallel_failed_without_reason` — required whenever at least
+      one `parallel_failed` wave had no `failure_reason` (note:
+      `rejection_reasons_by_phase` on a parallel_failed event is the
+      pre-attempt deferred-phase block reason, NOT a substitute for
+      the runtime failure cause).
+    - `no_recorded_reason` — fallback when an explanation is required
+      but no specific degraded shape applies and `rejection_reasons`
+      is empty.
+
+    The finalizer must inspect the aggregate's
+    `tiers_with_missing_telemetry`,
+    `waves_parallel_rejected_without_reason`, and
+    `waves_parallel_failed_without_reason` counters to decide which
+    degraded tokens to include.
 }
 ```
 

--- a/hooks/__tests__/mpl-require-finalize-artifacts.test.mjs
+++ b/hooks/__tests__/mpl-require-finalize-artifacts.test.mjs
@@ -385,6 +385,55 @@ execution_tiers:
     assert.match(r.reason, /no_parallel_explanation_missing_reasons/);
   });
 
+  it('#214 codex r1 [logic]: tier-id-only explanation blocks even when computed.rejection_reasons is empty (missing-telemetry path)', () => {
+    // Degraded path: explanation required but no concrete reason was
+    // recorded. Tier-id mention alone gave zero information about why
+    // parallelism was lost. The hook requires explicit degraded-cause
+    // vocabulary (missing_telemetry / parallel_rejected_without_reason /
+    // parallel_failed_without_reason / no_recorded_reason).
+    writeArtifacts();
+    writeDecompositionWithParallelTier();
+    // No event for tier 1 → aggregator surfaces tiers_with_missing_telemetry: [1]
+    // and tiers_parallel_rejected: 1 (expected - executed).
+    writeSchedulerEvents([]);
+    writeSummaryScheduler({
+      tiers_total: 1,
+      tiers_parallel_requested: 1,
+      tiers_parallel_executed: 0,
+      tiers_parallel_rejected: 1,
+      tiers_with_missing_telemetry: [1],
+      waves_parallel_rejected: 0,
+      waves_parallel_failed: 0,
+      tiers_with_partial_rejection: [],
+      rejection_reasons: [],
+      no_parallel_explanation: 'tier 1',
+    });
+    const r = runHook();
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason, /no_parallel_explanation_missing_degraded_cause/);
+    assert.match(r.reason, /missing_telemetry/);
+  });
+
+  it('#214 codex r1 [logic]: explanation passes when degraded-cause token is named (missing_telemetry)', () => {
+    writeArtifacts();
+    writeDecompositionWithParallelTier();
+    writeSchedulerEvents([]);
+    writeSummaryScheduler({
+      tiers_total: 1,
+      tiers_parallel_requested: 1,
+      tiers_parallel_executed: 0,
+      tiers_parallel_rejected: 1,
+      tiers_with_missing_telemetry: [1],
+      waves_parallel_rejected: 0,
+      waves_parallel_failed: 0,
+      tiers_with_partial_rejection: [],
+      rejection_reasons: [],
+      no_parallel_explanation: 'tier 1 lost parallelism due to missing_telemetry (no scheduler event recorded)',
+    });
+    const r = runHook();
+    assert.equal(r.continue, true);
+  });
+
   it('allows finalize when parallel-requested tier failed at runtime but no_parallel_explanation is filled', () => {
     writeArtifacts();
     writeDecompositionWithParallelTier();

--- a/hooks/__tests__/mpl-require-finalize-artifacts.test.mjs
+++ b/hooks/__tests__/mpl-require-finalize-artifacts.test.mjs
@@ -626,6 +626,83 @@ phases:
     assert.match(r.reason, /parallel_failed_without_reason/);
   });
 
+  it('#214 codex r4 [logic]: concrete reason on one tier + reasonless parallel_failed on another — BOTH must be named', () => {
+    writeArtifacts();
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'decomposition.yaml'), `
+goal_contract_hash: c
+execution_tiers:
+  - tier: 1
+    parallel: true
+    phases: [phase-1]
+  - tier: 2
+    parallel: true
+    phases: [phase-2]
+phases:
+  - id: phase-1
+  - id: phase-2
+`);
+    writeSchedulerEvents([
+      // tier 1: parallel_rejected with concrete file_overlap
+      { tier: 1, selected_mode: 'parallel_rejected',
+        rejection_reasons_by_phase: { 'phase-1': ['file_overlap'] } },
+      // tier 2: parallel_failed with NO failure_reason → reasonless failure
+      { tier: 2, selected_mode: 'parallel_failed' },
+    ]);
+    writeSummaryScheduler({
+      tiers_total: 2,
+      tiers_parallel_requested: 2,
+      tiers_parallel_executed: 0,
+      tiers_parallel_rejected: 2,
+      tiers_with_missing_telemetry: [],
+      waves_parallel_rejected: 1,
+      waves_parallel_failed: 1,
+      tiers_with_partial_rejection: [],
+      rejection_reasons: ['file_overlap'],
+      // Names only the concrete reason — tier 2's reasonless failure is hidden.
+      no_parallel_explanation: 'tier 1 and tier 2 lost parallelism due to file_overlap',
+    });
+    const r = runHook();
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason, /no_parallel_explanation_missing_degraded_cause/);
+    assert.match(r.reason, /parallel_failed_without_reason/);
+  });
+
+  it('#214 codex r4 [logic]: same mixed case passes when explanation names BOTH file_overlap AND parallel_failed_without_reason', () => {
+    writeArtifacts();
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'decomposition.yaml'), `
+goal_contract_hash: c
+execution_tiers:
+  - tier: 1
+    parallel: true
+    phases: [phase-1]
+  - tier: 2
+    parallel: true
+    phases: [phase-2]
+phases:
+  - id: phase-1
+  - id: phase-2
+`);
+    writeSchedulerEvents([
+      { tier: 1, selected_mode: 'parallel_rejected',
+        rejection_reasons_by_phase: { 'phase-1': ['file_overlap'] } },
+      { tier: 2, selected_mode: 'parallel_failed' },
+    ]);
+    writeSummaryScheduler({
+      tiers_total: 2,
+      tiers_parallel_requested: 2,
+      tiers_parallel_executed: 0,
+      tiers_parallel_rejected: 2,
+      tiers_with_missing_telemetry: [],
+      waves_parallel_rejected: 1,
+      waves_parallel_failed: 1,
+      tiers_with_partial_rejection: [],
+      rejection_reasons: ['file_overlap'],
+      no_parallel_explanation: 'tier 1 rejected due to file_overlap; tier 2 hit parallel_failed_without_reason',
+    });
+    const r = runHook();
+    assert.equal(r.continue, true);
+  });
+
   it('allows finalize when parallel-requested tier failed at runtime but no_parallel_explanation is filled', () => {
     writeArtifacts();
     writeDecompositionWithParallelTier();

--- a/hooks/__tests__/mpl-require-finalize-artifacts.test.mjs
+++ b/hooks/__tests__/mpl-require-finalize-artifacts.test.mjs
@@ -514,6 +514,118 @@ phases:
     assert.equal(r.continue, true);
   });
 
+  it('#214 codex r3 [logic]: missing_telemetry + reasonless parallel_failed wave — BOTH tokens required', () => {
+    writeArtifacts();
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'decomposition.yaml'), `
+goal_contract_hash: c
+execution_tiers:
+  - tier: 1
+    parallel: true
+    phases: [phase-1]
+  - tier: 2
+    parallel: true
+    phases: [phase-2]
+phases:
+  - id: phase-1
+  - id: phase-2
+`);
+    writeSchedulerEvents([
+      // tier 1: no event → missing_telemetry
+      // tier 2: parallel_failed with NO failure_reason → reasonless failure
+      { tier: 2, selected_mode: 'parallel_failed' },
+    ]);
+    writeSummaryScheduler({
+      tiers_total: 2,
+      tiers_parallel_requested: 2,
+      tiers_parallel_executed: 0,
+      tiers_parallel_rejected: 2,
+      tiers_with_missing_telemetry: [1],
+      waves_parallel_rejected: 0,
+      waves_parallel_failed: 1,
+      tiers_with_partial_rejection: [],
+      rejection_reasons: [],
+      // Names only one of the two required degraded causes.
+      no_parallel_explanation: 'tier 1 and tier 2 lost parallelism due to missing_telemetry',
+    });
+    const r = runHook();
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason, /no_parallel_explanation_missing_degraded_cause/);
+    assert.match(r.reason, /parallel_failed_without_reason/);
+  });
+
+  it('#214 codex r3 [logic]: reasonless rejected + reasonless failed — both tokens required, both must be named', () => {
+    writeArtifacts();
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'decomposition.yaml'), `
+goal_contract_hash: c
+execution_tiers:
+  - tier: 1
+    parallel: true
+    phases: [phase-1]
+  - tier: 2
+    parallel: true
+    phases: [phase-2]
+phases:
+  - id: phase-1
+  - id: phase-2
+`);
+    writeSchedulerEvents([
+      { tier: 1, selected_mode: 'parallel_rejected' },
+      { tier: 2, selected_mode: 'parallel_failed' },
+    ]);
+    writeSummaryScheduler({
+      tiers_total: 2,
+      tiers_parallel_requested: 2,
+      tiers_parallel_executed: 0,
+      tiers_parallel_rejected: 2,
+      tiers_with_missing_telemetry: [],
+      waves_parallel_rejected: 1,
+      waves_parallel_failed: 1,
+      tiers_with_partial_rejection: [],
+      rejection_reasons: [],
+      no_parallel_explanation: 'tier 1 hit parallel_rejected_without_reason; tier 2 hit parallel_failed_without_reason',
+    });
+    const r = runHook();
+    assert.equal(r.continue, true);
+  });
+
+  it('#214 codex r3 [logic]: same case but only one of the two tokens named → block', () => {
+    writeArtifacts();
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'decomposition.yaml'), `
+goal_contract_hash: c
+execution_tiers:
+  - tier: 1
+    parallel: true
+    phases: [phase-1]
+  - tier: 2
+    parallel: true
+    phases: [phase-2]
+phases:
+  - id: phase-1
+  - id: phase-2
+`);
+    writeSchedulerEvents([
+      { tier: 1, selected_mode: 'parallel_rejected' },
+      { tier: 2, selected_mode: 'parallel_failed' },
+    ]);
+    writeSummaryScheduler({
+      tiers_total: 2,
+      tiers_parallel_requested: 2,
+      tiers_parallel_executed: 0,
+      tiers_parallel_rejected: 2,
+      tiers_with_missing_telemetry: [],
+      waves_parallel_rejected: 1,
+      waves_parallel_failed: 1,
+      tiers_with_partial_rejection: [],
+      rejection_reasons: [],
+      // Names only the rejected_without_reason side; the parallel_failed_without_reason cause stays hidden.
+      no_parallel_explanation: 'tier 1 and tier 2 lost parallelism due to parallel_rejected_without_reason',
+    });
+    const r = runHook();
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason, /no_parallel_explanation_missing_degraded_cause/);
+    assert.match(r.reason, /parallel_failed_without_reason/);
+  });
+
   it('allows finalize when parallel-requested tier failed at runtime but no_parallel_explanation is filled', () => {
     writeArtifacts();
     writeDecompositionWithParallelTier();

--- a/hooks/__tests__/mpl-require-finalize-artifacts.test.mjs
+++ b/hooks/__tests__/mpl-require-finalize-artifacts.test.mjs
@@ -434,6 +434,86 @@ execution_tiers:
     assert.equal(r.continue, true);
   });
 
+  it('#214 codex r2 [logic]: MIXED degraded telemetry + concrete reason — both axes must be named', () => {
+    // tier 1 has missing telemetry; tier 2 has a concrete file_overlap.
+    // Pre-r2 the degraded-cause check skipped because computedReasons
+    // was non-empty, so an explanation that only named file_overlap
+    // hid tier 1's telemetry loss. Now both axes are independently
+    // required.
+    writeArtifacts();
+    // Two-tier decomposition.
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'decomposition.yaml'), `
+goal_contract_hash: c
+execution_tiers:
+  - tier: 1
+    parallel: true
+    phases: [phase-1]
+  - tier: 2
+    parallel: true
+    phases: [phase-2]
+phases:
+  - id: phase-1
+  - id: phase-2
+`);
+    writeSchedulerEvents([
+      // No event for tier 1 → missing telemetry.
+      { tier: 2, selected_mode: 'parallel_rejected',
+        rejection_reasons_by_phase: { 'phase-2': ['file_overlap'] } },
+    ]);
+    writeSummaryScheduler({
+      tiers_total: 2,
+      tiers_parallel_requested: 2,
+      tiers_parallel_executed: 0,
+      tiers_parallel_rejected: 2,
+      tiers_with_missing_telemetry: [1],
+      waves_parallel_rejected: 1,
+      waves_parallel_failed: 0,
+      tiers_with_partial_rejection: [],
+      rejection_reasons: ['file_overlap'],
+      // Names only the concrete reason — tier 1's missing_telemetry is hidden.
+      no_parallel_explanation: 'tier 1 and tier 2 lost parallelism due to file_overlap',
+    });
+    const r = runHook();
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason, /no_parallel_explanation_missing_degraded_cause/);
+    assert.match(r.reason, /missing_telemetry/);
+  });
+
+  it('#214 codex r2 [logic]: mixed case passes when explanation names BOTH file_overlap AND missing_telemetry', () => {
+    writeArtifacts();
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'decomposition.yaml'), `
+goal_contract_hash: c
+execution_tiers:
+  - tier: 1
+    parallel: true
+    phases: [phase-1]
+  - tier: 2
+    parallel: true
+    phases: [phase-2]
+phases:
+  - id: phase-1
+  - id: phase-2
+`);
+    writeSchedulerEvents([
+      { tier: 2, selected_mode: 'parallel_rejected',
+        rejection_reasons_by_phase: { 'phase-2': ['file_overlap'] } },
+    ]);
+    writeSummaryScheduler({
+      tiers_total: 2,
+      tiers_parallel_requested: 2,
+      tiers_parallel_executed: 0,
+      tiers_parallel_rejected: 2,
+      tiers_with_missing_telemetry: [1],
+      waves_parallel_rejected: 1,
+      waves_parallel_failed: 0,
+      tiers_with_partial_rejection: [],
+      rejection_reasons: ['file_overlap'],
+      no_parallel_explanation: 'tier 1 had missing_telemetry (no event recorded); tier 2 rejected due to file_overlap',
+    });
+    const r = runHook();
+    assert.equal(r.continue, true);
+  });
+
   it('allows finalize when parallel-requested tier failed at runtime but no_parallel_explanation is filled', () => {
     writeArtifacts();
     writeDecompositionWithParallelTier();

--- a/hooks/__tests__/mpl-require-finalize-artifacts.test.mjs
+++ b/hooks/__tests__/mpl-require-finalize-artifacts.test.mjs
@@ -287,6 +287,104 @@ execution_tiers:
     assert.match(r.reason, /scheduler:no_parallel_explanation_required_but_missing/);
   });
 
+  it('#214: blocks finalize when no_parallel_explanation mentions only the tier id and not a computed reason', () => {
+    // codex r17 on PR #213: "tier 1" passed the tier-id mention check
+    // even though no rejection reason was named. The explanation must
+    // identify WHY parallelism was lost.
+    writeArtifacts();
+    writeDecompositionWithParallelTier();
+    writeSchedulerEvents([
+      { tier: 1, selected_mode: 'parallel_rejected',
+        rejection_reasons_by_phase: { 'phase-1': ['file_overlap'] } },
+    ]);
+    writeSummaryScheduler({
+      tiers_total: 1,
+      tiers_parallel_requested: 1,
+      tiers_parallel_executed: 0,
+      tiers_parallel_rejected: 1,
+      tiers_with_missing_telemetry: [],
+      waves_parallel_rejected: 1,
+      waves_parallel_failed: 0,
+      tiers_with_partial_rejection: [],
+      rejection_reasons: ['file_overlap'],
+      no_parallel_explanation: 'tier 1',
+    });
+    const r = runHook();
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason, /scheduler:no_parallel_explanation_missing_reasons/);
+    assert.match(r.reason, /file_overlap/);
+  });
+
+  it('#214: allows finalize when explanation names both the tier id AND a computed reason (canonical token)', () => {
+    writeArtifacts();
+    writeDecompositionWithParallelTier();
+    writeSchedulerEvents([
+      { tier: 1, selected_mode: 'parallel_rejected',
+        rejection_reasons_by_phase: { 'phase-1': ['file_overlap'] } },
+    ]);
+    writeSummaryScheduler({
+      tiers_total: 1,
+      tiers_parallel_requested: 1,
+      tiers_parallel_executed: 0,
+      tiers_parallel_rejected: 1,
+      tiers_with_missing_telemetry: [],
+      waves_parallel_rejected: 1,
+      waves_parallel_failed: 0,
+      tiers_with_partial_rejection: [],
+      rejection_reasons: ['file_overlap'],
+      no_parallel_explanation: 'tier 1 rejected due to file_overlap between phase-1 impact files',
+    });
+    const r = runHook();
+    assert.equal(r.continue, true);
+  });
+
+  it('#214: allows finalize when explanation uses a hyphen variant of the reason ("file-overlap")', () => {
+    writeArtifacts();
+    writeDecompositionWithParallelTier();
+    writeSchedulerEvents([
+      { tier: 1, selected_mode: 'parallel_rejected',
+        rejection_reasons_by_phase: { 'phase-1': ['file_overlap'] } },
+    ]);
+    writeSummaryScheduler({
+      tiers_total: 1,
+      tiers_parallel_requested: 1,
+      tiers_parallel_executed: 0,
+      tiers_parallel_rejected: 1,
+      tiers_with_missing_telemetry: [],
+      waves_parallel_rejected: 1,
+      waves_parallel_failed: 0,
+      tiers_with_partial_rejection: [],
+      rejection_reasons: ['file_overlap'],
+      no_parallel_explanation: 'tier 1 lost parallelism (file-overlap, two phases touching the same path)',
+    });
+    const r = runHook();
+    assert.equal(r.continue, true);
+  });
+
+  it('#214: blocks when explanation paraphrases the reason without canonical vocabulary', () => {
+    writeArtifacts();
+    writeDecompositionWithParallelTier();
+    writeSchedulerEvents([
+      { tier: 1, selected_mode: 'parallel_rejected',
+        rejection_reasons_by_phase: { 'phase-1': ['file_overlap'] } },
+    ]);
+    writeSummaryScheduler({
+      tiers_total: 1,
+      tiers_parallel_requested: 1,
+      tiers_parallel_executed: 0,
+      tiers_parallel_rejected: 1,
+      tiers_with_missing_telemetry: [],
+      waves_parallel_rejected: 1,
+      waves_parallel_failed: 0,
+      tiers_with_partial_rejection: [],
+      rejection_reasons: ['file_overlap'],
+      no_parallel_explanation: 'tier 1 had conflicting files between phases',
+    });
+    const r = runHook();
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason, /no_parallel_explanation_missing_reasons/);
+  });
+
   it('allows finalize when parallel-requested tier failed at runtime but no_parallel_explanation is filled', () => {
     writeArtifacts();
     writeDecompositionWithParallelTier();
@@ -303,7 +401,11 @@ execution_tiers:
       waves_parallel_failed: 1,
       tiers_with_partial_rejection: [],
       rejection_reasons: ['worker_dispatch_error'],
-      no_parallel_explanation: 'tier 1 attempted parallel execution but worker dispatch failed; fell back to sequential retry',
+      // #214: explanation must use the canonical reason token
+      // (worker_dispatch_error / worker-dispatch-error / worker dispatch error),
+      // not a paraphrase. Updated from the original "worker dispatch failed"
+      // wording to satisfy the new content-strength check.
+      no_parallel_explanation: 'tier 1 hit worker_dispatch_error during parallel execution; fell back to sequential retry',
     });
     const r = runHook();
     assert.equal(r.continue, true);
@@ -626,7 +728,9 @@ execution_tiers:
       waves_parallel_failed: 0,
       tiers_with_partial_rejection: [],
       rejection_reasons: ['single_ready_phase'],
-      no_parallel_explanation: 'tier 1 ran sequentially: only one phase ready in the wave',
+      // #214: use the canonical reason token so the new content-strength
+      // check passes.
+      no_parallel_explanation: 'tier 1 ran sequentially due to single_ready_phase in the wave',
     });
     const r = runHook();
     assert.equal(r.continue, true);

--- a/hooks/__tests__/mpl-require-finalize-artifacts.test.mjs
+++ b/hooks/__tests__/mpl-require-finalize-artifacts.test.mjs
@@ -703,6 +703,92 @@ phases:
     assert.equal(r.continue, true);
   });
 
+  it('#214 codex r5 [logic]: parallel_failed event with ready_but_blocked_reason but no failure_reason is reasonless', () => {
+    // For parallel_failed events, rejection_reasons_by_phase carries
+    // ready_but_blocked_reason (pre-attempt deferred state), NOT the
+    // runtime failure cause. failure_reason is the runtime cause.
+    // Pre-r5 the shared eventHasOwnReason() treated rejection_reasons_by_phase
+    // as a substitute and hid reasonless runtime failures.
+    writeArtifacts();
+    writeDecompositionWithParallelTier();
+    writeSchedulerEvents([
+      {
+        tier: 1,
+        selected_mode: 'parallel_failed',
+        // ready_but_blocked_reason data on a parallel_failed event —
+        // NOT the runtime failure cause.
+        rejection_reasons_by_phase: { 'phase-1': ['file_overlap'] },
+        // No failure_reason!
+      },
+    ]);
+    writeSummaryScheduler({
+      tiers_total: 1,
+      tiers_parallel_requested: 1,
+      tiers_parallel_executed: 0,
+      tiers_parallel_rejected: 1,
+      tiers_with_missing_telemetry: [],
+      waves_parallel_rejected: 0,
+      waves_parallel_failed: 1,
+      tiers_with_partial_rejection: [],
+      // Explanation names only file_overlap (the deferred-phase block reason),
+      // not the runtime failure cause.
+      rejection_reasons: ['file_overlap'],
+      no_parallel_explanation: 'tier 1 lost parallelism due to file_overlap',
+    });
+    const r = runHook();
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason, /no_parallel_explanation_missing_degraded_cause/);
+    assert.match(r.reason, /parallel_failed_without_reason/);
+  });
+
+  it('#214 codex r5 [contract-break]: substring forms like "file_overlapping" / "xfile_overlapx" do NOT satisfy the token check', () => {
+    writeArtifacts();
+    writeDecompositionWithParallelTier();
+    writeSchedulerEvents([
+      { tier: 1, selected_mode: 'parallel_rejected',
+        rejection_reasons_by_phase: { 'phase-1': ['file_overlap'] } },
+    ]);
+    writeSummaryScheduler({
+      tiers_total: 1,
+      tiers_parallel_requested: 1,
+      tiers_parallel_executed: 0,
+      tiers_parallel_rejected: 1,
+      tiers_with_missing_telemetry: [],
+      waves_parallel_rejected: 1,
+      waves_parallel_failed: 0,
+      tiers_with_partial_rejection: [],
+      rejection_reasons: ['file_overlap'],
+      // "file_overlapping" used to substring-match file_overlap.
+      no_parallel_explanation: 'tier 1 had file_overlapping issues across phases',
+    });
+    const r = runHook();
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason, /no_parallel_explanation_missing_reasons/);
+  });
+
+  it('#214 codex r5: legitimate hyphen variant "file-overlap" still passes (word-boundary check is correct)', () => {
+    writeArtifacts();
+    writeDecompositionWithParallelTier();
+    writeSchedulerEvents([
+      { tier: 1, selected_mode: 'parallel_rejected',
+        rejection_reasons_by_phase: { 'phase-1': ['file_overlap'] } },
+    ]);
+    writeSummaryScheduler({
+      tiers_total: 1,
+      tiers_parallel_requested: 1,
+      tiers_parallel_executed: 0,
+      tiers_parallel_rejected: 1,
+      tiers_with_missing_telemetry: [],
+      waves_parallel_rejected: 1,
+      waves_parallel_failed: 0,
+      tiers_with_partial_rejection: [],
+      rejection_reasons: ['file_overlap'],
+      no_parallel_explanation: 'tier 1 rejected (file-overlap on phase-1 impact files)',
+    });
+    const r = runHook();
+    assert.equal(r.continue, true);
+  });
+
   it('allows finalize when parallel-requested tier failed at runtime but no_parallel_explanation is filled', () => {
     writeArtifacts();
     writeDecompositionWithParallelTier();

--- a/hooks/lib/mpl-scheduler-aggregate.mjs
+++ b/hooks/lib/mpl-scheduler-aggregate.mjs
@@ -332,6 +332,12 @@ export function aggregateScheduler(cwd, state) {
   const rejectionReasonSet = new Set();
   let wavesParallelRejected = 0;
   let wavesParallelFailed = 0;
+  // Codex r4 on PR #229 [logic]: per-event reasonless counters so the
+  // finalize gate can detect "one tier has concrete reason + another
+  // has reasonless failed/rejected wave" — not derivable from the
+  // global rejection_reasons union alone.
+  let wavesParallelRejectedWithoutReason = 0;
+  let wavesParallelFailedWithoutReason = 0;
 
   function collectRejectionReasons(e) {
     if (Array.isArray(e?.rejection_reasons)) {
@@ -349,15 +355,28 @@ export function aggregateScheduler(cwd, state) {
     }
   }
 
+  function eventHasOwnReason(e) {
+    if (Array.isArray(e?.rejection_reasons) && e.rejection_reasons.some((r) => typeof r === 'string' && r)) return true;
+    if (e?.rejection_reasons_by_phase && typeof e.rejection_reasons_by_phase === 'object') {
+      for (const v of Object.values(e.rejection_reasons_by_phase)) {
+        if (typeof v === 'string' && v) return true;
+        if (Array.isArray(v) && v.some((r) => typeof r === 'string' && r)) return true;
+      }
+    }
+    if (typeof e?.failure_reason === 'string' && e.failure_reason) return true;
+    return false;
+  }
   for (const e of events) {
     tiersSeen.add(Number(e.tier));
     if (e.selected_mode === 'parallel') tiersWithParallelEvent.add(Number(e.tier));
     if (e.selected_mode === 'parallel_rejected') {
       tiersWithRejectedEvent.add(Number(e.tier));
       wavesParallelRejected += 1;
+      if (!eventHasOwnReason(e)) wavesParallelRejectedWithoutReason += 1;
     }
     if (e.selected_mode === 'parallel_failed') {
       wavesParallelFailed += 1;
+      if (!eventHasOwnReason(e)) wavesParallelFailedWithoutReason += 1;
     }
     // Collect rejection reasons from EVERY event — the finalize prompt's
     // rejection_reasons rule is "union across all events", including
@@ -397,6 +416,8 @@ export function aggregateScheduler(cwd, state) {
     tiers_with_missing_telemetry: tiersWithMissingTelemetry,
     waves_parallel_rejected: wavesParallelRejected,
     waves_parallel_failed: wavesParallelFailed,
+    waves_parallel_rejected_without_reason: wavesParallelRejectedWithoutReason,
+    waves_parallel_failed_without_reason: wavesParallelFailedWithoutReason,
     tiers_with_partial_rejection: tiersWithPartialRejection,
     rejection_reasons: [...rejectionReasonSet].sort(),
     affected_tier_ids,

--- a/hooks/lib/mpl-scheduler-aggregate.mjs
+++ b/hooks/lib/mpl-scheduler-aggregate.mjs
@@ -355,7 +355,16 @@ export function aggregateScheduler(cwd, state) {
     }
   }
 
-  function eventHasOwnReason(e) {
+  // Codex r5 on PR #229 [logic]: the reasonless check must be
+  // mode-specific. For parallel_rejected events, rejection_reasons /
+  // rejection_reasons_by_phase carry the planning-time rejection cause.
+  // For parallel_failed events, failure_reason is the runtime cause —
+  // rejection_reasons_by_phase on a parallel_failed event is the
+  // ready_but_blocked_reason for deferred phases (pre-attempt state,
+  // not a substitute for runtime failure cause). Sharing one
+  // eventHasOwnReason helper across both modes was treating
+  // ready_but_blocked_reason as if it explained the failure.
+  function rejectedEventHasReason(e) {
     if (Array.isArray(e?.rejection_reasons) && e.rejection_reasons.some((r) => typeof r === 'string' && r)) return true;
     if (e?.rejection_reasons_by_phase && typeof e.rejection_reasons_by_phase === 'object') {
       for (const v of Object.values(e.rejection_reasons_by_phase)) {
@@ -363,8 +372,10 @@ export function aggregateScheduler(cwd, state) {
         if (Array.isArray(v) && v.some((r) => typeof r === 'string' && r)) return true;
       }
     }
-    if (typeof e?.failure_reason === 'string' && e.failure_reason) return true;
     return false;
+  }
+  function failedEventHasReason(e) {
+    return typeof e?.failure_reason === 'string' && e.failure_reason.length > 0;
   }
   for (const e of events) {
     tiersSeen.add(Number(e.tier));
@@ -372,11 +383,11 @@ export function aggregateScheduler(cwd, state) {
     if (e.selected_mode === 'parallel_rejected') {
       tiersWithRejectedEvent.add(Number(e.tier));
       wavesParallelRejected += 1;
-      if (!eventHasOwnReason(e)) wavesParallelRejectedWithoutReason += 1;
+      if (!rejectedEventHasReason(e)) wavesParallelRejectedWithoutReason += 1;
     }
     if (e.selected_mode === 'parallel_failed') {
       wavesParallelFailed += 1;
-      if (!eventHasOwnReason(e)) wavesParallelFailedWithoutReason += 1;
+      if (!failedEventHasReason(e)) wavesParallelFailedWithoutReason += 1;
     }
     // Collect rejection reasons from EVERY event — the finalize prompt's
     // rejection_reasons rule is "union across all events", including

--- a/hooks/mpl-require-finalize-artifacts.mjs
+++ b/hooks/mpl-require-finalize-artifacts.mjs
@@ -280,48 +280,55 @@ function schedulerExplanationMissing(cwd, state) {
   // is unambiguous (see commands/mpl-run-finalize.md for the
   // producer-side contract; finalize agents are instructed to use
   // verbatim rejection_reasons tokens).
-  if (explanationFilled && computedReasons.length > 0) {
-    const lowerExplanation = explanation.toLowerCase();
-    const reasonMatched = computedReasons.some((reason) => {
-      const r = String(reason).toLowerCase();
-      const variants = [r, r.replace(/_/g, '-'), r.replace(/_/g, ' ')];
-      return variants.some((v) => lowerExplanation.includes(v));
-    });
-    if (!reasonMatched) {
+  if (!explanationFilled) return null;
+  const lowerExplanation = explanation.toLowerCase();
+  const containsToken = (token) => {
+    const t = String(token).toLowerCase();
+    const variants = [t, t.replace(/_/g, '-'), t.replace(/_/g, ' ')];
+    return variants.some((v) => lowerExplanation.includes(v));
+  };
+
+  // Axis 1: when computed.rejection_reasons is populated, at least one
+  // canonical token MUST appear verbatim (snake_case / hyphen / space).
+  if (computedReasons.length > 0) {
+    const matched = computedReasons.some(containsToken);
+    if (!matched) {
       return `scheduler:no_parallel_explanation_missing_reasons:expected_one_of=[${computedReasons.join(',')}]`;
     }
   }
-  // #214 + codex r1 [logic]: degraded-telemetry path. When the
-  // aggregate says an explanation is required but computed.rejection_reasons
-  // is empty (e.g. tiers_with_missing_telemetry non-empty, or events that
-  // omitted rejection_reasons/failure_reason), the tier-id-mention check
-  // alone lets "tier 1" through with no cause named — the same
-  // observability failure the canonical-token check closes for the
-  // populated case. Require explicit cause vocabulary derived from
-  // the aggregate shape itself.
-  if (explanationFilled && computedReasons.length === 0 && explanationRequiredFromAggregate(computed)) {
-    const lowerExplanation = explanation.toLowerCase();
-    const degradedReasonVocab = [];
+
+  // #214 + codex r1/r2 [logic]: degraded-telemetry axis is INDEPENDENT
+  // of the rejection-reasons axis. Codex r2 showed a mixed run (one
+  // missing-telemetry tier + one tier with file_overlap) bypassed the
+  // degraded-cause check because computedReasons.length > 0. Now the
+  // required token list is built from the aggregate shape itself, and
+  // EACH required token must appear in the explanation — concrete
+  // reasons and degraded causes are complementary requirements, not
+  // alternatives.
+  const requiredDegraded = [];
+  if (explanationRequiredFromAggregate(computed)) {
     if (Array.isArray(computed.tiers_with_missing_telemetry) && computed.tiers_with_missing_telemetry.length > 0) {
-      degradedReasonVocab.push('missing_telemetry');
+      requiredDegraded.push('missing_telemetry');
     }
-    if ((computed.waves_parallel_rejected || 0) > 0) {
-      degradedReasonVocab.push('parallel_rejected_without_reason');
+    if (computedReasons.length === 0) {
+      // No concrete reasons recorded at all — require ONE generic
+      // degraded cause. (Telemetry-present axis above already handles
+      // its own token; here we only fall through if telemetry is also
+      // empty but the aggregate still requires an explanation.)
+      if (!requiredDegraded.includes('missing_telemetry')) {
+        if ((computed.waves_parallel_rejected || 0) > 0) {
+          requiredDegraded.push('parallel_rejected_without_reason');
+        } else if ((computed.waves_parallel_failed || 0) > 0) {
+          requiredDegraded.push('parallel_failed_without_reason');
+        } else {
+          requiredDegraded.push('no_recorded_reason');
+        }
+      }
     }
-    if ((computed.waves_parallel_failed || 0) > 0) {
-      degradedReasonVocab.push('parallel_failed_without_reason');
-    }
-    // Default if none of the above shaped the aggregate but explanation
-    // is still required — preserve the gate signal with a generic token.
-    if (degradedReasonVocab.length === 0) {
-      degradedReasonVocab.push('no_recorded_reason');
-    }
-    const matched = degradedReasonVocab.some((token) => {
-      const variants = [token, token.replace(/_/g, '-'), token.replace(/_/g, ' ')];
-      return variants.some((v) => lowerExplanation.includes(v));
-    });
-    if (!matched) {
-      return `scheduler:no_parallel_explanation_missing_degraded_cause:expected_one_of=[${degradedReasonVocab.join(',')}]`;
+  }
+  for (const token of requiredDegraded) {
+    if (!containsToken(token)) {
+      return `scheduler:no_parallel_explanation_missing_degraded_cause:expected=${token}`;
     }
   }
   return null;

--- a/hooks/mpl-require-finalize-artifacts.mjs
+++ b/hooks/mpl-require-finalize-artifacts.mjs
@@ -305,31 +305,32 @@ function schedulerExplanationMissing(cwd, state) {
   // EACH required token must appear in the explanation — concrete
   // reasons and degraded causes are complementary requirements, not
   // alternatives.
-  // Codex r3 [logic]: accumulate every applicable degraded token
-  // INDEPENDENTLY. The earlier priority chain (`else if`) let a
-  // missing_telemetry tier + a reasonless parallel_failed wave finalize
-  // with only one of the two named, hiding the runtime failure cause.
+  // Codex r3/r4 [logic]: accumulate every applicable degraded token
+  // INDEPENDENTLY. The r3 fix used a global `reasonless` flag
+  // (computedReasons.length === 0) which codex r4 showed misses
+  // cross-tier mixed cases — one tier with a concrete reason + another
+  // tier with a reasonless parallel_failed wave never set reasonless,
+  // so parallel_failed_without_reason was never required.
+  //
+  // Per-event reasonless counters now come from the aggregator
+  // (waves_parallel_rejected_without_reason /
+  // waves_parallel_failed_without_reason) so each axis is checked
+  // independently regardless of whether other waves had reasons.
   const requiredDegraded = [];
   if (explanationRequiredFromAggregate(computed)) {
     if (Array.isArray(computed.tiers_with_missing_telemetry) && computed.tiers_with_missing_telemetry.length > 0) {
       requiredDegraded.push('missing_telemetry');
     }
-    // For reasonless rejected/failed waves: when computedReasons is
-    // empty AND the wave counter is non-zero, at least one wave of
-    // that shape had no recorded cause. (We can't distinguish per-
-    // event "had reason vs didn't" from the aggregate, so the
-    // conservative trigger is `computedReasons.length === 0` —
-    // mirrors how missing_telemetry is detected at the tier level.)
-    const reasonless = computedReasons.length === 0;
-    if (reasonless && (computed.waves_parallel_rejected || 0) > 0) {
+    if ((computed.waves_parallel_rejected_without_reason || 0) > 0) {
       requiredDegraded.push('parallel_rejected_without_reason');
     }
-    if (reasonless && (computed.waves_parallel_failed || 0) > 0) {
+    if ((computed.waves_parallel_failed_without_reason || 0) > 0) {
       requiredDegraded.push('parallel_failed_without_reason');
     }
     // Catch-all: aggregate still requires an explanation but no
-    // specific degraded shape was identified.
-    if (requiredDegraded.length === 0 && reasonless) {
+    // specific degraded shape was identified (and no concrete reasons
+    // were recorded).
+    if (requiredDegraded.length === 0 && computedReasons.length === 0) {
       requiredDegraded.push('no_recorded_reason');
     }
   }

--- a/hooks/mpl-require-finalize-artifacts.mjs
+++ b/hooks/mpl-require-finalize-artifacts.mjs
@@ -282,10 +282,21 @@ function schedulerExplanationMissing(cwd, state) {
   // verbatim rejection_reasons tokens).
   if (!explanationFilled) return null;
   const lowerExplanation = explanation.toLowerCase();
+  // Codex r5 on PR #229 [contract-break]: substring-only matching let
+  // `file_overlapping` or `xfile_overlapx` satisfy `file_overlap`,
+  // weakening the grep-friendly-vocabulary guarantee. Tokens must
+  // appear at word boundaries — adjacent characters must be
+  // non-token (i.e. not [A-Za-z0-9_-]). Hyphen is treated as a
+  // token character because hyphen variants use hyphen mid-token.
   const containsToken = (token) => {
     const t = String(token).toLowerCase();
     const variants = [t, t.replace(/_/g, '-'), t.replace(/_/g, ' ')];
-    return variants.some((v) => lowerExplanation.includes(v));
+    return variants.some((v) => {
+      if (!v) return false;
+      const escaped = v.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      const re = new RegExp(`(^|[^A-Za-z0-9_-])${escaped}(?=[^A-Za-z0-9_-]|$)`);
+      return re.test(lowerExplanation);
+    });
   };
 
   // Axis 1: when computed.rejection_reasons is populated, at least one

--- a/hooks/mpl-require-finalize-artifacts.mjs
+++ b/hooks/mpl-require-finalize-artifacts.mjs
@@ -264,6 +264,31 @@ function schedulerExplanationMissing(cwd, state) {
       return `scheduler:no_parallel_explanation_missing_tier_refs:[${missingMentions.join(',')}]`;
     }
   }
+  // #214: tier-id-only explanations (e.g. "tier 1") used to pass even
+  // when computed.rejection_reasons named concrete reasons like
+  // "file_overlap" or "depends_on_predecessor_failure". The summary
+  // must actually name at least one such reason — otherwise an operator
+  // reading it has zero information about WHY parallelism was lost.
+  //
+  // Each computed reason has a canonical lowercase snake_case form
+  // (e.g. "file_overlap"). The explanation matches a reason when it
+  // either includes the exact token, OR includes any of its hyphen-/
+  // space-separated variants (e.g. "file-overlap", "file overlap"),
+  // case-insensitively. Free text containing the same words in
+  // different order or stem (e.g. "overlapping files") does NOT match
+  // — operators MUST use the canonical vocabulary so the gate signal
+  // is unambiguous.
+  if (explanationFilled && computedReasons.length > 0) {
+    const lowerExplanation = explanation.toLowerCase();
+    const reasonMatched = computedReasons.some((reason) => {
+      const r = String(reason).toLowerCase();
+      const variants = [r, r.replace(/_/g, '-'), r.replace(/_/g, ' ')];
+      return variants.some((v) => lowerExplanation.includes(v));
+    });
+    if (!reasonMatched) {
+      return `scheduler:no_parallel_explanation_missing_reasons:expected_one_of=[${computedReasons.join(',')}]`;
+    }
+  }
   return null;
 }
 

--- a/hooks/mpl-require-finalize-artifacts.mjs
+++ b/hooks/mpl-require-finalize-artifacts.mjs
@@ -305,25 +305,32 @@ function schedulerExplanationMissing(cwd, state) {
   // EACH required token must appear in the explanation — concrete
   // reasons and degraded causes are complementary requirements, not
   // alternatives.
+  // Codex r3 [logic]: accumulate every applicable degraded token
+  // INDEPENDENTLY. The earlier priority chain (`else if`) let a
+  // missing_telemetry tier + a reasonless parallel_failed wave finalize
+  // with only one of the two named, hiding the runtime failure cause.
   const requiredDegraded = [];
   if (explanationRequiredFromAggregate(computed)) {
     if (Array.isArray(computed.tiers_with_missing_telemetry) && computed.tiers_with_missing_telemetry.length > 0) {
       requiredDegraded.push('missing_telemetry');
     }
-    if (computedReasons.length === 0) {
-      // No concrete reasons recorded at all — require ONE generic
-      // degraded cause. (Telemetry-present axis above already handles
-      // its own token; here we only fall through if telemetry is also
-      // empty but the aggregate still requires an explanation.)
-      if (!requiredDegraded.includes('missing_telemetry')) {
-        if ((computed.waves_parallel_rejected || 0) > 0) {
-          requiredDegraded.push('parallel_rejected_without_reason');
-        } else if ((computed.waves_parallel_failed || 0) > 0) {
-          requiredDegraded.push('parallel_failed_without_reason');
-        } else {
-          requiredDegraded.push('no_recorded_reason');
-        }
-      }
+    // For reasonless rejected/failed waves: when computedReasons is
+    // empty AND the wave counter is non-zero, at least one wave of
+    // that shape had no recorded cause. (We can't distinguish per-
+    // event "had reason vs didn't" from the aggregate, so the
+    // conservative trigger is `computedReasons.length === 0` —
+    // mirrors how missing_telemetry is detected at the tier level.)
+    const reasonless = computedReasons.length === 0;
+    if (reasonless && (computed.waves_parallel_rejected || 0) > 0) {
+      requiredDegraded.push('parallel_rejected_without_reason');
+    }
+    if (reasonless && (computed.waves_parallel_failed || 0) > 0) {
+      requiredDegraded.push('parallel_failed_without_reason');
+    }
+    // Catch-all: aggregate still requires an explanation but no
+    // specific degraded shape was identified.
+    if (requiredDegraded.length === 0 && reasonless) {
+      requiredDegraded.push('no_recorded_reason');
     }
   }
   for (const token of requiredDegraded) {

--- a/hooks/mpl-require-finalize-artifacts.mjs
+++ b/hooks/mpl-require-finalize-artifacts.mjs
@@ -277,7 +277,9 @@ function schedulerExplanationMissing(cwd, state) {
   // case-insensitively. Free text containing the same words in
   // different order or stem (e.g. "overlapping files") does NOT match
   // — operators MUST use the canonical vocabulary so the gate signal
-  // is unambiguous.
+  // is unambiguous (see commands/mpl-run-finalize.md for the
+  // producer-side contract; finalize agents are instructed to use
+  // verbatim rejection_reasons tokens).
   if (explanationFilled && computedReasons.length > 0) {
     const lowerExplanation = explanation.toLowerCase();
     const reasonMatched = computedReasons.some((reason) => {
@@ -287,6 +289,39 @@ function schedulerExplanationMissing(cwd, state) {
     });
     if (!reasonMatched) {
       return `scheduler:no_parallel_explanation_missing_reasons:expected_one_of=[${computedReasons.join(',')}]`;
+    }
+  }
+  // #214 + codex r1 [logic]: degraded-telemetry path. When the
+  // aggregate says an explanation is required but computed.rejection_reasons
+  // is empty (e.g. tiers_with_missing_telemetry non-empty, or events that
+  // omitted rejection_reasons/failure_reason), the tier-id-mention check
+  // alone lets "tier 1" through with no cause named — the same
+  // observability failure the canonical-token check closes for the
+  // populated case. Require explicit cause vocabulary derived from
+  // the aggregate shape itself.
+  if (explanationFilled && computedReasons.length === 0 && explanationRequiredFromAggregate(computed)) {
+    const lowerExplanation = explanation.toLowerCase();
+    const degradedReasonVocab = [];
+    if (Array.isArray(computed.tiers_with_missing_telemetry) && computed.tiers_with_missing_telemetry.length > 0) {
+      degradedReasonVocab.push('missing_telemetry');
+    }
+    if ((computed.waves_parallel_rejected || 0) > 0) {
+      degradedReasonVocab.push('parallel_rejected_without_reason');
+    }
+    if ((computed.waves_parallel_failed || 0) > 0) {
+      degradedReasonVocab.push('parallel_failed_without_reason');
+    }
+    // Default if none of the above shaped the aggregate but explanation
+    // is still required — preserve the gate signal with a generic token.
+    if (degradedReasonVocab.length === 0) {
+      degradedReasonVocab.push('no_recorded_reason');
+    }
+    const matched = degradedReasonVocab.some((token) => {
+      const variants = [token, token.replace(/_/g, '-'), token.replace(/_/g, ' ')];
+      return variants.some((v) => lowerExplanation.includes(v));
+    });
+    if (!matched) {
+      return `scheduler:no_parallel_explanation_missing_degraded_cause:expected_one_of=[${degradedReasonVocab.join(',')}]`;
     }
   }
   return null;


### PR DESCRIPTION
## Summary

- Closes #214. `schedulerExplanationMissing` now enforces that, for runs where `computed.rejection_reasons` is non-empty, `no_parallel_explanation` MUST reference at least one of those reasons as a canonical token (snake_case, hyphen, or space variant), case-insensitive.
- Tier-id-only explanations (e.g. `'tier 1'` for a tier with `rejection_reasons: ['file_overlap']`) now fail closed.
- Two pre-existing fixtures updated to use canonical reason tokens so the prose explanation aligns with the structured `rejection_reasons` field. Four new #214 tests cover the matrix.

## Why

Codex r17 on PR #213 flagged this: the existing tier-id-mention check stopped `n/a`-style placeholders but let `'tier 1'` slip through with no actual reason named. The summary's structured `rejection_reasons` field already carries the canonical vocabulary — requiring the prose to reuse one of those tokens keeps the two sources of truth in sync.

## Approach

The new check runs after the existing tier-id-mention check. For each `computed.rejection_reasons` entry, the explanation is searched for the exact token, or its hyphen-/space-separated form (case-insensitive). A miss returns `scheduler:no_parallel_explanation_missing_reasons:expected_one_of=[...]` so operators get a concrete fix hint.

Canonical-vocabulary enforcement (rather than stemming / synonym match) is deliberate — the operator can paste the exact `rejection_reasons` value to satisfy the gate; ambiguous paraphrase like "conflicting files" fails so the diagnostic signal stays clear.

## Test plan

- [x] `node --test hooks/__tests__/mpl-require-finalize-artifacts.test.mjs` — 31/31 pass, including 4 new #214 tests.
- [x] Full hook suite — 1267/1267 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)