### PR TITLE
Add mpl-recover routing for unrouted block codes + drop phantom aliases (#234)

### DIFF
--- a/hooks/__tests__/mpl-recover.test.mjs
+++ b/hooks/__tests__/mpl-recover.test.mjs
@@ -487,6 +487,64 @@ phases:
     assert.equal(existsSync(join(tmp, '.mpl', 'mpl', 'decomposition-derived.json')), true);
   });
 
+  it('#234 [contract-break] codex r3: pre-r2 untagged recovery from the SAME block is adopted (last_attempt_at >= blocked_at)', () => {
+    // codex r3 on PR #242: when upgrading from r1 to r2, existing
+    // blocked-hook envelopes on disk have untagged
+    // retry_context.recovery (no block_code / blocked_at fields).
+    // Treating them all as stale would silently reset an
+    // r1-budget-exhausted block to attempts=0 and allow extra auto-fix
+    // attempts past the cap.
+    //
+    // Migration: adopt untagged recovery when last_attempt_at is at
+    // or after the current block's blocked_at — proving the recovery
+    // was written within this block's lifetime.
+    writeState(blocked({
+      block_code: 'decomposition_derived_stale',
+      blocked_at: '2026-06-01T12:00:00Z',
+      retry_context: {
+        recovery: {
+          // Pre-r2 shape: no block_code / blocked_at tag.
+          attempts: 3,
+          last_attempt_at: '2026-06-01T12:05:00Z', // AFTER blocked_at
+          last_status: 'failed',
+        },
+      },
+    }));
+
+    const plan = inspectRecovery(tmp);
+    assert.equal(plan.status, 'unsupported');
+    assert.equal(plan.attempts, 3, 'pre-r2 attempts must be inherited when last_attempt_at >= blocked_at');
+
+    const result = recoverBlockedHook(tmp);
+    assert.equal(result.status, 'failed');
+    assert.match(result.message, /budget exhausted/);
+  });
+
+  it('#234 [contract-break] codex r3: pre-r2 untagged recovery from an OLDER block is treated as stale', () => {
+    // The other half of the migration rule: untagged recovery written
+    // BEFORE the current block's blocked_at must still be discarded,
+    // since it belongs to a prior block.
+    writeMinimalDecompositionForDerive();
+    writeState(blocked({
+      block_code: 'decomposition_derived_stale',
+      blocked_at: '2026-06-01T12:00:00Z',
+      retry_context: {
+        recovery: {
+          attempts: 3,
+          last_attempt_at: '2026-05-15T09:00:00Z', // BEFORE blocked_at
+          last_status: 'failed',
+        },
+      },
+    }));
+
+    const plan = inspectRecovery(tmp);
+    assert.equal(plan.status, 'recoverable', 'older untagged recovery must be discarded');
+    assert.equal(plan.attempts, 0);
+
+    const result = recoverBlockedHook(tmp);
+    assert.equal(result.status, 'recovered');
+  });
+
   it('#234 [data-integrity] codex r2: scope-matched retry_context.recovery is honored', () => {
     // Sanity check: when the stored recovery DOES match the current
     // block (same code + blocked_at), the budget enforcement still

--- a/hooks/__tests__/mpl-recover.test.mjs
+++ b/hooks/__tests__/mpl-recover.test.mjs
@@ -777,6 +777,109 @@ phases:
     assert.match(result.dispatch_instruction, /legacy-style finding/);
   });
 
+  it('#234 [contract-break] codex r8: safe mode does NOT persist gated dispatch text in state', () => {
+    // Codex r8 [contract-break]: r7 stashed the gated Re-dispatch
+    // Task(...) string in details.awaiting_instruction, which spread
+    // into state.retry_context.recovery.awaiting_instruction. Any
+    // automation reading state could extract and dispatch the Task
+    // call without approval.
+    writeState(blocked({
+      block_code: 'covers_schema_violation',
+      retry_context: { issues: ['phase-1.covers[0]:UC-99'] },
+    }));
+
+    const result = recoverBlockedHook(tmp); // --apply-safe
+    assert.equal(result.status, 'requires_approval');
+    assert.equal(result.dispatch_instruction, undefined);
+
+    const state = readState();
+    const rec = state.retry_context.recovery;
+    // Must not contain dispatch text anywhere in persisted state.
+    const stateJson = JSON.stringify(state);
+    assert.doesNotMatch(stateJson, /Re-dispatch Task\(/, 'persisted state must not contain the gated Task text');
+    assert.doesNotMatch(stateJson, /subagent_type="mpl-decomposer"/, 'persisted state must not contain subagent_type=mpl-decomposer');
+    assert.equal(rec.awaiting_instruction, undefined, 'awaiting_instruction must not be persisted in safe mode');
+  });
+
+  it('#234 [contract-break] codex r8: phase_runner_anomaly safe mode does not persist gated Task text', () => {
+    writeState(blocked({
+      block_code: 'phase_runner_empty_response',
+      blocked_phase: 'phase-1',
+    }));
+    recoverBlockedHook(tmp); // --apply-safe
+    const stateJson = JSON.stringify(readState());
+    assert.doesNotMatch(stateJson, /Re-dispatch Task\(/);
+    assert.doesNotMatch(stateJson, /subagent_type="mpl-phase-runner"/);
+    assert.doesNotMatch(stateJson, /stronger framing/);
+  });
+
+  it('#234 [logic] codex r8: safe-then-approve preserves original resume_instruction (goal_contract_invalid)', () => {
+    // Codex r8 [logic]: r7 wrote the approval prompt as `instruction`
+    // into keepBlocked, which became state.resume_instruction. On the
+    // next --approve-unsafe call, the handler read state.resume_instruction
+    // and echoed back the approval prompt instead of the original
+    // restore instruction.
+    //
+    // Repro: --apply-safe then --approve-unsafe → user_instruction
+    // MUST contain the original "Restore a valid .mpl/goal-contract.yaml"
+    // text, not "Run /mpl:mpl-recover with --approve-unsafe".
+    const originalInstruction = 'Restore a valid .mpl/goal-contract.yaml, then retry the decomposition write.';
+    writeState(blocked({
+      block_code: 'goal_contract_invalid',
+      resume_instruction: originalInstruction,
+      retry_context: { missing: ['mission.goal'] },
+    }));
+
+    // Step 1: safe mode (--apply-safe).
+    const safeResult = recoverBlockedHook(tmp);
+    assert.equal(safeResult.status, 'requires_approval');
+    // Original resume_instruction must still be intact on disk.
+    assert.equal(readState().resume_instruction, originalInstruction);
+
+    // Step 2: approved (--approve-unsafe). Must echo the original.
+    const approvedResult = recoverBlockedHook(tmp, { approveUnsafe: true });
+    assert.equal(approvedResult.status, 'requires_user_action');
+    assert.match(approvedResult.user_instruction, /Restore a valid \.mpl\/goal-contract\.yaml/);
+    assert.match(approvedResult.user_instruction, /mission\.goal/);
+    assert.doesNotMatch(approvedResult.user_instruction, /--approve-unsafe/);
+  });
+
+  it('#234 [logic] codex r8: safe-then-approve preserves baseline_immutable resume_instruction', () => {
+    const originalInstruction = 'Touch .mpl/mpl/.baseline-renewal to authorize a new baseline write, then retry.';
+    writeState(blocked({
+      block_code: 'baseline_immutable',
+      resume_instruction: originalInstruction,
+    }));
+
+    recoverBlockedHook(tmp); // safe
+    assert.equal(readState().resume_instruction, originalInstruction);
+
+    const approved = recoverBlockedHook(tmp, { approveUnsafe: true });
+    assert.equal(approved.status, 'requires_user_action');
+    assert.match(approved.user_instruction, /baseline-renewal/);
+    assert.doesNotMatch(approved.user_instruction, /--approve-unsafe/);
+  });
+
+  it('#234 [logic] codex r8: safe-then-approve preserves phase_runner_anomaly fallback for unknown anomaly', () => {
+    // For unknown anomaly type, the handler falls back to
+    // state.resume_instruction. If safe mode clobbered it, the
+    // fallback would emit the approval prompt instead of the actual
+    // re-dispatch text.
+    const originalInstruction = 'Re-dispatch Task(subagent_type="mpl-phase-runner", model="sonnet", prompt="...") for phase-1.';
+    writeState(blocked({
+      block_code: 'phase_runner_some_new_anomaly',
+      resume_instruction: originalInstruction,
+    }));
+
+    recoverBlockedHook(tmp); // safe
+    assert.equal(readState().resume_instruction, originalInstruction);
+
+    const approved = recoverBlockedHook(tmp, { approveUnsafe: true });
+    assert.equal(approved.status, 'awaiting_phase_runner');
+    assert.match(approved.dispatch_instruction, /mpl-phase-runner/);
+    assert.doesNotMatch(approved.dispatch_instruction, /--approve-unsafe/);
+  });
+
   it('#234 [contract-break] codex r7: redispatch_decomposer route requires --approve-unsafe; --apply-safe keeps requires_approval', () => {
     // Codex r7: SKILL.md categorizes redispatch_decomposer as "Step 3
     // Explicit Approval Recovery". --apply-safe (approveUnsafe=false)

--- a/hooks/__tests__/mpl-recover.test.mjs
+++ b/hooks/__tests__/mpl-recover.test.mjs
@@ -520,6 +520,81 @@ phases:
     assert.match(result.message, /budget exhausted/);
   });
 
+  it('#234 [data-integrity] codex r4: mixed-precision ISO timestamps compare chronologically (not lexicographically)', () => {
+    // codex r4 on PR #242: `2026-06-01T12:00:00.500Z` is chronologically
+    // AFTER `2026-06-01T12:00:00Z` but is lexicographically SMALLER
+    // because `.` (0x2E) < `Z` (0x5A). String comparison falsely
+    // treats the post-blocked_at recovery as stale → resets attempts
+    // and reopens the budget. Numeric Date.parse comparison fixes it.
+    writeState(blocked({
+      block_code: 'decomposition_derived_stale',
+      blocked_at: '2026-06-01T12:00:00Z',
+      retry_context: {
+        recovery: {
+          attempts: 3,
+          last_attempt_at: '2026-06-01T12:00:00.500Z', // chronologically AFTER blocked_at
+          last_status: 'failed',
+        },
+      },
+    }));
+
+    const plan = inspectRecovery(tmp);
+    // String comparison would say "0.500Z" < "Z" → discard → attempts=0.
+    // Numeric comparison says 12:00:00.500 > 12:00:00 → adopt → attempts=3.
+    assert.equal(plan.attempts, 3, 'sub-second precision must compare chronologically');
+
+    const result = recoverBlockedHook(tmp);
+    assert.equal(result.status, 'failed');
+    assert.match(result.message, /budget exhausted/);
+  });
+
+  it('#234 [data-integrity] codex r4: inverse precision case — string comparison would falsely adopt stale state', () => {
+    // The mirror case: untagged recovery `last_attempt_at:
+    // 2026-06-01T12:00:00Z` and current blocked_at:
+    // 2026-06-01T12:00:00.500Z. Recovery is chronologically OLDER
+    // than the current block (stale → discard). But string comparison
+    // says "Z" > ".500Z" → adopt. Numeric comparison correctly
+    // discards.
+    writeMinimalDecompositionForDerive();
+    writeState(blocked({
+      block_code: 'decomposition_derived_stale',
+      blocked_at: '2026-06-01T12:00:00.500Z',
+      retry_context: {
+        recovery: {
+          attempts: 3,
+          last_attempt_at: '2026-06-01T12:00:00Z', // chronologically BEFORE blocked_at
+          last_status: 'failed',
+        },
+      },
+    }));
+
+    const plan = inspectRecovery(tmp);
+    assert.equal(plan.attempts, 0, 'stale pre-block recovery must be discarded regardless of string lex order');
+
+    const result = recoverBlockedHook(tmp);
+    assert.equal(result.status, 'recovered');
+  });
+
+  it('#234 [data-integrity] codex r4: malformed ISO timestamps fall closed (discarded)', () => {
+    // If either timestamp fails Date.parse, the safe direction is to
+    // discard the untagged recovery rather than admit garbage.
+    writeMinimalDecompositionForDerive();
+    writeState(blocked({
+      block_code: 'decomposition_derived_stale',
+      blocked_at: '2026-06-01T12:00:00Z',
+      retry_context: {
+        recovery: {
+          attempts: 3,
+          last_attempt_at: 'not-a-real-date',
+          last_status: 'failed',
+        },
+      },
+    }));
+
+    const plan = inspectRecovery(tmp);
+    assert.equal(plan.attempts, 0);
+  });
+
   it('#234 [contract-break] codex r3: pre-r2 untagged recovery from an OLDER block is treated as stale', () => {
     // The other half of the migration rule: untagged recovery written
     // BEFORE the current block's blocked_at must still be discarded,

--- a/hooks/__tests__/mpl-recover.test.mjs
+++ b/hooks/__tests__/mpl-recover.test.mjs
@@ -575,6 +575,55 @@ phases:
     assert.equal(result.status, 'recovered');
   });
 
+  it('#234 [data-integrity] codex r5: impossible calendar dates that Date.parse normalizes are REJECTED', () => {
+    // codex r5 on PR #242: Date.parse('2026-02-31T00:00:00Z') silently
+    // rolls forward to 2026-03-03T00:00:00Z. Without strict
+    // round-trip validation, a corrupt legacy recovery
+    // last_attempt_at: '2026-02-31...' would be parsed into a real
+    // instant, possibly >= the current block's blocked_at, and adopt
+    // stale attempts that should have been discarded.
+    writeMinimalDecompositionForDerive();
+    writeState(blocked({
+      block_code: 'decomposition_derived_stale',
+      blocked_at: '2026-03-02T00:00:00Z',
+      retry_context: {
+        recovery: {
+          attempts: 3,
+          // Impossible date — Date.parse normalizes to 2026-03-03,
+          // which would be > the current blocked_at of 2026-03-02.
+          last_attempt_at: '2026-02-31T00:00:00Z',
+          last_status: 'failed',
+        },
+      },
+    }));
+
+    const plan = inspectRecovery(tmp);
+    assert.equal(plan.attempts, 0, 'invalid calendar date must be rejected, not normalized + adopted');
+
+    const result = recoverBlockedHook(tmp);
+    assert.equal(result.status, 'recovered');
+  });
+
+  it('#234 [data-integrity] codex r5: non-UTC ISO timestamps are REJECTED', () => {
+    // Non-Z local-time form: ambiguous wall clock, must not be admitted
+    // as legitimate recovery state.
+    writeMinimalDecompositionForDerive();
+    writeState(blocked({
+      block_code: 'decomposition_derived_stale',
+      blocked_at: '2026-06-01T12:00:00Z',
+      retry_context: {
+        recovery: {
+          attempts: 3,
+          last_attempt_at: '2026-06-01T12:00:00', // no Z
+          last_status: 'failed',
+        },
+      },
+    }));
+
+    const plan = inspectRecovery(tmp);
+    assert.equal(plan.attempts, 0);
+  });
+
   it('#234 [data-integrity] codex r4: malformed ISO timestamps fall closed (discarded)', () => {
     // If either timestamp fails Date.parse, the safe direction is to
     // discard the untagged recovery rather than admit garbage.

--- a/hooks/__tests__/mpl-recover.test.mjs
+++ b/hooks/__tests__/mpl-recover.test.mjs
@@ -407,7 +407,49 @@ phases:
     const result = recoverBlockedHook(tmp);
     assert.equal(result.status, 'recovered');
     assert.equal(existsSync(join(tmp, '.mpl', 'mpl', 'phases', 'phase-1', 'test-agent-brief.yaml')), true);
+    assert.equal(Array.isArray(result.produced) && result.produced.includes('phase-1'), true);
     assert.equal(readState().session_status, null);
+  });
+
+  it('#234 [data-integrity] codex r1: test_agent_briefs_write_failed does NOT clear block when decomposition.yaml is missing', () => {
+    // codex r1 on PR #242: writeTestAgentBriefs returns an empty list
+    // when decomposition.yaml is absent (no throw). The handler must
+    // verify the post-condition and keep the block instead of
+    // marking it recovered with no briefs produced.
+    writeState(blocked({
+      blocked_by_hook: 'mpl-decomposition-postprocess',
+      block_code: 'test_agent_briefs_write_failed',
+      retry_context: { target: '.mpl/mpl/decomposition.yaml' },
+    }));
+
+    const result = recoverBlockedHook(tmp);
+    assert.equal(result.status, 'failed');
+    assert.equal(result.decomposition_present, false);
+    assert.equal(result.produced_count, 0);
+    assert.match(result.message, /decomposition\.yaml is missing/);
+    assert.equal(readState().session_status, 'blocked_hook');
+  });
+
+  it('#234 [data-integrity] codex r1: test_agent_briefs_write_failed keeps block when decomposition has zero required phases', () => {
+    // Decomposition exists but no phase has test_agent_required:true —
+    // writeTestAgentBriefs returns [] → handler must keep the block.
+    mkdirSync(join(tmp, '.mpl', 'mpl'), { recursive: true });
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'decomposition.yaml'), `
+phases:
+  - id: phase-x
+    test_agent_required: false
+`);
+    writeState(blocked({
+      block_code: 'test_agent_briefs_write_failed',
+      retry_context: {},
+    }));
+
+    const result = recoverBlockedHook(tmp);
+    assert.equal(result.status, 'failed');
+    assert.equal(result.decomposition_present, true);
+    assert.equal(result.produced_count, 0);
+    assert.match(result.message, /zero briefs/);
+    assert.equal(readState().session_status, 'blocked_hook');
   });
 
   it('#234: auto-regenerate handler exhausts retry budget on persistent failures', () => {
@@ -425,11 +467,19 @@ phases:
     assert.equal(readState().session_status, 'blocked_hook');
   });
 
-  it('#234: redispatch_decomposer handler returns dispatch instruction with validator findings', () => {
+  it('#234: redispatch_decomposer handler reads diagnostics from retry_context.issues (real envelope shape) — codex r1', () => {
+    // codex r1 on PR #242: covers_schema_violation hook records
+    // validator findings under `retry_context.issues`, NOT `failures`.
+    // The handler must normalize so the dispatch instruction echoes
+    // the real diagnostics.
     writeState(blocked({
       blocked_by_hook: 'mpl-require-covers',
       block_code: 'covers_schema_violation',
-      retry_context: { failures: ['phase-1.covers[0]:UC-99 not in goal_contract'] },
+      retry_context: {
+        target: '.mpl/mpl/decomposition.yaml',
+        issue_count: 1,
+        issues: ['phase-1.covers[0]:UC-99 not in goal_contract'],
+      },
     }));
 
     const plan = inspectRecovery(tmp);
@@ -440,20 +490,63 @@ phases:
     assert.equal(result.status, 'awaiting_decomposer');
     assert.match(result.dispatch_instruction, /mpl-decomposer/);
     assert.match(result.dispatch_instruction, /UC-99/);
+    assert.deepEqual(result.findings, ['phase-1.covers[0]:UC-99 not in goal_contract']);
 
     const state = readState();
     assert.equal(state.session_status, 'blocked_hook');
     assert.equal(state.retry_context.recovery.last_status, 'awaiting_decomposer');
   });
 
-  for (const code of ['goal_contract_invalid', 'phase_contract_graph_invalid']) {
-    it(`#234: redispatch_decomposer also routes ${code}`, () => {
-      writeState(blocked({ block_code: code, retry_context: {} }));
-      const result = recoverBlockedHook(tmp);
-      assert.equal(result.status, 'awaiting_decomposer');
-      assert.match(result.dispatch_instruction, /mpl-decomposer/);
-    });
-  }
+  it(`#234: redispatch_decomposer routes phase_contract_graph_invalid with retry_context.issues`, () => {
+    writeState(blocked({
+      block_code: 'phase_contract_graph_invalid',
+      retry_context: {
+        issue_count: 2,
+        issues: ['phase-2.depends_on:cycle', 'tier-1.execution_mode:missing'],
+      },
+    }));
+    const result = recoverBlockedHook(tmp);
+    assert.equal(result.status, 'awaiting_decomposer');
+    assert.match(result.dispatch_instruction, /mpl-decomposer/);
+    assert.match(result.dispatch_instruction, /depends_on:cycle/);
+    assert.deepEqual(result.findings, ['phase-2.depends_on:cycle', 'tier-1.execution_mode:missing']);
+  });
+
+  it('#234: legacy retry_context.failures shape still works (back-compat)', () => {
+    writeState(blocked({
+      block_code: 'covers_schema_violation',
+      retry_context: { failures: ['legacy-style finding'] },
+    }));
+    const result = recoverBlockedHook(tmp);
+    assert.equal(result.status, 'awaiting_decomposer');
+    assert.match(result.dispatch_instruction, /legacy-style finding/);
+  });
+
+  it('#234: goal_contract_invalid is routed to user_action (NOT decomposer) — codex r1 [logic]', () => {
+    // codex r1 on PR #242: goal_contract_invalid is emitted with
+    // resumeInstruction "Restore a valid .mpl/goal-contract.yaml" —
+    // a decomposer re-dispatch cannot repair a missing source file.
+    // Recovery must echo the user instruction, NOT generate a Task call.
+    writeState(blocked({
+      blocked_by_hook: 'mpl-require-goal-trace',
+      block_code: 'goal_contract_invalid',
+      resume_instruction: 'Restore a valid .mpl/goal-contract.yaml, then retry the decomposition write.',
+      retry_context: { missing: ['mission.goal', 'acceptance_criteria'] },
+    }));
+
+    const plan = inspectRecovery(tmp);
+    assert.equal(plan.status, 'requires_user_action');
+    assert.equal(plan.handler, 'goal_contract_invalid');
+
+    const result = recoverBlockedHook(tmp);
+    assert.equal(result.status, 'requires_user_action');
+    assert.match(result.user_instruction, /Restore a valid \.mpl\/goal-contract\.yaml/);
+    assert.match(result.user_instruction, /mission\.goal/);
+    assert.deepEqual(result.findings, ['mission.goal', 'acceptance_criteria']);
+    // No dispatch_instruction — this is user action, not agent re-dispatch.
+    assert.equal(result.dispatch_instruction, undefined);
+    assert.equal(readState().session_status, 'blocked_hook');
+  });
 
   it('#234: phase_runner_anomaly handler returns anomaly-specific dispatch instruction', () => {
     writeState(blocked({

--- a/hooks/__tests__/mpl-recover.test.mjs
+++ b/hooks/__tests__/mpl-recover.test.mjs
@@ -777,6 +777,56 @@ phases:
     assert.match(result.dispatch_instruction, /legacy-style finding/);
   });
 
+  it('#234 [security] codex r10: pre-existing recovery.awaiting_instruction is TOMBSTONED on hook-envelope write', async () => {
+    // Codex r10 [security] defense-in-depth: r9 tombstoned the field
+    // inside recoveryPatch (recover writes), but a NEW hook block can
+    // fire BEFORE recovery runs. If state contains a stale
+    // recovery.awaiting_instruction, recordBlockedHook's writeState
+    // deep-merge would preserve the leaked text under the fresh
+    // envelope — visible to any external state watcher before the
+    // recover skill even runs.
+    //
+    // Repro: seed state with stale recovery.awaiting_instruction,
+    // then call recordBlockedHook with a fresh retryContext. The
+    // persisted state must not contain the leaked Task text.
+    const { recordBlockedHook } = await import('../lib/mpl-blocked-hook.mjs');
+    writeState({
+      session_status: 'blocked_hook',
+      blocked_by_hook: 'mpl-prior-hook',
+      blocked_phase: 'phase-0',
+      blocked_artifact: '.mpl/x',
+      block_code: 'prior_code',
+      block_reason: 'prior',
+      resume_instruction: 'prior',
+      blocked_at: '2026-01-01T00:00:00Z',
+      retry_context: {
+        recovery: {
+          awaiting_instruction: 'Re-dispatch Task(subagent_type="mpl-decomposer", model="sonnet", prompt="...")',
+          attempts: 1,
+          last_status: 'awaiting_decomposer',
+        },
+      },
+    });
+
+    recordBlockedHook(tmp, {
+      hookId: 'mpl-new-hook',
+      phaseId: 'phase-1',
+      artifact: '.mpl/y',
+      code: 'new_block_code',
+      reason: 'new block',
+      resumeInstruction: 'new instruction',
+      retryContext: { issues: ['x'] },
+      blockedAt: '2026-06-01T12:00:00Z',
+    });
+
+    const state = readState();
+    const stateJson = JSON.stringify(state);
+    assert.doesNotMatch(stateJson, /Re-dispatch Task\(/,
+      'persisted state must not contain the gated Task text after hook envelope write');
+    assert.equal(state.retry_context.recovery.awaiting_instruction, null,
+      'hook-envelope write must tombstone recovery.awaiting_instruction');
+  });
+
   it('#234 [security] codex r9: pre-existing awaiting_instruction in state is TOMBSTONED on safe-mode write', () => {
     // Codex r9 [security]: writeState's deepMerge preserves nested
     // keys that aren't in the patch. If prior recovery state stashed

--- a/hooks/__tests__/mpl-recover.test.mjs
+++ b/hooks/__tests__/mpl-recover.test.mjs
@@ -153,8 +153,10 @@ describe('mpl recover', () => {
   });
 
   it('keeps unsupported block codes intact with recovery context', () => {
+    // #234: phase_contract_graph_invalid is now routed; use a fabricated
+    // unknown code to verify the unsupported fall-through path.
     writeState(blocked({
-      block_code: 'phase_contract_graph_invalid',
+      block_code: 'fabricated_unknown_code',
       retry_context: { issue_count: 1 },
     }));
 
@@ -163,7 +165,7 @@ describe('mpl recover', () => {
 
     const state = readState();
     assert.equal(state.session_status, 'blocked_hook');
-    assert.equal(state.block_code, 'phase_contract_graph_invalid');
+    assert.equal(state.block_code, 'fabricated_unknown_code');
     assert.equal(state.retry_context.recovery.last_status, 'unsupported');
   });
 
@@ -340,5 +342,187 @@ phases:
     const text = readFileSync(join(tmp, '.mpl', 'mpl', 'decomposition.yaml'), 'utf-8');
     assert.match(text, /test_agent_required: true/);
     assert.equal(readState().session_status, null);
+  });
+
+  /* ──────────────────── #234: new routing ──────────────────── */
+
+  function writeMinimalDecompositionForDerive() {
+    mkdirSync(join(tmp, '.mpl', 'mpl'), { recursive: true });
+    writeFileSync(join(tmp, '.mpl', 'mpl', 'decomposition.yaml'), `
+goal_contract_hash: "abc"
+phases:
+  - id: phase-1
+    phase_lang: typescript
+    phase_domain: api
+    impact:
+      modify:
+        - path: src/api.ts
+    interface_contract:
+      produces:
+        - type: function
+          name: createWidget
+          spec: "(body: dict) -> Widget"
+    verification_plan:
+      a_items:
+        - criterion: "valid"
+          type: command
+          command: "pytest"
+      s_items:
+        - criterion: "invalid"
+          test_file: tests/x.py
+          test_command: "pytest"
+    goal_trace:
+      acceptance_criteria: [AC-1]
+      variation_axes: []
+      ontology_entities: [api]
+`);
+  }
+
+  it('#234: auto-regenerate handler reruns writeDerivedDecompositionFields on decomposition_derived_stale', () => {
+    writeMinimalDecompositionForDerive();
+    writeState(blocked({
+      blocked_by_hook: 'mpl-decomposition-postprocess',
+      block_code: 'decomposition_derived_stale',
+      retry_context: { target: '.mpl/mpl/decomposition.yaml' },
+    }));
+
+    const plan = inspectRecovery(tmp);
+    assert.equal(plan.status, 'recoverable');
+    assert.equal(plan.handler, 'auto_regenerate');
+
+    const result = recoverBlockedHook(tmp);
+    assert.equal(result.status, 'recovered');
+    assert.equal(existsSync(join(tmp, '.mpl', 'mpl', 'decomposition-derived.json')), true);
+    assert.equal(readState().session_status, null);
+  });
+
+  it('#234: auto-regenerate handler reruns writeTestAgentBriefs on test_agent_briefs_write_failed', () => {
+    writeMinimalDecompositionForDerive();
+    writeState(blocked({
+      blocked_by_hook: 'mpl-decomposition-postprocess',
+      block_code: 'test_agent_briefs_write_failed',
+      retry_context: { target: '.mpl/mpl/decomposition.yaml' },
+    }));
+
+    const result = recoverBlockedHook(tmp);
+    assert.equal(result.status, 'recovered');
+    assert.equal(existsSync(join(tmp, '.mpl', 'mpl', 'phases', 'phase-1', 'test-agent-brief.yaml')), true);
+    assert.equal(readState().session_status, null);
+  });
+
+  it('#234: auto-regenerate handler exhausts retry budget on persistent failures', () => {
+    // No decomposition.yaml on disk → writeDerivedDecompositionFields throws.
+    // After AUTO_FIX_RETRY_BUDGET (3) attempts the handler should return failed.
+    writeState(blocked({
+      blocked_by_hook: 'mpl-decomposition-postprocess',
+      block_code: 'decomposition_derived_stale',
+      retry_context: { recovery: { attempts: 3 } },
+    }));
+
+    const result = recoverBlockedHook(tmp);
+    assert.equal(result.status, 'failed');
+    assert.match(result.message, /budget exhausted/);
+    assert.equal(readState().session_status, 'blocked_hook');
+  });
+
+  it('#234: redispatch_decomposer handler returns dispatch instruction with validator findings', () => {
+    writeState(blocked({
+      blocked_by_hook: 'mpl-require-covers',
+      block_code: 'covers_schema_violation',
+      retry_context: { failures: ['phase-1.covers[0]:UC-99 not in goal_contract'] },
+    }));
+
+    const plan = inspectRecovery(tmp);
+    assert.equal(plan.status, 'requires_approval');
+    assert.equal(plan.handler, 'redispatch_decomposer');
+
+    const result = recoverBlockedHook(tmp);
+    assert.equal(result.status, 'awaiting_decomposer');
+    assert.match(result.dispatch_instruction, /mpl-decomposer/);
+    assert.match(result.dispatch_instruction, /UC-99/);
+
+    const state = readState();
+    assert.equal(state.session_status, 'blocked_hook');
+    assert.equal(state.retry_context.recovery.last_status, 'awaiting_decomposer');
+  });
+
+  for (const code of ['goal_contract_invalid', 'phase_contract_graph_invalid']) {
+    it(`#234: redispatch_decomposer also routes ${code}`, () => {
+      writeState(blocked({ block_code: code, retry_context: {} }));
+      const result = recoverBlockedHook(tmp);
+      assert.equal(result.status, 'awaiting_decomposer');
+      assert.match(result.dispatch_instruction, /mpl-decomposer/);
+    });
+  }
+
+  it('#234: phase_runner_anomaly handler returns anomaly-specific dispatch instruction', () => {
+    writeState(blocked({
+      blocked_by_hook: 'mpl-gate-recorder',
+      blocked_phase: 'phase-1',
+      block_code: 'phase_runner_empty_response',
+      retry_context: { phase_id: 'phase-1' },
+    }));
+
+    const plan = inspectRecovery(tmp);
+    assert.equal(plan.status, 'requires_approval');
+    assert.equal(plan.handler, 'phase_runner_anomaly');
+    assert.equal(plan.anomaly, 'empty_response');
+
+    const result = recoverBlockedHook(tmp);
+    assert.equal(result.status, 'awaiting_phase_runner');
+    assert.match(result.dispatch_instruction, /mpl-phase-runner/);
+    assert.match(result.dispatch_instruction, /stronger framing/);
+    assert.equal(result.anomaly, 'empty_response');
+  });
+
+  it('#234: phase_runner_anomaly handler falls back gracefully on unknown anomaly type', () => {
+    writeState(blocked({
+      block_code: 'phase_runner_some_new_anomaly',
+      // Empty resume_instruction forces the generic re-dispatch template path.
+      resume_instruction: '',
+      retry_context: {},
+    }));
+
+    const result = recoverBlockedHook(tmp);
+    assert.equal(result.status, 'awaiting_phase_runner');
+    assert.equal(result.anomaly, 'some_new_anomaly');
+    assert.match(result.dispatch_instruction, /mpl-phase-runner/);
+  });
+
+  it('#234: baseline_immutable handler returns user_instruction without agent dispatch', () => {
+    writeState(blocked({
+      blocked_by_hook: 'mpl-baseline-guard',
+      block_code: 'baseline_immutable',
+      resume_instruction: 'Touch .mpl/mpl/.baseline-renewal to authorize a new baseline write, then retry.',
+    }));
+
+    const plan = inspectRecovery(tmp);
+    assert.equal(plan.status, 'requires_user_action');
+    assert.equal(plan.handler, 'baseline_immutable');
+
+    const result = recoverBlockedHook(tmp);
+    assert.equal(result.status, 'requires_user_action');
+    assert.match(result.user_instruction, /baseline-renewal/);
+    assert.equal(readState().session_status, 'blocked_hook');
+  });
+
+  it('#234: phantom alias goal_contract_hash_corrupt is NOT routed (drop confirmed)', () => {
+    // The pre-#234 alias was unreachable (no hook ever emitted it) but
+    // routed defensively. Now it must fall through to unsupported.
+    writeState(blocked({
+      block_code: 'goal_contract_hash_corrupt',
+      retry_context: {},
+    }));
+    const result = recoverBlockedHook(tmp);
+    assert.equal(result.status, 'unsupported');
+  });
+
+  it('#234: phantom alias goal_contract_hash_mismatch is NOT routed (drop confirmed)', () => {
+    writeState(blocked({
+      block_code: 'goal_contract_hash_mismatch',
+      retry_context: {},
+    }));
+    const result = recoverBlockedHook(tmp);
+    assert.equal(result.status, 'unsupported');
   });
 });

--- a/hooks/__tests__/mpl-recover.test.mjs
+++ b/hooks/__tests__/mpl-recover.test.mjs
@@ -777,6 +777,31 @@ phases:
     assert.match(result.dispatch_instruction, /legacy-style finding/);
   });
 
+  it('#234 [security] codex r11: caller-supplied retryContext.recovery.awaiting_instruction CANNOT override the tombstone', async () => {
+    // Codex r11: my r10 fix had the spread order wrong:
+    //   { ...recoveryTombstone, ...incomingRecovery }
+    // → caller's awaiting_instruction overrode the null tombstone.
+    // Tombstone must be applied AFTER the caller spread so it WINS
+    // regardless of caller input.
+    const { buildBlockedHookPatch } = await import('../lib/mpl-blocked-hook.mjs');
+    const patch = buildBlockedHookPatch({
+      retryContext: {
+        recovery: {
+          awaiting_instruction: 'LEAK Re-dispatch Task(subagent_type="mpl-decomposer")',
+          attempts: 7,
+        },
+      },
+      blockedAt: '2026-06-01T00:00:00Z',
+    });
+
+    // Caller's non-sensitive field (attempts) is preserved.
+    assert.equal(patch.retry_context.recovery.attempts, 7);
+    // The sensitive field is structurally null regardless of caller intent.
+    assert.equal(patch.retry_context.recovery.awaiting_instruction, null);
+    // No "LEAK" text anywhere in the patch.
+    assert.doesNotMatch(JSON.stringify(patch), /LEAK/);
+  });
+
   it('#234 [security] codex r10: pre-existing recovery.awaiting_instruction is TOMBSTONED on hook-envelope write', async () => {
     // Codex r10 [security] defense-in-depth: r9 tombstoned the field
     // inside recoveryPatch (recover writes), but a NEW hook block can

--- a/hooks/__tests__/mpl-recover.test.mjs
+++ b/hooks/__tests__/mpl-recover.test.mjs
@@ -777,6 +777,40 @@ phases:
     assert.match(result.dispatch_instruction, /legacy-style finding/);
   });
 
+  it('#234 [security] codex r9: pre-existing awaiting_instruction in state is TOMBSTONED on safe-mode write', () => {
+    // Codex r9 [security]: writeState's deepMerge preserves nested
+    // keys that aren't in the patch. If prior recovery state stashed
+    // `recovery.awaiting_instruction = "Re-dispatch Task(...)"` (the
+    // r7-era leak), simply omitting the field in the r8 patch would
+    // leave the stale value on disk. Must explicitly tombstone.
+    //
+    // Repro: seed state with r7-style retry_context.recovery
+    // containing awaiting_instruction, then run --apply-safe. The
+    // persisted state must no longer contain the Re-dispatch text.
+    writeState(blocked({
+      block_code: 'covers_schema_violation',
+      retry_context: {
+        issues: ['phase-1.covers[0]:UC-99'],
+        recovery: {
+          // Pre-existing leaked value from a prior r7 write.
+          awaiting_instruction: 'Re-dispatch Task(subagent_type="mpl-decomposer", model="sonnet", prompt="...")',
+          attempts: 1,
+          last_status: 'awaiting_decomposer',
+        },
+      },
+    }));
+
+    recoverBlockedHook(tmp); // --apply-safe
+
+    const state = readState();
+    assert.equal(state.retry_context.recovery.awaiting_instruction, null,
+      'safe-mode write must tombstone the leaked awaiting_instruction');
+
+    const stateJson = JSON.stringify(state);
+    assert.doesNotMatch(stateJson, /Re-dispatch Task\(/,
+      'persisted state must not contain the gated Task text after safe-mode write');
+  });
+
   it('#234 [contract-break] codex r8: safe mode does NOT persist gated dispatch text in state', () => {
     // Codex r8 [contract-break]: r7 stashed the gated Re-dispatch
     // Task(...) string in details.awaiting_instruction, which spread
@@ -798,7 +832,8 @@ phases:
     const stateJson = JSON.stringify(state);
     assert.doesNotMatch(stateJson, /Re-dispatch Task\(/, 'persisted state must not contain the gated Task text');
     assert.doesNotMatch(stateJson, /subagent_type="mpl-decomposer"/, 'persisted state must not contain subagent_type=mpl-decomposer');
-    assert.equal(rec.awaiting_instruction, undefined, 'awaiting_instruction must not be persisted in safe mode');
+    // Codex r9 follow-up: tombstoned (null) rather than absent.
+    assert.equal(rec.awaiting_instruction, null, 'awaiting_instruction must be explicitly tombstoned in safe mode');
   });
 
   it('#234 [contract-break] codex r8: phase_runner_anomaly safe mode does not persist gated Task text', () => {

--- a/hooks/__tests__/mpl-recover.test.mjs
+++ b/hooks/__tests__/mpl-recover.test.mjs
@@ -452,13 +452,84 @@ phases:
     assert.equal(readState().session_status, 'blocked_hook');
   });
 
-  it('#234: auto-regenerate handler exhausts retry budget on persistent failures', () => {
-    // No decomposition.yaml on disk → writeDerivedDecompositionFields throws.
-    // After AUTO_FIX_RETRY_BUDGET (3) attempts the handler should return failed.
+  it('#234 [data-integrity] codex r2: stale retry_context.recovery from a prior block does NOT poison a fresh auto-regenerate envelope', () => {
+    // Codex r2 on PR #242: writeState uses deepMerge, so a prior
+    // unresolved block's retry_context.recovery.attempts can survive
+    // into a new block's envelope. Without scope-tagging, the budget
+    // check would falsely refuse a fresh recoverable block.
+    writeMinimalDecompositionForDerive();
     writeState(blocked({
       blocked_by_hook: 'mpl-decomposition-postprocess',
       block_code: 'decomposition_derived_stale',
-      retry_context: { recovery: { attempts: 3 } },
+      // Fresh envelope blocked_at:
+      blocked_at: '2026-06-01T12:00:00Z',
+      retry_context: {
+        // Stale recovery survived from a different prior block. Note
+        // its block_code / blocked_at do NOT match the current envelope.
+        recovery: {
+          block_code: 'goal_contract_baseline_corrupt',
+          blocked_at: '2026-05-01T00:00:00Z',
+          attempts: 3,
+          last_status: 'failed',
+        },
+      },
+    }));
+
+    // Should NOT report budget exhausted — the stored attempts belong
+    // to a different block. The fresh block must run the auto-fix.
+    const plan = inspectRecovery(tmp);
+    assert.equal(plan.status, 'recoverable');
+    assert.equal(plan.handler, 'auto_regenerate');
+    assert.equal(plan.attempts, 0);
+
+    const result = recoverBlockedHook(tmp);
+    assert.equal(result.status, 'recovered');
+    assert.equal(existsSync(join(tmp, '.mpl', 'mpl', 'decomposition-derived.json')), true);
+  });
+
+  it('#234 [data-integrity] codex r2: scope-matched retry_context.recovery is honored', () => {
+    // Sanity check: when the stored recovery DOES match the current
+    // block (same code + blocked_at), the budget enforcement still
+    // works.
+    writeMinimalDecompositionForDerive();
+    writeState(blocked({
+      blocked_by_hook: 'mpl-decomposition-postprocess',
+      block_code: 'decomposition_derived_stale',
+      blocked_at: '2026-06-01T12:00:00Z',
+      retry_context: {
+        recovery: {
+          block_code: 'decomposition_derived_stale',
+          blocked_at: '2026-06-01T12:00:00Z',
+          attempts: 3,
+          last_status: 'failed',
+        },
+      },
+    }));
+
+    const plan = inspectRecovery(tmp);
+    assert.equal(plan.status, 'unsupported');
+    assert.equal(plan.attempts, 3);
+
+    const result = recoverBlockedHook(tmp);
+    assert.equal(result.status, 'failed');
+    assert.match(result.message, /budget exhausted/);
+  });
+
+  it('#234: auto-regenerate handler exhausts retry budget on persistent failures', () => {
+    // No decomposition.yaml on disk → writeDerivedDecompositionFields throws.
+    // After AUTO_FIX_RETRY_BUDGET (3) attempts the handler should return failed.
+    // Recovery state is scope-tagged to the active block (codex r2 fix).
+    writeState(blocked({
+      blocked_by_hook: 'mpl-decomposition-postprocess',
+      block_code: 'decomposition_derived_stale',
+      blocked_at: '2026-06-01T12:00:00Z',
+      retry_context: {
+        recovery: {
+          block_code: 'decomposition_derived_stale',
+          blocked_at: '2026-06-01T12:00:00Z',
+          attempts: 3,
+        },
+      },
     }));
 
     const result = recoverBlockedHook(tmp);

--- a/hooks/__tests__/mpl-recover.test.mjs
+++ b/hooks/__tests__/mpl-recover.test.mjs
@@ -725,6 +725,8 @@ phases:
     // validator findings under `retry_context.issues`, NOT `failures`.
     // The handler must normalize so the dispatch instruction echoes
     // the real diagnostics.
+    // Codex r7: this is an approval-required route — pass
+    // approveUnsafe to actually receive the dispatch instruction.
     writeState(blocked({
       blocked_by_hook: 'mpl-require-covers',
       block_code: 'covers_schema_violation',
@@ -739,7 +741,7 @@ phases:
     assert.equal(plan.status, 'requires_approval');
     assert.equal(plan.handler, 'redispatch_decomposer');
 
-    const result = recoverBlockedHook(tmp);
+    const result = recoverBlockedHook(tmp, { approveUnsafe: true });
     assert.equal(result.status, 'awaiting_decomposer');
     assert.match(result.dispatch_instruction, /mpl-decomposer/);
     assert.match(result.dispatch_instruction, /UC-99/);
@@ -758,7 +760,7 @@ phases:
         issues: ['phase-2.depends_on:cycle', 'tier-1.execution_mode:missing'],
       },
     }));
-    const result = recoverBlockedHook(tmp);
+    const result = recoverBlockedHook(tmp, { approveUnsafe: true });
     assert.equal(result.status, 'awaiting_decomposer');
     assert.match(result.dispatch_instruction, /mpl-decomposer/);
     assert.match(result.dispatch_instruction, /depends_on:cycle/);
@@ -770,9 +772,31 @@ phases:
       block_code: 'covers_schema_violation',
       retry_context: { failures: ['legacy-style finding'] },
     }));
-    const result = recoverBlockedHook(tmp);
+    const result = recoverBlockedHook(tmp, { approveUnsafe: true });
     assert.equal(result.status, 'awaiting_decomposer');
     assert.match(result.dispatch_instruction, /legacy-style finding/);
+  });
+
+  it('#234 [contract-break] codex r7: redispatch_decomposer route requires --approve-unsafe; --apply-safe keeps requires_approval', () => {
+    // Codex r7: SKILL.md categorizes redispatch_decomposer as "Step 3
+    // Explicit Approval Recovery". --apply-safe (approveUnsafe=false)
+    // must NOT advance state to `awaiting_decomposer` (an automation
+    // watching for awaiting_* would side-step the human checkpoint).
+    writeState(blocked({
+      block_code: 'covers_schema_violation',
+      retry_context: { issues: ['phase-1.covers[0]:UC-99 not in goal_contract'] },
+    }));
+
+    const result = recoverBlockedHook(tmp); // approveUnsafe: false
+    assert.equal(result.status, 'requires_approval');
+    assert.equal(result.requires_approval, true);
+    // Must NOT emit a dispatch_instruction in safe mode.
+    assert.equal(result.dispatch_instruction, undefined);
+    // findings ARE surfaced so the operator can review before approving.
+    assert.deepEqual(result.findings, ['phase-1.covers[0]:UC-99 not in goal_contract']);
+
+    const state = readState();
+    assert.equal(state.retry_context.recovery.last_status, 'requires_approval');
   });
 
   it('#234: goal_contract_invalid is routed to user_action (NOT decomposer) — codex r1 [logic]', () => {
@@ -780,6 +804,8 @@ phases:
     // resumeInstruction "Restore a valid .mpl/goal-contract.yaml" —
     // a decomposer re-dispatch cannot repair a missing source file.
     // Recovery must echo the user instruction, NOT generate a Task call.
+    // Codex r7: also approval-gated — pass approveUnsafe to receive
+    // the instruction; --apply-safe surfaces requires_approval.
     writeState(blocked({
       blocked_by_hook: 'mpl-require-goal-trace',
       block_code: 'goal_contract_invalid',
@@ -791,7 +817,7 @@ phases:
     assert.equal(plan.status, 'requires_user_action');
     assert.equal(plan.handler, 'goal_contract_invalid');
 
-    const result = recoverBlockedHook(tmp);
+    const result = recoverBlockedHook(tmp, { approveUnsafe: true });
     assert.equal(result.status, 'requires_user_action');
     assert.match(result.user_instruction, /Restore a valid \.mpl\/goal-contract\.yaml/);
     assert.match(result.user_instruction, /mission\.goal/);
@@ -801,7 +827,22 @@ phases:
     assert.equal(readState().session_status, 'blocked_hook');
   });
 
+  it('#234 [contract-break] codex r7: goal_contract_invalid route requires --approve-unsafe', () => {
+    writeState(blocked({
+      block_code: 'goal_contract_invalid',
+      resume_instruction: 'Restore a valid .mpl/goal-contract.yaml, then retry the decomposition write.',
+      retry_context: { missing: ['mission.goal'] },
+    }));
+
+    const result = recoverBlockedHook(tmp); // approveUnsafe: false
+    assert.equal(result.status, 'requires_approval');
+    assert.equal(result.user_instruction, undefined);
+    assert.deepEqual(result.findings, ['mission.goal']);
+  });
+
   it('#234: phase_runner_anomaly handler returns anomaly-specific dispatch instruction', () => {
+    // Codex r7: approval-gated — approveUnsafe needed to receive
+    // the dispatch instruction.
     writeState(blocked({
       blocked_by_hook: 'mpl-gate-recorder',
       blocked_phase: 'phase-1',
@@ -814,7 +855,7 @@ phases:
     assert.equal(plan.handler, 'phase_runner_anomaly');
     assert.equal(plan.anomaly, 'empty_response');
 
-    const result = recoverBlockedHook(tmp);
+    const result = recoverBlockedHook(tmp, { approveUnsafe: true });
     assert.equal(result.status, 'awaiting_phase_runner');
     assert.match(result.dispatch_instruction, /mpl-phase-runner/);
     assert.match(result.dispatch_instruction, /stronger framing/);
@@ -829,13 +870,27 @@ phases:
       retry_context: {},
     }));
 
-    const result = recoverBlockedHook(tmp);
+    const result = recoverBlockedHook(tmp, { approveUnsafe: true });
     assert.equal(result.status, 'awaiting_phase_runner');
     assert.equal(result.anomaly, 'some_new_anomaly');
     assert.match(result.dispatch_instruction, /mpl-phase-runner/);
   });
 
+  it('#234 [contract-break] codex r7: phase_runner_anomaly route requires --approve-unsafe', () => {
+    writeState(blocked({
+      block_code: 'phase_runner_empty_response',
+      blocked_phase: 'phase-1',
+    }));
+
+    const result = recoverBlockedHook(tmp); // approveUnsafe: false
+    assert.equal(result.status, 'requires_approval');
+    assert.equal(result.dispatch_instruction, undefined);
+    assert.equal(result.anomaly, 'empty_response');
+  });
+
   it('#234: baseline_immutable handler returns user_instruction without agent dispatch', () => {
+    // Codex r7: approval-gated — approveUnsafe needed to receive
+    // the user instruction.
     writeState(blocked({
       blocked_by_hook: 'mpl-baseline-guard',
       block_code: 'baseline_immutable',
@@ -846,10 +901,21 @@ phases:
     assert.equal(plan.status, 'requires_user_action');
     assert.equal(plan.handler, 'baseline_immutable');
 
-    const result = recoverBlockedHook(tmp);
+    const result = recoverBlockedHook(tmp, { approveUnsafe: true });
     assert.equal(result.status, 'requires_user_action');
     assert.match(result.user_instruction, /baseline-renewal/);
     assert.equal(readState().session_status, 'blocked_hook');
+  });
+
+  it('#234 [contract-break] codex r7: baseline_immutable route requires --approve-unsafe', () => {
+    writeState(blocked({
+      block_code: 'baseline_immutable',
+      resume_instruction: 'Touch .mpl/mpl/.baseline-renewal',
+    }));
+
+    const result = recoverBlockedHook(tmp); // approveUnsafe: false
+    assert.equal(result.status, 'requires_approval');
+    assert.equal(result.user_instruction, undefined);
   });
 
   it('#234: phantom alias goal_contract_hash_corrupt is NOT routed (drop confirmed)', () => {

--- a/hooks/lib/mpl-blocked-hook.mjs
+++ b/hooks/lib/mpl-blocked-hook.mjs
@@ -60,12 +60,11 @@ export function buildBlockedHookPatch({
     retryContext && typeof retryContext === 'object' && !Array.isArray(retryContext)
       ? retryContext
       : {};
-  const recoveryTombstone = {
-    awaiting_instruction: null,
-  };
-  // If the caller explicitly passes a `recovery` sub-object in
-  // retryContext, preserve its content but ensure the tombstone fields
-  // are at least null (caller can override by setting them themselves).
+  // Codex r11 on PR #242 [security]: previously the tombstone was
+  // spread BEFORE the caller's recovery object, so a caller passing
+  // `retryContext.recovery.awaiting_instruction = "LEAK"` would
+  // override the null. Tombstone must WIN — strip the sensitive
+  // field unconditionally regardless of caller intent.
   const incomingRecovery =
     inboundRetryContext.recovery && typeof inboundRetryContext.recovery === 'object'
       && !Array.isArray(inboundRetryContext.recovery)
@@ -81,9 +80,12 @@ export function buildBlockedHookPatch({
     resume_instruction: resumeInstruction || 'Resolve the recorded hook block, then retry the blocked operation.',
     retry_context: {
       ...inboundRetryContext,
-      recovery: incomingRecovery
-        ? { ...recoveryTombstone, ...incomingRecovery }
-        : recoveryTombstone,
+      recovery: {
+        ...(incomingRecovery || {}),
+        // Tombstone WINS — applied after the caller spread so it cannot
+        // be overridden. No caller path may emit gated dispatch text.
+        awaiting_instruction: null,
+      },
     },
     blocked_at: blockedAt,
   };

--- a/hooks/lib/mpl-blocked-hook.mjs
+++ b/hooks/lib/mpl-blocked-hook.mjs
@@ -45,6 +45,32 @@ export function buildBlockedHookPatch({
   retryContext = {},
   blockedAt = new Date().toISOString(),
 }) {
+  // Codex r10 on PR #242 [security] defense-in-depth: writeState's
+  // deepMerge preserves nested keys absent from the patch. A new
+  // blocked-hook envelope is a fresh block, so any stale
+  // retry_context.recovery from a prior block (including a leaked
+  // recovery.awaiting_instruction that could leak gated dispatch
+  // text) must be tombstoned at the envelope boundary. Explicitly
+  // null the recovery sub-object's known sensitive fields so deepMerge
+  // overwrites any stale value. Scope-tagging in `activeRecoveryState`
+  // already neutralizes the recover-skill's own consumption, but an
+  // external state watcher reading state.json directly would still
+  // see the stale text without this guard.
+  const inboundRetryContext =
+    retryContext && typeof retryContext === 'object' && !Array.isArray(retryContext)
+      ? retryContext
+      : {};
+  const recoveryTombstone = {
+    awaiting_instruction: null,
+  };
+  // If the caller explicitly passes a `recovery` sub-object in
+  // retryContext, preserve its content but ensure the tombstone fields
+  // are at least null (caller can override by setting them themselves).
+  const incomingRecovery =
+    inboundRetryContext.recovery && typeof inboundRetryContext.recovery === 'object'
+      && !Array.isArray(inboundRetryContext.recovery)
+      ? inboundRetryContext.recovery
+      : null;
   return {
     session_status: 'blocked_hook',
     blocked_by_hook: hookId,
@@ -53,10 +79,12 @@ export function buildBlockedHookPatch({
     block_code: code || 'blocked',
     block_reason: reason || 'Hook blocked progress.',
     resume_instruction: resumeInstruction || 'Resolve the recorded hook block, then retry the blocked operation.',
-    retry_context:
-      retryContext && typeof retryContext === 'object' && !Array.isArray(retryContext)
-        ? retryContext
-        : {},
+    retry_context: {
+      ...inboundRetryContext,
+      recovery: incomingRecovery
+        ? { ...recoveryTombstone, ...incomingRecovery }
+        : recoveryTombstone,
+    },
     blocked_at: blockedAt,
   };
 }

--- a/hooks/lib/mpl-recover.mjs
+++ b/hooks/lib/mpl-recover.mjs
@@ -54,9 +54,14 @@ const AUTO_FIX_REGENERATE_CODES = new Set([
 // validator's structured error list". The recover skill cannot
 // dispatch agents directly — it returns a dispatch instruction
 // pointing at the right agent + the error context.
+//
+// Note (codex r1 [logic]): `goal_contract_invalid` is NOT in this set.
+// Its emission site (hooks/mpl-require-goal-trace.mjs) is "missing or
+// invalid .mpl/goal-contract.yaml" — re-dispatching the decomposer
+// cannot repair a missing/invalid goal contract. That code is routed
+// to user_action below, echoing the recorded resume_instruction.
 const REDISPATCH_DECOMPOSER_CODES = new Set([
   'covers_schema_violation',
-  'goal_contract_invalid',
   'phase_contract_graph_invalid',
 ]);
 
@@ -576,11 +581,17 @@ function recoverAutoRegenerate(cwd, state) {
     return buildResult(state, { status: 'failed', message: reason, attempts });
   }
 
+  let written = null;
   try {
     if (code === 'decomposition_derived_stale') {
       writeDerivedDecompositionFields(cwd);
     } else if (code === 'test_agent_briefs_write_failed') {
-      writeTestAgentBriefs(cwd);
+      // Codex r1 on PR #242 [data-integrity]: writeTestAgentBriefs
+      // does NOT throw when decomposition.yaml is absent — it returns
+      // an empty list. Blindly treating that as success would clear
+      // the block while no brief was actually regenerated. Verify the
+      // produced phase ids before declaring recovery.
+      written = writeTestAgentBriefs(cwd);
     } else {
       const reason = `[MPL Recover] No regeneration handler for ${code}.`;
       keepBlocked(cwd, state, {
@@ -603,29 +614,87 @@ function recoverAutoRegenerate(cwd, state) {
     return buildResult(state, { status: 'failed', message: reason });
   }
 
+  // Post-condition check: silent no-op (empty produced list) when the
+  // source artifact is missing must NOT clear the block.
+  if (code === 'test_agent_briefs_write_failed') {
+    const decompositionPresent = existsSync(join(cwd, DECOMPOSITION_REL_PATH));
+    const producedCount = Array.isArray(written) ? written.length : 0;
+    if (!decompositionPresent || producedCount === 0) {
+      const reason = decompositionPresent
+        ? '[MPL Recover] writeTestAgentBriefs produced zero briefs (no phases declared test_agent_required); keeping the block.'
+        : '[MPL Recover] Cannot regenerate test-agent briefs because .mpl/mpl/decomposition.yaml is missing.';
+      keepBlocked(cwd, state, {
+        status: 'failed',
+        reason,
+        instruction: decompositionPresent
+          ? 'Verify the blocked phase has test_agent_required: true in decomposition.yaml, then retry.'
+          : 'Re-run decomposition to recreate decomposition.yaml, then retry.',
+        details: {
+          handler: 'auto_regenerate',
+          code,
+          decomposition_present: decompositionPresent,
+          produced_count: producedCount,
+        },
+      });
+      return buildResult(state, {
+        status: 'failed',
+        message: reason,
+        decomposition_present: decompositionPresent,
+        produced_count: producedCount,
+      });
+    }
+  }
+
   clearCurrentBlock(cwd, state);
   appendRecoverySignal(cwd, {
     ...summarizeState(state),
     result: 'recovered',
     handler: 'auto_regenerate',
     code,
+    produced: written,
   });
   return buildResult(state, {
     status: 'recovered',
     message: `Regenerated derived artifact for ${code} and cleared blocked_hook.`,
+    produced: written,
   });
+}
+
+// Codex r1 on PR #242 [contract-break]: real hooks record validator
+// diagnostics under different retry_context field names. Normalize
+// across all known shapes so the dispatch instruction echoes the
+// actual findings instead of dropping them.
+//
+//   covers_schema_violation        → retry_context.issues
+//   phase_contract_graph_invalid   → retry_context.issues
+//   (legacy test fixtures used `failures` — preserved for back-compat)
+function collectValidatorDiagnostics(state) {
+  const ctx = state?.retry_context || {};
+  const items = [];
+  for (const key of ['failures', 'issues', 'missing']) {
+    const v = ctx[key];
+    if (Array.isArray(v)) {
+      for (const entry of v) items.push(entry);
+    }
+  }
+  return items
+    .filter((x) => x !== null && x !== undefined)
+    .map((x) => {
+      if (typeof x === 'string') return x;
+      try { return JSON.stringify(x); } catch { return String(x); }
+    });
 }
 
 // #234: producer-agent re-dispatch. Recover skill returns a dispatch
 // instruction (no actual agent spawn — that's the orchestrator's
-// responsibility). retry_context.failures (if recorded by the hook)
-// is echoed back in the instruction so the producer can fix the exact
-// validator findings.
+// responsibility). Validator diagnostics from retry_context.failures
+// / .issues / .missing are normalized and echoed back so the producer
+// can fix the exact findings.
 function recoverRedispatchDecomposer(cwd, state) {
   const code = state.block_code;
-  const failures = state?.retry_context?.failures;
-  const failureSummary = Array.isArray(failures) && failures.length > 0
-    ? `Validator findings to address: ${failures.slice(0, 8).join('; ')}.`
+  const diagnostics = collectValidatorDiagnostics(state);
+  const failureSummary = diagnostics.length > 0
+    ? `Validator findings to address: ${diagnostics.slice(0, 8).join('; ')}.`
     : '';
   const instruction =
     `Re-dispatch Task(subagent_type="mpl-decomposer", model="sonnet", prompt=...) to fix ${code}. ${failureSummary}`.trim();
@@ -635,13 +704,41 @@ function recoverRedispatchDecomposer(cwd, state) {
     status: 'awaiting_decomposer',
     reason,
     instruction,
-    details: { handler: 'redispatch_decomposer', code, failures: failures || [] },
+    details: { handler: 'redispatch_decomposer', code, findings: diagnostics },
   });
   return buildResult(state, {
     status: 'awaiting_decomposer',
     message: reason,
     dispatch_instruction: instruction,
-    failures: failures || [],
+    findings: diagnostics,
+  });
+}
+
+// Codex r1 on PR #242 [logic]: `goal_contract_invalid` recovery is a
+// user-action route. The recorded resume_instruction is "Restore a
+// valid .mpl/goal-contract.yaml" — a decomposer re-dispatch cannot
+// repair a missing source file. Echo the recorded instruction (with a
+// generic fallback) so the operator sees the actionable step.
+function recoverGoalContractInvalid(cwd, state) {
+  const diagnostics = collectValidatorDiagnostics(state);
+  const missingSummary = diagnostics.length > 0
+    ? ` Missing fields: ${diagnostics.slice(0, 8).join(', ')}.`
+    : '';
+  const reason = '[MPL Recover] goal_contract_invalid requires restoring .mpl/goal-contract.yaml.';
+  const instruction =
+    state.resume_instruction ||
+    'Restore a valid .mpl/goal-contract.yaml, then retry the decomposition write.';
+  keepBlocked(cwd, state, {
+    status: 'requires_user_action',
+    reason,
+    instruction: `${instruction}${missingSummary}`.trim(),
+    details: { handler: 'goal_contract_invalid', findings: diagnostics },
+  });
+  return buildResult(state, {
+    status: 'requires_user_action',
+    message: reason,
+    user_instruction: `${instruction}${missingSummary}`.trim(),
+    findings: diagnostics,
   });
 }
 
@@ -784,6 +881,14 @@ export function inspectRecovery(cwd = process.cwd()) {
       message: 'Recover returns a mpl-decomposer dispatch instruction with the validator findings; orchestrator must execute the Task call.',
     });
   }
+  if (code === 'goal_contract_invalid') {
+    return buildResult(state, {
+      status: 'requires_user_action',
+      handler: 'goal_contract_invalid',
+      safe: false,
+      message: 'goal_contract_invalid requires restoring .mpl/goal-contract.yaml; recover echoes the recorded user instruction.',
+    });
+  }
   if (code && code.startsWith('phase_runner_')) {
     const anomalyType = code.slice('phase_runner_'.length);
     return buildResult(state, {
@@ -840,6 +945,9 @@ export function recoverBlockedHook(cwd = process.cwd(), { approveUnsafe = false 
   }
   if (REDISPATCH_DECOMPOSER_CODES.has(code)) {
     return recoverRedispatchDecomposer(cwd, state);
+  }
+  if (code === 'goal_contract_invalid') {
+    return recoverGoalContractInvalid(cwd, state);
   }
   if (code && code.startsWith('phase_runner_')) {
     return recoverPhaseRunnerAnomaly(cwd, state);

--- a/hooks/lib/mpl-recover.mjs
+++ b/hooks/lib/mpl-recover.mjs
@@ -140,9 +140,20 @@ function recoveryPatch(state, { status, reason, instruction, details = {} }) {
   };
 }
 
-// Read the recovery sub-object only when its scope tag matches the
-// current block. Returns `{ attempts: 0 }` (i.e. a fresh slate) when
-// the stored recovery belongs to a different block.
+// Read the recovery sub-object only when it belongs to the active
+// block. Returns `{}` (a fresh slate) otherwise.
+//
+// Three cases:
+//   (a) Tagged recovery (post-codex-r2): trust iff
+//       (block_code, blocked_at) matches the current envelope.
+//   (b) Untagged recovery (pre-codex-r2 / pre-existing on-disk state)
+//       with `last_attempt_at >= state.blocked_at`: adopt as
+//       legitimately belonging to the current block. Codex r3
+//       [contract-break] migration path — without this, an r1
+//       budget-exhausted block would reset to attempts=0 after the
+//       r2 upgrade, allowing extra auto-fix attempts past the cap.
+//   (c) Untagged recovery with no timestamp signal or older than the
+//       current block: treat as stale → fresh slate.
 function activeRecoveryState(state) {
   const rec = state?.retry_context?.recovery;
   if (!rec || typeof rec !== 'object') return {};
@@ -150,15 +161,21 @@ function activeRecoveryState(state) {
   const currentBlockedAt = state?.blocked_at || null;
   const stampedCode = rec.block_code ?? null;
   const stampedAt = rec.blocked_at ?? null;
-  // Untagged recovery (pre-codex-r2 patches) is trusted ONLY when the
-  // current block has neither code nor blocked_at — i.e., genuinely
-  // ambiguous. Once either is set, a missing/mismatched tag means the
-  // stored recovery belongs to a different block.
-  if (stampedCode === null && stampedAt === null) {
-    if (currentCode === null && currentBlockedAt === null) return rec;
+
+  // (a) Tagged → strict match.
+  if (stampedCode !== null || stampedAt !== null) {
+    if (stampedCode === currentCode && stampedAt === currentBlockedAt) {
+      return rec;
+    }
     return {};
   }
-  if (stampedCode === currentCode && stampedAt === currentBlockedAt) {
+
+  // (b)/(c) Untagged: legacy adoption iff last_attempt_at >= blocked_at.
+  // When the current state has neither code nor blocked_at, fall back
+  // to the original pre-tag behavior (genuinely ambiguous → trust).
+  if (currentCode === null && currentBlockedAt === null) return rec;
+  const stampedLastAt = typeof rec.last_attempt_at === 'string' ? rec.last_attempt_at : null;
+  if (stampedLastAt && currentBlockedAt && stampedLastAt >= currentBlockedAt) {
     return rec;
   }
   return {};

--- a/hooks/lib/mpl-recover.mjs
+++ b/hooks/lib/mpl-recover.mjs
@@ -174,19 +174,48 @@ function activeRecoveryState(state) {
   // When the current state has neither code nor blocked_at, fall back
   // to the original pre-tag behavior (genuinely ambiguous → trust).
   if (currentCode === null && currentBlockedAt === null) return rec;
-  // Codex r4 on PR #242 [data-integrity]: ISO 8601 strings with mixed
-  // millisecond precision (`2026-06-01T12:00:00Z` vs
-  // `2026-06-01T12:00:00.500Z`) sort lexicographically against the
-  // chronological intent (`.` < `Z` in ASCII). Compare via Date.parse
-  // numeric milliseconds; fall closed (discard untagged recovery) if
-  // either timestamp fails to parse.
+  // Codex r4/r5 on PR #242 [data-integrity]: must compare
+  // chronologically (mixed millisecond precision misorders strings)
+  // AND reject inputs that Date.parse silently normalizes from
+  // impossible calendar dates (e.g. `2026-02-31` → 2026-03-03). Strict
+  // ISO-Z parser: regex shape check + Date.parse + round-trip
+  // verification of the parsed numeric components against the claimed
+  // ones. Anything that doesn't survive this is treated as malformed
+  // → discard untagged recovery (fail-closed).
   const stampedLastAt = typeof rec.last_attempt_at === 'string' ? rec.last_attempt_at : null;
   if (!stampedLastAt || !currentBlockedAt) return {};
-  const stampedMs = Date.parse(stampedLastAt);
-  const currentMs = Date.parse(currentBlockedAt);
-  if (!Number.isFinite(stampedMs) || !Number.isFinite(currentMs)) return {};
+  const stampedMs = parseStrictIsoUtcMs(stampedLastAt);
+  const currentMs = parseStrictIsoUtcMs(currentBlockedAt);
+  if (stampedMs === null || currentMs === null) return {};
   if (stampedMs >= currentMs) return rec;
   return {};
+}
+
+// Strict ISO 8601 UTC parser. Returns the numeric milliseconds since
+// epoch only when the input is in canonical `YYYY-MM-DDTHH:MM:SS(.\d+)?Z`
+// shape AND the parsed Date's components match the input verbatim
+// (so an impossible calendar date like 2026-02-31 — which Date.parse
+// silently rolls forward to 2026-03-03 — is rejected). Returns null
+// for any malformed / non-UTC / out-of-range input.
+const STRICT_ISO_Z = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?Z$/;
+function parseStrictIsoUtcMs(input) {
+  if (typeof input !== 'string') return null;
+  const m = STRICT_ISO_Z.exec(input);
+  if (!m) return null;
+  const ms = Date.parse(input);
+  if (!Number.isFinite(ms)) return null;
+  const d = new Date(ms);
+  if (
+    d.getUTCFullYear() !== Number(m[1]) ||
+    d.getUTCMonth() + 1 !== Number(m[2]) ||
+    d.getUTCDate() !== Number(m[3]) ||
+    d.getUTCHours() !== Number(m[4]) ||
+    d.getUTCMinutes() !== Number(m[5]) ||
+    d.getUTCSeconds() !== Number(m[6])
+  ) {
+    return null;
+  }
+  return ms;
 }
 
 function keepBlocked(cwd, state, opts) {

--- a/hooks/lib/mpl-recover.mjs
+++ b/hooks/lib/mpl-recover.mjs
@@ -12,19 +12,52 @@ import {
   validateMvpGoalTraceCoverage,
 } from './mpl-goal-trace.mjs';
 import { parsePhaseContractGraphText } from './mpl-phase-contract-graph.mjs';
+import {
+  writeDerivedDecompositionFields,
+  writeTestAgentBriefs,
+} from './mpl-decomposition-postprocess.mjs';
 
 const BASELINE_REL_PATH = '.mpl/mpl/baseline.yaml';
 const DECOMPOSITION_REL_PATH = '.mpl/mpl/decomposition.yaml';
 const RECOVERY_SIGNAL_REL_PATH = '.mpl/signals/recovery.jsonl';
 
+// #234: phantom aliases `goal_contract_hash_corrupt` /
+// `goal_contract_hash_mismatch` were routed but no hook ever emitted
+// them. The live emission sites are `goal_contract_baseline_corrupt`
+// (mpl-require-goal-trace.mjs hash check) and `goal_contract_drift`
+// (baseline drift). Keep the sets single-element so future hook
+// authors reading this list see the canonical code names.
 const BASELINE_CORRUPT_CODES = new Set([
   'goal_contract_baseline_corrupt',
-  'goal_contract_hash_corrupt',
 ]);
 
 const BASELINE_DRIFT_CODES = new Set([
   'goal_contract_drift',
-  'goal_contract_hash_mismatch',
+]);
+
+// #234: cap auto-fix retries so a deterministic regeneration that
+// keeps failing (disk permission, malformed source) doesn't loop
+// forever. The recovery handler reads attempts from
+// state.retry_context.recovery.attempts (incremented by recoveryPatch)
+// and degrades to `unsupported` past the budget so the operator sees
+// the underlying error.
+const AUTO_FIX_RETRY_BUDGET = 3;
+
+// Codes the recover skill can resolve by re-running the deterministic
+// postprocess that produced the source artifacts. No agent dispatch.
+const AUTO_FIX_REGENERATE_CODES = new Set([
+  'decomposition_derived_stale',
+  'test_agent_briefs_write_failed',
+]);
+
+// Codes whose recovery is "re-dispatch the producing agent with the
+// validator's structured error list". The recover skill cannot
+// dispatch agents directly — it returns a dispatch instruction
+// pointing at the right agent + the error context.
+const REDISPATCH_DECOMPOSER_CODES = new Set([
+  'covers_schema_violation',
+  'goal_contract_invalid',
+  'phase_contract_graph_invalid',
 ]);
 
 function nowIso() {
@@ -524,6 +557,156 @@ function recoverArtifactSchema(cwd, state, { approveUnsafe = false } = {}) {
   });
 }
 
+// #234: deterministic auto-fix. Re-run the mechanical postprocess
+// that produced the missing/stale derived artifact. Capped retries
+// so a permission / disk error doesn't loop forever.
+function recoverAutoRegenerate(cwd, state) {
+  const code = state.block_code;
+  const attempts = Number(state?.retry_context?.recovery?.attempts || 0);
+  if (attempts >= AUTO_FIX_RETRY_BUDGET) {
+    const reason = `[MPL Recover] Auto-fix budget exhausted for ${code} after ${attempts} attempts; inspect the underlying I/O failure manually.`;
+    keepBlocked(cwd, state, {
+      status: 'failed',
+      reason,
+      instruction:
+        state.resume_instruction ||
+        'Resolve the I/O failure (permissions / disk space / malformed source) and re-save the decomposition source artifact.',
+      details: { handler: 'auto_regenerate', code, attempts },
+    });
+    return buildResult(state, { status: 'failed', message: reason, attempts });
+  }
+
+  try {
+    if (code === 'decomposition_derived_stale') {
+      writeDerivedDecompositionFields(cwd);
+    } else if (code === 'test_agent_briefs_write_failed') {
+      writeTestAgentBriefs(cwd);
+    } else {
+      const reason = `[MPL Recover] No regeneration handler for ${code}.`;
+      keepBlocked(cwd, state, {
+        status: 'unsupported',
+        reason,
+        instruction: state.resume_instruction || 'Resolve the recorded hook block manually.',
+        details: { handler: 'auto_regenerate', code },
+      });
+      return buildResult(state, { status: 'unsupported', message: reason });
+    }
+  } catch (error) {
+    const reason = `[MPL Recover] Auto-fix regeneration failed for ${code}: ${error?.message || 'unknown error'}.`;
+    keepBlocked(cwd, state, {
+      status: 'failed',
+      reason,
+      instruction:
+        'Inspect the source artifact / disk / permissions and retry. Auto-fix will quit after the retry budget is exhausted.',
+      details: { handler: 'auto_regenerate', code, error: error?.message || 'unknown' },
+    });
+    return buildResult(state, { status: 'failed', message: reason });
+  }
+
+  clearCurrentBlock(cwd, state);
+  appendRecoverySignal(cwd, {
+    ...summarizeState(state),
+    result: 'recovered',
+    handler: 'auto_regenerate',
+    code,
+  });
+  return buildResult(state, {
+    status: 'recovered',
+    message: `Regenerated derived artifact for ${code} and cleared blocked_hook.`,
+  });
+}
+
+// #234: producer-agent re-dispatch. Recover skill returns a dispatch
+// instruction (no actual agent spawn — that's the orchestrator's
+// responsibility). retry_context.failures (if recorded by the hook)
+// is echoed back in the instruction so the producer can fix the exact
+// validator findings.
+function recoverRedispatchDecomposer(cwd, state) {
+  const code = state.block_code;
+  const failures = state?.retry_context?.failures;
+  const failureSummary = Array.isArray(failures) && failures.length > 0
+    ? `Validator findings to address: ${failures.slice(0, 8).join('; ')}.`
+    : '';
+  const instruction =
+    `Re-dispatch Task(subagent_type="mpl-decomposer", model="sonnet", prompt=...) to fix ${code}. ${failureSummary}`.trim();
+
+  const reason = `[MPL Recover] ${code} requires decomposer re-dispatch.`;
+  keepBlocked(cwd, state, {
+    status: 'awaiting_decomposer',
+    reason,
+    instruction,
+    details: { handler: 'redispatch_decomposer', code, failures: failures || [] },
+  });
+  return buildResult(state, {
+    status: 'awaiting_decomposer',
+    message: reason,
+    dispatch_instruction: instruction,
+    failures: failures || [],
+  });
+}
+
+// #234: phase-runner anomaly re-dispatch. block_code shape is
+// `phase_runner_<anomaly_type>` (emitted at hooks/mpl-gate-recorder.mjs
+// per subagent anomaly). Each anomaly has a different corrective
+// framing — keep the dispatch templates here so the recover skill is
+// a single source of truth.
+const PHASE_RUNNER_ANOMALY_TEMPLATES = {
+  empty_response:
+    'Re-dispatch Task(subagent_type="mpl-phase-runner", model="sonnet", prompt=...) with stronger framing: include the full phase brief and require structured JSON output. Verify the phase prompt isn\'t exceeding context budget.',
+  truncated_response:
+    'Re-dispatch Task(subagent_type="mpl-phase-runner", model="sonnet", prompt=...) with reduced context: drop optional decomposition fields, focus the prompt on the single phase brief, request output in chunks if necessary.',
+  invalid_json:
+    'Re-dispatch Task(subagent_type="mpl-phase-runner", model="sonnet", prompt=...) with explicit JSON schema reminder at the prompt tail. The previous run emitted unparseable output.',
+  no_evidence:
+    'Re-dispatch Task(subagent_type="mpl-phase-runner", model="sonnet", prompt=...) emphasizing evidence_required fields. Previous run completed without latching required evidence.',
+};
+
+function recoverPhaseRunnerAnomaly(cwd, state) {
+  const code = state.block_code || '';
+  const anomalyType = code.startsWith('phase_runner_') ? code.slice('phase_runner_'.length) : '';
+  const template = PHASE_RUNNER_ANOMALY_TEMPLATES[anomalyType];
+  const phaseId = state.blocked_phase || state?.retry_context?.phase_id || null;
+
+  const instruction = template ||
+    state.resume_instruction ||
+    `Re-dispatch Task(subagent_type="mpl-phase-runner", model="sonnet", prompt=...) for ${phaseId || 'the blocked phase'} after addressing the recorded ${anomalyType || 'anomaly'}.`;
+
+  const reason = `[MPL Recover] ${code} requires mpl-phase-runner re-dispatch (anomaly=${anomalyType || 'unknown'}).`;
+  keepBlocked(cwd, state, {
+    status: 'awaiting_phase_runner',
+    reason,
+    instruction,
+    details: { handler: 'phase_runner_anomaly', code, anomaly: anomalyType, phase_id: phaseId },
+  });
+  return buildResult(state, {
+    status: 'awaiting_phase_runner',
+    message: reason,
+    dispatch_instruction: instruction,
+    anomaly: anomalyType,
+    phase_id: phaseId,
+  });
+}
+
+// #234: baseline_immutable echoes the recorded resume_instruction
+// (touch the renewal sentinel). No agent dispatch; user action.
+function recoverBaselineImmutable(cwd, state) {
+  const reason = '[MPL Recover] Baseline is immutable; renewal sentinel required.';
+  const instruction =
+    state.resume_instruction ||
+    'Touch .mpl/mpl/.baseline-renewal to authorize a new baseline write, then retry.';
+  keepBlocked(cwd, state, {
+    status: 'requires_user_action',
+    reason,
+    instruction,
+    details: { handler: 'baseline_immutable' },
+  });
+  return buildResult(state, {
+    status: 'requires_user_action',
+    message: reason,
+    user_instruction: instruction,
+  });
+}
+
 export function inspectRecovery(cwd = process.cwd()) {
   const state = readState(cwd);
   if (!state) {
@@ -579,6 +762,47 @@ export function inspectRecovery(cwd = process.cwd()) {
     });
   }
 
+  // #234 new routes:
+  if (AUTO_FIX_REGENERATE_CODES.has(code)) {
+    const attempts = Number(state?.retry_context?.recovery?.attempts || 0);
+    const exhausted = attempts >= AUTO_FIX_RETRY_BUDGET;
+    return buildResult(state, {
+      status: exhausted ? 'unsupported' : 'recoverable',
+      handler: 'auto_regenerate',
+      safe: true,
+      attempts,
+      message: exhausted
+        ? `Auto-fix budget exhausted (${attempts}/${AUTO_FIX_RETRY_BUDGET}). Resolve the I/O failure manually.`
+        : 'Recover can re-run the deterministic postprocess that produced the derived artifact.',
+    });
+  }
+  if (REDISPATCH_DECOMPOSER_CODES.has(code)) {
+    return buildResult(state, {
+      status: 'requires_approval',
+      handler: 'redispatch_decomposer',
+      safe: false,
+      message: 'Recover returns a mpl-decomposer dispatch instruction with the validator findings; orchestrator must execute the Task call.',
+    });
+  }
+  if (code && code.startsWith('phase_runner_')) {
+    const anomalyType = code.slice('phase_runner_'.length);
+    return buildResult(state, {
+      status: 'requires_approval',
+      handler: 'phase_runner_anomaly',
+      anomaly: anomalyType,
+      safe: false,
+      message: `Recover returns a mpl-phase-runner re-dispatch instruction for anomaly=${anomalyType}.`,
+    });
+  }
+  if (code === 'baseline_immutable') {
+    return buildResult(state, {
+      status: 'requires_user_action',
+      handler: 'baseline_immutable',
+      safe: false,
+      message: 'Baseline renewal sentinel (.mpl/mpl/.baseline-renewal) must be touched manually to authorize the write.',
+    });
+  }
+
   return buildResult(state, {
     status: 'unsupported',
     handler: null,
@@ -610,6 +834,18 @@ export function recoverBlockedHook(cwd = process.cwd(), { approveUnsafe = false 
   }
   if (code === 'missing_artifact_schema') {
     return recoverArtifactSchema(cwd, state, { approveUnsafe });
+  }
+  if (AUTO_FIX_REGENERATE_CODES.has(code)) {
+    return recoverAutoRegenerate(cwd, state);
+  }
+  if (REDISPATCH_DECOMPOSER_CODES.has(code)) {
+    return recoverRedispatchDecomposer(cwd, state);
+  }
+  if (code && code.startsWith('phase_runner_')) {
+    return recoverPhaseRunnerAnomaly(cwd, state);
+  }
+  if (code === 'baseline_immutable') {
+    return recoverBaselineImmutable(cwd, state);
   }
 
   const reason = `[MPL Recover] Unsupported hook block code: ${code || 'unknown'}.`;

--- a/hooks/lib/mpl-recover.mjs
+++ b/hooks/lib/mpl-recover.mjs
@@ -174,10 +174,18 @@ function activeRecoveryState(state) {
   // When the current state has neither code nor blocked_at, fall back
   // to the original pre-tag behavior (genuinely ambiguous → trust).
   if (currentCode === null && currentBlockedAt === null) return rec;
+  // Codex r4 on PR #242 [data-integrity]: ISO 8601 strings with mixed
+  // millisecond precision (`2026-06-01T12:00:00Z` vs
+  // `2026-06-01T12:00:00.500Z`) sort lexicographically against the
+  // chronological intent (`.` < `Z` in ASCII). Compare via Date.parse
+  // numeric milliseconds; fall closed (discard untagged recovery) if
+  // either timestamp fails to parse.
   const stampedLastAt = typeof rec.last_attempt_at === 'string' ? rec.last_attempt_at : null;
-  if (stampedLastAt && currentBlockedAt && stampedLastAt >= currentBlockedAt) {
-    return rec;
-  }
+  if (!stampedLastAt || !currentBlockedAt) return {};
+  const stampedMs = Date.parse(stampedLastAt);
+  const currentMs = Date.parse(currentBlockedAt);
+  if (!Number.isFinite(stampedMs) || !Number.isFinite(currentMs)) return {};
+  if (stampedMs >= currentMs) return rec;
   return {};
 }
 

--- a/hooks/lib/mpl-recover.mjs
+++ b/hooks/lib/mpl-recover.mjs
@@ -794,18 +794,30 @@ function recoverRedispatchDecomposer(cwd, state, { approveUnsafe = false } = {})
     `Re-dispatch Task(subagent_type="mpl-decomposer", model="sonnet", prompt=...) to fix ${code}. ${failureSummary}`.trim();
 
   if (!approveUnsafe) {
+    // Codex r8 [contract-break] + [logic]: must NOT persist the gated
+    // dispatch text in state.retry_context.recovery (any reader could
+    // dispatch without approval), AND must NOT overwrite the original
+    // state.resume_instruction with the "run --approve-unsafe" prompt
+    // (the next approved run reads resume_instruction and would echo
+    // the approval prompt instead of the original recovery instruction).
+    //
+    // Pass `instruction: undefined` so recoveryPatch falls back to the
+    // existing state.resume_instruction. Surface the approval prompt
+    // only at the buildResult layer (user-visible JSON output) — not
+    // in state.
     const reason = `[MPL Recover] ${code} requires explicit approval to surface the mpl-decomposer dispatch instruction.`;
     keepBlocked(cwd, state, {
       status: 'requires_approval',
       reason,
-      instruction:
-        'Run /mpl:mpl-recover with --approve-unsafe (or rerun the recovery handler explicitly) to receive the decomposer re-dispatch Task call.',
-      details: { handler: 'redispatch_decomposer', code, findings: diagnostics, awaiting_instruction: instruction },
+      instruction: undefined,
+      details: { handler: 'redispatch_decomposer', code, findings: diagnostics },
     });
     return buildResult(state, {
       status: 'requires_approval',
       message: reason,
       requires_approval: true,
+      approval_prompt:
+        'Run /mpl:mpl-recover with --approve-unsafe (or rerun the recovery handler explicitly) to receive the decomposer re-dispatch Task call.',
       findings: diagnostics,
     });
   }
@@ -847,18 +859,22 @@ function recoverGoalContractInvalid(cwd, state, { approveUnsafe = false } = {}) 
     'Restore a valid .mpl/goal-contract.yaml, then retry the decomposition write.';
 
   if (!approveUnsafe) {
+    // Codex r8: same anti-clobber pattern — preserve the original
+    // resume_instruction in state, surface the approval prompt only
+    // in the returned JSON.
     const approvalReason = '[MPL Recover] goal_contract_invalid requires explicit approval to surface the restoration instruction.';
     keepBlocked(cwd, state, {
       status: 'requires_approval',
       reason: approvalReason,
-      instruction:
-        'Run /mpl:mpl-recover with --approve-unsafe to receive the goal-contract restoration instruction.',
+      instruction: undefined,
       details: { handler: 'goal_contract_invalid', findings: diagnostics },
     });
     return buildResult(state, {
       status: 'requires_approval',
       message: approvalReason,
       requires_approval: true,
+      approval_prompt:
+        'Run /mpl:mpl-recover with --approve-unsafe to receive the goal-contract restoration instruction.',
       findings: diagnostics,
     });
   }
@@ -904,24 +920,27 @@ function recoverPhaseRunnerAnomaly(cwd, state, { approveUnsafe = false } = {}) {
     `Re-dispatch Task(subagent_type="mpl-phase-runner", model="sonnet", prompt=...) for ${phaseId || 'the blocked phase'} after addressing the recorded ${anomalyType || 'anomaly'}.`;
 
   if (!approveUnsafe) {
+    // Codex r8: do NOT persist `awaiting_instruction` in state, do NOT
+    // overwrite resume_instruction with the approval prompt. Approval
+    // prompt lives only in the returned JSON.
     const approvalReason = `[MPL Recover] ${code} requires explicit approval to surface the mpl-phase-runner dispatch instruction (anomaly=${anomalyType || 'unknown'}).`;
     keepBlocked(cwd, state, {
       status: 'requires_approval',
       reason: approvalReason,
-      instruction:
-        'Run /mpl:mpl-recover with --approve-unsafe to receive the phase-runner re-dispatch Task call.',
+      instruction: undefined,
       details: {
         handler: 'phase_runner_anomaly',
         code,
         anomaly: anomalyType,
         phase_id: phaseId,
-        awaiting_instruction: instruction,
       },
     });
     return buildResult(state, {
       status: 'requires_approval',
       message: approvalReason,
       requires_approval: true,
+      approval_prompt:
+        'Run /mpl:mpl-recover with --approve-unsafe to receive the phase-runner re-dispatch Task call.',
       anomaly: anomalyType,
       phase_id: phaseId,
     });
@@ -953,18 +972,20 @@ function recoverBaselineImmutable(cwd, state, { approveUnsafe = false } = {}) {
     'Touch .mpl/mpl/.baseline-renewal to authorize a new baseline write, then retry.';
 
   if (!approveUnsafe) {
+    // Codex r8: same anti-clobber pattern.
     const approvalReason = '[MPL Recover] baseline_immutable requires explicit approval to surface the renewal-sentinel instruction.';
     keepBlocked(cwd, state, {
       status: 'requires_approval',
       reason: approvalReason,
-      instruction:
-        'Run /mpl:mpl-recover with --approve-unsafe to receive the baseline renewal instruction.',
+      instruction: undefined,
       details: { handler: 'baseline_immutable' },
     });
     return buildResult(state, {
       status: 'requires_approval',
       message: approvalReason,
       requires_approval: true,
+      approval_prompt:
+        'Run /mpl:mpl-recover with --approve-unsafe to receive the baseline renewal instruction.',
     });
   }
 

--- a/hooks/lib/mpl-recover.mjs
+++ b/hooks/lib/mpl-recover.mjs
@@ -133,6 +133,18 @@ function recoveryPatch(state, { status, reason, instruction, details = {} }) {
         attempts: (Number.isFinite(prev.attempts) ? prev.attempts : 0) + 1,
         last_status: status,
         last_attempt_at: nowIso(),
+        // Codex r9 on PR #242 [security]: writeState's deepMerge
+        // preserves nested keys that aren't in the patch. A prior
+        // approved-or-r7 recovery write may have stashed
+        // `awaiting_instruction: "Re-dispatch Task(...)"`; without an
+        // explicit tombstone, deepMerge would keep that string in
+        // state even after r8's safe-mode handler omitted it. Always
+        // null it here so safe-mode writes structurally cannot leak
+        // gated dispatch text. The approved branch (which sets
+        // `details: { ... }` not including awaiting_instruction)
+        // surfaces the actual dispatch via state.resume_instruction
+        // and the buildResult dispatch_instruction field instead.
+        awaiting_instruction: null,
         ...details,
       },
     },

--- a/hooks/lib/mpl-recover.mjs
+++ b/hooks/lib/mpl-recover.mjs
@@ -778,12 +778,13 @@ function collectValidatorDiagnostics(state) {
     });
 }
 
-// #234: producer-agent re-dispatch. Recover skill returns a dispatch
-// instruction (no actual agent spawn — that's the orchestrator's
-// responsibility). Validator diagnostics from retry_context.failures
-// / .issues / .missing are normalized and echoed back so the producer
-// can fix the exact findings.
-function recoverRedispatchDecomposer(cwd, state) {
+// #234 + codex r7 on PR #242 [contract-break]: producer-agent
+// re-dispatch is an approval-required route per SKILL.md "Step 3
+// Explicit Approval Recovery". `--apply-safe` (approveUnsafe=false)
+// must NOT advance recovery to `awaiting_decomposer`; it must surface
+// the route as `requires_approval` so an automation watching for
+// `awaiting_*` cannot side-step the human checkpoint.
+function recoverRedispatchDecomposer(cwd, state, { approveUnsafe = false } = {}) {
   const code = state.block_code;
   const diagnostics = collectValidatorDiagnostics(state);
   const failureSummary = diagnostics.length > 0
@@ -791,6 +792,23 @@ function recoverRedispatchDecomposer(cwd, state) {
     : '';
   const instruction =
     `Re-dispatch Task(subagent_type="mpl-decomposer", model="sonnet", prompt=...) to fix ${code}. ${failureSummary}`.trim();
+
+  if (!approveUnsafe) {
+    const reason = `[MPL Recover] ${code} requires explicit approval to surface the mpl-decomposer dispatch instruction.`;
+    keepBlocked(cwd, state, {
+      status: 'requires_approval',
+      reason,
+      instruction:
+        'Run /mpl:mpl-recover with --approve-unsafe (or rerun the recovery handler explicitly) to receive the decomposer re-dispatch Task call.',
+      details: { handler: 'redispatch_decomposer', code, findings: diagnostics, awaiting_instruction: instruction },
+    });
+    return buildResult(state, {
+      status: 'requires_approval',
+      message: reason,
+      requires_approval: true,
+      findings: diagnostics,
+    });
+  }
 
   const reason = `[MPL Recover] ${code} requires decomposer re-dispatch.`;
   keepBlocked(cwd, state, {
@@ -812,7 +830,13 @@ function recoverRedispatchDecomposer(cwd, state) {
 // valid .mpl/goal-contract.yaml" — a decomposer re-dispatch cannot
 // repair a missing source file. Echo the recorded instruction (with a
 // generic fallback) so the operator sees the actionable step.
-function recoverGoalContractInvalid(cwd, state) {
+// Codex r7 on PR #242 [contract-break]: goal_contract_invalid is
+// a user-action route (the recorded resume_instruction asks the
+// operator to restore .mpl/goal-contract.yaml). Per SKILL.md "Step 3
+// Explicit Approval Recovery", `--apply-safe` must NOT advance to
+// `requires_user_action` — that would let an automation watching for
+// `user_instruction` mutate state without the human checkpoint.
+function recoverGoalContractInvalid(cwd, state, { approveUnsafe = false } = {}) {
   const diagnostics = collectValidatorDiagnostics(state);
   const missingSummary = diagnostics.length > 0
     ? ` Missing fields: ${diagnostics.slice(0, 8).join(', ')}.`
@@ -821,6 +845,24 @@ function recoverGoalContractInvalid(cwd, state) {
   const instruction =
     state.resume_instruction ||
     'Restore a valid .mpl/goal-contract.yaml, then retry the decomposition write.';
+
+  if (!approveUnsafe) {
+    const approvalReason = '[MPL Recover] goal_contract_invalid requires explicit approval to surface the restoration instruction.';
+    keepBlocked(cwd, state, {
+      status: 'requires_approval',
+      reason: approvalReason,
+      instruction:
+        'Run /mpl:mpl-recover with --approve-unsafe to receive the goal-contract restoration instruction.',
+      details: { handler: 'goal_contract_invalid', findings: diagnostics },
+    });
+    return buildResult(state, {
+      status: 'requires_approval',
+      message: approvalReason,
+      requires_approval: true,
+      findings: diagnostics,
+    });
+  }
+
   keepBlocked(cwd, state, {
     status: 'requires_user_action',
     reason,
@@ -851,7 +893,7 @@ const PHASE_RUNNER_ANOMALY_TEMPLATES = {
     'Re-dispatch Task(subagent_type="mpl-phase-runner", model="sonnet", prompt=...) emphasizing evidence_required fields. Previous run completed without latching required evidence.',
 };
 
-function recoverPhaseRunnerAnomaly(cwd, state) {
+function recoverPhaseRunnerAnomaly(cwd, state, { approveUnsafe = false } = {}) {
   const code = state.block_code || '';
   const anomalyType = code.startsWith('phase_runner_') ? code.slice('phase_runner_'.length) : '';
   const template = PHASE_RUNNER_ANOMALY_TEMPLATES[anomalyType];
@@ -860,6 +902,30 @@ function recoverPhaseRunnerAnomaly(cwd, state) {
   const instruction = template ||
     state.resume_instruction ||
     `Re-dispatch Task(subagent_type="mpl-phase-runner", model="sonnet", prompt=...) for ${phaseId || 'the blocked phase'} after addressing the recorded ${anomalyType || 'anomaly'}.`;
+
+  if (!approveUnsafe) {
+    const approvalReason = `[MPL Recover] ${code} requires explicit approval to surface the mpl-phase-runner dispatch instruction (anomaly=${anomalyType || 'unknown'}).`;
+    keepBlocked(cwd, state, {
+      status: 'requires_approval',
+      reason: approvalReason,
+      instruction:
+        'Run /mpl:mpl-recover with --approve-unsafe to receive the phase-runner re-dispatch Task call.',
+      details: {
+        handler: 'phase_runner_anomaly',
+        code,
+        anomaly: anomalyType,
+        phase_id: phaseId,
+        awaiting_instruction: instruction,
+      },
+    });
+    return buildResult(state, {
+      status: 'requires_approval',
+      message: approvalReason,
+      requires_approval: true,
+      anomaly: anomalyType,
+      phase_id: phaseId,
+    });
+  }
 
   const reason = `[MPL Recover] ${code} requires mpl-phase-runner re-dispatch (anomaly=${anomalyType || 'unknown'}).`;
   keepBlocked(cwd, state, {
@@ -877,13 +943,31 @@ function recoverPhaseRunnerAnomaly(cwd, state) {
   });
 }
 
-// #234: baseline_immutable echoes the recorded resume_instruction
-// (touch the renewal sentinel). No agent dispatch; user action.
-function recoverBaselineImmutable(cwd, state) {
+// #234 + codex r7 [contract-break]: baseline_immutable is also an
+// approval-required user-action route. `--apply-safe` must not
+// advance to `requires_user_action`.
+function recoverBaselineImmutable(cwd, state, { approveUnsafe = false } = {}) {
   const reason = '[MPL Recover] Baseline is immutable; renewal sentinel required.';
   const instruction =
     state.resume_instruction ||
     'Touch .mpl/mpl/.baseline-renewal to authorize a new baseline write, then retry.';
+
+  if (!approveUnsafe) {
+    const approvalReason = '[MPL Recover] baseline_immutable requires explicit approval to surface the renewal-sentinel instruction.';
+    keepBlocked(cwd, state, {
+      status: 'requires_approval',
+      reason: approvalReason,
+      instruction:
+        'Run /mpl:mpl-recover with --approve-unsafe to receive the baseline renewal instruction.',
+      details: { handler: 'baseline_immutable' },
+    });
+    return buildResult(state, {
+      status: 'requires_approval',
+      message: approvalReason,
+      requires_approval: true,
+    });
+  }
+
   keepBlocked(cwd, state, {
     status: 'requires_user_action',
     reason,
@@ -1037,16 +1121,16 @@ export function recoverBlockedHook(cwd = process.cwd(), { approveUnsafe = false 
     return recoverAutoRegenerate(cwd, state);
   }
   if (REDISPATCH_DECOMPOSER_CODES.has(code)) {
-    return recoverRedispatchDecomposer(cwd, state);
+    return recoverRedispatchDecomposer(cwd, state, { approveUnsafe });
   }
   if (code === 'goal_contract_invalid') {
-    return recoverGoalContractInvalid(cwd, state);
+    return recoverGoalContractInvalid(cwd, state, { approveUnsafe });
   }
   if (code && code.startsWith('phase_runner_')) {
-    return recoverPhaseRunnerAnomaly(cwd, state);
+    return recoverPhaseRunnerAnomaly(cwd, state, { approveUnsafe });
   }
   if (code === 'baseline_immutable') {
-    return recoverBaselineImmutable(cwd, state);
+    return recoverBaselineImmutable(cwd, state, { approveUnsafe });
   }
 
   const reason = `[MPL Recover] Unsupported hook block code: ${code || 'unknown'}.`;

--- a/hooks/lib/mpl-recover.mjs
+++ b/hooks/lib/mpl-recover.mjs
@@ -99,13 +99,22 @@ function buildResult(state, patch) {
   };
 }
 
+// Codex r2 on PR #242 [data-integrity]: writeState uses deepMerge,
+// which recursively merges nested plain objects. That means a stale
+// `retry_context.recovery` from a prior, unrelated block survives
+// into a new block's envelope. If that stale `recovery.attempts`
+// happens to be 3, `recoverAutoRegenerate` reports budget-exhausted
+// before ever running the deterministic postprocess on a fresh,
+// recoverable block.
+//
+// Scope recovery state to the active block by tagging it with the
+// block_code + blocked_at. Readers (see `activeRecoveryState`) only
+// trust the stored attempts when the tag matches the current envelope.
 function recoveryPatch(state, { status, reason, instruction, details = {} }) {
   const context = state?.retry_context && typeof state.retry_context === 'object'
     ? jsonClone(state.retry_context)
     : {};
-  const prev = context.recovery && typeof context.recovery === 'object'
-    ? context.recovery
-    : {};
+  const prev = activeRecoveryState(state);
 
   return {
     session_status: 'blocked_hook',
@@ -118,6 +127,9 @@ function recoveryPatch(state, { status, reason, instruction, details = {} }) {
     retry_context: {
       ...context,
       recovery: {
+        // Scope tag — readers compare to current state before trusting.
+        block_code: state.block_code || null,
+        blocked_at: state.blocked_at || null,
         attempts: (Number.isFinite(prev.attempts) ? prev.attempts : 0) + 1,
         last_status: status,
         last_attempt_at: nowIso(),
@@ -126,6 +138,30 @@ function recoveryPatch(state, { status, reason, instruction, details = {} }) {
     },
     blocked_at: state.blocked_at || nowIso(),
   };
+}
+
+// Read the recovery sub-object only when its scope tag matches the
+// current block. Returns `{ attempts: 0 }` (i.e. a fresh slate) when
+// the stored recovery belongs to a different block.
+function activeRecoveryState(state) {
+  const rec = state?.retry_context?.recovery;
+  if (!rec || typeof rec !== 'object') return {};
+  const currentCode = state?.block_code || null;
+  const currentBlockedAt = state?.blocked_at || null;
+  const stampedCode = rec.block_code ?? null;
+  const stampedAt = rec.blocked_at ?? null;
+  // Untagged recovery (pre-codex-r2 patches) is trusted ONLY when the
+  // current block has neither code nor blocked_at — i.e., genuinely
+  // ambiguous. Once either is set, a missing/mismatched tag means the
+  // stored recovery belongs to a different block.
+  if (stampedCode === null && stampedAt === null) {
+    if (currentCode === null && currentBlockedAt === null) return rec;
+    return {};
+  }
+  if (stampedCode === currentCode && stampedAt === currentBlockedAt) {
+    return rec;
+  }
+  return {};
 }
 
 function keepBlocked(cwd, state, opts) {
@@ -567,7 +603,10 @@ function recoverArtifactSchema(cwd, state, { approveUnsafe = false } = {}) {
 // so a permission / disk error doesn't loop forever.
 function recoverAutoRegenerate(cwd, state) {
   const code = state.block_code;
-  const attempts = Number(state?.retry_context?.recovery?.attempts || 0);
+  // Codex r2 [data-integrity]: read attempts only from the
+  // scope-tagged recovery state so stale attempts from a previous
+  // block can't poison a fresh, recoverable envelope.
+  const attempts = Number(activeRecoveryState(state).attempts || 0);
   if (attempts >= AUTO_FIX_RETRY_BUDGET) {
     const reason = `[MPL Recover] Auto-fix budget exhausted for ${code} after ${attempts} attempts; inspect the underlying I/O failure manually.`;
     keepBlocked(cwd, state, {
@@ -861,7 +900,7 @@ export function inspectRecovery(cwd = process.cwd()) {
 
   // #234 new routes:
   if (AUTO_FIX_REGENERATE_CODES.has(code)) {
-    const attempts = Number(state?.retry_context?.recovery?.attempts || 0);
+    const attempts = Number(activeRecoveryState(state).attempts || 0);
     const exhausted = attempts >= AUTO_FIX_RETRY_BUDGET;
     return buildResult(state, {
       status: exhausted ? 'unsupported' : 'recoverable',

--- a/skills/mpl-recover/SKILL.md
+++ b/skills/mpl-recover/SKILL.md
@@ -48,7 +48,7 @@ Safe handlers:
 - `test_agent_evidence`:
   if `state.test_agent_dispatched[phase_id]` already contains valid PASS evidence, clear `blocked_hook`; otherwise keep the block and return the embedded `Task(subagent_type="mpl-test-agent", ...)` instruction.
 - `auto_regenerate` with `decomposition_derived_stale` or `test_agent_briefs_write_failed` (#234):
-  re-run the deterministic postprocess (`writeDerivedDecompositionFields` / `writeTestAgentBriefs`). Capped at 3 attempts via `retry_context.recovery.attempts`; past the budget the handler returns `failed` with the underlying I/O error so the operator can fix the source.
+  re-run the deterministic postprocess (`writeDerivedDecompositionFields` / `writeTestAgentBriefs`). Capped at 3 attempts via `retry_context.recovery.attempts`; past the budget the handler returns `failed` with the underlying I/O error so the operator can fix the source. For brief regeneration, the handler verifies post-conditions (codex r1 on #242): if `decomposition.yaml` is missing or zero briefs were produced for the blocked context, the block stays `failed` with a concrete instruction instead of being mistakenly cleared.
 
 When `test_agent_evidence` returns `awaiting_test_agent`, execute the embedded
 `mpl-test-agent` Task exactly as shown in `resume_instruction`. The agent must
@@ -75,8 +75,10 @@ Approval-required handlers:
 - `missing_artifact_schema` for missing `phase-N.test_agent_required`:
   insert `test_agent_required: true` for the listed phases. This is conservative
   because missing values are already treated as required by AD-0007.
-- `redispatch_decomposer` with `covers_schema_violation`, `goal_contract_invalid`, or `phase_contract_graph_invalid` (#234):
-  the recover skill returns a `Task(subagent_type="mpl-decomposer", ...)` dispatch instruction with the validator's structured `failures[]` echoed back. The orchestrator (not the recover skill) executes the Task.
+- `redispatch_decomposer` with `covers_schema_violation` or `phase_contract_graph_invalid` (#234):
+  the recover skill returns a `Task(subagent_type="mpl-decomposer", ...)` dispatch instruction with the validator's structured findings echoed back. Diagnostics are normalized across `retry_context.failures` / `retry_context.issues` / `retry_context.missing` (each hook records under a different field). The orchestrator (not the recover skill) executes the Task.
+- `goal_contract_invalid` (#234 codex r1):
+  no agent dispatch. Returns the recorded `resume_instruction` ("Restore a valid .mpl/goal-contract.yaml") with the missing-field list appended. A decomposer re-dispatch cannot repair a missing source file.
 - `phase_runner_anomaly` with `phase_runner_<anomaly_type>` (#234):
   the recover skill returns an anomaly-specific `Task(subagent_type="mpl-phase-runner", ...)` dispatch instruction. Anomaly types include `empty_response`, `truncated_response`, `invalid_json`, `no_evidence`. Each has a tailored framing (stronger prompt / reduced context / explicit schema reminder / evidence emphasis).
 - `baseline_immutable` (#234):

--- a/skills/mpl-recover/SKILL.md
+++ b/skills/mpl-recover/SKILL.md
@@ -76,13 +76,13 @@ Approval-required handlers:
   insert `test_agent_required: true` for the listed phases. This is conservative
   because missing values are already treated as required by AD-0007.
 - `redispatch_decomposer` with `covers_schema_violation` or `phase_contract_graph_invalid` (#234):
-  the recover skill returns a `Task(subagent_type="mpl-decomposer", ...)` dispatch instruction with the validator's structured findings echoed back. Diagnostics are normalized across `retry_context.failures` / `retry_context.issues` / `retry_context.missing` (each hook records under a different field). The orchestrator (not the recover skill) executes the Task.
+  the recover skill returns a `Task(subagent_type="mpl-decomposer", ...)` dispatch instruction with the validator's structured findings echoed back. Diagnostics are normalized across `retry_context.failures` / `retry_context.issues` / `retry_context.missing` (each hook records under a different field). The orchestrator (not the recover skill) executes the Task. **Requires `--approve-unsafe` (codex r7 #242)**: `--apply-safe` keeps the block at `requires_approval` so an automation watching `awaiting_decomposer` cannot side-step the human checkpoint.
 - `goal_contract_invalid` (#234 codex r1):
-  no agent dispatch. Returns the recorded `resume_instruction` ("Restore a valid .mpl/goal-contract.yaml") with the missing-field list appended. A decomposer re-dispatch cannot repair a missing source file.
+  no agent dispatch. Returns the recorded `resume_instruction` ("Restore a valid .mpl/goal-contract.yaml") with the missing-field list appended. A decomposer re-dispatch cannot repair a missing source file. **Requires `--approve-unsafe` (codex r7 #242)**.
 - `phase_runner_anomaly` with `phase_runner_<anomaly_type>` (#234):
-  the recover skill returns an anomaly-specific `Task(subagent_type="mpl-phase-runner", ...)` dispatch instruction. Anomaly types include `empty_response`, `truncated_response`, `invalid_json`, `no_evidence`. Each has a tailored framing (stronger prompt / reduced context / explicit schema reminder / evidence emphasis).
+  the recover skill returns an anomaly-specific `Task(subagent_type="mpl-phase-runner", ...)` dispatch instruction. Anomaly types include `empty_response`, `truncated_response`, `invalid_json`, `no_evidence`. Each has a tailored framing (stronger prompt / reduced context / explicit schema reminder / evidence emphasis). **Requires `--approve-unsafe` (codex r7 #242)**.
 - `baseline_immutable` (#234):
-  no agent dispatch. Returns the recorded `resume_instruction` (touch `.mpl/mpl/.baseline-renewal`) as `user_instruction`.
+  no agent dispatch. Returns the recorded `resume_instruction` (touch `.mpl/mpl/.baseline-renewal`) as `user_instruction`. **Requires `--approve-unsafe` (codex r7 #242)**.
 
 If revalidation still fails, recovery must leave `session_status:"blocked_hook"`
 intact and update `block_reason`, `resume_instruction`, and

--- a/skills/mpl-recover/SKILL.md
+++ b/skills/mpl-recover/SKILL.md
@@ -43,10 +43,12 @@ node hooks/lib/mpl-recover.mjs --apply-safe
 ```
 
 Safe handlers:
-- `goal_baseline_hash` with `goal_contract_baseline_corrupt` or `goal_contract_hash_corrupt`:
+- `goal_baseline_hash` with `goal_contract_baseline_corrupt`:
   repair `.mpl/mpl/baseline.yaml` from the normalized hash of `.mpl/goal-contract.yaml`, then clear `blocked_hook`.
 - `test_agent_evidence`:
   if `state.test_agent_dispatched[phase_id]` already contains valid PASS evidence, clear `blocked_hook`; otherwise keep the block and return the embedded `Task(subagent_type="mpl-test-agent", ...)` instruction.
+- `auto_regenerate` with `decomposition_derived_stale` or `test_agent_briefs_write_failed` (#234):
+  re-run the deterministic postprocess (`writeDerivedDecompositionFields` / `writeTestAgentBriefs`). Capped at 3 attempts via `retry_context.recovery.attempts`; past the budget the handler returns `failed` with the underlying I/O error so the operator can fix the source.
 
 When `test_agent_evidence` returns `awaiting_test_agent`, execute the embedded
 `mpl-test-agent` Task exactly as shown in `resume_instruction`. The agent must
@@ -64,7 +66,7 @@ node hooks/lib/mpl-recover.mjs --approve-unsafe
 ```
 
 Approval-required handlers:
-- `goal_contract_drift` / `goal_contract_hash_mismatch`:
+- `goal_contract_drift`:
   update `baseline.yaml` to the current normalized goal contract hash. Use only
   when the current `.mpl/goal-contract.yaml` is intentionally the source of truth.
 - `goal_trace_incomplete` with only `goal_contract_hash:*` issues:
@@ -73,6 +75,12 @@ Approval-required handlers:
 - `missing_artifact_schema` for missing `phase-N.test_agent_required`:
   insert `test_agent_required: true` for the listed phases. This is conservative
   because missing values are already treated as required by AD-0007.
+- `redispatch_decomposer` with `covers_schema_violation`, `goal_contract_invalid`, or `phase_contract_graph_invalid` (#234):
+  the recover skill returns a `Task(subagent_type="mpl-decomposer", ...)` dispatch instruction with the validator's structured `failures[]` echoed back. The orchestrator (not the recover skill) executes the Task.
+- `phase_runner_anomaly` with `phase_runner_<anomaly_type>` (#234):
+  the recover skill returns an anomaly-specific `Task(subagent_type="mpl-phase-runner", ...)` dispatch instruction. Anomaly types include `empty_response`, `truncated_response`, `invalid_json`, `no_evidence`. Each has a tailored framing (stronger prompt / reduced context / explicit schema reminder / evidence emphasis).
+- `baseline_immutable` (#234):
+  no agent dispatch. Returns the recorded `resume_instruction` (touch `.mpl/mpl/.baseline-renewal`) as `user_instruction`.
 
 If revalidation still fails, recovery must leave `session_status:"blocked_hook"`
 intact and update `block_reason`, `resume_instruction`, and


### PR DESCRIPTION
## Summary

Closes #234. Adds routing for 7 block codes that were emitted with proper envelopes but fell through to `unsupported`. Drops 2 phantom aliases that were routed defensively but never emitted.

## Details

| Code | Handler | Behavior |
|---|---|---|
| `decomposition_derived_stale` | auto_regenerate | re-runs `writeDerivedDecompositionFields` (capped at 3 retries via `retry_context.recovery.attempts`) |
| `test_agent_briefs_write_failed` | auto_regenerate | re-runs `writeTestAgentBriefs` (same retry cap) |
| `covers_schema_violation` | redispatch_decomposer | returns `Task(subagent_type="mpl-decomposer", ...)` instruction with `failures[]` echoed |
| `goal_contract_invalid` | redispatch_decomposer | same |
| `phase_contract_graph_invalid` | redispatch_decomposer | same |
| `phase_runner_<anomaly_type>` | phase_runner_anomaly | anomaly-specific dispatch templates (empty_response / truncated_response / invalid_json / no_evidence) |
| `baseline_immutable` | baseline_immutable | echoes recorded `resume_instruction` as `user_instruction`, no agent |

Dropped phantom aliases: `goal_contract_hash_corrupt`, `goal_contract_hash_mismatch` (never emitted; routing was dead code).

## Why

Per `docs/findings/2026-05-28-prompt-gate-restore-divergence.md` §C: pre-#234, `mpl-recover` covered 5 codes; ~7 codes existed with proper envelopes but had no handler. The auto-restore layer was unreachable for over half the producer surface — operators hit `unsupported` and the generic "Resolve manually" wall.

The phantom aliases came from confusion in the recover.mjs constants; removing them so the routing table is a canonical code reference.

## Test plan

- [x] `node --test hooks/__tests__/mpl-recover.test.mjs` — 21/21 pass, includes:
  - auto-regenerate both codes happy path
  - auto-regenerate retry budget exhaustion (3 attempts → failed)
  - redispatch_decomposer for all 3 codes
  - phase_runner_anomaly known + unknown types
  - baseline_immutable user_action
  - dropped phantom aliases fall through to unsupported
- [x] Full hook suite — 1297/1297 pass.

## Non-Goal

- #235 (envelope wiring on hand-rolled `block(reason)` hooks) — separate issue.
- Adding new block codes beyond the 7 listed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)