### PR TITLE
docs: prompt → gate → restore divergence audit + relaxation plan

### DIFF
--- a/docs/findings/2026-05-28-enforcement-relaxation-plan.md
+++ b/docs/findings/2026-05-28-enforcement-relaxation-plan.md
@@ -1,0 +1,92 @@
+# Enforcement Relaxation Plan
+
+**Date**: 2026-05-28
+**Source**: companion to `docs/findings/2026-05-28-prompt-gate-restore-divergence.md`
+**Context**: user request — "모든 케이스를 hook으로 차단하면 너무 경직되니, 완화할 수 있는 부분 검토"
+
+## Existing relaxation infrastructure
+
+Already in place (v0.18.0 / issue #110):
+
+- `hooks/lib/mpl-config.mjs::ENFORCEMENT_DEFAULTS` — per-rule policy table with `warn` / `block` / `off`. All 8 currently-defined rules ship at `warn` by default.
+- `strict: false` global elevation switch — when `true`, every per-rule `warn` elevates to `block`.
+- Per-hook boolean toggles (e.g. `phase_evidence_latch_required: false`) for full opt-out.
+- Per-hook dedicated config files (e.g. `.mpl/config/test-agent-brief-enforcement.json` from #225) for hook-specific mode.
+- Telemetry-only path: `continue: true, systemMessage: "..."` surfaces a diagnostic without blocking.
+
+**The relaxation lever is not missing — it's just not wired up everywhere.** Most B-category hooks (bare `block(reason)` without envelope, no config consultation) bypass the system entirely.
+
+## Three relaxation tiers
+
+| Tier | When to apply | Mechanism |
+|---|---|---|
+| **block** | invariant violations that corrupt state or skip evidence — recovery without intervention is impossible | `decision: "block"` + `recordBlockedHook` envelope + `mpl-recover` routing |
+| **warn** | rule violation that the user should see but doesn't corrupt state — pipeline can continue, fix is deferred | `continue: true, systemMessage: "..."` + (optional) telemetry record |
+| **telemetry** | drift signal worth measuring across runs, no immediate user action — e.g. coordination quality | append to a learning log file, no surface | 
+
+## Relaxation evaluation per finding
+
+Re-evaluating each finding from the divergence audit. **Default: warn.** Block only where state corruption / unrecoverable evidence loss is at stake. Telemetry where the rule is about coordination drift rather than artifact correctness.
+
+### A. Layer-1-only rules
+
+| # | Rule | Recommended tier | Reasoning |
+|---|---|---|---|
+| A1 | Orchestrator must NOT Write/Edit `decomposition.yaml` | **block** | Direct violation corrupts the only source of phase truth. write-guard should detect Write/Edit on `decomposition.yaml` from any non-`mpl-decomposer` agent. |
+| A2 | HA-01 vague delegation prompt | **warn** | Pattern-matching Task prompts ("이전 결과 참고해서", "알아서") is heuristic — false positives possible. Surface as systemMessage with the matched phrase so operator can confirm or override. NOT block; soft signal first. |
+| A3 | `mpl-cancel` must not `rm .mpl/mpl/**` etc. | **block** | Destructive operation on protected paths is irreversible. Promote from current allowlist behavior to per-path blocklist with explicit override flag. |
+| A4 | `mpl-validate-output` JSON-fence rule | **warn** | Already advisory by design. The risk of breaking legitimate output formats (especially `mpl-interviewer` natural-language responses) is real. Stay at warn; add structured telemetry so violation rate is measurable. |
+| A5 | `test_command: "TODO(integration-ci)"` placeholder | **warn** → **block on finalize** | Block only at finalize trigger when other Phase 0 artifacts are present. Early decomposition can ship with placeholders during iteration; finalize must not. |
+| A6 | Probing hints → ≥1 adversarial test | **warn** | Mapping hint → test is heuristic; a single high-quality test may cover multiple hints. Warn first; block only if zero tests reference any hint. |
+| A7 | Seed Generator "No invention" / `ambiguity_notes` | **warn** | Validation is "did the agent use the escape hatch when uncertain", inherently judgement-based. Warn surfaces; block here would mass-fire on benign cases. |
+| A8 | HA-02 BEGIN/END region mirror | **telemetry** | Pure development-time discipline. Could be a pre-commit lint, but a runtime hook adds cost and rarely triggers. Telemetry: log when the two files' regions diverge so reviewers see it. |
+| A9 | Retry 2 "must not do" reflection | **telemetry** | Coordination quality, not correctness. Log presence/absence; surface in mpl-doctor summary. |
+| A10 | Interviewer comparison table | **warn** | Already substring-checked at advisory level. Quality concern, not state-corruption. Stay warn. |
+
+### B. Layer-2 blocks without Layer-3 envelope
+
+For each, the fix is to call `recordBlockedHook` so `mpl-recover` can dispatch. But the level of THAT block can vary:
+
+| Hook | Recommended tier | Note |
+|---|---|---|
+| `mpl-state-invariant.mjs:174-179` (I13 fast-track Phase 0) | **block** with envelope | The single stopgap against direct state.json tampering — must stay block, must add envelope. |
+| `mpl-write-guard.mjs:220-225, 259-265` (`direct_source_edit`, `phase_scope_violation`) | **honor enforcement config** | These already have `ENFORCEMENT_DEFAULTS` entries at `warn`. The current bare `block` ignores the config and over-enforces. Fix: respect the policy. Default warn, escalate to block via `strict: true` or per-rule override. |
+| `mpl-require-test-agent-brief.mjs:51` | **mode already exists** (warn/block/off via own config) — add envelope on block path | The hook resolves enforcement mode but the block path doesn't envelope. Connect to `recordBlockedHook`. |
+| `mpl-require-phase-evidence.mjs:44`, `mpl-require-finalize-artifacts.mjs:41`, `mpl-require-completed-phase-immutability.mjs:41`, `mpl-require-whole-goal-closure.mjs:40` | **block** with envelope | These guard finalize-time evidence — state corruption if bypassed. Stay block, add envelope. |
+| `mpl-require-decomposition-delta.mjs:48`, `mpl-require-chain-assignment.mjs:44`, `mpl-require-phase-contract-graph.mjs` | **block** with envelope | Decomposition completeness — must block on missing structure. |
+| `mpl-require-e2e.mjs:54`, `mpl-require-e2e-authenticity.mjs:49` | **honor enforcement config** | Already opt-out toggles exist (`e2e_authenticity_required: true`). Default block stays appropriate but make it config-driven. |
+| `mpl-validate-pp-schema.mjs:83` | **warn → block on finalize** | Schema validation can have transient drift during iteration; block only when persisting. |
+| `mpl-phase-controller.mjs:1130-1138` (small-plan / mvp_scope conflict) | **block** | Pipeline-mode conflict — must resolve before continuing. Stay block, add envelope explaining the two paths. |
+| `mpl-bash-timeout.mjs:74-79`, `mpl-fallback-grep.mjs:139-143` | **already config-driven** (timeout/anti-pattern in defaults at `warn`) — fix: respect config | Currently bypasses its own config. Wire to ENFORCEMENT_DEFAULTS. |
+
+### C. Layer-3 routing gap
+
+Each unrouted code below should get a `mpl-recover` handler. Severity is the *severity of the dead-end*, not the rule:
+
+| Code | Routing recommendation |
+|---|---|
+| `decomposition_derived_stale`, `test_agent_briefs_write_failed` | Common handler: re-run the mechanical postprocess (`writeDerivedDecompositionFields` / `writeTestAgentBriefs`) since both are deterministic regenerations. Recover should be auto-fix, not agent-dispatch. |
+| `phase_runner_*` (anomaly types) | Per-anomaly type handler. Empty response → re-dispatch with stronger framing. Truncated → re-dispatch with shorter context. Etc. Each anomaly type already has a recovery template in `mpl-gate-recorder.mjs`; lift those to `mpl-recover`. |
+| `covers_schema_violation`, `goal_contract_invalid`, `phase_contract_graph_invalid` | Common handler: re-dispatch the corresponding decomposer / interviewer agent with the validator's structured error list. |
+| `baseline_immutable` | The hook's `resume_instruction` is already concrete (touch the renewal sentinel) — recover can echo it as a one-shot user task, no agent dispatch needed. |
+| Phantom `goal_contract_hash_corrupt` / `goal_contract_hash_mismatch` aliases | Delete (no emission site) OR rename emission to match (lower-risk: keep current emission name, drop aliases). |
+
+### D. Diagnostic gaps
+
+| Gap | Recommended action |
+|---|---|
+| `mpl-require-test-agent-brief` missing from trace PURPOSES | Add label entry. One-line fix. |
+| Trace's bidirectional `endsWith` | Tighten to slash-boundary suffix match. One-line fix. |
+| `pathCategory === 'state'` not differentiated | Add a `state` branch to `shouldIncludeHook` that filters to state-touching hooks only. |
+
+## Sequencing recommendation
+
+1. **First**: B-category — wire bare `block(reason)` to `recordBlockedHook` + `mpl-recover` routing. This is mechanical and unlocks recovery for the most-tripped hooks. Most can stay at block tier but use envelope.
+2. **Second**: C-category — add the missing `mpl-recover` handlers + drop phantom aliases. Auto-fix paths (mechanical regeneration) ship first since they're cheapest.
+3. **Third**: A-category high-severity (A1, A3) — write-guard tightening with explicit blocklist on protected paths.
+4. **Fourth**: A-category warn/telemetry items — add structured telemetry surface (mpl-doctor / mpl-trace integration) without changing block behavior.
+5. **Deferred**: A2 (HA-01 prompt heuristic) — needs design pass on false-positive tolerance.
+
+## Default policy reaffirmation
+
+v0.18.0 said "default: transitional warn, exp16+에서 strict: true". The current state is that ~half the hooks respect this policy (read enforcement config) and ~half bypass it (hand-rolled `block`). **The relaxation work is NOT loosening rules — it's making the hand-rolled hooks respect the policy that already exists.** A workspace that opts into `strict: true` should see consistent block behavior across all hooks; a default workspace should see consistent warn-mode surfacing.

--- a/docs/findings/2026-05-28-prompt-gate-restore-divergence.md
+++ b/docs/findings/2026-05-28-prompt-gate-restore-divergence.md
@@ -1,0 +1,100 @@
+# Prompt → Gate → Restore 3-Layer Pattern Divergence Audit
+
+**Date**: 2026-05-28
+**Scope**: post-Exp22 follow-up cycle (PRs #226 / #227 / #228 / #229 / #231 merged)
+**Trigger**: user audit request — "현재 구현체에서 내가 생각한 flow → 프롬프트 권고 / gate를 통한 체크 / 자동 restore와 어긋나는 부분"
+
+## Intended 3-Layer Pattern
+
+1. **Layer 1 — Prompt 권고**: `agents/*.md`, `commands/*.md`, `skills/*/SKILL.md` give agents instructions and MUST/SHOULD rules.
+2. **Layer 2 — Gate 체크**: `hooks/*.mjs` mechanically enforce as PreToolUse / PostToolUse hooks; on violation emit `{ continue: false, decision: "block", reason }`.
+3. **Layer 3 — 자동 Restore**: on a Layer-2 block, the hook records a `blocked_hook` envelope (`hooks/lib/mpl-blocked-hook.mjs::recordBlockedHook`) into `.mpl/state.json` with `block_code` / `blocked_artifact` / `resume_instruction` / `retry_context`. `skills/mpl-recover/SKILL.md` reads that envelope and dispatches the corrective agent.
+
+A hook that emits a block without an envelope leaves the user staring at a wall with no recovery path. A `block_code` not in `mpl-recover`'s routing table falls through to `unsupported` — same outcome.
+
+## Findings
+
+### A. Layer-1-only rules (no Layer-2 gate)
+
+Prompts assert MUSTs that no hook enforces. A drifted agent can violate them undetected.
+
+| # | Rule | Where prompted | Why gate is missing | Sev |
+|---|---|---|---|---|
+| A1 | Orchestrator must NOT directly `Write/Edit .mpl/mpl/decomposition.yaml` | `commands/mpl-run-decompose.md:16, 24, 188` | `hooks/mpl-write-guard.mjs:54-62` explicitly *allows* `.mpl/` paths. Content gates only check `generated_by: mpl-decomposer` string presence — they don't verify the actual writer. | HIGH |
+| A2 | HA-01: vague delegation prompts ("이전 결과 참고해서 구현해", "알아서 판단해") PROHIBITED | `commands/mpl-run.md:15-19` | No PreToolUse hook inspects Task tool prompts for these patterns. `grep "HA-01\|synthesis" hooks/` returns nothing outside hook-trace. | HIGH |
+| A3 | `mpl-cancel` must NEVER `rm` under `.mpl/mpl/**`, `.mpl/contracts/*.json`, `docs/learnings/`, `.mpl/memory/` | `skills/mpl-cancel/SKILL.md:104, 108, 110, 113` | `hooks/mpl-write-guard.mjs:111` actively *allowlists* `rm -rf .mpl` as a "safe cleanup" pattern — the dangerous-bash check permits the exact destructive operation the skill forbids. | HIGH |
+| A4 | `mpl-validate-output` is registered but advisory-only | `hooks/mpl-validate-output.mjs:95-110` | Hook emits `[VALIDATION FAILED]` as a `systemMessage` and never sets `decision: "block"`. Required-section checks are case-insensitive substring matches — a JSON-fence rule like "Final output MUST be valid JSON in ```json fences" (`agents/mpl-phase-runner.md:140`) is not enforced. | HIGH |
+| A5 | e2e `test_command` must not be a placeholder like `TODO(integration-ci)` | `agents/mpl-decomposer.md:180-181` | `mpl-require-e2e.mjs` only checks non-null / non-empty; `mpl-require-e2e-authenticity.mjs` filters `MOCK_PATTERN` tokens but not `TODO(...)`. | MED |
+| A6 | Probing hints MUST produce ≥1 adversarial test | `agents/mpl-test-agent.md:175-180` | `mpl-require-test-agent.mjs` passes hints into the dispatch brief but `lib/mpl-test-agent-evidence.mjs` does not check the resulting `test_files_created` references any hint. | MED |
+| A7 | Seed Generator "No invention" — unknowns recorded as `ambiguity_notes`, not guessed | `agents/mpl-seed-generator.md:49` | `mpl-validate-seed.mjs` validates `todo_structure` fields but never checks `ambiguity_notes` presence/usage. Hallucinated `files_to_modify` paths are undetectable until phase execution fails. | MED |
+| A8 | `mpl-test-agent.md` HA-02 BEGIN/END region must mirror to `prompts/modules/adversarial-verification-ha02.md` in the same commit | `agents/mpl-test-agent.md:181-183` | No pre-commit / hook compares the two regions. Pure social contract. | LOW |
+| A9 | `mpl-phase-runner` Retry 2 must reflect prior failure into a "must not do" list | `agents/mpl-phase-runner.md:105` | `fix_loop_count` is tracked but retry prompt content not inspected. | LOW |
+| A10 | Interviewer Hypothesis-as-Options + Contrast-Based comparison table | `agents/mpl-interviewer.md:57-58, 73-74, 171` | `mpl-validate-output.mjs:57-61` only checks for the literal strings `PP-`, `Priority Order`, `Interview Metadata` (substring, non-blocking). | LOW |
+
+### B. Layer-2 blocks WITHOUT a Layer-3 envelope
+
+Hooks call a hand-rolled `function block(reason) { console.log(JSON.stringify({continue:false, decision:"block", reason})); }` helper, bypassing `recordBlockedHook`. State.json's `blocked_by_hook` / `block_code` / `retry_context` are never populated, so `mpl-recover` has nothing to dispatch.
+
+| Hook | Block path | Severity |
+|---|---|---|
+| `hooks/mpl-state-invariant.mjs:174-179` | I13 fast-track Phase 0 invariant — the only stopgap against direct state.json tampering and it leaves no recovery trail | CRITICAL |
+| `hooks/mpl-write-guard.mjs:220-225, 259-265` | `direct_source_edit`, `phase_scope_violation` — the most-likely-tripped PreToolUse gates during normal work | HIGH |
+| `hooks/mpl-require-test-agent-brief.mjs:51` | new in #226 — brief missing/invalid | HIGH |
+| `hooks/mpl-require-phase-evidence.mjs:44` | phase evidence missing | HIGH |
+| `hooks/mpl-require-finalize-artifacts.mjs:41` | finalize artifacts missing | HIGH |
+| `hooks/mpl-require-completed-phase-immutability.mjs:41` | completed phase mutation | HIGH |
+| `hooks/mpl-require-decomposition-delta.mjs:48` | decomposition delta missing | HIGH |
+| `hooks/mpl-require-chain-assignment.mjs:44` | chain assignment missing | HIGH |
+| `hooks/mpl-require-e2e.mjs:54` | e2e fields missing | HIGH |
+| `hooks/mpl-require-e2e-authenticity.mjs:49` | e2e authenticity violation | HIGH |
+| `hooks/mpl-require-whole-goal-closure.mjs:40` | whole-goal closure missing | HIGH |
+| `hooks/mpl-validate-pp-schema.mjs:83` | pp schema violation | HIGH |
+| `hooks/mpl-phase-controller.mjs:1130-1138` | small-plan / mvp_scope conflict | MED |
+| `hooks/mpl-bash-timeout.mjs:74-79`, `hooks/mpl-fallback-grep.mjs:139-143` | bash timeout, Tier-1 anti-pattern | MED |
+
+**Failure mode**: when one of these fires, `state.json` may even fail the `BLOCKED_HOOK_STALE` invariant because the envelope shape is partial (or absent). The user is told "blocked" with a reason string and no recovery handle.
+
+### C. Layer-3 routing gap (envelope recorded but `mpl-recover` doesn't handle the code)
+
+`hooks/lib/mpl-recover.mjs:20-28, 537-580` routes 5 code families. Several codes are correctly enveloped at emission but fall through to `unsupported`.
+
+| Code | Emitted at | Routed in `mpl-recover.mjs`? |
+|---|---|---|
+| `covers_schema_violation` | `hooks/mpl-require-covers.mjs:235` | NO |
+| `decomposition_derived_stale` | `hooks/mpl-decomposition-postprocess.mjs:51` | NO |
+| `test_agent_briefs_write_failed` | `hooks/mpl-decomposition-postprocess.mjs:68` (new in #226) | NO |
+| `goal_contract_invalid` | `hooks/mpl-require-goal-trace.mjs:106` | NO |
+| `baseline_immutable` | `hooks/mpl-baseline-guard.mjs:118` | NO |
+| `phase_runner_*` (anomaly type) | `hooks/mpl-gate-recorder.mjs:423` (new in #218) | NO |
+| `phase_contract_graph_invalid` | `hooks/mpl-require-phase-contract-graph.mjs:199` | NO |
+
+**Phantom codes** routed but never emitted:
+
+- `goal_contract_hash_corrupt`, `goal_contract_hash_mismatch` — `mpl-recover.mjs:20-28` references these aliases; the live hook emits `goal_contract_baseline_corrupt` / `goal_contract_drift` only. Confusing for future hook authors reading recover.mjs as the canonical code list.
+
+### D. Diagnostic gaps (Layer-3 trace coverage)
+
+| Gap | Severity |
+|---|---|
+| `mpl-require-test-agent-brief` (new in #226) absent from `hooks/lib/mpl-hook-trace.mjs::PURPOSES` map — surfaces as default "registered hook" label, no domain context | MED |
+| `hooks/lib/mpl-hook-trace.mjs:172` bidirectional `endsWith` artifact match — no slash-boundary check, `foo.yaml` matches `barfoo.yaml` | LOW |
+| `pathCategory === 'state'` is computed but `shouldIncludeHook` doesn't differentiate it from `file` — diagnostic noise, not silent failure | LOW |
+
+## Pattern Summary
+
+- **A** (Layer 1 only): rules live in prompts; drifted agents can violate silently. ~10 rules.
+- **B** (Layer 2, no Layer 3 envelope): 10+ hooks block without recording, leaving the user at a dead end.
+- **C** (Layer 3 routing incomplete): 7+ block codes exist with proper envelopes but `mpl-recover` returns `unsupported`.
+- **D** (Layer 3 diagnostic surface): trace tool's coverage drifted away from the new #226-era hooks.
+
+The dominant divergence pattern is **layer-skip without notification**: a hook either bypasses Layer 3 (B), or Layer 3 doesn't know how to handle what Layer 2 emits (C). Both produce the same user-visible failure mode (wall with no recovery path), so they're effectively the same defect class.
+
+## Audit method
+
+Three parallel `general-purpose` agent reads on 2026-05-28 with grep + `Read` only (no edits), each scoped to one category. Findings cross-checked against `hooks/lib/mpl-recover.mjs:20-28, 537-580` (routing table), `hooks/lib/mpl-blocked-hook.mjs` (envelope shape), `hooks/lib/mpl-hook-trace.mjs::PURPOSES` (trace coverage), and `recordBlockedHook` call sites.
+
+## Non-goals (deferred)
+
+- Issue #232 (recorder semantic gaps: exit code vs leading command, strict/recorder allowlist divergence) is intentional design per PR #231 r5/r6 rebuttals — not in this audit.
+- Issue #230 (canonical `failure_code` field) is a producer-side schema change — not in this audit.
+- `mpl-validate-output` advisory→blocking conversion needs a separate design pass (false positives risk).

--- a/docs/findings/2026-05-29-over-enforcement-audit.md
+++ b/docs/findings/2026-05-29-over-enforcement-audit.md
@@ -1,0 +1,107 @@
+# Over-Enforcement Audit
+
+**Date**: 2026-05-29
+**Source**: companion to the prompt → gate → restore divergence audit (`docs/findings/2026-05-28-*`)
+**Trigger**: user follow-up — "너무 과도한 조건으로 인하여 오히려 다양한 가능성을 막는 장애물이 되는지 mpl 전반적으로 전수 검토"
+
+## Permanent rule (re-affirmed)
+
+3-tier — **prompt 권고 → gate hard blocking → restore** — stays. The audit below is NOT about loosening this principle. It's about cases where the *current implementation* of the gate layer is binary (block / off) where it should be 3-mode (warn / block / off + config-driven thresholds), or hard-codes a single algorithm where multiple legitimate alternatives exist.
+
+Existing infrastructure already supports 3-mode:
+- `hooks/lib/mpl-config.mjs::ENFORCEMENT_DEFAULTS` — per-rule `warn` / `block` / `off`.
+- `strict: false` global elevation switch.
+- Per-hook boolean toggles (`*_required: false`) for full opt-out.
+- Per-hook dedicated config files (e.g. #225 brief enforcement).
+
+**The audit's relaxation work = migrating binary-block hooks to the existing 3-mode infrastructure + adding config knobs for hard-coded thresholds. NOT removing the gates.**
+
+## Audit method
+
+Three parallel `general-purpose` agent reads on 2026-05-29 scoped to:
+1. Hook-layer hard blocks (no config, no override).
+2. Prompt / schema over-prescription (single forced algorithm).
+3. Lifecycle + parallelism over-constraint.
+
+Findings cross-checked against `hooks/lib/mpl-config.mjs`, existing `*_required` toggles, and the recover-skill routing table.
+
+## Findings — grouped by relaxation pattern
+
+### A. Hard-coded threshold / allowlist needing config knob
+
+| # | Where | What's hard-coded | Blocks legitimate workflow | Severity |
+|---|---|---|---|---|
+| **A1** | `hooks/lib/mpl-phase0-artifacts.mjs:37-74` + I13 | required artifacts list (raw-scan.md, design-intent.yaml, contracts/*.json) | README typo fix through MPL forces all 3 artifacts. Only `_no-boundaries.json` carve-out for contracts. | HIGH |
+| **A2** | `hooks/mpl-require-test-agent.mjs:454` | default `test_agent_required !== false` (absence = required per AD-0007) | Every legacy / hand-written decomposition trips it; no project-wide opt-out | HIGH |
+| **A3** | `hooks/mpl-phase-controller.mjs:360-378, 391-410` | ambiguity threshold = literal `0.2` | Score 0.21 stays in ambiguity-resolve forever; no force-proceed path | HIGH |
+| **A4** | `hooks/lib/mpl-gate-classify.mjs:150-163` STRICT_GATE_HEAD_ALLOWLIST | 10-head allowlist (tsc/eslint/ruff/mypy/vitest/jest/pytest/mocha/playwright/cypress/wdio/npm/pnpm/yarn/npx/cargo/go) | deno/bun/biome/phpunit/rspec/swift/dotnet/gradle/mvn/tox/nox/mix all rejected; locks manual recovery to a JS/Python/Rust/Go monoculture | HIGH |
+| **A5** | `hooks/lib/bash-timeout-categories.mjs:22-61` | vitest/jest 300_000ms ceiling, build 180_000ms | monorepo Nx/Turborepo full-test, `cargo build --release` exceed; no per-project override | MED |
+| **A6** | `hooks/mpl-require-e2e-authenticity.mjs:40` MOCK_PATTERN | `/\b(mock|stub|fake|msw|...)\b/i` matched anywhere in command | `playwright test --grep "mockable-payment-fallback"`, `cargo test fake_clock_integration`, `pytest -k "not stubbed"` false-positive | MED |
+| **A7** | `hooks/mpl-require-e2e-authenticity.mjs:42, 204-209, 257-267` | Tauri-specific FAKE_RUNTIME_E2E_PATTERN applied to all `real_desktop` | Electron / Qt / wxWidgets / native macOS with comments about other runtimes hit it; scratch tauri.conf.json triggers tauri_capabilities_missing | LOW-MED |
+
+**Relaxation pattern**: extract literals into `.mpl/config.json` (e.g. `phase0_artifacts_required`, `ambiguity_threshold`, `gate_classify.allowed_heads`, `bash_timeout.{category}.max_ms`). Default values stay at current hard-coded ones — config only enables override.
+
+### B. Lifecycle / state transition forcing single path
+
+| # | Where | What's forced | Blocks legitimate workflow | Severity |
+|---|---|---|---|---|
+| **B1** | `hooks/mpl-require-completed-phase-immutability.mjs:80-99` + `hooks/lib/mpl-completed-phase-immutability.mjs:69-94` | byte-for-byte equality on entire phase YAML block | comment fix, whitespace, anchor addition all block; only `completed_phase_immutability_required: false` (binary off) | MED |
+| **B2** | `hooks/mpl-phase-controller.mjs:964-984` | active cohort → forced revert to phase2-sprint | user with PASS gate evidence + stale `current_cut_id` can't proceed to phase3-gate | MED |
+| **B3** | `hooks/mpl-phase-controller.mjs:1068-1086` | first-detected stagnation → auto-finalize phase4-fix | brief plateau mid-bug → forced partial completion; `stagnation_window: 3` exists but decision fires on first detection | MED |
+| **B4** | `hooks/mpl-require-whole-goal-closure.mjs:51-93` | every contract AC + AX covered for `finalize_done=true` | intentional partial-MVP after release-finalize blocked; only binary off | MED |
+| **B5** | `hooks/mpl-baseline-guard.mjs:91-127` | renewal sentinel is touch-and-pray, unscoped | new PP discovery in Phase 2 forces full baseline reset; no per-field renewal | MED |
+| **B6** | `hooks/mpl-phase-controller.mjs:544-554` | PLAN.md `[FAILED]` → stays in phase2-sprint | deferred-by-decision TODO has no honest marker; user must lie with `[x]` | LOW-MED |
+| **B7** | `hooks/mpl-require-decomposition-delta.mjs:131-134` | `newCount !== oldCount + 1` rejects monotonic > +1 | forward consolidation after corrupted state recovery blocked even when intermediate deltas exist on disk | LOW |
+
+**Relaxation pattern**: scope immutability to load-bearing fields (B1), accept advisory stopReason instead of forced transition (B2/B3), recognize partial / deferred markers as first-class (B4/B6), per-field renewal manifest (B5), allow forward consolidation when delta files exist (B7).
+
+### C. Prompt / schema over-prescription
+
+| # | Where | What's prescribed | Alternative blocked | Severity |
+|---|---|---|---|---|
+| **C1** | `agents/mpl-test-agent.md:60-68, 192` | per-domain min test count floor (5 per function, 4 CRUD + migration, etc.) | contract-derived test counts (one assertion per `produces[].params/returns` key), property-based testing (1 generator → many cases), proportional coverage | HIGH |
+| **C2** | `commands/mpl-run-execute.md:871-912` + dispatch loop | `mpl-adversarial-reviewer` required per phase | low-risk infra/docs phases (no `reviewer_required: bool` mirror of `test_agent_required`); doubles token cost | HIGH |
+| **C3** | `commands/mpl-run-execute.md:460` Rule 4 | per-TODO test (no batching) | refactor (rename type + update callers + fix interface) — can't compile until all land; broken intermediate states forced | MED |
+| **C4** | `agents/mpl-decomposer.md:487-508`, AP-DECOMP-05 (line 638) | `type_policy` / `error_spec` with `applies: false` MUST be emitted for every phase | "absence = N/A" convention; output budget directly contradicts "Phase 5 diet" line 14 | MED |
+| **C5** | `agents/mpl-test-agent.md:32` + `mpl-run-execute.md:686-707` | "Write tests in the project's existing test framework" + `commands_run[].exit_code == 0` | ad-hoc verification scripts, shell contract probes, framework-introduction for phases lacking test infra | MED |
+| **C6** | `commands/mpl-run-execute-gates.md:138-146` | Hard 1 demands lint+type+build, ≥1 must run, else FAIL | docs-only repos, prompt-only projects, research scratchpads; `evidence_required: [goal_trace]` legal but Hard 1 still demands tooling | MED |
+| **C7** | `agents/mpl-decomposer.md:606-611`, line 50 | `go_no_go` closed enum (READY/READY_WITH_CAVEATS/NOT_READY/RE_INTERVIEW) | free-form risk note; no executor branches on READY_WITH_CAVEATS vs READY | LOW-MED |
+| **C8** | `agents/mpl-test-agent.md:87-92` | "Final assistant message MUST start with ```json fence" — prose forbidden even after the fence | human-readable preamble before JSON block (natural shape when bugs found and context matters) | LOW |
+
+**Relaxation pattern**: replace count floors with derive-from-contract rules (C1), add `*_required: bool` mirrors (C2), seed-declared batch mode (C3), drop forced-emit-absent (C4/C7), allow shell evidence shape (C5), per-evidence-type Hard 1 opt-out (C6), allow surrounding prose (C8).
+
+## Cross-cutting themes
+
+1. **Binary block/off is the dominant shape.** Only `bash_timeout_violation`, `direct_source_edit`, `phase_scope_violation`, etc. (~8 rules) use the 3-mode `warn`/`block`/`off` policy. ~20+ blocks are binary. The infrastructure exists; the wire-up is missing.
+
+2. **Hard-coded literals masquerade as policy.** `0.2` ambiguity threshold, `300_000` test timeout, 5-test floor — all should be config knobs with current value as default.
+
+3. **Allowlists drift behind language ecosystem.** STRICT_GATE_HEAD_ALLOWLIST covers TypeScript/Python/Rust/Go. Bun/Deno/PHP/Swift/.NET/Elixir users hit walls.
+
+4. **Lifecycle assumes single forward path.** No "I know what I'm doing" override. Cohort revert, stagnation auto-finalize, ambiguity threshold — all are decisions a sufficiently sophisticated operator should be able to override with an explicit flag.
+
+5. **Schema prescription duplicates gate enforcement.** Many prompt MUSTs (e.g. test count floor, type_policy emission) restate what gates already check, removing the prompt → gate gradient.
+
+## Recommended new issues (over and above #234–#238)
+
+Per the user's standing "scope expansion → split" rule:
+
+- **(NEW1) Hard-coded threshold → config-driven**: A1 (phase0 artifacts), A2 (test_agent default), A3 (ambiguity threshold), A4 (STRICT_GATE_HEAD_ALLOWLIST), A5 (bash_timeout ceilings). All same mechanical pattern (extract literal → config).
+- **(NEW2) Lifecycle binary → 3-mode migration**: B1 (completed-phase immutability scope), B2 (phase3 revert advisory), B3 (phase4 convergence threshold), B4 (whole-goal cohort closure), B6 (deferred TODO marker).
+- **(NEW3) Prompt over-prescription cleanup**: C1 (test count floor → contract-derived), C2 (reviewer_required opt-out), C3 (batch_test seed flag), C4 (type_policy optional), C6 (Hard 1 evidence_required honors).
+
+## Review of pending issues #234–#238 against this lens
+
+| Issue | 3-tier alignment | Over-enforcement risk | Reshape? |
+|---|---|---|---|
+| #234 (mpl-recover routing) | ✓ clean — restore enhancement, no new constraint | None | proceed as-is |
+| #235 (envelope wiring) | ✓ aligned — wires hand-rolled blocks to existing config | I13 must stay hard-block (single stopgap); document this | proceed, note I13 exception |
+| #236 (write-guard tightening) | ⚠ adds new hard blocks | A1 (decomposition.yaml writer): PreToolUse cannot identify calling agent identity for Write/Edit. A3 (protected-path rm): needs override mechanism. | RESHAPE — A1 to telemetry (content-marker check only), A3 with explicit override flag |
+| #237 (trace diagnostic) | ✓ clean | D2 endsWith tightening may affect PR #228 tests | proceed, pre-verify |
+| #238 (telemetry surface) | ✓ aligned — mostly warn/telemetry | A5 finalize-time elevation is new constraint; new file may duplicate existing telemetry | RESHAPE — integrate vs new-file decision; A5 elevation behind config flag |
+
+## Non-goals (deferred)
+
+- This audit does NOT propose removing any gate. Every finding is a relaxation of *how* the gate fires (config knob / warn tier / override path), not whether it fires.
+- Tightening under-enforcement (the prior 2026-05-28 audit) is orthogonal and continues per issues #234-238.
+- Issues #230 / #232 (Exp22 follow-up scope expansions) are separate concerns.


### PR DESCRIPTION
## Summary

Three companion design docs from the post-Exp22 audit sweep. No code changes.

- `docs/findings/2026-05-28-prompt-gate-restore-divergence.md` — where the 3-tier (prompt 권고 → gate block → restore) pattern breaks down. Categories A (prompt-only) / B (gate without envelope) / C (envelope without routing) / D (trace coverage).
- `docs/findings/2026-05-28-enforcement-relaxation-plan.md` — per-finding tier recommendation (block / warn / telemetry) so the cleanup work isn't "block everything."
- `docs/findings/2026-05-29-over-enforcement-audit.md` — where Layer 2 OVER-applies. Categories A (hard-coded threshold) / B (lifecycle binary block) / C (prompt over-prescription).

## Why now

After the 5-issue Exp22 follow-up cycle (PRs #226 / #227 / #228 / #229 / #231), the user asked for a sweep against the intended pattern. The first audit found under-enforcement; the second confirmed the relaxation lever (ENFORCEMENT_DEFAULTS) already exists; the third found over-enforcement that prevents legitimate workflows.

## Resulting issues

Under-enforcement track:
- #234 (mpl-recover routing)
- #235 (envelope wiring)
- #236 (write-guard tightening — reshape note added on A1 / A3)
- #237 (trace diagnostic)
- #238 (telemetry surface — reshape note added on integration vs new file)

Over-enforcement track:
- #239 (hard-coded thresholds → config)
- #240 (lifecycle binary → 3-mode + scope load-bearing fields)
- #241 (prompt over-prescription cleanup)

## Key takeaway

The relaxation lever already exists — `hooks/lib/mpl-config.mjs::ENFORCEMENT_DEFAULTS` defines per-rule `warn`/`block`/`off` policies. Most cleanup work is **wiring hand-rolled blocks to the existing policy + extracting hard-coded literals to config** — NOT introducing new constraint surface area.

## Test plan

- [x] Docs only — no code changes, no tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)