### PR TITLE
mpl-hook-trace diagnostic gaps — PURPOSES + slash-boundary + state focus (#237)

### DIFF
--- a/hooks/__tests__/mpl-hook-trace.test.mjs
+++ b/hooks/__tests__/mpl-hook-trace.test.mjs
@@ -483,6 +483,53 @@ describe('mpl-hook-trace', () => {
     }
   });
 
+  it('#237 codex r5 [logic]: pure-backslash POSIX filename does NOT fabricate path boundary', () => {
+    // Codex r5: previous r4 narrowing treated pure-backslash + no
+    // forward slash as Windows. But on POSIX, `foo\state.json` is a
+    // single literal basename. Falsely classifying as Windows
+    // normalized to `foo/state.json` and matched `state.json` artifact.
+    const trace = traceHookChain({
+      targetPath: 'foo\\state.json',
+      state: {
+        schema_version: CURRENT_SCHEMA_VERSION,
+        session_status: 'blocked_hook',
+        blocked_by_hook: 'mpl-require-test-agent',
+        blocked_artifact: 'state.json',
+        blocked_phase: 'phase-1',
+        block_code: 'x',
+        block_reason: 'x',
+        resume_instruction: 'x',
+        blocked_at: '2026-05-27T00:00:00.000Z',
+        retry_context: {},
+      },
+    });
+    const row = trace.hooks.find((h) => h.hook_id === 'mpl-require-test-agent');
+    assert.notEqual(row?.status, 'currently_blocking',
+      'pure-backslash POSIX basename must not match a state.json artifact');
+  });
+
+  it('#237 codex r5 [logic]: pure-backslash `.mpl\\state.json` target classifies as file (not state)', () => {
+    // The pathCategory side of the same issue: `.mpl\state.json`
+    // on POSIX is a single basename `.mpl\state.json`, NOT the
+    // canonical state path. Must classify as file so the
+    // file-category hook chain (not state focus) appears.
+    const tmp = mkdtempSync(join(tmpdir(), 'mpl-hook-trace-r5-pure-bs-'));
+    try {
+      mkdirSync(join(tmp, '.mpl'), { recursive: true });
+      writeFileSync(join(tmp, '.mpl', 'state.json'), JSON.stringify({
+        schema_version: CURRENT_SCHEMA_VERSION,
+        current_phase: 'phase2-sprint',
+      }));
+      const trace = traceHookChain({
+        targetPath: '.mpl\\state.json',
+        cwd: tmp,
+      });
+      assert.equal(trace.category, 'file');
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it('#237 codex r4 [logic]: POSIX literal-backslash filename does NOT fabricate a path boundary', () => {
     // codex r4 on PR #243: r3 unconditional `\` → `/` normalization
     // broke a POSIX edge case. `src/foo\state.json` on POSIX is a
@@ -542,10 +589,13 @@ describe('mpl-hook-trace', () => {
       'backslash target must normalize and match forward-slash artifact');
   });
 
-  it('#237 codex r3 [logic]: blockStatusFor handles backslash on the artifact side too', () => {
-    // Mirror case: artifact stored with backslashes (unlikely but
-    // possible if a hook on Windows wrote it). Trace target uses
-    // forward slashes.
+  it('#237 codex r5 [logic]: POSIX pure-backslash artifact does NOT fabricate boundary against forward-slash target', () => {
+    // Codex r5 on PR #243: previously pure-backslash (no `/`) was
+    // treated as Windows-shaped and normalized. That broke the
+    // POSIX semantics where backslash is a legal filename
+    // character. New rule: only drive-letter / UNC paths are
+    // normalized; pure-backslash relative strings are treated as
+    // POSIX literal filenames.
     const trace = traceHookChain({
       targetPath: '/repo/.mpl/state.json',
       state: {
@@ -553,6 +603,30 @@ describe('mpl-hook-trace', () => {
         session_status: 'blocked_hook',
         blocked_by_hook: 'mpl-require-test-agent',
         blocked_artifact: '.mpl\\state.json',
+        blocked_phase: 'phase-1',
+        block_code: 'x',
+        block_reason: 'x',
+        resume_instruction: 'x',
+        blocked_at: '2026-05-27T00:00:00.000Z',
+        retry_context: {},
+      },
+    });
+    const row = trace.hooks.find((h) => h.hook_id === 'mpl-require-test-agent');
+    // The artifact `.mpl\state.json` is a literal POSIX filename
+    // with a backslash, not the canonical `.mpl/state.json`. Match
+    // must fail.
+    assert.notEqual(row?.status, 'currently_blocking');
+  });
+
+  it('#237 codex r5 [logic]: UNC-style artifact normalizes and matches a forward-slash target', () => {
+    // UNC path remains unambiguously Windows-shaped — normalize.
+    const trace = traceHookChain({
+      targetPath: '//server/share/.mpl/state.json',
+      state: {
+        schema_version: CURRENT_SCHEMA_VERSION,
+        session_status: 'blocked_hook',
+        blocked_by_hook: 'mpl-require-test-agent',
+        blocked_artifact: '\\\\server\\share\\.mpl\\state.json',
         blocked_phase: 'phase-1',
         block_code: 'x',
         block_reason: 'x',

--- a/hooks/__tests__/mpl-hook-trace.test.mjs
+++ b/hooks/__tests__/mpl-hook-trace.test.mjs
@@ -458,13 +458,26 @@ describe('mpl-hook-trace', () => {
       });
       assert.equal(trace.category, 'state');
       const ids = trace.hooks.map((h) => h.hook_id);
-      // E2E authenticity must NOT appear — it's a pure file-write
-      // policy guard that doesn't read state.
-      assert.equal(ids.includes('mpl-require-e2e-authenticity'), false,
-        'state trace should not surface unrelated file-write hooks');
+      // Codex r1: pure file-write policy guards that don't read state
+      // must NOT appear. mpl-write-guard / mpl-fallback-grep are
+      // delegation / anti-pattern checks unrelated to state.
+      assert.equal(ids.includes('mpl-write-guard'), false,
+        'state trace should not surface mpl-write-guard');
+      assert.equal(ids.includes('mpl-fallback-grep'), false,
+        'state trace should not surface mpl-fallback-grep');
       // mpl-state-invariant SHOULD appear — it's the canonical state
       // reader.
       assert.equal(ids.includes('mpl-state-invariant'), true);
+      // Codex r1: mpl-gate-recorder (PostToolUse on Bash|Task|Agent)
+      // must appear in state traces — it reads / writes
+      // state.gate_results. Without matcher-independent STATE_FOCUS
+      // evaluation, it would be silently dropped.
+      assert.equal(ids.includes('mpl-gate-recorder'), true,
+        'mpl-gate-recorder must appear in state trace regardless of matcher');
+      // Codex r1: mpl-require-e2e reads state.e2e_results before
+      // blocking finalize_done=true. Must appear in state traces.
+      assert.equal(ids.includes('mpl-require-e2e'), true,
+        'mpl-require-e2e must appear in state trace');
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }

--- a/hooks/__tests__/mpl-hook-trace.test.mjs
+++ b/hooks/__tests__/mpl-hook-trace.test.mjs
@@ -483,6 +483,51 @@ describe('mpl-hook-trace', () => {
     }
   });
 
+  it('#237 codex r2 [logic]: pathCategory requires slash-boundary — `src/foo.mpl/state.json` is `file`, not `state`', () => {
+    // Codex r2 on PR #243: pathCategory used bare `endsWith('.mpl/state.json')`
+    // which matched `src/foo.mpl/state.json` (a regular file in a
+    // directory called `foo.mpl`). The state-focus filter then
+    // narrowed the hook chain, hiding the legitimate file hooks the
+    // operator needed to debug a real file artifact.
+    const tmp = mkdtempSync(join(tmpdir(), 'mpl-hook-trace-r2-'));
+    try {
+      mkdirSync(join(tmp, '.mpl'), { recursive: true });
+      writeFileSync(join(tmp, '.mpl', 'state.json'), JSON.stringify({
+        schema_version: CURRENT_SCHEMA_VERSION,
+        current_phase: 'phase2-sprint',
+      }));
+      const trace = traceHookChain({
+        targetPath: 'src/foo.mpl/state.json',
+        cwd: tmp,
+      });
+      assert.equal(trace.category, 'file', 'non-canonical .mpl directory must classify as file');
+      const ids = trace.hooks.map((h) => h.hook_id);
+      // The legitimate file hooks must appear for this file target.
+      assert.equal(ids.includes('mpl-write-guard'), true,
+        'mpl-write-guard must appear for a file-category trace');
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('#237 codex r2 [logic]: pathCategory requires slash-boundary for decomposition too', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'mpl-hook-trace-r2-decomp-'));
+    try {
+      mkdirSync(join(tmp, '.mpl'), { recursive: true });
+      writeFileSync(join(tmp, '.mpl', 'state.json'), JSON.stringify({
+        schema_version: CURRENT_SCHEMA_VERSION,
+        current_phase: 'phase2-sprint',
+      }));
+      const trace = traceHookChain({
+        targetPath: 'foo.mpl/mpl/decomposition.yaml',
+        cwd: tmp,
+      });
+      assert.equal(trace.category, 'file');
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it('#237 D3: non-state category trace still includes the broader set', () => {
     // Sanity check: tracing a code file path returns the full hook
     // chain (not the narrow state focus).

--- a/hooks/__tests__/mpl-hook-trace.test.mjs
+++ b/hooks/__tests__/mpl-hook-trace.test.mjs
@@ -4,7 +4,7 @@ import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync
 import { join } from 'path';
 import { tmpdir } from 'os';
 
-import { formatHookTrace, traceHookChain } from '../lib/mpl-hook-trace.mjs';
+import { findPurposeGaps, formatHookTrace, traceHookChain } from '../lib/mpl-hook-trace.mjs';
 import { CURRENT_SCHEMA_VERSION } from '../lib/mpl-state.mjs';
 
 describe('mpl-hook-trace', () => {
@@ -363,6 +363,132 @@ describe('mpl-hook-trace', () => {
       const row = trace.hooks.find((h) => h.hook_id === 'mpl-require-goal-trace');
       assert.equal(row.status, 'currently_blocking');
       assert.match(formatHookTrace(trace), /BLOCKING/);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  /* ──────────────────── #237 D1 / D2 / D3 ──────────────────── */
+
+  it('#237 D1: every hook id registered in hooks.json has a PURPOSES entry', () => {
+    const gaps = findPurposeGaps();
+    assert.deepEqual(gaps, [], `PURPOSES missing entries for: ${gaps.join(', ')}`);
+  });
+
+  it('#237 D2: slash-boundary match — `state.json` does NOT match `state.test_agent_dispatched.phase-1.state.json`', () => {
+    // Pre-D2: bidirectional endsWith treated artifact `state.json` and
+    // target `barstate.json` as matching. Now requires `/` boundary.
+    const tmp = mkdtempSync(join(tmpdir(), 'mpl-hook-trace-d2-'));
+    try {
+      mkdirSync(join(tmp, '.mpl'), { recursive: true });
+      writeFileSync(join(tmp, '.mpl', 'state.json'), JSON.stringify({
+        schema_version: CURRENT_SCHEMA_VERSION,
+        current_phase: 'phase2-sprint',
+        session_status: 'blocked_hook',
+        blocked_by_hook: 'mpl-require-test-agent',
+        blocked_phase: 'phase-1',
+        blocked_artifact: 'state.json', // suffix-only, no path
+        block_code: 'missing_or_invalid_test_agent_evidence',
+        block_reason: 'block',
+        resume_instruction: 'dispatch test-agent',
+        blocked_at: '2026-05-27T00:00:00.000Z',
+        retry_context: { phase_id: 'phase-1' },
+      }));
+      const trace = traceHookChain({
+        targetPath: 'src/api/widgets.test.state.json', // shares suffix but different file
+        cwd: tmp,
+      });
+      const row = trace.hooks.find((h) => h.hook_id === 'mpl-require-test-agent');
+      // Without slash boundary, would falsely report currently_blocking.
+      // With boundary, status is not currently_blocking for this target.
+      if (row) {
+        assert.notEqual(row.status, 'currently_blocking',
+          'must NOT match a target that only shares a non-path-segment suffix');
+      }
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('#237 D2: slash-boundary match — `.mpl/state.json` artifact DOES match target `state.json`', () => {
+    // Sanity check: legitimate suffix match (artifact = path-prefixed
+    // target with `/` boundary) still works.
+    const tmp = mkdtempSync(join(tmpdir(), 'mpl-hook-trace-d2-ok-'));
+    try {
+      mkdirSync(join(tmp, '.mpl'), { recursive: true });
+      writeFileSync(join(tmp, '.mpl', 'state.json'), JSON.stringify({
+        schema_version: CURRENT_SCHEMA_VERSION,
+        current_phase: 'phase2-sprint',
+        session_status: 'blocked_hook',
+        blocked_by_hook: 'mpl-require-test-agent',
+        blocked_phase: 'phase-1',
+        blocked_artifact: '.mpl/state.json',
+        block_code: 'missing_or_invalid_test_agent_evidence',
+        block_reason: 'block',
+        resume_instruction: 'dispatch test-agent',
+        blocked_at: '2026-05-27T00:00:00.000Z',
+        retry_context: { phase_id: 'phase-1' },
+      }));
+      const trace = traceHookChain({
+        targetPath: '/tmp/some/path/.mpl/state.json',
+        cwd: tmp,
+      });
+      const row = trace.hooks.find((h) => h.hook_id === 'mpl-require-test-agent');
+      assert.equal(row.status, 'currently_blocking');
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('#237 D3: state-category trace omits hooks that do not read state', () => {
+    // Pre-D3: trace on `.mpl/state.json` returned every Edit/Write
+    // PreToolUse hook, including ones like mpl-require-e2e-authenticity
+    // that don't read state — pure noise. Post-D3: only STATE_FOCUS
+    // members appear (plus any active blocker, which is force-included).
+    const tmp = mkdtempSync(join(tmpdir(), 'mpl-hook-trace-d3-'));
+    try {
+      mkdirSync(join(tmp, '.mpl'), { recursive: true });
+      writeFileSync(join(tmp, '.mpl', 'state.json'), JSON.stringify({
+        schema_version: CURRENT_SCHEMA_VERSION,
+        current_phase: 'phase2-sprint',
+      }));
+      const trace = traceHookChain({
+        targetPath: '.mpl/state.json',
+        cwd: tmp,
+      });
+      assert.equal(trace.category, 'state');
+      const ids = trace.hooks.map((h) => h.hook_id);
+      // E2E authenticity must NOT appear — it's a pure file-write
+      // policy guard that doesn't read state.
+      assert.equal(ids.includes('mpl-require-e2e-authenticity'), false,
+        'state trace should not surface unrelated file-write hooks');
+      // mpl-state-invariant SHOULD appear — it's the canonical state
+      // reader.
+      assert.equal(ids.includes('mpl-state-invariant'), true);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('#237 D3: non-state category trace still includes the broader set', () => {
+    // Sanity check: tracing a code file path returns the full hook
+    // chain (not the narrow state focus).
+    const tmp = mkdtempSync(join(tmpdir(), 'mpl-hook-trace-d3-non-state-'));
+    try {
+      mkdirSync(join(tmp, '.mpl'), { recursive: true });
+      writeFileSync(join(tmp, '.mpl', 'state.json'), JSON.stringify({
+        schema_version: CURRENT_SCHEMA_VERSION,
+        current_phase: 'phase2-sprint',
+      }));
+      const trace = traceHookChain({
+        targetPath: 'src/api/widgets.ts',
+        cwd: tmp,
+      });
+      assert.equal(trace.category, 'file');
+      const ids = trace.hooks.map((h) => h.hook_id);
+      // file-category should include the broader set of file-write
+      // PreToolUse hooks.
+      assert.equal(ids.includes('mpl-require-e2e-authenticity'), true);
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }

--- a/hooks/__tests__/mpl-hook-trace.test.mjs
+++ b/hooks/__tests__/mpl-hook-trace.test.mjs
@@ -483,6 +483,58 @@ describe('mpl-hook-trace', () => {
     }
   });
 
+  it('#237 codex r3 [logic]: blockStatusFor normalizes backslash paths for active-blocker match', () => {
+    // codex r3 on PR #243: pathCategory normalized backslash to
+    // forward slash but blockStatusFor compared raw strings. A
+    // Windows-style target `C:\repo\.mpl\state.json` with a normalized
+    // blocked_artifact `.mpl/state.json` got `currently_blocking` lost
+    // and reported as `registered_blocking_other_artifact` — active
+    // blocker hidden from the trace despite the target being correctly
+    // recognized as state category.
+    const trace = traceHookChain({
+      targetPath: 'C:\\repo\\.mpl\\state.json',
+      state: {
+        schema_version: CURRENT_SCHEMA_VERSION,
+        session_status: 'blocked_hook',
+        blocked_by_hook: 'mpl-require-test-agent',
+        blocked_artifact: '.mpl/state.json',
+        blocked_phase: 'phase-1',
+        block_code: 'missing_or_invalid_test_agent_evidence',
+        block_reason: 'block',
+        resume_instruction: 'dispatch test-agent',
+        blocked_at: '2026-05-27T00:00:00.000Z',
+        retry_context: { phase_id: 'phase-1' },
+      },
+    });
+    const row = trace.hooks.find((h) => h.hook_id === 'mpl-require-test-agent');
+    assert.ok(row, 'active blocker must appear in trace');
+    assert.equal(row.status, 'currently_blocking',
+      'backslash target must normalize and match forward-slash artifact');
+  });
+
+  it('#237 codex r3 [logic]: blockStatusFor handles backslash on the artifact side too', () => {
+    // Mirror case: artifact stored with backslashes (unlikely but
+    // possible if a hook on Windows wrote it). Trace target uses
+    // forward slashes.
+    const trace = traceHookChain({
+      targetPath: '/repo/.mpl/state.json',
+      state: {
+        schema_version: CURRENT_SCHEMA_VERSION,
+        session_status: 'blocked_hook',
+        blocked_by_hook: 'mpl-require-test-agent',
+        blocked_artifact: '.mpl\\state.json',
+        blocked_phase: 'phase-1',
+        block_code: 'x',
+        block_reason: 'x',
+        resume_instruction: 'x',
+        blocked_at: '2026-05-27T00:00:00.000Z',
+        retry_context: {},
+      },
+    });
+    const row = trace.hooks.find((h) => h.hook_id === 'mpl-require-test-agent');
+    assert.equal(row?.status, 'currently_blocking');
+  });
+
   it('#237 codex r2 [logic]: pathCategory requires slash-boundary — `src/foo.mpl/state.json` is `file`, not `state`', () => {
     // Codex r2 on PR #243: pathCategory used bare `endsWith('.mpl/state.json')`
     // which matched `src/foo.mpl/state.json` (a regular file in a

--- a/hooks/__tests__/mpl-hook-trace.test.mjs
+++ b/hooks/__tests__/mpl-hook-trace.test.mjs
@@ -483,6 +483,36 @@ describe('mpl-hook-trace', () => {
     }
   });
 
+  it('#237 codex r4 [logic]: POSIX literal-backslash filename does NOT fabricate a path boundary', () => {
+    // codex r4 on PR #243: r3 unconditional `\` → `/` normalization
+    // broke a POSIX edge case. `src/foo\state.json` on POSIX is a
+    // single basename `foo\state.json`, not a `state.json` segment.
+    // Unconditional normalization let it falsely match a `state.json`
+    // artifact. Narrowed normalization (drive-letter / UNC /
+    // pure-backslash only) keeps POSIX semantics.
+    const trace = traceHookChain({
+      // Mixed `/\` path: backslash here is a literal filename character.
+      targetPath: 'src/foo\\state.json',
+      state: {
+        schema_version: CURRENT_SCHEMA_VERSION,
+        session_status: 'blocked_hook',
+        blocked_by_hook: 'mpl-require-test-agent',
+        blocked_artifact: 'state.json',
+        blocked_phase: 'phase-1',
+        block_code: 'x',
+        block_reason: 'x',
+        resume_instruction: 'x',
+        blocked_at: '2026-05-27T00:00:00.000Z',
+        retry_context: {},
+      },
+    });
+    const row = trace.hooks.find((h) => h.hook_id === 'mpl-require-test-agent');
+    // Must NOT be currently_blocking — POSIX `foo\state.json` is a
+    // different file from `state.json`.
+    assert.notEqual(row?.status, 'currently_blocking',
+      'POSIX literal-backslash filename must not fabricate a path boundary');
+  });
+
   it('#237 codex r3 [logic]: blockStatusFor normalizes backslash paths for active-blocker match', () => {
     // codex r3 on PR #243: pathCategory normalized backslash to
     // forward slash but blockStatusFor compared raw strings. A

--- a/hooks/lib/mpl-hook-trace.mjs
+++ b/hooks/lib/mpl-hook-trace.mjs
@@ -235,8 +235,15 @@ function blockStatusFor(hookId, state, targetPath) {
   if (missing.length > 0) {
     return 'invalid_blocked_envelope';
   }
-  const artifact = String(state.blocked_artifact || '').trim();
-  const target = String(targetPath || '').trim();
+  // Codex r3 on PR #243: pathCategory normalizes backslash to forward
+  // slash but blockStatusFor compared raw strings, so a Windows-style
+  // target (`C:\repo\.mpl\state.json`) with a normalized blocked_artifact
+  // (`.mpl/state.json`) would be classified as state but reported as
+  // `registered_blocking_other_artifact` — the active blocker hidden
+  // from the trace. Apply the same `\` → `/` normalization before
+  // comparison so the boundary check is path-shape-agnostic.
+  const artifact = String(state.blocked_artifact || '').trim().replace(/\\/g, '/');
+  const target = String(targetPath || '').trim().replace(/\\/g, '/');
   if (!target) {
     return 'invalid_blocked_envelope';
   }

--- a/hooks/lib/mpl-hook-trace.mjs
+++ b/hooks/lib/mpl-hook-trace.mjs
@@ -187,23 +187,22 @@ function endsWithSegment(path, segment) {
   return path.endsWith('/' + segment);
 }
 
-// Conservative Windows-shape detection. Returns the input normalized
-// to forward slashes ONLY when the input is structurally Windows
-// (drive letter, UNC, or pure-backslash). Mixed `/\` paths and
-// POSIX paths with literal backslash in filenames are left alone.
+// Codex r5 on PR #243: narrow Windows-shape detection to ONLY
+// unambiguous Windows path forms — drive letter (`C:\...`) and UNC
+// (`\\server\share`). Pure-backslash relative strings like
+// `foo\state.json` are NOT classified as Windows: on POSIX,
+// backslash is a legal filename character and the input is a single
+// basename, not a separated path. Mixed `/\` paths already preserve
+// POSIX semantics. Drop the pure-backslash branch because the
+// runtime cannot disambiguate "Windows path" from "POSIX literal
+// filename" without an explicit context flag.
 function normalizeWindowsPath(p) {
   if (typeof p !== 'string' || !p) return p;
-  const hasBackslash = p.includes('\\');
-  if (!hasBackslash) return p;
-  const hasForward = p.includes('/');
+  if (!p.includes('\\')) return p;
   // Drive letter prefix (e.g. `C:\`, `c:\`, or `c:/`).
   if (/^[A-Za-z]:[/\\]/.test(p)) return p.replace(/\\/g, '/');
   // UNC prefix (`\\server\share`).
   if (p.startsWith('\\\\')) return p.replace(/\\/g, '/');
-  // Pure-backslash separators (no `/` anywhere).
-  if (!hasForward) return p.replace(/\\/g, '/');
-  // Mixed `/\` — treat backslash as a literal filename character
-  // (POSIX-correct behavior).
   return p;
 }
 

--- a/hooks/lib/mpl-hook-trace.mjs
+++ b/hooks/lib/mpl-hook-trace.mjs
@@ -175,12 +175,22 @@ function matcherIncludes(matcher, tools) {
   });
 }
 
+// Codex r2 on PR #243 [logic]: pathCategory must require a slash
+// boundary on the suffix match. Without it, `src/foo.mpl/state.json`
+// — a regular file in a directory called `foo.mpl` — would be
+// miscategorized as the canonical state path, and the same applies
+// to `foo.mpl/mpl/decomposition.yaml` vs the canonical decomposition
+// path. The state/decomposition focus filters then hide the legitimate
+// file hooks for these targets.
+function endsWithSegment(path, segment) {
+  if (path === segment) return true;
+  return path.endsWith('/' + segment);
+}
+
 function pathCategory(targetPath) {
   const normalized = String(targetPath || '').replace(/\\/g, '/');
-  if (normalized.endsWith(DECOMPOSITION_PATH) || normalized === DECOMPOSITION_PATH) {
-    return 'decomposition';
-  }
-  if (normalized.endsWith('.mpl/state.json')) return 'state';
+  if (endsWithSegment(normalized, DECOMPOSITION_PATH)) return 'decomposition';
+  if (endsWithSegment(normalized, '.mpl/state.json')) return 'state';
   return 'file';
 }
 

--- a/hooks/lib/mpl-hook-trace.mjs
+++ b/hooks/lib/mpl-hook-trace.mjs
@@ -187,8 +187,28 @@ function endsWithSegment(path, segment) {
   return path.endsWith('/' + segment);
 }
 
+// Conservative Windows-shape detection. Returns the input normalized
+// to forward slashes ONLY when the input is structurally Windows
+// (drive letter, UNC, or pure-backslash). Mixed `/\` paths and
+// POSIX paths with literal backslash in filenames are left alone.
+function normalizeWindowsPath(p) {
+  if (typeof p !== 'string' || !p) return p;
+  const hasBackslash = p.includes('\\');
+  if (!hasBackslash) return p;
+  const hasForward = p.includes('/');
+  // Drive letter prefix (e.g. `C:\`, `c:\`, or `c:/`).
+  if (/^[A-Za-z]:[/\\]/.test(p)) return p.replace(/\\/g, '/');
+  // UNC prefix (`\\server\share`).
+  if (p.startsWith('\\\\')) return p.replace(/\\/g, '/');
+  // Pure-backslash separators (no `/` anywhere).
+  if (!hasForward) return p.replace(/\\/g, '/');
+  // Mixed `/\` — treat backslash as a literal filename character
+  // (POSIX-correct behavior).
+  return p;
+}
+
 function pathCategory(targetPath) {
-  const normalized = String(targetPath || '').replace(/\\/g, '/');
+  const normalized = normalizeWindowsPath(String(targetPath || ''));
   if (endsWithSegment(normalized, DECOMPOSITION_PATH)) return 'decomposition';
   if (endsWithSegment(normalized, '.mpl/state.json')) return 'state';
   return 'file';
@@ -235,15 +255,20 @@ function blockStatusFor(hookId, state, targetPath) {
   if (missing.length > 0) {
     return 'invalid_blocked_envelope';
   }
-  // Codex r3 on PR #243: pathCategory normalizes backslash to forward
-  // slash but blockStatusFor compared raw strings, so a Windows-style
-  // target (`C:\repo\.mpl\state.json`) with a normalized blocked_artifact
-  // (`.mpl/state.json`) would be classified as state but reported as
-  // `registered_blocking_other_artifact` — the active blocker hidden
-  // from the trace. Apply the same `\` → `/` normalization before
-  // comparison so the boundary check is path-shape-agnostic.
-  const artifact = String(state.blocked_artifact || '').trim().replace(/\\/g, '/');
-  const target = String(targetPath || '').trim().replace(/\\/g, '/');
+  // Codex r3/r4 on PR #243: balance two concrete edge cases:
+  //   r3 — `C:\repo\.mpl\state.json` (Windows-style) target should
+  //        match `.mpl/state.json` artifact (active blocker visible).
+  //   r4 — `src/foo\state.json` on POSIX is a single filename
+  //        `foo\state.json`; unconditional `\` → `/` would fabricate
+  //        a path boundary and falsely match a `state.json` artifact.
+  //
+  // Conservative narrowing: only normalize when the input is
+  // structurally Windows-shaped — drive-letter prefix, UNC prefix,
+  // OR pure-backslash with no forward slashes. Mixed `/\` paths and
+  // bare-backslash-in-segment leave the raw comparison alone, which
+  // preserves the r4 POSIX semantics.
+  const artifact = normalizeWindowsPath(String(state.blocked_artifact || '').trim());
+  const target = normalizeWindowsPath(String(targetPath || '').trim());
   if (!target) {
     return 'invalid_blocked_envelope';
   }

--- a/hooks/lib/mpl-hook-trace.mjs
+++ b/hooks/lib/mpl-hook-trace.mjs
@@ -94,11 +94,16 @@ const DECOMPOSITION_FOCUS = new Set([
   'mpl-require-test-agent',
 ]);
 
-// #237 D3: hooks that read state.json fields. A trace of
-// `.mpl/state.json` should narrow to these instead of including every
-// Edit/Write hook (most of which never touch state). Hooks not in the
-// set still appear when there's an active blocker or when the matcher
-// hits the queried tool.
+// #237 D3 (+ codex r1 on PR #243): hooks that read state.json fields.
+// A trace of `.mpl/state.json` should narrow to these instead of
+// including every Edit/Write hook (most of which never touch state).
+// Hooks not in the set still appear when there's an active blocker.
+//
+// Codex r1: STATE_FOCUS membership is evaluated INDEPENDENTLY of the
+// hook's matcher — what matters is whether the hook reads state, not
+// whether it fires on file-write tools. The earlier matcher-gated
+// check dropped `mpl-gate-recorder` (PostToolUse on Bash|Task|Agent)
+// and other non-file-write state readers from state traces.
 const STATE_FOCUS = new Set([
   'mpl-state-invariant',
   'mpl-phase-controller',
@@ -114,6 +119,10 @@ const STATE_FOCUS = new Set([
   'mpl-require-decomposition-delta',
   'mpl-decomposition-postprocess',
   'mpl-require-test-agent-brief',
+  // Codex r1: reads state.e2e_results before blocking finalize_done=true.
+  'mpl-require-e2e',
+  // Codex r1: reads state.e2e_results / state.security_results for authenticity check.
+  'mpl-require-e2e-authenticity',
 ]);
 
 function readHooksConfig(pluginRoot = DEFAULT_PLUGIN_ROOT) {
@@ -177,28 +186,28 @@ function pathCategory(targetPath) {
 
 function shouldIncludeHook({ eventName, matcher, hookId, category }) {
   const fileWriteTools = ['Edit', 'Write', 'MultiEdit'];
+  // #237 D3 + codex r1 on PR #243: for state category, STATE_FOCUS
+  // membership is evaluated FIRST and INDEPENDENTLY of the matcher.
+  // A hook that reads state must appear regardless of whether its
+  // matcher fires on file-write tools, Bash, or Task. Hooks outside
+  // the focus list are filtered out even if their matcher would
+  // otherwise admit them — that's the whole point of the focus.
+  if (category === 'state') {
+    if (eventName === 'Stop') return true;
+    return STATE_FOCUS.has(hookId);
+  }
   if (eventName === 'PreToolUse') {
-    // #237 D3: state-category trace narrows file-write PreToolUse hooks
-    // to the ones that actually read state. The decomposition branch
-    // already had its own focus filter.
-    if (category === 'state' && matcherIncludes(matcher, fileWriteTools)) {
-      return STATE_FOCUS.has(hookId);
-    }
     if (matcherIncludes(matcher, fileWriteTools)) return true;
     if (category === 'decomposition' && matcherIncludes(matcher, ['Task', 'Agent'])) return true;
     return !matcher;
   }
   if (eventName === 'PostToolUse') {
-    if (category === 'state' && matcherIncludes(matcher, fileWriteTools)) {
-      return STATE_FOCUS.has(hookId);
-    }
     if (matcherIncludes(matcher, fileWriteTools)) return true;
     if (category === 'decomposition' && matcherIncludes(matcher, ['Task', 'Agent'])) return true;
     return !matcher;
   }
   if (eventName === 'Stop') return true;
   if (category === 'decomposition') return DECOMPOSITION_FOCUS.has(hookId);
-  if (category === 'state') return STATE_FOCUS.has(hookId);
   return false;
 }
 

--- a/hooks/lib/mpl-hook-trace.mjs
+++ b/hooks/lib/mpl-hook-trace.mjs
@@ -78,6 +78,9 @@ const PURPOSES = {
   'mpl-compaction-tracker': 'compaction telemetry',
   'mpl-session-init': 'session initialization',
   'mpl-keyword-detector': 'MPL keyword/slash command detection',
+  // #237 D1: hooks added after the original map was authored. Verified
+  // by comparing hooks.json registered ids against PURPOSES keys.
+  'mpl-require-test-agent-brief': 'test-agent brief validation gate (PreToolUse on Task)',
 };
 
 const DECOMPOSITION_PATH = '.mpl/mpl/decomposition.yaml';
@@ -91,9 +94,48 @@ const DECOMPOSITION_FOCUS = new Set([
   'mpl-require-test-agent',
 ]);
 
+// #237 D3: hooks that read state.json fields. A trace of
+// `.mpl/state.json` should narrow to these instead of including every
+// Edit/Write hook (most of which never touch state). Hooks not in the
+// set still appear when there's an active blocker or when the matcher
+// hits the queried tool.
+const STATE_FOCUS = new Set([
+  'mpl-state-invariant',
+  'mpl-phase-controller',
+  'mpl-gate-recorder',
+  'mpl-tool-tracker',
+  'mpl-context-monitor',
+  'mpl-require-test-agent',
+  'mpl-require-finalize-artifacts',
+  'mpl-require-completed-phase-immutability',
+  'mpl-require-phase-evidence',
+  'mpl-require-whole-goal-closure',
+  'mpl-baseline-guard',
+  'mpl-require-decomposition-delta',
+  'mpl-decomposition-postprocess',
+  'mpl-require-test-agent-brief',
+]);
+
 function readHooksConfig(pluginRoot = DEFAULT_PLUGIN_ROOT) {
   const path = join(pluginRoot, 'hooks', 'hooks.json');
   return JSON.parse(readFileSync(path, 'utf-8'));
+}
+
+// #237 D1: regression hook so tests can audit PURPOSES against the
+// live hooks.json registry. Returns the list of hook ids registered
+// in hooks.json that are missing from the PURPOSES map. An empty
+// array means every registered hook has a concrete label.
+export function findPurposeGaps(pluginRoot = DEFAULT_PLUGIN_ROOT) {
+  const config = readHooksConfig(pluginRoot);
+  const registered = new Set();
+  for (const regs of Object.values(config.hooks || {})) {
+    for (const r of regs || []) {
+      for (const h of r.hooks || []) {
+        registered.add(hookIdFromCommand(h.command));
+      }
+    }
+  }
+  return [...registered].filter((id) => !(id in PURPOSES)).sort();
 }
 
 function hookIdFromCommand(command) {
@@ -136,17 +178,27 @@ function pathCategory(targetPath) {
 function shouldIncludeHook({ eventName, matcher, hookId, category }) {
   const fileWriteTools = ['Edit', 'Write', 'MultiEdit'];
   if (eventName === 'PreToolUse') {
+    // #237 D3: state-category trace narrows file-write PreToolUse hooks
+    // to the ones that actually read state. The decomposition branch
+    // already had its own focus filter.
+    if (category === 'state' && matcherIncludes(matcher, fileWriteTools)) {
+      return STATE_FOCUS.has(hookId);
+    }
     if (matcherIncludes(matcher, fileWriteTools)) return true;
     if (category === 'decomposition' && matcherIncludes(matcher, ['Task', 'Agent'])) return true;
     return !matcher;
   }
   if (eventName === 'PostToolUse') {
+    if (category === 'state' && matcherIncludes(matcher, fileWriteTools)) {
+      return STATE_FOCUS.has(hookId);
+    }
     if (matcherIncludes(matcher, fileWriteTools)) return true;
     if (category === 'decomposition' && matcherIncludes(matcher, ['Task', 'Agent'])) return true;
     return !matcher;
   }
   if (eventName === 'Stop') return true;
   if (category === 'decomposition') return DECOMPOSITION_FOCUS.has(hookId);
+  if (category === 'state') return STATE_FOCUS.has(hookId);
   return false;
 }
 
@@ -169,7 +221,15 @@ function blockStatusFor(hookId, state, targetPath) {
   if (!target) {
     return 'invalid_blocked_envelope';
   }
-  if (artifact === target || target.endsWith(artifact) || artifact.endsWith(target)) {
+  // #237 D2: slash-boundary match. Bidirectional endsWith without a
+  // boundary was overly permissive — target `foo.yaml` matched stored
+  // artifact `barfoo.yaml` and vice versa. Now either exact match OR
+  // suffix match where the boundary is a `/` separator.
+  if (
+    artifact === target ||
+    (artifact && target.endsWith('/' + artifact)) ||
+    (target && artifact.endsWith('/' + target))
+  ) {
     return 'currently_blocking';
   }
   return 'registered_blocking_other_artifact';


### PR DESCRIPTION
## Summary

Closes #237. Three small diagnostic fixes to `hooks/lib/mpl-hook-trace.mjs`.

- **D1** — `mpl-require-test-agent-brief` (added in PR #225 / #226) was missing from PURPOSES, so trace rendered it as default "registered hook". Added entry + new `findPurposeGaps()` export + regression test so the map can't drift again.
- **D2** — bidirectional `endsWith` artifact match was overly permissive (`foo.yaml` matched `barfoo.yaml`). Tightened to require a `/` boundary in the suffix match.
- **D3** — `pathCategory === 'state'` was computed but never differentiated from `'file'` in `shouldIncludeHook`. New `STATE_FOCUS` set narrows state-target traces to hooks that actually read state fields; active blocker is still force-included regardless of focus (#217 preserved).

## Why

Per `docs/findings/2026-05-28-prompt-gate-restore-divergence.md` §D — these are degraded operator UX issues. Each in isolation is small, but together they erode confidence in trace output when debugging a blocked run.

## Test plan

- [x] `node --test hooks/__tests__/mpl-hook-trace.test.mjs` — 17/17 pass, includes 5 new #237 tests:
  - D1: every registered hook id has a PURPOSES entry
  - D2: suffix match without `/` boundary is rejected
  - D2: suffix match with `/` boundary is accepted
  - D3: state-category trace narrows to STATE_FOCUS members
  - D3: non-state category preserves broader hook set
- [x] Full hook suite — 1326/1326 pass.

## Non-Goal

- `mpl-recover` routing — separate issue (#234, MERGED in #242).
- Hand-rolled `block(reason)` cleanup — separate issue (#235).

🤖 Generated with [Claude Code](https://claude.com/claude-code)