### PR TITLE
Tighten mpl-write-guard for protected paths (#236 A1 + A3)

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -456,7 +456,7 @@ All Discoveries are recorded in `.mpl/discoveries.md`.
 |----|--------|------|------------|
 | `mpl-compaction-tracker` | PreCompact | Track compaction events and create checkpoints (F-31). | v0.13.x baseline |
 | `mpl-auto-permit` | PreToolUse | Apply learned safe permission decisions (F-34). | v0.13.x baseline |
-| `mpl-write-guard` | PreToolUse: Edit/Write/MultiEdit/Bash | Warn or block unsafe direct source edits and dangerous shell commands while MPL is active. | v0.13.x baseline; MultiEdit/MCP hardening v0.18.1 |
+| `mpl-write-guard` | PreToolUse: Edit/Write/MultiEdit/Bash/Task/Agent | Warn or block unsafe direct source edits and dangerous shell commands; #236: protect mpl-cancel SKILL paths from `rm -rf` and require mpl-decomposer subagent identity for decomposition.yaml writes. | v0.13.x baseline; MultiEdit/MCP hardening v0.18.1; protected-path + decomposition-writer v0.18.5 |
 | `mpl-bash-timeout` | PreToolUse: Bash | Enforce timeout budgets on build, lint, test, and verification commands. | v0.18.1 |
 | `mpl-state-invariant` | PreToolUse: Task/Agent/Edit/Write/MultiEdit; Stop | Validate state schema, gate evidence, pause/block status, and completion invariants before state can drift. | v0.18.1; I10/I11 recovery v0.18.4 |
 | `mpl-require-e2e` | PreToolUse: Edit/Write/MultiEdit | Block finalize when required E2E scenarios or UC coverage are missing, failing, or explicitly uncovered. | v0.15.2; UC coverage v0.16.0 |

--- a/hooks/__tests__/mpl-issue-236-write-guard-tighten.test.mjs
+++ b/hooks/__tests__/mpl-issue-236-write-guard-tighten.test.mjs
@@ -476,6 +476,60 @@ test('#236 A1 claude r14 [security]: decomposition.yaml writer-identity check ru
   }
 });
 
+test('#236 A1 codex r20 [security]: Bash state.json forgery while MPL deactivated is blocked', () => {
+  // Codex r20: pre-r20 the Bash state.json guard ran AFTER isMplActive.
+  // In an inactive workspace (current_phase=completed) a Bash redirect
+  // could plant a forged decomposer_dispatch. Fix: move the Bash
+  // state.json guard BEFORE the isMplActive short-circuit, same shape
+  // as the r13 Write/Edit guard.
+  const cwd = freshWorkspace();
+  try {
+    writeFileSync(
+      join(cwd, '.mpl', 'state.json'),
+      JSON.stringify({ current_phase: 'completed' }),
+    );
+    const decision = runHook(cwd, {
+      cwd,
+      tool_name: 'Bash',
+      tool_input: { command: 'printf forged > .mpl/state.json' },
+    });
+    assert.equal(decision.decision, 'block');
+    assert.match(decision.reason, /decomposer_dispatch|state\.json/);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('#236 A1 claude r20 [security]: filePath POSIX-normalize before protected-file regex', () => {
+  // Claude r20: `.mpl//mpl/decomposition.yaml`, `.mpl/./state.json`,
+  // and other path-redundancy forms bypassed the regex which required
+  // single slashes. Fix: posix.normalize the file_path before each
+  // DECOMPOSITION_FILE_REGEX / STATE_FILE_REGEX test.
+  const cwd = freshWorkspace();
+  try {
+    for (const filePath of [
+      '.mpl//mpl/decomposition.yaml',
+      '.mpl/./mpl/decomposition.yaml',
+      '.mpl//state.json',
+      '.mpl/./state.json',
+      '.mpl/foo/../mpl/decomposition.yaml',
+    ]) {
+      const decision = runHook(cwd, {
+        cwd,
+        tool_name: 'Write',
+        tool_input: { file_path: filePath, content: 'forged' },
+      });
+      assert.equal(
+        decision.decision,
+        'block',
+        `expected path-normalize block for: ${filePath}`,
+      );
+    }
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
 test('#236 A1 codex r19 [security]: pipeline writer downstream of safe-read head is blocked', () => {
   // Codex r19: `printf forged | sponge .mpl/mpl/decomposition.yaml`
   // has a safe-read head (`printf`) but a downstream writer (`sponge`)

--- a/hooks/__tests__/mpl-issue-236-write-guard-tighten.test.mjs
+++ b/hooks/__tests__/mpl-issue-236-write-guard-tighten.test.mjs
@@ -400,6 +400,54 @@ test('#236 A3 claude r2 [security]: ancestors of protected roots are blocked too
   }
 });
 
+test('#236 A1 claude r13 [security]: 2-step deactivation chain via Write/Edit is blocked', () => {
+  // Claude r13: an attacker can flip current_phase to 'completed'
+  // via a benign-looking Write/Edit (no forbidden field), then once
+  // isMplActive returns false the next Write of forged dispatch
+  // fields short-circuits the hook. The structural fix is to refuse
+  // ANY Write/Edit to .mpl/state.json BEFORE the isMplActive
+  // short-circuit, regardless of payload.
+  const cwd = freshWorkspace();
+  try {
+    // Step 1: deactivation Write — must block now.
+    const deactivate = runHook(cwd, {
+      cwd,
+      tool_name: 'Write',
+      tool_input: {
+        file_path: '.mpl/state.json',
+        content: JSON.stringify({ current_phase: 'completed' }),
+      },
+    });
+    assert.equal(deactivate.decision, 'block',
+      'deactivation Write to state.json must block');
+
+    // Even simpler write: blocked too.
+    const plain = runHook(cwd, {
+      cwd,
+      tool_name: 'Write',
+      tool_input: {
+        file_path: '.mpl/state.json',
+        content: JSON.stringify({ current_phase: 'phase-2' }),
+      },
+    });
+    assert.equal(plain.decision, 'block');
+
+    // Edit form blocked too.
+    const edit = runHook(cwd, {
+      cwd,
+      tool_name: 'Edit',
+      tool_input: {
+        file_path: '.mpl/state.json',
+        old_string: 'phase-1',
+        new_string: 'phase-2',
+      },
+    });
+    assert.equal(edit.decision, 'block');
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
 test('#236 A1 codex r13 [security]: ANY Bash write to .mpl/state.json is blocked (base64/heredoc/etc. forgery)', () => {
   // Codex r13: a literal-keyword check (decomposer_dispatch /
   // first_transcript_seen) can't catch base64-decoded payloads. The
@@ -740,16 +788,10 @@ test('#236 A1 claude r9 [security]: planting decomposer_dispatch via Write/Edit 
     });
     assert.equal(editDecision.decision, 'block');
 
-    // Sanity: writing OTHER state fields still works.
-    const plainState = runHook(cwd, {
-      cwd,
-      tool_name: 'Write',
-      tool_input: {
-        file_path: '.mpl/state.json',
-        content: JSON.stringify({ current_phase: 'phase-2' }),
-      },
-    });
-    assert.notEqual(plainState.decision, 'block');
+    // r13 structural change: ANY Write/Edit to .mpl/state.json now
+    // blocks. The "benign" sanity case is inverted per the r13
+    // contract (state writes go through writeState() / mpl_state_write,
+    // not direct Write/Edit tool).
   } finally {
     rmSync(cwd, { recursive: true, force: true });
   }

--- a/hooks/__tests__/mpl-issue-236-write-guard-tighten.test.mjs
+++ b/hooks/__tests__/mpl-issue-236-write-guard-tighten.test.mjs
@@ -476,6 +476,45 @@ test('#236 A1 claude r14 [security]: decomposition.yaml writer-identity check ru
   }
 });
 
+test('#236 A1 codex r16 [security]: Bash writes to decomposition.yaml gated BEFORE isMplActive', () => {
+  // Codex r16: the pre-isMplActive Write/Edit guard for
+  // decomposition.yaml didn't cover Bash. With MPL deactivated,
+  // `printf forged > .mpl/mpl/decomposition.yaml` slipped past.
+  const cwd = freshWorkspace();
+  try {
+    writeFileSync(
+      join(cwd, '.mpl', 'state.json'),
+      JSON.stringify({ current_phase: 'completed' }),
+    );
+    for (const command of [
+      'printf forged > .mpl/mpl/decomposition.yaml',
+      'echo forged | tee .mpl/mpl/decomposition.yaml',
+      'dd if=/tmp/forged of=.mpl/mpl/decomposition.yaml',
+      'install -m 0644 /tmp/forged .mpl/mpl/decomposition.yaml',
+    ]) {
+      const decision = runHook(cwd, {
+        cwd,
+        tool_name: 'Bash',
+        tool_input: { command },
+      });
+      assert.equal(
+        decision.decision,
+        'block',
+        `expected Bash decomposition.yaml write block for: ${command}`,
+      );
+    }
+    // Sanity: read-only ops on decomposition.yaml still pass.
+    const read = runHook(cwd, {
+      cwd,
+      tool_name: 'Bash',
+      tool_input: { command: 'cat .mpl/mpl/decomposition.yaml' },
+    });
+    assert.notEqual(read.decision, 'block');
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
 test('#236 A1 codex r15 [security]: find -exec writing state.json is blocked (find removed from safe-read)', () => {
   // Codex r15: `find` was in SAFE_READ_HEADS but `-exec sh -c '… > $1'`
   // bypassed the static regex check (target was a runtime-substituted

--- a/hooks/__tests__/mpl-issue-236-write-guard-tighten.test.mjs
+++ b/hooks/__tests__/mpl-issue-236-write-guard-tighten.test.mjs
@@ -476,6 +476,43 @@ test('#236 A1 claude r14 [security]: decomposition.yaml writer-identity check ru
   }
 });
 
+test('#236 A1 codex r19 [security]: pipeline writer downstream of safe-read head is blocked', () => {
+  // Codex r19: `printf forged | sponge .mpl/mpl/decomposition.yaml`
+  // has a safe-read head (`printf`) but a downstream writer (`sponge`)
+  // that overwrites the protected file. Pre-fix the head-only check
+  // missed this. Fix: split on `|`/`;`/`&` and require EVERY pipeline
+  // segment's head verb to be in SAFE_READS.
+  const cwd = freshWorkspace();
+  try {
+    for (const command of [
+      'printf forged | sponge .mpl/mpl/decomposition.yaml',
+      'printf forged | sponge .mpl/state.json',
+      'cat /tmp/forged | install -m 0644 /dev/stdin .mpl/mpl/decomposition.yaml',
+      'echo forged | perl -pi -e0 .mpl/state.json',
+    ]) {
+      const decision = runHook(cwd, {
+        cwd,
+        tool_name: 'Bash',
+        tool_input: { command },
+      });
+      assert.equal(
+        decision.decision,
+        'block',
+        `expected pipeline-writer block for: ${command}`,
+      );
+    }
+    // Sanity: all-safe-read pipeline still passes.
+    const allSafe = runHook(cwd, {
+      cwd,
+      tool_name: 'Bash',
+      tool_input: { command: 'cat .mpl/state.json | grep phase | wc -l' },
+    });
+    assert.notEqual(allSafe.decision, 'block');
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
 test('#236 A1 claude r18 [security]: multi-statement / multi-redirect symlink bypass is closed', () => {
   // Claude r18: r17's single-shot .match() only checked the FIRST
   // redirect target. A multi-statement command with a benign first

--- a/hooks/__tests__/mpl-issue-236-write-guard-tighten.test.mjs
+++ b/hooks/__tests__/mpl-issue-236-write-guard-tighten.test.mjs
@@ -400,6 +400,93 @@ test('#236 A3 claude r2 [security]: ancestors of protected roots are blocked too
   }
 });
 
+test('#236 A3 codex r7 [data-integrity]: parameter-expansion `${var}` after same-line assignment is blocked', () => {
+  // Codex r7: `p=.mpl; rm -rf ${p}/mpl` reaches the shell as
+  // `rm -rf .mpl/mpl`. Pre-fix the tokenizer saw `${p}/mpl` and
+  // couldn't resolve. Fix substitutes simple `name=value`
+  // assignments collected from the same command line.
+  const cwd = freshWorkspace();
+  try {
+    for (const command of [
+      'p=.mpl; rm -rf ${p}/mpl',
+      'p=docs; rm -rf ${p}/learnings',
+      'p=.mpl; rm -rf $p/mpl',
+      'export p=.mpl && rm -rf "${p}/contracts"',
+    ]) {
+      const decision = runHook(cwd, {
+        cwd,
+        tool_name: 'Bash',
+        tool_input: { command },
+      });
+      assert.equal(
+        decision.decision,
+        'block',
+        `expected parameter-expansion block for: ${command}`,
+      );
+    }
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('#236 A3 claude r7 [data-integrity]: non-rm destructive ops are blocked too', () => {
+  // Claude r7: the mpl-cancel SKILL forbids "deleting" protected paths
+  // — `mv`-away, `>`-truncate, `shred`, `unlink`, `cp /dev/null`,
+  // `truncate -s 0` are all forms of deletion the hook is supposed to
+  // gate. Pre-fix entry gate was rm/find -delete only.
+  const cwd = freshWorkspace();
+  try {
+    for (const command of [
+      'mv .mpl/mpl /tmp/stolen',
+      '> .mpl/mpl/decomposition.yaml',
+      '>> .mpl/mpl/log',
+      'shred -u .mpl/mpl/decomposition.yaml',
+      'unlink .mpl/mpl/decomposition.yaml',
+      'cp /dev/null .mpl/mpl/decomposition.yaml',
+      'truncate -s 0 .mpl/mpl/decomposition.yaml',
+      'echo hello > .mpl/contracts/foo',
+    ]) {
+      const decision = runHook(cwd, {
+        cwd,
+        tool_name: 'Bash',
+        tool_input: { command },
+      });
+      assert.equal(
+        decision.decision,
+        'block',
+        `expected non-rm destructive block for: ${command}`,
+      );
+    }
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('#236 A3: non-destructive read operations against protected paths still pass', () => {
+  const cwd = freshWorkspace();
+  try {
+    for (const command of [
+      'ls .mpl/mpl/',
+      'cat .mpl/mpl/decomposition.yaml',
+      'grep -r foo .mpl/mpl/',
+      'find .mpl/mpl -type f',
+    ]) {
+      const decision = runHook(cwd, {
+        cwd,
+        tool_name: 'Bash',
+        tool_input: { command },
+      });
+      assert.notEqual(
+        decision.decision,
+        'block',
+        `read-only op should not be blocked: ${command}`,
+      );
+    }
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
 test('#236 A3 codex r6 [data-integrity]: glob-expansion operands are blocked when they can match protected roots', () => {
   // Codex r6: `rm -rf .mpl/m*` expands to `.mpl/mpl .mpl/memory` in
   // real bash. Glob meta (`*`, `?`, `[…]`) in the token wasn't

--- a/hooks/__tests__/mpl-issue-236-write-guard-tighten.test.mjs
+++ b/hooks/__tests__/mpl-issue-236-write-guard-tighten.test.mjs
@@ -590,6 +590,45 @@ test('#236 A3 claude r25 [security]: gzip per-segment scan — later -k does not
   }
 });
 
+test('#236 A3 codex r27 [data-integrity]: quote/backslash-concat destructive VERB tokens still trip the gate', () => {
+  // Codex r27: before the fix, `isDestructive` matched `\brm\b` /
+  // `\bgzip\b` on the partially-stripped command (only sudo/time/nice/
+  // env removed). Quote- and backslash-fragmented verbs (`r"m"`,
+  // `g"zip"`, `g\zip`) bypassed the gate because the literal token
+  // wasn't present until after the inline quote/backslash normalization
+  // that ran LATER in matchesProtectedDelete. Fix: hoist the full
+  // `normalizeShellCommand` call to the top of matchesProtectedDelete
+  // so the destructive-verb regexes see the shell-equivalent form.
+  const cwd = freshWorkspace();
+  try {
+    writeFileSync(join(cwd, '.mpl', 'mpl', 'foo'), 'data');
+    for (const command of [
+      'r"m" -rf .mpl/mpl',
+      'r""m -rf .mpl/mpl',
+      "r'm' -rf .mpl/mpl",
+      'r\\m -rf .mpl/mpl',
+      'g"zip" .mpl/mpl/foo',
+      'g\\zip .mpl/mpl/foo',
+      'g""zip .mpl/mpl/foo',
+      'sh"red" -u .mpl/mpl/foo',
+      't"e"e .mpl/mpl/foo > /dev/null',
+    ]) {
+      const decision = runHook(cwd, {
+        cwd,
+        tool_name: 'Bash',
+        tool_input: { command },
+      });
+      assert.equal(
+        decision.decision,
+        'block',
+        `expected codex r27 verb-concat block for: ${command}`,
+      );
+    }
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
 test('#236 A3 codex r26 [security]: -k / --keep AFTER `--` is a filename, not a flag', () => {
   // Codex r26: `gzip -- .mpl/mpl/-k`. The pre-fix per-segment regex saw
   // `-k` anywhere in the segment and incorrectly suppressed

--- a/hooks/__tests__/mpl-issue-236-write-guard-tighten.test.mjs
+++ b/hooks/__tests__/mpl-issue-236-write-guard-tighten.test.mjs
@@ -92,14 +92,21 @@ test('#236 A1: orchestrator direct Edit of decomposition.yaml is blocked', () =>
   }
 });
 
-test('#236 A1: Write of decomposition.yaml after mpl-decomposer dispatch is allowed', () => {
+test('#236 A1: Write from a DIFFERENT transcript than the dispatcher is allowed within TTL', () => {
+  // Codex r1 retry fix: dispatch records the orchestrator's
+  // transcript_path; only writes from a DIFFERENT transcript (the
+  // subagent's) pass identity.
   const cwd = freshWorkspace();
   try {
-    // Step 1: orchestrator dispatches Agent(subagent_type='mpl-decomposer').
-    // Write-guard records state.decomposer_dispatch.
+    const orchestratorTranscript = '/tmp/transcript-orchestrator.jsonl';
+    const subagentTranscript = '/tmp/transcript-decomposer.jsonl';
+
+    // Step 1: orchestrator dispatches Agent. Hook pins orchestrator's
+    // transcript_path in state.
     const dispatchDecision = runHook(cwd, {
       cwd,
       tool_name: 'Task',
+      transcript_path: orchestratorTranscript,
       tool_input: {
         subagent_type: 'mpl-decomposer',
         prompt: 'Decompose ...',
@@ -109,18 +116,72 @@ test('#236 A1: Write of decomposition.yaml after mpl-decomposer dispatch is allo
     const dispatchState = readState(cwd);
     assert.ok(dispatchState.decomposer_dispatch, 'expected decomposer_dispatch flag');
     assert.equal(typeof dispatchState.decomposer_dispatch.dispatched_at, 'string');
+    assert.equal(
+      dispatchState.decomposer_dispatch.parent_transcript_path,
+      orchestratorTranscript,
+    );
 
-    // Step 2: subagent writes decomposition.yaml — allowed.
-    const writeDecision = runHook(cwd, {
+    // Step 2a: SUBAGENT writes decomposition.yaml from its OWN
+    // transcript — allowed.
+    const subagentWrite = runHook(cwd, {
       cwd,
       tool_name: 'Write',
+      transcript_path: subagentTranscript,
       tool_input: {
         file_path: '.mpl/mpl/decomposition.yaml',
         content: 'phases: []\ngenerated_by: mpl-decomposer\n',
       },
     });
-    assert.equal(writeDecision.continue, true);
-    assert.equal(writeDecision.suppressOutput, true);
+    assert.equal(subagentWrite.continue, true);
+    assert.equal(subagentWrite.suppressOutput, true);
+
+    // Step 2b: ORCHESTRATOR writes the same file from the SAME
+    // transcript as the dispatcher — codex r1 retry repro shape.
+    // Must still block: the dispatch flag is a capability for the
+    // SUBAGENT, not an ambient unlock.
+    const orchestratorWrite = runHook(cwd, {
+      cwd,
+      tool_name: 'Write',
+      transcript_path: orchestratorTranscript,
+      tool_input: {
+        file_path: '.mpl/mpl/decomposition.yaml',
+        content: 'phases: []\ngenerated_by: forged\n',
+      },
+    });
+    assert.equal(orchestratorWrite.continue, false);
+    assert.equal(orchestratorWrite.decision, 'block');
+    assert.match(orchestratorWrite.reason, /#236 A1/);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('#236 A1: legacy dispatch flag without parent_transcript_path is rejected (fail-closed)', () => {
+  const cwd = freshWorkspace();
+  try {
+    // Pre-fill state with a time-only dispatch (no parent_transcript_path).
+    writeFileSync(
+      join(cwd, '.mpl', 'state.json'),
+      JSON.stringify(
+        {
+          current_phase: 'phase-1',
+          decomposer_dispatch: { dispatched_at: new Date().toISOString() },
+        },
+        null,
+        2,
+      ),
+    );
+    const decision = runHook(cwd, {
+      cwd,
+      tool_name: 'Write',
+      transcript_path: '/tmp/subagent.jsonl',
+      tool_input: { file_path: '.mpl/mpl/decomposition.yaml', content: 'x' },
+    });
+    assert.equal(
+      decision.decision,
+      'block',
+      'legacy time-only dispatch without parent_transcript_path must be rejected',
+    );
   } finally {
     rmSync(cwd, { recursive: true, force: true });
   }
@@ -266,6 +327,71 @@ test('#236 A3: rm targeting node_modules (safe-cleanup) still passes silently', 
     });
     assert.equal(decision.continue, true);
     assert.equal(decision.suppressOutput, true);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('#236 A3 claude r1: shell-expansion / subshell / pushd bypass forms are all blocked', () => {
+  // Concrete repros from claude r1 [logic]. Defense-in-depth: a
+  // substring match covers expansion forms (`$PWD`, `$(pwd)`) and
+  // variable operands; widened tokenization covers parenthesized
+  // subshells and pushd splits.
+  const cwd = freshWorkspace();
+  try {
+    // The substring check + widened tokenization covers shell-expansion,
+    // subshell, and variable-operand forms. `pushd <target> && rm -rf <rel>`
+    // is a working-directory-change pattern the hook cannot fully resolve
+    // without a shell parser — operators using that form should rely on
+    // the dangerous-bash warning and the MPL_FORCE_PURGE escape hatch.
+    const bypasses = [
+      'rm -rf $PWD/.mpl/mpl',
+      'rm -rf "$PWD/.mpl/mpl"',
+      'rm -rf $(pwd)/.mpl/mpl',
+      '(cd /tmp && rm -rf .mpl/mpl)',
+      'a=docs/learnings; rm -rf $a',
+    ];
+    for (const command of bypasses) {
+      const decision = runHook(cwd, {
+        cwd,
+        tool_name: 'Bash',
+        tool_input: { command },
+      });
+      assert.equal(
+        decision.decision,
+        'block',
+        `expected protected-delete block for: ${command}`,
+      );
+    }
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('#236 A3 codex r1 retry: workspace-absolute `rm -rf /abs/.../.mpl/mpl` is blocked', () => {
+  const cwd = freshWorkspace();
+  try {
+    const decision = runHook(cwd, {
+      cwd,
+      tool_name: 'Bash',
+      tool_input: { command: `rm -rf ${cwd}/.mpl/mpl` },
+    });
+    assert.equal(decision.decision, 'block');
+    assert.match(decision.reason, /#236 A3/);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('#236 A3 codex r1 retry: path-traversal `rm -rf .mpl/mpl/../mpl` is blocked', () => {
+  const cwd = freshWorkspace();
+  try {
+    const decision = runHook(cwd, {
+      cwd,
+      tool_name: 'Bash',
+      tool_input: { command: 'rm -rf .mpl/mpl/../mpl' },
+    });
+    assert.equal(decision.decision, 'block');
   } finally {
     rmSync(cwd, { recursive: true, force: true });
   }

--- a/hooks/__tests__/mpl-issue-236-write-guard-tighten.test.mjs
+++ b/hooks/__tests__/mpl-issue-236-write-guard-tighten.test.mjs
@@ -400,6 +400,113 @@ test('#236 A3 claude r2 [security]: ancestors of protected roots are blocked too
   }
 });
 
+test('#236 A1 codex r12 [security]: only the first-seen (orchestrator-role) transcript may dispatch mpl-decomposer', () => {
+  // Codex r12: the dispatch flag was recorded for ANY Task caller
+  // claiming `subagent_type='mpl-decomposer'`. A non-orchestrator
+  // subagent (phase-runner) could dispatch and the orchestrator
+  // could then walk through the resulting window. Fix: bind the
+  // dispatcher-role to the FIRST transcript observed in the session.
+  const cwd = freshWorkspace();
+  try {
+    const orchestratorTranscript = '/tmp/orch.jsonl';
+    const phaseRunnerTranscript = '/tmp/phase-runner.jsonl';
+
+    // 1) Orchestrator's first call (any tool) records first_transcript_seen.
+    runHook(cwd, {
+      cwd,
+      tool_name: 'Bash',
+      transcript_path: orchestratorTranscript,
+      tool_input: { command: 'ls' },
+    });
+
+    // 2) Phase-runner (different transcript) tries to dispatch
+    // mpl-decomposer. Hook does NOT record dispatch.
+    runHook(cwd, {
+      cwd,
+      tool_name: 'Task',
+      transcript_path: phaseRunnerTranscript,
+      tool_input: { subagent_type: 'mpl-decomposer' },
+    });
+    const attackState = readState(cwd);
+    assert.ok(!attackState.decomposer_dispatch,
+      'nested-dispatcher dispatch must NOT be recorded');
+
+    // 3) Orchestrator's Write to decomposition.yaml is rejected
+    // because no dispatch is active.
+    const writeAttempt = runHook(cwd, {
+      cwd,
+      tool_name: 'Write',
+      transcript_path: orchestratorTranscript,
+      tool_input: { file_path: '.mpl/mpl/decomposition.yaml', content: 'forged' },
+    });
+    assert.equal(writeAttempt.decision, 'block');
+    assert.match(writeAttempt.reason, /#236 A1/);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('#236 A1 codex r12 [security]: legit orchestrator → decomposer flow still works', () => {
+  const cwd = freshWorkspace();
+  try {
+    const orchestratorTranscript = '/tmp/orch.jsonl';
+    const decomposerTranscript = '/tmp/decomposer.jsonl';
+
+    // Orchestrator establishes first_transcript_seen.
+    runHook(cwd, {
+      cwd, tool_name: 'Bash', transcript_path: orchestratorTranscript,
+      tool_input: { command: 'ls' },
+    });
+    // Orchestrator dispatches decomposer.
+    runHook(cwd, {
+      cwd, tool_name: 'Task', transcript_path: orchestratorTranscript,
+      tool_input: { subagent_type: 'mpl-decomposer' },
+    });
+    const dispatchState = readState(cwd);
+    assert.ok(dispatchState.decomposer_dispatch,
+      'orchestrator dispatch SHOULD be recorded');
+    // Decomposer writes — allowed.
+    const decomposerWrite = runHook(cwd, {
+      cwd, tool_name: 'Write', transcript_path: decomposerTranscript,
+      tool_input: { file_path: '.mpl/mpl/decomposition.yaml', content: 'legit' },
+    });
+    assert.equal(decomposerWrite.continue, true);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('#236 A1 claude r12 [security]: shell-normalization bypasses on Bash dispatch-forgery guard are closed', () => {
+  // Claude r12: the Bash guard used a raw substring check. Quote-concat,
+  // backslash-escape, ANSI-C escape, slash-collapse forms of
+  // `.mpl/state.json` and `decomposer_dispatch` all bypassed. Fix:
+  // normalize via the shared `normalizeShellCommand` helper before
+  // the substring test.
+  const cwd = freshWorkspace();
+  try {
+    for (const command of [
+      `echo decomposer_dispatch > .mpl"/"state.json`,
+      `echo decomposer_dispatch > .mpl\\/state.json`,
+      `echo decomposer_dispatch > .mpl//state.json`,
+      String.raw`echo decomposer_dispatch > $'.mpl\x2fstate.json'`,
+      String.raw`echo decomposer_dispatch > .mpl/state.json`,
+    ]) {
+      const decision = runHook(cwd, {
+        cwd,
+        tool_name: 'Bash',
+        tool_input: { command },
+      });
+      assert.equal(
+        decision.decision,
+        'block',
+        `expected shell-normalize bypass to be blocked: ${command}`,
+      );
+    }
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
 test('#236 A1 claude r11 [security]: Bash that mentions both .mpl/state.json AND decomposer_dispatch is blocked', () => {
   // Claude r11 [security]: the r9 Write/Edit guard only covered the
   // Write/Edit tool surface. The orchestrator could still forge the

--- a/hooks/__tests__/mpl-issue-236-write-guard-tighten.test.mjs
+++ b/hooks/__tests__/mpl-issue-236-write-guard-tighten.test.mjs
@@ -400,6 +400,71 @@ test('#236 A3 claude r2 [security]: ancestors of protected roots are blocked too
   }
 });
 
+test('#236 A1 codex r13 [security]: ANY Bash write to .mpl/state.json is blocked (base64/heredoc/etc. forgery)', () => {
+  // Codex r13: a literal-keyword check (decomposer_dispatch /
+  // first_transcript_seen) can't catch base64-decoded payloads. The
+  // structural fix is to refuse ANY Bash command that writes to
+  // .mpl/state.json — the hook itself uses writeState() (not Bash)
+  // so legit hook operation is unaffected.
+  const cwd = freshWorkspace();
+  try {
+    const base64Payload = Buffer.from(JSON.stringify({
+      current_phase: 'phase-1',
+      decomposer_dispatch: {
+        dispatched_at: '2026-05-29T00:00:00Z',
+        parent_transcript_path: '/tmp/other.jsonl',
+      },
+    })).toString('base64');
+    for (const command of [
+      `printf %s ${base64Payload} | base64 -d > .mpl/state.json`,
+      'echo opaque-blob > .mpl/state.json',
+      'cat /tmp/forged | tee .mpl/state.json',
+      'dd if=/tmp/forged of=.mpl/state.json',
+      'mv /tmp/forged .mpl/state.json',
+      'cp /tmp/forged .mpl/state.json',
+      `node -e fs.writeFileSync(".mpl/state.json", "forged")`,
+    ]) {
+      const decision = runHook(cwd, {
+        cwd,
+        tool_name: 'Bash',
+        tool_input: { command },
+      });
+      assert.equal(
+        decision.decision,
+        'block',
+        `expected Bash state.json write block for: ${command}`,
+      );
+    }
+    // Sanity: read-only ops against state.json still pass.
+    for (const command of [
+      'cat .mpl/state.json',
+      'ls .mpl/state.json',
+      'jq . .mpl/state.json',
+      'grep current_phase .mpl/state.json',
+    ]) {
+      const decision = runHook(cwd, {
+        cwd,
+        tool_name: 'Bash',
+        tool_input: { command },
+      });
+      assert.notEqual(
+        decision.decision,
+        'block',
+        `read-only on state.json should not block: ${command}`,
+      );
+    }
+    // Sanity: writes to OTHER .mpl files (not state.json) unaffected.
+    const otherWrite = runHook(cwd, {
+      cwd,
+      tool_name: 'Bash',
+      tool_input: { command: 'echo x > .mpl/runbook.md' },
+    });
+    assert.notEqual(otherWrite.decision, 'block');
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
 test('#236 A1 codex r12 [security]: only the first-seen (orchestrator-role) transcript may dispatch mpl-decomposer', () => {
   // Codex r12: the dispatch flag was recorded for ANY Task caller
   // claiming `subagent_type='mpl-decomposer'`. A non-orchestrator
@@ -538,13 +603,10 @@ test('#236 A1 claude r11 [security]: Bash that mentions both .mpl/state.json AND
       );
       assert.match(decision.reason, /decomposer_dispatch/);
     }
-    // Sanity: Bash that touches state.json WITHOUT decomposer_dispatch passes.
-    const benign = runHook(cwd, {
-      cwd,
-      tool_name: 'Bash',
-      tool_input: { command: 'echo hello > .mpl/state.json' },
-    });
-    assert.notEqual(benign.decision, 'block');
+    // r13 structural change: ANY Bash write to .mpl/state.json now
+    // blocks (forgery-class via base64/heredoc/etc. is unconditional).
+    // Bash reads of state.json (cat/ls) still pass — see the
+    // standalone r13 test.
   } finally {
     rmSync(cwd, { recursive: true, force: true });
   }

--- a/hooks/__tests__/mpl-issue-236-write-guard-tighten.test.mjs
+++ b/hooks/__tests__/mpl-issue-236-write-guard-tighten.test.mjs
@@ -400,6 +400,106 @@ test('#236 A3 claude r2 [security]: ancestors of protected roots are blocked too
   }
 });
 
+test('#236 A3 codex r10 [data-integrity]: interpreter one-liners that mention protected paths are blocked', () => {
+  // Codex r10: `node -e "require('fs').rmSync('.mpl/mpl')"`,
+  // `python -c "shutil.rmtree('.mpl/mpl')"` can destroy protected
+  // paths without invoking any shell-level destructive verb. Fix:
+  // add common interpreter heads to the entry gate; the substring +
+  // token check then catches the protected target literal inside
+  // the eval body. Pure read-only interpreter use is NOT blocked.
+  const cwd = freshWorkspace();
+  try {
+    for (const command of [
+      `node -e require('fs').rmSync('.mpl/mpl')`,
+      `python -c shutil.rmtree('.mpl/mpl')`,
+      `perl -e unlink('.mpl/contracts/foo')`,
+      `ruby -e File.delete('.mpl/memory/state')`,
+    ]) {
+      const decision = runHook(cwd, {
+        cwd,
+        tool_name: 'Bash',
+        tool_input: { command },
+      });
+      assert.equal(
+        decision.decision,
+        'block',
+        `expected interpreter-eval block for: ${command}`,
+      );
+    }
+    // Sanity: read-only interpreter use (no protected mention) passes.
+    for (const command of ['node script.js', 'python -m pytest', 'ruby --version']) {
+      const decision = runHook(cwd, {
+        cwd,
+        tool_name: 'Bash',
+        tool_input: { command },
+      });
+      assert.notEqual(
+        decision.decision,
+        'block',
+        `read-only interpreter use should not block: ${command}`,
+      );
+    }
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('#236 A1 claude r9 [security]: planting decomposer_dispatch via Write/Edit of .mpl/state.json is blocked', () => {
+  // Concrete repro: the orchestrator has Write access to .mpl/state.json
+  // (it sits in the /\.mpl\// allowlist), so it could forge the
+  // decomposer_dispatch flag to satisfy isDecomposerDispatchActive
+  // and Write decomposition.yaml from its own transcript. Fix: any
+  // Write/Edit to .mpl/state.json whose payload mentions the
+  // `decomposer_dispatch` key is rejected — only this hook is
+  // allowed to set the flag.
+  const cwd = freshWorkspace();
+  try {
+    // Write payload mentioning decomposer_dispatch.
+    const writeDecision = runHook(cwd, {
+      cwd,
+      tool_name: 'Write',
+      tool_input: {
+        file_path: '.mpl/state.json',
+        content: JSON.stringify({
+          current_phase: 'phase-1',
+          decomposer_dispatch: {
+            dispatched_at: new Date().toISOString(),
+            parent_transcript_path: '/tmp/fake.jsonl',
+          },
+        }),
+      },
+    });
+    assert.equal(writeDecision.continue, false);
+    assert.equal(writeDecision.decision, 'block');
+    assert.match(writeDecision.reason, /decomposer_dispatch/);
+
+    // Edit form too.
+    const editDecision = runHook(cwd, {
+      cwd,
+      tool_name: 'Edit',
+      tool_input: {
+        file_path: '.mpl/state.json',
+        old_string: '"current_phase":"phase-1"',
+        new_string: '"current_phase":"phase-1","decomposer_dispatch":{"dispatched_at":"x","parent_transcript_path":"y"}',
+      },
+    });
+    assert.equal(editDecision.decision, 'block');
+
+    // Sanity: writing OTHER state fields still works.
+    const plainState = runHook(cwd, {
+      cwd,
+      tool_name: 'Write',
+      tool_input: {
+        file_path: '.mpl/state.json',
+        content: JSON.stringify({ current_phase: 'phase-2' }),
+      },
+    });
+    assert.notEqual(plainState.decision, 'block');
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
 test('#236 A3 codex r9 [data-integrity]: writer utilities (tee, dd of=) are blocked on protected paths', () => {
   // Codex r9: `tee FILE` opens FILE for write and overwrites it;
   // `dd of=FILE` does the same. Pre-fix entry gate didn't include

--- a/hooks/__tests__/mpl-issue-236-write-guard-tighten.test.mjs
+++ b/hooks/__tests__/mpl-issue-236-write-guard-tighten.test.mjs
@@ -400,6 +400,67 @@ test('#236 A3 claude r2 [security]: ancestors of protected roots are blocked too
   }
 });
 
+test('#236 A3 claude r5 [data-integrity]: brace expansion is normalized before matching', () => {
+  // Claude r5: `rm -rf .mpl/{mpl,contracts}` deletes both protected
+  // paths in real bash. Cartesian forms (`{.mpl,docs}/{mpl,learnings}`)
+  // and partial forms (`.mpl/mp{l,n}`) too. The fix expands every
+  // `prefix{a,b,…}suffix` per-token (cartesian when multiple groups)
+  // before the substring + token checks.
+  const cwd = freshWorkspace();
+  try {
+    for (const command of [
+      'rm -rf .mpl/{mpl,contracts}',
+      'rm -rf .mpl/{mpl,contracts,memory}',
+      'rm -rf {.mpl,docs}/{mpl,learnings}',
+      'rm -rf .mpl/mp{l,n}',
+      'rm -rf .{mpl,omc}/mpl',
+    ]) {
+      const decision = runHook(cwd, {
+        cwd,
+        tool_name: 'Bash',
+        tool_input: { command },
+      });
+      assert.equal(
+        decision.decision,
+        'block',
+        `expected brace-expansion block for: ${command}`,
+      );
+    }
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('#236 A3 codex r5 [data-integrity]: ANSI-C quoted escape sequences are decoded before matching', () => {
+  // Codex r5: Bash $'…' ANSI-C quoting decodes hex/octal/Unicode
+  // escapes. `rm -rf $'.mpl\\x2fmpl'` deletes `.mpl/mpl`. The fix
+  // decodes \xHH / \uHHHH / \UHHHHHHHH / \OOO before the generic
+  // backslash strip so they don't get clobbered to `x2f`.
+  const cwd = freshWorkspace();
+  try {
+    for (const command of [
+      String.raw`rm -rf $'.mpl\x2fmpl'`,
+      String.raw`rm -rf $'.mpl\057mpl'`,
+      String.raw`rm -rf $'.mpl/mpl'`,
+      String.raw`rm -rf $'docs\x2flearnings'`,
+      String.raw`rm -rf $'docs\057learnings'`,
+    ]) {
+      const decision = runHook(cwd, {
+        cwd,
+        tool_name: 'Bash',
+        tool_input: { command },
+      });
+      assert.equal(
+        decision.decision,
+        'block',
+        `expected ANSI-C decode block for: ${command}`,
+      );
+    }
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
 test('#236 A3 codex r4 [data-integrity]: backslash-escaped path separators are blocked', () => {
   // Codex r4: POSIX shells remove `\X` escapes before exec, so
   // `rm -rf .mpl\/mpl` and `rm -rf docs\/learnings` actually delete

--- a/hooks/__tests__/mpl-issue-236-write-guard-tighten.test.mjs
+++ b/hooks/__tests__/mpl-issue-236-write-guard-tighten.test.mjs
@@ -400,6 +400,34 @@ test('#236 A3 claude r2 [security]: ancestors of protected roots are blocked too
   }
 });
 
+test('#236 A3 codex r9 [data-integrity]: writer utilities (tee, dd of=) are blocked on protected paths', () => {
+  // Codex r9: `tee FILE` opens FILE for write and overwrites it;
+  // `dd of=FILE` does the same. Pre-fix entry gate didn't include
+  // these writer utilities so the protected operand check never ran.
+  const cwd = freshWorkspace();
+  try {
+    for (const command of [
+      'echo x | tee .mpl/mpl/decomposition.yaml',
+      'echo x | tee -a .mpl/mpl/log',
+      'tee -a .mpl/contracts/foo',
+      'dd if=/dev/zero of=.mpl/mpl/decomposition.yaml',
+    ]) {
+      const decision = runHook(cwd, {
+        cwd,
+        tool_name: 'Bash',
+        tool_input: { command },
+      });
+      assert.equal(
+        decision.decision,
+        'block',
+        `expected writer-utility block for: ${command}`,
+      );
+    }
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
 test('#236 A3 codex r8 [data-integrity]: no-space and fd-prefix redirects are blocked', () => {
   // Codex r8: POSIX shell redirection doesn't require whitespace
   // after `>`/`>>`/`&>`. Pre-fix entry gate required `\s` after `>`.

--- a/hooks/__tests__/mpl-issue-236-write-guard-tighten.test.mjs
+++ b/hooks/__tests__/mpl-issue-236-write-guard-tighten.test.mjs
@@ -448,6 +448,39 @@ test('#236 A1 claude r13 [security]: 2-step deactivation chain via Write/Edit is
   }
 });
 
+test('#236 A1 codex r14 [security]: structural safe-read-allowlist closes unbounded writer-verb gap', () => {
+  // Codex r14: the verb allowlist (rm/mv/tee/dd/install/...) is
+  // unbounded — every round another writer utility surfaces. The
+  // structural rule: only known-safe-read heads may mention
+  // .mpl/state.json. Any other command (writer utility the hook
+  // hasn't heard of yet) is presumed-write and blocked.
+  const cwd = freshWorkspace();
+  try {
+    // Writer utilities the hook never explicitly enumerated.
+    for (const command of [
+      'install -m 0644 /tmp/forged .mpl/state.json',
+      'pax -rw /tmp .mpl/state.json',
+      'cpio -i .mpl/state.json',
+      'mktemp .mpl/state.json',
+      'touch .mpl/state.json',
+      'xxd -r .mpl/state.json',
+    ]) {
+      const decision = runHook(cwd, {
+        cwd,
+        tool_name: 'Bash',
+        tool_input: { command },
+      });
+      assert.equal(
+        decision.decision,
+        'block',
+        `expected structural state.json write block for: ${command}`,
+      );
+    }
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
 test('#236 A1 codex r13 [security]: ANY Bash write to .mpl/state.json is blocked (base64/heredoc/etc. forgery)', () => {
   // Codex r13: a literal-keyword check (decomposer_dispatch /
   // first_transcript_seen) can't catch base64-decoded payloads. The

--- a/hooks/__tests__/mpl-issue-236-write-guard-tighten.test.mjs
+++ b/hooks/__tests__/mpl-issue-236-write-guard-tighten.test.mjs
@@ -368,6 +368,69 @@ test('#236 A3 claude r1: shell-expansion / subshell / pushd bypass forms are all
   }
 });
 
+test('#236 A3 claude r2 [security]: ancestors of protected roots are blocked too', () => {
+  // Concrete repros — `rm -rf .mpl` destroys `.mpl/mpl`, `.mpl/contracts`,
+  // `.mpl/memory`. `find . -delete` destroys everything under cwd
+  // including protected. Pre-fix substring + descendant-only check
+  // missed these.
+  const cwd = freshWorkspace();
+  try {
+    for (const command of [
+      'rm -rf .mpl',
+      'rm -rf .mpl/',
+      'rm -rf docs/',
+      'rm -rf docs',
+      'find docs -delete',
+      'find . -name "*.yaml" -delete',
+      'find . -delete',
+    ]) {
+      const decision = runHook(cwd, {
+        cwd,
+        tool_name: 'Bash',
+        tool_input: { command },
+      });
+      assert.equal(
+        decision.decision,
+        'block',
+        `expected ancestor/find traversal block for: ${command}`,
+      );
+    }
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('#236 A3 codex r3 [data-integrity]: quote-concatenation forgery is blocked', () => {
+  // Codex r3: POSIX shells concatenate adjacent quoted fragments,
+  // so `.mpl/""mpl`, `.mpl"/"mpl`, `.mpl''/''mpl` all resolve to
+  // `.mpl/mpl` at execution time. The fix strips all `"` and `'`
+  // and backticks from the command before the substring + token
+  // checks so quote-concatenation forgery collapses to the same
+  // literal a real shell would see.
+  const cwd = freshWorkspace();
+  try {
+    for (const command of [
+      `rm -rf .mpl/""mpl`,
+      `rm -rf .mpl"/"mpl`,
+      `rm -rf .mpl''/''mpl`,
+      `rm -rf 'doc's'/'learnings`,
+    ]) {
+      const decision = runHook(cwd, {
+        cwd,
+        tool_name: 'Bash',
+        tool_input: { command },
+      });
+      assert.equal(
+        decision.decision,
+        'block',
+        `expected quote-concat block for: ${command}`,
+      );
+    }
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
 test('#236 A3 codex r2: redundant-slash shell-expanded paths are still blocked (slash collapse)', () => {
   // Codex r2 [logic]: real shell normalizes `//` after expansion;
   // `$PWD/.mpl//mpl` deletes `.mpl/mpl` just fine.
@@ -390,6 +453,72 @@ test('#236 A3 codex r2: redundant-slash shell-expanded paths are still blocked (
         `expected slash-collapse to catch: ${command}`,
       );
     }
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('#236 A1 claude r3 [contract-break]: re-dispatch of mpl-decomposer resets the child lock so the new run is allowed', () => {
+  // Concrete repro shape: APPEND-MODE / RECOMPOSE-MODE re-dispatches
+  // the decomposer (see commands/mpl-run-decompose.md). Without the
+  // explicit child_transcript_path: null on each dispatch, the
+  // previous run's lock persists and the second run's writes are
+  // wrongly rejected.
+  const cwd = freshWorkspace();
+  try {
+    const orchestratorTranscript = '/tmp/transcript-orchestrator.jsonl';
+    const decomposer1Transcript = '/tmp/transcript-decomposer-1.jsonl';
+    const decomposer2Transcript = '/tmp/transcript-decomposer-2.jsonl';
+
+    // Run 1: dispatch + first decomposer Write captures lock.
+    runHook(cwd, {
+      cwd,
+      tool_name: 'Task',
+      transcript_path: orchestratorTranscript,
+      tool_input: { subagent_type: 'mpl-decomposer', prompt: '...' },
+    });
+    runHook(cwd, {
+      cwd,
+      tool_name: 'Write',
+      transcript_path: decomposer1Transcript,
+      tool_input: { file_path: '.mpl/mpl/decomposition.yaml', content: 'v1' },
+    });
+    const afterRun1 = readState(cwd);
+    assert.equal(
+      afterRun1.decomposer_dispatch.child_transcript_path,
+      decomposer1Transcript,
+    );
+
+    // Run 2: orchestrator re-dispatches (recompose). New dispatch
+    // must reset the locked child to null.
+    runHook(cwd, {
+      cwd,
+      tool_name: 'Task',
+      transcript_path: orchestratorTranscript,
+      tool_input: { subagent_type: 'mpl-decomposer', prompt: '...' },
+    });
+    const afterRun2Dispatch = readState(cwd);
+    assert.equal(
+      afterRun2Dispatch.decomposer_dispatch.child_transcript_path,
+      null,
+      'Expected re-dispatch to clear the locked child transcript',
+    );
+
+    // The NEW decomposer (fresh transcript) writes — allowed.
+    const newDecomposerWrite = runHook(cwd, {
+      cwd,
+      tool_name: 'Write',
+      transcript_path: decomposer2Transcript,
+      tool_input: { file_path: '.mpl/mpl/decomposition.yaml', content: 'v2' },
+    });
+    assert.equal(newDecomposerWrite.continue, true);
+
+    // New child lock recorded as the second decomposer.
+    const afterRun2Write = readState(cwd);
+    assert.equal(
+      afterRun2Write.decomposer_dispatch.child_transcript_path,
+      decomposer2Transcript,
+    );
   } finally {
     rmSync(cwd, { recursive: true, force: true });
   }

--- a/hooks/__tests__/mpl-issue-236-write-guard-tighten.test.mjs
+++ b/hooks/__tests__/mpl-issue-236-write-guard-tighten.test.mjs
@@ -400,6 +400,39 @@ test('#236 A3 claude r2 [security]: ancestors of protected roots are blocked too
   }
 });
 
+test('#236 A3 codex r6 [data-integrity]: glob-expansion operands are blocked when they can match protected roots', () => {
+  // Codex r6: `rm -rf .mpl/m*` expands to `.mpl/mpl .mpl/memory` in
+  // real bash. Glob meta (`*`, `?`, `[…]`) in the token wasn't
+  // resolved against protected roots. Fix: when token contains glob
+  // meta, take the literal prefix and check if any protected root
+  // starts with that prefix (or vice versa) — any expansion could
+  // land on a protected path.
+  const cwd = freshWorkspace();
+  try {
+    for (const command of [
+      'rm -rf .mpl/m*',
+      'rm -rf .mpl/*',
+      'rm -rf docs/*',
+      'rm -rf .mpl/m?l',
+      'rm -rf docs/learn*',
+      'rm -rf .mp[lk]/mpl',
+    ]) {
+      const decision = runHook(cwd, {
+        cwd,
+        tool_name: 'Bash',
+        tool_input: { command },
+      });
+      assert.equal(
+        decision.decision,
+        'block',
+        `expected glob block for: ${command}`,
+      );
+    }
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
 test('#236 A3 claude r5 [data-integrity]: brace expansion is normalized before matching', () => {
   // Claude r5: `rm -rf .mpl/{mpl,contracts}` deletes both protected
   // paths in real bash. Cartesian forms (`{.mpl,docs}/{mpl,learnings}`)

--- a/hooks/__tests__/mpl-issue-236-write-guard-tighten.test.mjs
+++ b/hooks/__tests__/mpl-issue-236-write-guard-tighten.test.mjs
@@ -400,6 +400,49 @@ test('#236 A3 claude r2 [security]: ancestors of protected roots are blocked too
   }
 });
 
+test('#236 A1 claude r11 [security]: Bash that mentions both .mpl/state.json AND decomposer_dispatch is blocked', () => {
+  // Claude r11 [security]: the r9 Write/Edit guard only covered the
+  // Write/Edit tool surface. The orchestrator could still forge the
+  // decomposer_dispatch flag via Bash:
+  //   echo '{"decomposer_dispatch":…}' > .mpl/state.json
+  //   tee .mpl/state.json
+  //   dd of=.mpl/state.json
+  //   node -e 'fs.writeFileSync(".mpl/state.json", …)'
+  // Fix: any Bash command that mentions BOTH `.mpl/state.json` and
+  // `decomposer_dispatch` is rejected. Benign Bash writes to state.json
+  // that don't carry the dispatch key pass through.
+  const cwd = freshWorkspace();
+  try {
+    for (const command of [
+      'echo decomposer_dispatch > .mpl/state.json',
+      'tee .mpl/state.json <<< decomposer_dispatch',
+      'dd of=.mpl/state.json if=/tmp/decomposer_dispatch.json',
+      'node -e fs.writeFileSync(".mpl/state.json", JSON.stringify({decomposer_dispatch:1}))',
+    ]) {
+      const decision = runHook(cwd, {
+        cwd,
+        tool_name: 'Bash',
+        tool_input: { command },
+      });
+      assert.equal(
+        decision.decision,
+        'block',
+        `expected dispatch-forgery-via-Bash block for: ${command}`,
+      );
+      assert.match(decision.reason, /decomposer_dispatch/);
+    }
+    // Sanity: Bash that touches state.json WITHOUT decomposer_dispatch passes.
+    const benign = runHook(cwd, {
+      cwd,
+      tool_name: 'Bash',
+      tool_input: { command: 'echo hello > .mpl/state.json' },
+    });
+    assert.notEqual(benign.decision, 'block');
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
 test('#236 A3 codex r11 [data-integrity]: tar --remove-files and rsync --remove-source-files are blocked', () => {
   // Codex r11: tar with --remove-files deletes the source file after
   // archiving; rsync with --remove-source-files does the same. Plain

--- a/hooks/__tests__/mpl-issue-236-write-guard-tighten.test.mjs
+++ b/hooks/__tests__/mpl-issue-236-write-guard-tighten.test.mjs
@@ -400,6 +400,49 @@ test('#236 A3 claude r2 [security]: ancestors of protected roots are blocked too
   }
 });
 
+test('#236 A3 codex r11 [data-integrity]: tar --remove-files and rsync --remove-source-files are blocked', () => {
+  // Codex r11: tar with --remove-files deletes the source file after
+  // archiving; rsync with --remove-source-files does the same. Plain
+  // tar / rsync without those flags is read-only-from-source and
+  // should NOT block.
+  const cwd = freshWorkspace();
+  try {
+    for (const command of [
+      'tar --remove-files -cf /tmp/mpl.tar .mpl/mpl',
+      'rsync --remove-source-files -av .mpl/mpl/ /tmp/dest/',
+    ]) {
+      const decision = runHook(cwd, {
+        cwd,
+        tool_name: 'Bash',
+        tool_input: { command },
+      });
+      assert.equal(
+        decision.decision,
+        'block',
+        `expected tar/rsync remove block for: ${command}`,
+      );
+    }
+    // Sanity: plain tar / rsync (no remove flag) → NOT block.
+    for (const command of [
+      'tar -cf /tmp/x.tar .mpl/mpl',
+      'rsync -av .mpl/mpl /tmp/',
+    ]) {
+      const decision = runHook(cwd, {
+        cwd,
+        tool_name: 'Bash',
+        tool_input: { command },
+      });
+      assert.notEqual(
+        decision.decision,
+        'block',
+        `plain tar/rsync (no remove flag) should NOT block: ${command}`,
+      );
+    }
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
 test('#236 A3 codex r10 [data-integrity]: interpreter one-liners that mention protected paths are blocked', () => {
   // Codex r10: `node -e "require('fs').rmSync('.mpl/mpl')"`,
   // `python -c "shutil.rmtree('.mpl/mpl')"` can destroy protected

--- a/hooks/__tests__/mpl-issue-236-write-guard-tighten.test.mjs
+++ b/hooks/__tests__/mpl-issue-236-write-guard-tighten.test.mjs
@@ -10,7 +10,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
-import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'fs';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, symlinkSync, unlinkSync } from 'fs';
 import { tmpdir } from 'os';
 import { execFileSync } from 'child_process';
 
@@ -471,6 +471,48 @@ test('#236 A1 claude r14 [security]: decomposition.yaml writer-identity check ru
     });
     assert.equal(decision.decision, 'block');
     assert.match(decision.reason, /#236 A1/);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('#236 A1 claude r17 [security]: symlink-indirection bypasses are closed', () => {
+  // Claude r17 found two-step symlink bypass:
+  //   Step 1: ln -s /abs/.mpl/mpl /tmp/safe-link
+  //   Step 2: printf forged > /tmp/safe-link/decomposition.yaml
+  // Fix (a): added `ln` to A3 destructive verbs so step 1 itself blocks.
+  // Fix (b): added realpath resolution on redirect target dirname so
+  //          a write through a pre-existing symlink is also blocked.
+  const cwd = freshWorkspace();
+  try {
+    // Step 1: ln creation blocks via A3 (substring `.mpl/mpl` in src).
+    const step1 = runHook(cwd, {
+      cwd,
+      tool_name: 'Bash',
+      tool_input: {
+        command: `ln -s ${cwd}/.mpl/mpl /tmp/mpl-r17-symlink-test`,
+      },
+    });
+    assert.equal(step1.decision, 'block',
+      'Step 1 (symlink creation pointing at protected) must block');
+
+    // Step 2: write through pre-existing symlink — also blocks via
+    // realpath resolution.
+    const symlinkPath = '/tmp/mpl-r17-test-link-' + Date.now();
+    try {
+      symlinkSync(join(cwd, '.mpl', 'mpl'), symlinkPath);
+      const step2 = runHook(cwd, {
+        cwd,
+        tool_name: 'Bash',
+        tool_input: {
+          command: `printf forged > ${symlinkPath}/decomposition.yaml`,
+        },
+      });
+      assert.equal(step2.decision, 'block',
+        'Step 2 (write through pre-existing symlink) must block');
+    } finally {
+      try { unlinkSync(symlinkPath); } catch {}
+    }
   } finally {
     rmSync(cwd, { recursive: true, force: true });
   }

--- a/hooks/__tests__/mpl-issue-236-write-guard-tighten.test.mjs
+++ b/hooks/__tests__/mpl-issue-236-write-guard-tighten.test.mjs
@@ -476,6 +476,90 @@ test('#236 A1 claude r14 [security]: decomposition.yaml writer-identity check ru
   }
 });
 
+test('#236 A1 claude r21 [security]: case-insensitive filesystem protection', () => {
+  // macOS APFS / Windows NTFS open `.MPL/MPL/...` against the same
+  // inode as `.mpl/mpl/...`. Fix: apply /i flag to protected-file
+  // regexes + lowercase normalized command before substring matches.
+  const cwd = freshWorkspace();
+  try {
+    // Write/Edit uppercase path.
+    const writeUpper = runHook(cwd, {
+      cwd,
+      tool_name: 'Write',
+      tool_input: { file_path: '.MPL/MPL/decomposition.yaml', content: 'forged' },
+    });
+    assert.equal(writeUpper.decision, 'block');
+    // Bash uppercase path.
+    const bashUpper = runHook(cwd, {
+      cwd,
+      tool_name: 'Bash',
+      tool_input: { command: 'printf forged > .MPL/MPL/decomposition.yaml' },
+    });
+    assert.equal(bashUpper.decision, 'block');
+    // state.json uppercase.
+    const stateUpper = runHook(cwd, {
+      cwd,
+      tool_name: 'Write',
+      tool_input: { file_path: '.MPL/STATE.json', content: '{}' },
+    });
+    assert.equal(stateUpper.decision, 'block');
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('#236 A1 claude r22 [security]: multi-level /X/../ traversal collapse', () => {
+  // Claude r22: r21 only collapsed ONE level. `.mpl/a/b/../../state.json`
+  // at depth 2 bypassed. Fix: iterate the regex until no more matches.
+  const cwd = freshWorkspace();
+  try {
+    for (const command of [
+      'node -e require("fs").writeFileSync(".mpl/a/b/../../state.json","{}")',
+      'node -e require("fs").writeFileSync(".mpl/x/y/z/../../../state.json","{}")',
+      'node -e require("fs").writeFileSync(".mpl/a/b/c/../../../mpl/decomposition.yaml","forged")',
+    ]) {
+      const decision = runHook(cwd, {
+        cwd,
+        tool_name: 'Bash',
+        tool_input: { command },
+      });
+      assert.equal(
+        decision.decision,
+        'block',
+        `expected multi-level traversal block for: ${command}`,
+      );
+    }
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('#236 A3 codex r22 [security]: rsync --delete variants are blocked', () => {
+  // Codex r22: `rsync --delete` prunes destination tree. Adding to
+  // destructive entry gate.
+  const cwd = freshWorkspace();
+  try {
+    for (const command of [
+      'rsync -a --delete /tmp/empty/ .mpl/mpl/',
+      'rsync -av --delete-before /tmp/empty/ .mpl/contracts/',
+      'rsync --delete-after /tmp/empty/ .mpl/memory/',
+    ]) {
+      const decision = runHook(cwd, {
+        cwd,
+        tool_name: 'Bash',
+        tool_input: { command },
+      });
+      assert.equal(
+        decision.decision,
+        'block',
+        `expected rsync --delete block for: ${command}`,
+      );
+    }
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
 test('#236 A1 codex r21 [security]: normalizeShellCommand collapses /./ and /X/../ in Bash interpreter args', () => {
   // Codex r21: `node -e 'fs.writeFileSync(".mpl/./state.json", ...)'`
   // bypassed the substring check because normalizeShellCommand only

--- a/hooks/__tests__/mpl-issue-236-write-guard-tighten.test.mjs
+++ b/hooks/__tests__/mpl-issue-236-write-guard-tighten.test.mjs
@@ -476,6 +476,33 @@ test('#236 A1 claude r14 [security]: decomposition.yaml writer-identity check ru
   }
 });
 
+test('#236 A1 claude r18 [security]: multi-statement / multi-redirect symlink bypass is closed', () => {
+  // Claude r18: r17's single-shot .match() only checked the FIRST
+  // redirect target. A multi-statement command with a benign first
+  // redirect plus a symlink-through second redirect slipped past.
+  // Fix: .matchAll() iterates EVERY redirect/tee/dd-of target.
+  const cwd = freshWorkspace();
+  try {
+    const symlinkPath = '/tmp/mpl-r18-test-link-' + Date.now();
+    symlinkSync(join(cwd, '.mpl', 'mpl'), symlinkPath);
+    try {
+      // Multi-statement: benign first, malicious second targeting symlink.
+      const command = `echo benign > /tmp/notice.log; printf forged > ${symlinkPath}/decomposition.yaml`;
+      const decision = runHook(cwd, {
+        cwd,
+        tool_name: 'Bash',
+        tool_input: { command },
+      });
+      assert.equal(decision.decision, 'block',
+        'Multi-statement symlink-through redirect must block');
+    } finally {
+      try { unlinkSync(symlinkPath); } catch {}
+    }
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
 test('#236 A1 claude r17 [security]: symlink-indirection bypasses are closed', () => {
   // Claude r17 found two-step symlink bypass:
   //   Step 1: ln -s /abs/.mpl/mpl /tmp/safe-link

--- a/hooks/__tests__/mpl-issue-236-write-guard-tighten.test.mjs
+++ b/hooks/__tests__/mpl-issue-236-write-guard-tighten.test.mjs
@@ -590,6 +590,62 @@ test('#236 A3 claude r25 [security]: gzip per-segment scan — later -k does not
   }
 });
 
+test('#236 A3 claude r27 [security]: -k/--keep keep-flag only counts as standalone token, not filename substring', () => {
+  // Claude r27 (generalizes Codex r26): `gzip .mpl/mpl/-k` (no `--`)
+  // was bypassing because the segment-wide `/(?:-k|--keep)\b/` regex
+  // matched the filename tail. Pure `gzip FILE` deletes FILE, so the
+  // matching filename `.mpl/mpl/-k` is destructive, but the gate saw
+  // `-k` substring and suppressed. Fix: tokenize the segment after
+  // the compressor verb and only treat `-k` / `--keep` / `--keep=…` /
+  // `-Xk…` as the keep flag when they're standalone option tokens.
+  const cwd = freshWorkspace();
+  try {
+    writeFileSync(join(cwd, '.mpl', 'mpl', '-k'), 'data');
+    writeFileSync(join(cwd, '.mpl', 'mpl', 'foo-k'), 'data');
+    writeFileSync(join(cwd, '.mpl', 'mpl', 'keep-this'), 'data');
+    for (const command of [
+      'gzip .mpl/mpl/-k',
+      'gzip .mpl/mpl/foo-k',
+      'gzip .mpl/mpl/keep-this',
+      'bzip2 .mpl/mpl/-k',
+      'xz .mpl/mpl/foo-k',
+      'zstd .mpl/mpl/-k',
+    ]) {
+      const decision = runHook(cwd, {
+        cwd,
+        tool_name: 'Bash',
+        tool_input: { command },
+      });
+      assert.equal(
+        decision.decision,
+        'block',
+        `expected claude r27 standalone-flag block for: ${command}`,
+      );
+    }
+    // Sanity: real flag forms still suppress (legitimate keep).
+    for (const command of [
+      'gzip -k .mpl/memory/some.md',
+      'gzip --keep .mpl/memory/some.md',
+      'gzip --keep=true .mpl/memory/some.md',
+      'gzip -kn .mpl/memory/some.md',
+      'gzip -nk .mpl/memory/some.md',
+    ]) {
+      const decision = runHook(cwd, {
+        cwd,
+        tool_name: 'Bash',
+        tool_input: { command },
+      });
+      assert.equal(
+        decision.continue,
+        true,
+        `expected legit keep flag to pass for: ${command}`,
+      );
+    }
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
 test('#236 A3 codex r27 [data-integrity]: quote/backslash-concat destructive VERB tokens still trip the gate', () => {
   // Codex r27: before the fix, `isDestructive` matched `\brm\b` /
   // `\bgzip\b` on the partially-stripped command (only sudo/time/nice/

--- a/hooks/__tests__/mpl-issue-236-write-guard-tighten.test.mjs
+++ b/hooks/__tests__/mpl-issue-236-write-guard-tighten.test.mjs
@@ -562,6 +562,34 @@ test('#236 A1 codex r24 [security]: cd-into-constructed-mpl + bare-filename redi
   }
 });
 
+test('#236 A3 claude r25 [security]: gzip per-segment scan — later -k does not suppress earlier unkeyed gzip', () => {
+  // Claude r25: `gzip .mpl/memory/some.md; gzip -k other.txt`. The
+  // unanchored negative lookahead saw `-k` later in the command and
+  // suppressed isDestructive for the FIRST gzip. Fix: per-segment
+  // scan via split on `[;|&\n]+`.
+  const cwd = freshWorkspace();
+  try {
+    for (const command of [
+      'gzip .mpl/memory/some.md; gzip -k other.txt',
+      'gzip .mpl/memory/some.md && echo unrelated --keep stuff',
+      'gzip .mpl/memory/some.md | xargs --keep-going echo',
+    ]) {
+      const decision = runHook(cwd, {
+        cwd,
+        tool_name: 'Bash',
+        tool_input: { command },
+      });
+      assert.equal(
+        decision.decision,
+        'block',
+        `expected gzip per-segment block for: ${command}`,
+      );
+    }
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
 test('#236 A3 claude r24 [security]: gzip / bzip2 / xz remove input file by default', () => {
   // Claude r24: `gzip FILE` deletes FILE after compression (no -k flag).
   // Same for bzip2 / xz / zstd. Treat as destructive against the

--- a/hooks/__tests__/mpl-issue-236-write-guard-tighten.test.mjs
+++ b/hooks/__tests__/mpl-issue-236-write-guard-tighten.test.mjs
@@ -368,6 +368,95 @@ test('#236 A3 claude r1: shell-expansion / subshell / pushd bypass forms are all
   }
 });
 
+test('#236 A3 codex r2: redundant-slash shell-expanded paths are still blocked (slash collapse)', () => {
+  // Codex r2 [logic]: real shell normalizes `//` after expansion;
+  // `$PWD/.mpl//mpl` deletes `.mpl/mpl` just fine.
+  const cwd = freshWorkspace();
+  try {
+    for (const command of [
+      'rm -rf $PWD/.mpl//mpl',
+      'rm -rf $(pwd)/.mpl//mpl',
+      'rm -rf .mpl///mpl/phases',
+      'rm -rf .mpl/mpl//',
+    ]) {
+      const decision = runHook(cwd, {
+        cwd,
+        tool_name: 'Bash',
+        tool_input: { command },
+      });
+      assert.equal(
+        decision.decision,
+        'block',
+        `expected slash-collapse to catch: ${command}`,
+      );
+    }
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('#236 A1 codex r2: lock-on-first-write — only the FIRST consuming child transcript may keep writing', () => {
+  // Codex r2 [contract-break]: without lock-on-first-write, any
+  // subagent active during the dispatch window could write
+  // decomposition.yaml. The first non-parent transcript that writes
+  // is locked; any OTHER transcript (e.g. a phase-runner) is rejected
+  // even though it differs from the orchestrator.
+  const cwd = freshWorkspace();
+  try {
+    const orchestratorTranscript = '/tmp/transcript-orchestrator.jsonl';
+    const decomposerTranscript = '/tmp/transcript-decomposer.jsonl';
+    const phaseRunnerTranscript = '/tmp/transcript-phase-runner.jsonl';
+
+    // 1) Orchestrator dispatches decomposer.
+    runHook(cwd, {
+      cwd,
+      tool_name: 'Task',
+      transcript_path: orchestratorTranscript,
+      tool_input: { subagent_type: 'mpl-decomposer', prompt: '...' },
+    });
+
+    // 2) Decomposer writes — first consumer, captures the lock.
+    const firstWrite = runHook(cwd, {
+      cwd,
+      tool_name: 'Write',
+      transcript_path: decomposerTranscript,
+      tool_input: { file_path: '.mpl/mpl/decomposition.yaml', content: 'x' },
+    });
+    assert.equal(firstWrite.continue, true);
+    assert.equal(firstWrite.suppressOutput, true);
+
+    // Confirm the child lock landed.
+    const lockedState = readState(cwd);
+    assert.equal(
+      lockedState.decomposer_dispatch.child_transcript_path,
+      decomposerTranscript,
+    );
+
+    // 3) Decomposer second write — still allowed.
+    const secondWriteSame = runHook(cwd, {
+      cwd,
+      tool_name: 'Edit',
+      transcript_path: decomposerTranscript,
+      tool_input: { file_path: '.mpl/mpl/decomposition.yaml', old_string: 'x', new_string: 'y' },
+    });
+    assert.equal(secondWriteSame.continue, true);
+
+    // 4) Some OTHER subagent (phase-runner, etc.) attempts to write
+    // decomposition.yaml. Different transcript — rejected.
+    const phaseRunnerWrite = runHook(cwd, {
+      cwd,
+      tool_name: 'Write',
+      transcript_path: phaseRunnerTranscript,
+      tool_input: { file_path: '.mpl/mpl/decomposition.yaml', content: 'forged' },
+    });
+    assert.equal(phaseRunnerWrite.continue, false);
+    assert.equal(phaseRunnerWrite.decision, 'block');
+    assert.match(phaseRunnerWrite.reason, /#236 A1/);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
 test('#236 A3 codex r1 retry: workspace-absolute `rm -rf /abs/.../.mpl/mpl` is blocked', () => {
   const cwd = freshWorkspace();
   try {

--- a/hooks/__tests__/mpl-issue-236-write-guard-tighten.test.mjs
+++ b/hooks/__tests__/mpl-issue-236-write-guard-tighten.test.mjs
@@ -534,6 +534,86 @@ test('#236 A1 claude r22 [security]: multi-level /X/../ traversal collapse', () 
   }
 });
 
+test('#236 A1 codex r24 [security]: cd-into-constructed-mpl + bare-filename redirect is blocked', () => {
+  // Codex r24: `cd .$(printf mpl)/mpl && printf forged > decomposition.yaml`
+  // constructs the path at runtime via command-substitution, cds into
+  // it, then writes bare basename. The static substring check misses
+  // the protected path. Fix: detect cd + cmdSub + bare protected
+  // basename redirect.
+  const cwd = freshWorkspace();
+  try {
+    for (const command of [
+      `cd .$(printf mpl)/mpl && printf forged > decomposition.yaml`,
+      `cd .$(printf mpl) && printf forged > state.json`,
+    ]) {
+      const decision = runHook(cwd, {
+        cwd,
+        tool_name: 'Bash',
+        tool_input: { command },
+      });
+      assert.equal(
+        decision.decision,
+        'block',
+        `expected cd-constructed block for: ${command}`,
+      );
+    }
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('#236 A3 claude r24 [security]: gzip / bzip2 / xz remove input file by default', () => {
+  // Claude r24: `gzip FILE` deletes FILE after compression (no -k flag).
+  // Same for bzip2 / xz / zstd. Treat as destructive against the
+  // operand path.
+  const cwd = freshWorkspace();
+  try {
+    for (const command of [
+      'gzip .mpl/memory/some.md',
+      'bzip2 .mpl/memory/some.md',
+      'xz .mpl/memory/some.md',
+      'gzip docs/learnings/learn.md',
+    ]) {
+      const decision = runHook(cwd, {
+        cwd,
+        tool_name: 'Bash',
+        tool_input: { command },
+      });
+      assert.equal(
+        decision.decision,
+        'block',
+        `expected gzip/bzip2/xz block for: ${command}`,
+      );
+    }
+    // Sanity: --keep flag preserves the input → NOT block.
+    const keep = runHook(cwd, {
+      cwd, tool_name: 'Bash',
+      tool_input: { command: 'gzip --keep .mpl/memory/some.md' },
+    });
+    assert.notEqual(keep.decision, 'block');
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('#236 A3 regression: filesystem-level ancestor (cd /tmp from /tmp/X) does NOT trip ancestor-of-protected', () => {
+  // Refinement after r24: the ancestor match was too broad — `cd /tmp`
+  // with cwd `/tmp/X` tripped because `/tmp` is a filesystem-level
+  // ancestor of `/tmp/X/.mpl/mpl`. Fix: only trigger ancestor match
+  // when the operand resolves to a path INSIDE the workspace cwd.
+  const cwd = freshWorkspace();
+  try {
+    const legit = runHook(cwd, {
+      cwd, tool_name: 'Bash',
+      tool_input: { command: 'cd /tmp && echo X > foo.txt' },
+    });
+    assert.notEqual(legit.decision, 'block',
+      '`cd /tmp` from a subdir must not be ancestor-blocked');
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
 test('#236 A3 claude r23 [security]: git clean -*x* sweeps .mpl/ (gitignored) is blocked', () => {
   // Claude r23: `git clean -fdx` deletes untracked + ignored files.
   // .mpl/ is gitignored on every real MPL workspace, so -x sweeps the

--- a/hooks/__tests__/mpl-issue-236-write-guard-tighten.test.mjs
+++ b/hooks/__tests__/mpl-issue-236-write-guard-tighten.test.mjs
@@ -400,6 +400,37 @@ test('#236 A3 claude r2 [security]: ancestors of protected roots are blocked too
   }
 });
 
+test('#236 A3 codex r4 [data-integrity]: backslash-escaped path separators are blocked', () => {
+  // Codex r4: POSIX shells remove `\X` escapes before exec, so
+  // `rm -rf .mpl\/mpl` and `rm -rf docs\/learnings` actually delete
+  // the protected paths. The fix strips every `\X` → `X` before the
+  // substring + token checks so backslash forgery collapses to the
+  // literal a real shell sees.
+  const cwd = freshWorkspace();
+  try {
+    for (const command of [
+      String.raw`rm -rf .mpl\/mpl`,
+      String.raw`rm -rf .mpl\/contracts`,
+      String.raw`rm -rf docs\/learnings`,
+      String.raw`rm -rf \.mpl/mpl`,
+      String.raw`rm -rf .\m\p\l/\m\p\l`,
+    ]) {
+      const decision = runHook(cwd, {
+        cwd,
+        tool_name: 'Bash',
+        tool_input: { command },
+      });
+      assert.equal(
+        decision.decision,
+        'block',
+        `expected backslash-escape block for: ${command}`,
+      );
+    }
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
 test('#236 A3 codex r3 [data-integrity]: quote-concatenation forgery is blocked', () => {
   // Codex r3: POSIX shells concatenate adjacent quoted fragments,
   // so `.mpl/""mpl`, `.mpl"/"mpl`, `.mpl''/''mpl` all resolve to

--- a/hooks/__tests__/mpl-issue-236-write-guard-tighten.test.mjs
+++ b/hooks/__tests__/mpl-issue-236-write-guard-tighten.test.mjs
@@ -476,6 +476,35 @@ test('#236 A1 claude r14 [security]: decomposition.yaml writer-identity check ru
   }
 });
 
+test('#236 A1 codex r21 [security]: normalizeShellCommand collapses /./ and /X/../ in Bash interpreter args', () => {
+  // Codex r21: `node -e 'fs.writeFileSync(".mpl/./state.json", ...)'`
+  // bypassed the substring check because normalizeShellCommand only
+  // collapsed `/+` but not `/./` or `/X/../`. Fix: extend normalize
+  // to collapse those forms too.
+  const cwd = freshWorkspace();
+  try {
+    for (const command of [
+      `node -e require("fs").writeFileSync(".mpl/./state.json","{}")`,
+      `python -c "open('.mpl/./state.json','w').write('{}')"`,
+      `node -e require("fs").writeFileSync(".mpl/foo/../state.json","{}")`,
+      `node -e require("fs").writeFileSync(".mpl/./mpl/decomposition.yaml","forged")`,
+    ]) {
+      const decision = runHook(cwd, {
+        cwd,
+        tool_name: 'Bash',
+        tool_input: { command },
+      });
+      assert.equal(
+        decision.decision,
+        'block',
+        `expected normalize block for: ${command}`,
+      );
+    }
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
 test('#236 A1 codex r20 [security]: Bash state.json forgery while MPL deactivated is blocked', () => {
   // Codex r20: pre-r20 the Bash state.json guard ran AFTER isMplActive.
   // In an inactive workspace (current_phase=completed) a Bash redirect

--- a/hooks/__tests__/mpl-issue-236-write-guard-tighten.test.mjs
+++ b/hooks/__tests__/mpl-issue-236-write-guard-tighten.test.mjs
@@ -400,6 +400,36 @@ test('#236 A3 claude r2 [security]: ancestors of protected roots are blocked too
   }
 });
 
+test('#236 A3 codex r8 [data-integrity]: no-space and fd-prefix redirects are blocked', () => {
+  // Codex r8: POSIX shell redirection doesn't require whitespace
+  // after `>`/`>>`/`&>`. Pre-fix entry gate required `\s` after `>`.
+  // Also fd-prefixed forms (`2>`, `1>>`) must trigger.
+  const cwd = freshWorkspace();
+  try {
+    for (const command of [
+      'echo x >.mpl/mpl/decomposition.yaml',
+      ': >.mpl/contracts/foo.json',
+      'cat /dev/null >.mpl/memory/state',
+      'echo y 2>.mpl/mpl/err.log',
+      'echo z >>.mpl/mpl/log',
+      'echo a &>.mpl/mpl/all',
+    ]) {
+      const decision = runHook(cwd, {
+        cwd,
+        tool_name: 'Bash',
+        tool_input: { command },
+      });
+      assert.equal(
+        decision.decision,
+        'block',
+        `expected no-space redirect block for: ${command}`,
+      );
+    }
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
 test('#236 A3 codex r7 [data-integrity]: parameter-expansion `${var}` after same-line assignment is blocked', () => {
   // Codex r7: `p=.mpl; rm -rf ${p}/mpl` reaches the shell as
   // `rm -rf .mpl/mpl`. Pre-fix the tokenizer saw `${p}/mpl` and

--- a/hooks/__tests__/mpl-issue-236-write-guard-tighten.test.mjs
+++ b/hooks/__tests__/mpl-issue-236-write-guard-tighten.test.mjs
@@ -1,0 +1,286 @@
+// #236 — write-guard tightening for protected paths.
+// A1: orchestrator MUST NOT Write/Edit `.mpl/mpl/decomposition.yaml`
+// (only the mpl-decomposer subagent may, gated by a state dispatch
+// flag with TTL).
+// A3: Bash `rm -rf` against any of the mpl-cancel SKILL-listed
+// protected paths is hard-blocked regardless of the safe-cleanup
+// allowlist; override via env `MPL_FORCE_PURGE=1`.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { execFileSync } from 'child_process';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const HOOKS_DIR = dirname(__dirname);
+const WRITE_GUARD = join(HOOKS_DIR, 'mpl-write-guard.mjs');
+
+function freshWorkspace() {
+  const dir = mkdtempSync(join(tmpdir(), 'mpl-236-'));
+  mkdirSync(join(dir, '.mpl'), { recursive: true });
+  mkdirSync(join(dir, '.mpl', 'mpl'), { recursive: true });
+  writeFileSync(
+    join(dir, '.mpl', 'state.json'),
+    JSON.stringify({ current_phase: 'phase-1' }, null, 2),
+  );
+  return dir;
+}
+
+function runHook(cwd, payload, env = {}) {
+  const out = execFileSync('node', [WRITE_GUARD], {
+    input: JSON.stringify(payload),
+    cwd,
+    encoding: 'utf-8',
+    env: { ...process.env, ...env },
+  });
+  return JSON.parse(out.trim());
+}
+
+function readState(cwd) {
+  return JSON.parse(readFileSync(join(cwd, '.mpl', 'state.json'), 'utf-8'));
+}
+
+// ---------- #236 A1: decomposition.yaml writer-identity ----------
+
+test('#236 A1: orchestrator direct Write of decomposition.yaml is blocked + envelope', () => {
+  const cwd = freshWorkspace();
+  try {
+    const decision = runHook(cwd, {
+      cwd,
+      tool_name: 'Write',
+      tool_input: {
+        file_path: '.mpl/mpl/decomposition.yaml',
+        content: 'phases: []\ngenerated_by: mpl-decomposer\n',
+      },
+    });
+    assert.equal(decision.continue, false);
+    assert.equal(decision.decision, 'block');
+    assert.match(decision.reason, /#236 A1/);
+    assert.match(decision.reason, /mpl-decomposer/);
+
+    const state = readState(cwd);
+    assert.equal(state.session_status, 'blocked_hook');
+    assert.equal(state.blocked_by_hook, 'mpl-write-guard');
+    assert.equal(state.block_code, 'decomposition_writer_violation');
+    assert.equal(state.blocked_artifact, '.mpl/mpl/decomposition.yaml');
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('#236 A1: orchestrator direct Edit of decomposition.yaml is blocked', () => {
+  const cwd = freshWorkspace();
+  try {
+    const decision = runHook(cwd, {
+      cwd,
+      tool_name: 'Edit',
+      tool_input: {
+        file_path: '.mpl/mpl/decomposition.yaml',
+        old_string: 'phases: []',
+        new_string: 'phases: [{id: phase-1}]',
+      },
+    });
+    assert.equal(decision.continue, false);
+    assert.equal(decision.decision, 'block');
+    assert.match(decision.reason, /decomposition\.yaml/);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('#236 A1: Write of decomposition.yaml after mpl-decomposer dispatch is allowed', () => {
+  const cwd = freshWorkspace();
+  try {
+    // Step 1: orchestrator dispatches Agent(subagent_type='mpl-decomposer').
+    // Write-guard records state.decomposer_dispatch.
+    const dispatchDecision = runHook(cwd, {
+      cwd,
+      tool_name: 'Task',
+      tool_input: {
+        subagent_type: 'mpl-decomposer',
+        prompt: 'Decompose ...',
+      },
+    });
+    assert.equal(dispatchDecision.continue, true);
+    const dispatchState = readState(cwd);
+    assert.ok(dispatchState.decomposer_dispatch, 'expected decomposer_dispatch flag');
+    assert.equal(typeof dispatchState.decomposer_dispatch.dispatched_at, 'string');
+
+    // Step 2: subagent writes decomposition.yaml — allowed.
+    const writeDecision = runHook(cwd, {
+      cwd,
+      tool_name: 'Write',
+      tool_input: {
+        file_path: '.mpl/mpl/decomposition.yaml',
+        content: 'phases: []\ngenerated_by: mpl-decomposer\n',
+      },
+    });
+    assert.equal(writeDecision.continue, true);
+    assert.equal(writeDecision.suppressOutput, true);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('#236 A1: stale decomposer_dispatch beyond TTL is treated as inactive', () => {
+  const cwd = freshWorkspace();
+  try {
+    // Plant a stale dispatch flag — 31 minutes in the past.
+    const stalePast = new Date(Date.now() - 31 * 60 * 1000).toISOString();
+    writeFileSync(
+      join(cwd, '.mpl', 'state.json'),
+      JSON.stringify(
+        { current_phase: 'phase-1', decomposer_dispatch: { dispatched_at: stalePast } },
+        null,
+        2,
+      ),
+    );
+    const decision = runHook(cwd, {
+      cwd,
+      tool_name: 'Write',
+      tool_input: { file_path: '.mpl/mpl/decomposition.yaml', content: 'x' },
+    });
+    assert.equal(decision.decision, 'block', 'stale dispatch must not unlock the write');
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('#236 A1: writer-identity check does NOT apply to non-decomposition paths', () => {
+  const cwd = freshWorkspace();
+  try {
+    // .mpl/goal-contract.yaml is allowed for orchestrator.
+    const decision = runHook(cwd, {
+      cwd,
+      tool_name: 'Write',
+      tool_input: { file_path: '.mpl/goal-contract.yaml', content: 'goal: ...' },
+    });
+    assert.equal(decision.continue, true);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+// ---------- #236 A3: protected-path delete ----------
+
+test('#236 A3: `rm -rf .mpl/mpl/...` is blocked + envelope', () => {
+  const cwd = freshWorkspace();
+  try {
+    const decision = runHook(cwd, {
+      cwd,
+      tool_name: 'Bash',
+      tool_input: { command: 'rm -rf .mpl/mpl/phases/phase-1' },
+    });
+    assert.equal(decision.continue, false);
+    assert.equal(decision.decision, 'block');
+    assert.match(decision.reason, /#236 A3/);
+    assert.match(decision.reason, /MPL_FORCE_PURGE/);
+
+    const state = readState(cwd);
+    assert.equal(state.block_code, 'protected_path_delete');
+    assert.equal(state.blocked_artifact, '.mpl/mpl');
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('#236 A3: `rm -rf .mpl/contracts`, `.mpl/memory`, `docs/learnings` all blocked', () => {
+  const cwd = freshWorkspace();
+  try {
+    for (const target of ['.mpl/contracts', '.mpl/memory', 'docs/learnings']) {
+      const decision = runHook(cwd, {
+        cwd,
+        tool_name: 'Bash',
+        tool_input: { command: `rm -rf ${target}` },
+      });
+      assert.equal(decision.decision, 'block', `expected ${target} to be blocked`);
+      assert.equal(JSON.parse(decision.reason ? '{"target": "' + readState(cwd).blocked_artifact + '"}' : '{}').target, target);
+    }
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('#236 A3: MPL_FORCE_PURGE=1 override allows the protected-path delete', () => {
+  const cwd = freshWorkspace();
+  try {
+    const decision = runHook(
+      cwd,
+      {
+        cwd,
+        tool_name: 'Bash',
+        tool_input: { command: 'rm -rf .mpl/mpl/phases/phase-1' },
+      },
+      { MPL_FORCE_PURGE: '1' },
+    );
+    // Not blocked by protected-path check. May still trip the
+    // dangerous-bash warning (which is non-blocking).
+    assert.equal(decision.continue, true);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('#236 A3: `sudo rm -rf .mpl/mpl/...` (wrapped) is still blocked', () => {
+  const cwd = freshWorkspace();
+  try {
+    const decision = runHook(cwd, {
+      cwd,
+      tool_name: 'Bash',
+      tool_input: { command: 'sudo rm -rf .mpl/mpl' },
+    });
+    assert.equal(decision.decision, 'block');
+    assert.match(decision.reason, /#236 A3/);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('#236 A3: rm targeting a NON-protected `.mpl` sibling (e.g. .mpl/signals) still passes the protected-path check', () => {
+  const cwd = freshWorkspace();
+  try {
+    const decision = runHook(cwd, {
+      cwd,
+      tool_name: 'Bash',
+      tool_input: { command: 'rm -rf .mpl/signals' },
+    });
+    // May still emit the dangerous-bash warning (no longer in
+    // safe-cleanup allowlist) but it is NOT a protected-path block.
+    assert.notEqual(decision.decision, 'block');
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('#236 A3: rm targeting node_modules (safe-cleanup) still passes silently', () => {
+  const cwd = freshWorkspace();
+  try {
+    const decision = runHook(cwd, {
+      cwd,
+      tool_name: 'Bash',
+      tool_input: { command: 'rm -rf ./node_modules' },
+    });
+    assert.equal(decision.continue, true);
+    assert.equal(decision.suppressOutput, true);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('#236 A3: `find docs/learnings -type f -delete` is blocked', () => {
+  const cwd = freshWorkspace();
+  try {
+    const decision = runHook(cwd, {
+      cwd,
+      tool_name: 'Bash',
+      tool_input: { command: 'find docs/learnings -type f -delete' },
+    });
+    assert.equal(decision.decision, 'block');
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});

--- a/hooks/__tests__/mpl-issue-236-write-guard-tighten.test.mjs
+++ b/hooks/__tests__/mpl-issue-236-write-guard-tighten.test.mjs
@@ -534,6 +534,82 @@ test('#236 A1 claude r22 [security]: multi-level /X/../ traversal collapse', () 
   }
 });
 
+test('#236 A3 claude r23 [security]: git clean -*x* sweeps .mpl/ (gitignored) is blocked', () => {
+  // Claude r23: `git clean -fdx` deletes untracked + ignored files.
+  // .mpl/ is gitignored on every real MPL workspace, so -x sweeps the
+  // entire .mpl/ tree.
+  const cwd = freshWorkspace();
+  try {
+    for (const command of [
+      'git clean -fdx',
+      'git clean -fdX',
+      'git clean -ffdx',
+      'git clean -fdx .mpl',
+      'git clean -fdx -- .mpl/mpl/',
+    ]) {
+      const decision = runHook(cwd, {
+        cwd,
+        tool_name: 'Bash',
+        tool_input: { command },
+      });
+      assert.equal(
+        decision.decision,
+        'block',
+        `expected git clean -*x* block for: ${command}`,
+      );
+    }
+    // Sanity: git clean WITHOUT -x doesn't reach into ignored files.
+    const safeClean = runHook(cwd, {
+      cwd, tool_name: 'Bash', tool_input: { command: 'git clean -fd' },
+    });
+    assert.notEqual(safeClean.decision, 'block');
+    // Sanity: legit git ops.
+    const status = runHook(cwd, {
+      cwd, tool_name: 'Bash', tool_input: { command: 'git status' },
+    });
+    assert.notEqual(status.decision, 'block');
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('#236 A3 codex r23 [security]: decoder + command-substitution runtime-constructed paths are blocked', () => {
+  // Codex r23: `p=$(base64 -d ...); rm -rf "$p"` constructs the
+  // protected path at runtime via command substitution + decoder.
+  // The literal string never appears in the static normalize form.
+  // Fix: any destructive command with both `base64`/`xxd`/`openssl
+  // base64` AND a command-substitution `$()` / backticks is treated
+  // as suspicious and blocked. MPL_FORCE_PURGE=1 escape applies.
+  const cwd = freshWorkspace();
+  try {
+    for (const command of [
+      'p=$(printf Lm1wbC9tcGw= | base64 -d); rm -rf "$p"',
+      'p=$(echo 2e6d706c2f6d706c | xxd -r -p); rm -rf "$p"',
+      'rm -rf $(printf .mpl/contracts | base64 -d 2>/dev/null || cat <<< .mpl/contracts)',
+    ]) {
+      const decision = runHook(cwd, {
+        cwd,
+        tool_name: 'Bash',
+        tool_input: { command },
+      });
+      assert.equal(
+        decision.decision,
+        'block',
+        `expected runtime-decoder block for: ${command}`,
+      );
+    }
+    // Sanity: legit base64 without rm passes.
+    const legitBase64 = runHook(cwd, {
+      cwd,
+      tool_name: 'Bash',
+      tool_input: { command: 'echo data | base64' },
+    });
+    assert.notEqual(legitBase64.decision, 'block');
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
 test('#236 A3 codex r22 [security]: rsync --delete variants are blocked', () => {
   // Codex r22: `rsync --delete` prunes destination tree. Adding to
   // destructive entry gate.

--- a/hooks/__tests__/mpl-issue-236-write-guard-tighten.test.mjs
+++ b/hooks/__tests__/mpl-issue-236-write-guard-tighten.test.mjs
@@ -448,6 +448,60 @@ test('#236 A1 claude r13 [security]: 2-step deactivation chain via Write/Edit is
   }
 });
 
+test('#236 A1 claude r14 [security]: decomposition.yaml writer-identity check runs BEFORE isMplActive short-circuit', () => {
+  // Claude r14: if Bash deactivation succeeds (claude r14 found a
+  // cmd-substitution bypass), step 2 — direct Write decomposition.yaml —
+  // must still block. The decomposition writer-identity check is now
+  // mirrored before the isMplActive short-circuit, the same shape as
+  // the r13 state.json guard.
+  const cwd = freshWorkspace();
+  try {
+    writeFileSync(
+      join(cwd, '.mpl', 'state.json'),
+      JSON.stringify({ current_phase: 'completed' }),
+    );
+    const decision = runHook(cwd, {
+      cwd,
+      tool_name: 'Write',
+      transcript_path: '/tmp/orch.jsonl',
+      tool_input: {
+        file_path: '.mpl/mpl/decomposition.yaml',
+        content: 'forged',
+      },
+    });
+    assert.equal(decision.decision, 'block');
+    assert.match(decision.reason, /#236 A1/);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('#236 A1 codex r15 [security]: find -exec writing state.json is blocked (find removed from safe-read)', () => {
+  // Codex r15: `find` was in SAFE_READ_HEADS but `-exec sh -c '… > $1'`
+  // bypassed the static regex check (target was a runtime-substituted
+  // `{}` placeholder). Fix: remove find from SAFE_READ_HEADS so any
+  // find mentioning state.json blocks.
+  const cwd = freshWorkspace();
+  try {
+    for (const command of [
+      'find .mpl/state.json -exec sh -c \'echo forged\' _ {} ;',
+    ]) {
+      const decision = runHook(cwd, {
+        cwd,
+        tool_name: 'Bash',
+        tool_input: { command },
+      });
+      assert.equal(
+        decision.decision,
+        'block',
+        `expected find block for: ${command}`,
+      );
+    }
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
 test('#236 A1 codex r14 [security]: structural safe-read-allowlist closes unbounded writer-verb gap', () => {
   // Codex r14: the verb allowlist (rm/mv/tee/dd/install/...) is
   // unbounded — every round another writer utility surfaces. The

--- a/hooks/__tests__/mpl-issue-236-write-guard-tighten.test.mjs
+++ b/hooks/__tests__/mpl-issue-236-write-guard-tighten.test.mjs
@@ -590,6 +590,52 @@ test('#236 A3 claude r25 [security]: gzip per-segment scan — later -k does not
   }
 });
 
+test('#236 A3 codex r26 [security]: -k / --keep AFTER `--` is a filename, not a flag', () => {
+  // Codex r26: `gzip -- .mpl/mpl/-k`. The pre-fix per-segment regex saw
+  // `-k` anywhere in the segment and incorrectly suppressed
+  // isDestructive even though `-k` was the operand (filename), not an
+  // option. POSIX `--` ends options, so any `-k`/`--keep` after it is
+  // a literal path. Fix: only inspect the pre-`--` portion of the
+  // segment for the keep flag.
+  const cwd = freshWorkspace();
+  try {
+    // Realize the `-k` filename on disk so it's a real protected target.
+    const protectedDir = join(cwd, '.mpl', 'mpl');
+    writeFileSync(join(protectedDir, '-k'), 'data');
+    writeFileSync(join(protectedDir, '--keep'), 'data');
+    for (const command of [
+      'gzip -- .mpl/mpl/-k',
+      'gzip -- .mpl/mpl/--keep',
+      'bzip2 -- .mpl/mpl/-k',
+      'xz -- .mpl/mpl/--keep',
+      'zstd -- .mpl/mpl/-k',
+    ]) {
+      const decision = runHook(cwd, {
+        cwd,
+        tool_name: 'Bash',
+        tool_input: { command },
+      });
+      assert.equal(
+        decision.decision,
+        'block',
+        `expected codex r26 -- block for: ${command}`,
+      );
+    }
+    // Sanity: real -k BEFORE `--` still suppresses (legitimate keep).
+    const legitKeep = runHook(cwd, {
+      cwd, tool_name: 'Bash',
+      tool_input: { command: 'gzip -k -- .mpl/memory/some.md' },
+    });
+    assert.equal(
+      legitKeep.continue,
+      true,
+      'real -k before `--` still keeps file',
+    );
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
 test('#236 A3 claude r24 [security]: gzip / bzip2 / xz remove input file by default', () => {
   // Claude r24: `gzip FILE` deletes FILE after compression (no -k flag).
   // Same for bzip2 / xz / zstd. Treat as destructive against the

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -22,7 +22,7 @@
         ]
       },
       {
-        "matcher": "Edit|Write|MultiEdit|Bash",
+        "matcher": "Edit|Write|MultiEdit|Bash|Task|Agent",
         "hooks": [
           {
             "type": "command",

--- a/hooks/mpl-write-guard.mjs
+++ b/hooks/mpl-write-guard.mjs
@@ -197,8 +197,15 @@ function matchesProtectedDelete(command, cwd) {
   // over-blocks on incidental mentions, but `MPL_FORCE_PURGE=1` is
   // already the operator escape hatch — over-blocking is the safe
   // direction for a destructive op.
+  //
+  // Codex r2 on PR #249 [logic]: a real shell normalizes runs of `/`
+  // after expansion (`$PWD/.mpl//mpl` deletes `.mpl/mpl` just fine).
+  // Collapse repeated slashes in the normalized command before the
+  // substring check so the defense is invariant under redundant-slash
+  // forgery.
+  const slashCollapsed = normalized.replace(/\/+/g, '/');
   for (const target of PROTECTED_DELETE_TARGETS) {
-    if (normalized.includes(target)) return target;
+    if (slashCollapsed.includes(target)) return target;
   }
 
   const resolvedRoots = PROTECTED_DELETE_TARGETS.map((target) => ({
@@ -255,13 +262,24 @@ function recordDecomposerDispatch(cwd, parentTranscriptPath) {
 // #236 A1: is the current write coming from the decomposer subagent?
 //   - dispatch flag must be set,
 //   - within the TTL,
-//   - AND the calling transcript_path must DIFFER from the recorded
-//     parent (orchestrator) transcript_path. A same-transcript write
-//     is the orchestrator itself, which the contract forbids.
+//   - the calling transcript_path must DIFFER from the recorded
+//     parent (orchestrator) transcript_path,
+//   - AND lock-on-first-write: the first non-parent transcript that
+//     writes decomposition.yaml under this dispatch is recorded as
+//     `child_transcript_path`. Subsequent writes MUST come from the
+//     same child transcript — any OTHER subagent (phase-runner, etc.)
+//     calling Write during the window would carry a third transcript
+//     and be rejected.
 //
 // When parent_transcript_path was not recorded (legacy state), we
 // fail closed — the writer-identity check cannot be satisfied without
 // a parent reference, so the write is rejected.
+//
+// Codex r2 on PR #249 [logic]: without lock-on-first-write, ANY
+// subagent active in the window could write decomposition.yaml — the
+// dispatch flag was a capability for "any non-orchestrator", not for
+// the specific decomposer. The lock binds the capability to the
+// FIRST consuming child.
 function isDecomposerDispatchActive(state, callerTranscriptPath) {
   const flag = state?.decomposer_dispatch;
   if (!flag || typeof flag.dispatched_at !== 'string') return false;
@@ -273,7 +291,33 @@ function isDecomposerDispatchActive(state, callerTranscriptPath) {
     : null;
   if (!parent) return false;
   if (!callerTranscriptPath || typeof callerTranscriptPath !== 'string') return false;
-  return callerTranscriptPath !== parent;
+  if (callerTranscriptPath === parent) return false;
+  // Lock-on-first-write: if a child transcript has already been
+  // recorded for this dispatch, only that exact transcript may proceed.
+  const lockedChild = typeof flag.child_transcript_path === 'string'
+    ? flag.child_transcript_path
+    : null;
+  if (lockedChild) return callerTranscriptPath === lockedChild;
+  // First consumer — caller is whoever is acting as the decomposer
+  // subagent. The actual locking write happens in main().
+  return true;
+}
+
+// #236 A1: record the locked child transcript on the FIRST allowed
+// Write/Edit of decomposition.yaml during the dispatch window.
+function lockDecomposerChild(cwd, callerTranscriptPath) {
+  try {
+    const state = readState(cwd) || {};
+    const flag = state.decomposer_dispatch;
+    if (!flag || typeof flag !== 'object') return;
+    if (typeof flag.child_transcript_path === 'string') return;
+    writeState(cwd, {
+      decomposer_dispatch: {
+        ...flag,
+        child_transcript_path: callerTranscriptPath,
+      },
+    });
+  } catch { /* best-effort */ }
 }
 
 function isAllowedPath(filePath, opts = {}) {
@@ -446,7 +490,10 @@ ensure you have the correct target path. The command will proceed, but please ve
       }));
       return;
     }
-    // Decomposer dispatch is active — allow + clear any stale envelope.
+    // Decomposer dispatch is active for THIS caller — lock the child
+    // transcript on first write so a third party can't reuse the
+    // window, then allow + clear any stale envelope.
+    lockDecomposerChild(cwd, callerTranscript);
     clearBlockedHook(cwd, { hookId: HOOK_ID, artifact: filePath });
     console.log(JSON.stringify({ continue: true, suppressOutput: true }));
     return;

--- a/hooks/mpl-write-guard.mjs
+++ b/hooks/mpl-write-guard.mjs
@@ -253,8 +253,12 @@ function matchesProtectedDelete(command, cwd) {
     /\bunlink\b/.test(normalized) ||
     /\btruncate\b/.test(normalized) ||
     /\bcp\b.*\/dev\/null/.test(normalized) ||
-    /(^|[\s;|&])>{1,2}\s/.test(normalized) ||
-    /(^|[\s;|&])&>{1}\s/.test(normalized)
+    // Codex r8 on PR #249 [data-integrity]: POSIX shell redirection
+    // does not require whitespace after `>`/`>>`/`&>`. `echo x
+    // >.mpl/mpl/foo` truncates the protected file. Allow optional
+    // fd-prefix (`2>`, `1>>`) and tolerate adjacent operand.
+    /(?:^|[\s;|&])\d?>{1,2}/.test(normalized) ||
+    /(?:^|[\s;|&])&>{1,2}/.test(normalized)
   );
   if (!isDestructive) return null;
 
@@ -317,7 +321,10 @@ function matchesProtectedDelete(command, cwd) {
   // Tokenize on whitespace AND `;`/`&&`/`||`/`|`/`(`/`)` so a
   // multi-command line + subshell surfaces every operand.
   const tokens = normalized
-    .split(/[\s;|&()]+/)
+    // Codex r8: also split on `>` / `<` so redirect operators with
+    // no whitespace before the operand (`echo x >.mpl/mpl/foo`) split
+    // off the path token cleanly.
+    .split(/[\s;|&()<>]+/)
     .map((t) => t.replace(/^[\\$]+/, '').replace(/[\\)]+$/, ''))
     .filter(Boolean);
 

--- a/hooks/mpl-write-guard.mjs
+++ b/hooks/mpl-write-guard.mjs
@@ -675,6 +675,60 @@ async function main() {
     }
   }
 
+  // Codex r16 on PR #249 [security]: also gate Bash writes to
+  // .mpl/mpl/decomposition.yaml BEFORE the isMplActive short-circuit.
+  // The Write/Edit pre-active guard above doesn't cover Bash.
+  // Without this, `printf forged > .mpl/mpl/decomposition.yaml` runs
+  // against a deactivated workspace and overwrites the
+  // decomposer-owned artifact through shell redirection.
+  if (isBashTool && process.env.MPL_FORCE_PURGE !== '1') {
+    const earlyCommand = (data.tool_input || data.toolInput || {}).command || '';
+    if (earlyCommand && existsSync(join(cwd, '.mpl'))) {
+      const normalizedEarly = normalizeShellCommand(earlyCommand);
+      const decompMention = /\.mpl\/mpl\/decomposition\.ya?ml/.test(normalizedEarly);
+      if (decompMention) {
+        const headM = normalizedEarly.match(/^(\w+)/);
+        const head = headM ? headM[1].toLowerCase() : '';
+        const SAFE_READS = new Set([
+          'cat', 'ls', 'head', 'tail', 'wc', 'file', 'stat', 'du', 'df',
+          'grep', 'rg', 'ag', 'ack', 'jq', 'yq',
+          'less', 'more', 'sort', 'uniq', 'tac', 'nl',
+          'diff', 'comm', 'sdiff',
+          'echo', 'printf', 'pwd', 'type', 'which',
+        ]);
+        const writesToDecomp = (
+          /[\d&]?>{1,2}[^|;&\n]*\.mpl\/mpl\/decomposition\.ya?ml/.test(normalizedEarly) ||
+          /\btee\b[^|;&]*\.mpl\/mpl\/decomposition\.ya?ml/.test(normalizedEarly) ||
+          /\bdd\b[^|;&]*\bof=[^|;&]*\.mpl\/mpl\/decomposition\.ya?ml/.test(normalizedEarly)
+        );
+        if (!SAFE_READS.has(head) || writesToDecomp) {
+          const reason =
+            `[MPL #236 A1] Refused Bash write to .mpl/mpl/decomposition.yaml: ` +
+            `only the mpl-decomposer subagent may emit this file. Bash writes ` +
+            `(including those allowed by a deactivated MPL state) bypass the ` +
+            `writer-identity gate. Use Agent(subagent_type='mpl-decomposer', ` +
+            `prompt='...'), OR set MPL_FORCE_PURGE=1 for a one-shot manual edit.`;
+          recordBlockedHook(cwd, {
+            hookId: HOOK_ID,
+            phaseId: (readState(cwd) || {}).current_phase,
+            artifact: '.mpl/mpl/decomposition.yaml',
+            code: 'decomposition_bash_write',
+            reason,
+            resumeInstruction:
+              `Dispatch Agent(subagent_type='mpl-decomposer'); do not write decomposition.yaml from Bash.`,
+            retryContext: { command: earlyCommand },
+          });
+          console.log(JSON.stringify({
+            continue: false,
+            decision: 'block',
+            reason,
+          }));
+          return;
+        }
+      }
+    }
+  }
+
   // Check if MPL is active
   if (!isMplActive(cwd)) {
     // MPL inactive: no interference

--- a/hooks/mpl-write-guard.mjs
+++ b/hooks/mpl-write-guard.mjs
@@ -190,6 +190,10 @@ function matchesProtectedDelete(command, cwd) {
   }
 
   // Pre-normalize:
+  //   - Codex r4 on PR #249 [data-integrity]: POSIX shells remove
+  //     backslash escapes before exec — `rm -rf .mpl\/mpl` deletes
+  //     `.mpl/mpl`. Strip every `\X` → `X` first so backslash-escape
+  //     forgery collapses to the same literal a real shell would see.
   //   - Codex r3 on PR #249 [data-integrity]: POSIX shells concatenate
   //     adjacent quote fragments. `.mpl/""mpl` and `.mpl"/"mpl` both
   //     resolve to `.mpl/mpl` at execution time. Strip every `"`, `'`,
@@ -198,9 +202,12 @@ function matchesProtectedDelete(command, cwd) {
   //   - Codex r2 on PR #249 [logic]: a real shell normalizes runs of
   //     `/` after expansion (`$PWD/.mpl//mpl` deletes `.mpl/mpl`).
   //     Collapse repeated slashes to one.
-  // Both transforms preserve token-boundary whitespace, so downstream
-  // tokenization still works.
-  normalized = normalized.replace(/["'`]/g, '').replace(/\/+/g, '/');
+  // All three transforms preserve token-boundary whitespace, so
+  // downstream tokenization still works.
+  normalized = normalized
+    .replace(/\\([\s\S])/g, '$1')
+    .replace(/["'`]/g, '')
+    .replace(/\/+/g, '/');
 
   // Claude r1 on PR #249 [logic] (concrete repros): shell-expansion
   // forms (`$PWD`, `$(pwd)`), parenthesized subshells, variable

--- a/hooks/mpl-write-guard.mjs
+++ b/hooks/mpl-write-guard.mjs
@@ -609,6 +609,45 @@ async function main() {
     // current_phase). This guards the deactivation chain even when
     // current_phase has been flipped to completed/cancelled.
     const isMplDir = existsSync(join(cwd, '.mpl'));
+
+    // Claude r14 on PR #249 [security]: also move the decomposition.yaml
+    // writer-identity check BEFORE the isMplActive short-circuit. The
+    // r13 state.json guard alone is insufficient because an attacker
+    // can deactivate MPL via Bash (command-substitution + cd + bare
+    // filename redirect bypasses the static normalize) and then
+    // direct-Write decomposition.yaml — the post-isMplActive
+    // writer-identity check never runs. Apply the same pre-active
+    // guard shape used by the state.json early-return.
+    if (earlyFilePath && DECOMPOSITION_FILE_REGEX.test(earlyFilePath) && isMplDir) {
+      const earlyState = readState(cwd) || {};
+      const earlyCallerTranscript = typeof data.transcript_path === 'string'
+        ? data.transcript_path
+        : (typeof data.transcriptPath === 'string' ? data.transcriptPath : null);
+      if (!isDecomposerDispatchActive(earlyState, earlyCallerTranscript)) {
+        const reason =
+          `[MPL #236 A1] Refused direct ${toolName} of decomposition.yaml: ` +
+          `only the mpl-decomposer subagent may emit this file. ` +
+          `Dispatch via Agent(subagent_type='mpl-decomposer', prompt='...') ` +
+          `and let it write.`;
+        recordBlockedHook(cwd, {
+          hookId: HOOK_ID,
+          phaseId: earlyState?.current_phase,
+          artifact: earlyFilePath,
+          code: 'decomposition_writer_violation',
+          reason,
+          resumeInstruction:
+            `Dispatch Agent(subagent_type='mpl-decomposer') and let it produce decomposition.yaml; do not Edit/Write it directly.`,
+          retryContext: { file_path: earlyFilePath, tool: toolName },
+        });
+        console.log(JSON.stringify({
+          continue: false,
+          decision: 'block',
+          reason,
+        }));
+        return;
+      }
+    }
+
     if (earlyFilePath && STATE_FILE_REGEX.test(earlyFilePath) && isMplDir) {
       const reason =
         `[MPL #236 A1] Refused direct ${toolName} of .mpl/state.json: only ` +
@@ -720,11 +759,16 @@ async function main() {
     // `printf X | base64 -d > .mpl/state.json` (head safe but redirect
     // target is state.json) AND novel writer utilities (install / pax /
     // cpio / touch / mktemp / etc., head not safe-read).
+    // Codex r15 on PR #249 [security]: removed `find` from the
+    // safe-read set. `find .mpl/state.json -exec sh -c 'echo forged
+    // > "$1"' _ {} \;` would otherwise pass — `find` head is safe-
+    // read but `-exec` invokes arbitrary shell that writes via a
+    // runtime-substituted `{}` operand which the static regex check
+    // can't see.
     const SAFE_READ_HEADS = new Set([
       'cat', 'ls', 'head', 'tail', 'wc', 'file', 'stat', 'du', 'df',
       'grep', 'rg', 'ag', 'ack',
       'jq', 'yq',
-      'find', // -delete is already rejected upstream as destructive
       'less', 'more',
       'sort', 'uniq', 'tac', 'nl',
       'diff', 'comm', 'sdiff',

--- a/hooks/mpl-write-guard.mjs
+++ b/hooks/mpl-write-guard.mjs
@@ -700,19 +700,28 @@ async function main() {
         // target in the command, not just the first. A multi-statement
         // line with a benign first redirect followed by a symlink-
         // through-protected second redirect would otherwise slip.
-        const targetRe = /(?:[\d&]?>{1,2}|\btee\b[^|;&]*|\bdd\b[^|;&]*\bof=)\s*([^\s|;&]+)/g;
+        //
+        // Claude r19 [security]: the tee alternation was greedy and
+        // swallowed the path itself via regex backtracking. Anchor
+        // tee's capture group AFTER any flag tokens: `tee (-X)* PATH`.
+        const targetRe = /(?:[\d&]?>{1,2}\s*|\btee\b(?:\s+-\S+)*\s+|\bdd\b[^|;&]*\bof=\s*)([^\s|;&]+)/g;
         for (const m of normalizedEarly.matchAll(targetRe)) {
           const target = m[1];
           const targetAbs = resolvePath(cwd, target);
-          try {
-            const realParent = realpathSync(dirname(targetAbs));
-            const candidate = join(realParent, basename(targetAbs));
-            if (/\.mpl\/mpl\/decomposition\.ya?ml$/.test(candidate)) {
-              decompMention = true;
-              symlinkWritesToDecomp = true;
-              break;
-            }
-          } catch { /* parent doesn't exist — skip realpath */ }
+          // Try the WHOLE target first (catches the case where the
+          // target itself is a symlink to a protected file). Fall back
+          // to realpath(dirname) if the target doesn't exist yet.
+          let candidate = null;
+          try { candidate = realpathSync(targetAbs); }
+          catch {
+            try { candidate = join(realpathSync(dirname(targetAbs)), basename(targetAbs)); }
+            catch { /* parent doesn't exist — skip */ }
+          }
+          if (candidate && /\.mpl\/mpl\/decomposition\.ya?ml$/.test(candidate)) {
+            decompMention = true;
+            symlinkWritesToDecomp = true;
+            break;
+          }
         }
       }
       if (decompMention) {
@@ -886,19 +895,22 @@ async function main() {
     // through-state.json forms (single or multi-statement) are caught.
     let symlinkWritesToStateJson = false;
     if (!stateJsonMention) {
-      const stateTargetRe = /(?:[\d&]?>{1,2}|\btee\b[^|;&]*|\bdd\b[^|;&]*\bof=)\s*([^\s|;&]+)/g;
+      // Claude r19 [security]: anchor tee's capture after option list.
+      const stateTargetRe = /(?:[\d&]?>{1,2}\s*|\btee\b(?:\s+-\S+)*\s+|\bdd\b[^|;&]*\bof=\s*)([^\s|;&]+)/g;
       for (const m of normalizedCommand.matchAll(stateTargetRe)) {
         const target = m[1];
         const targetAbs = resolvePath(cwd, target);
-        try {
-          const realParent = realpathSync(dirname(targetAbs));
-          const candidate = join(realParent, basename(targetAbs));
-          if (/\.mpl\/state\.json$/.test(candidate)) {
-            symlinkWritesToStateJson = true;
-            writesToStateJson = true;
-            break;
-          }
-        } catch { /* parent doesn't exist — skip */ }
+        let candidate = null;
+        try { candidate = realpathSync(targetAbs); }
+        catch {
+          try { candidate = join(realpathSync(dirname(targetAbs)), basename(targetAbs)); }
+          catch { /* skip */ }
+        }
+        if (candidate && /\.mpl\/state\.json$/.test(candidate)) {
+          symlinkWritesToStateJson = true;
+          writesToStateJson = true;
+          break;
+        }
       }
     }
     if ((stateJsonMention || symlinkWritesToStateJson) && (!isSafeRead || writesToStateJson) && process.env.MPL_FORCE_PURGE !== '1') {

--- a/hooks/mpl-write-guard.mjs
+++ b/hooks/mpl-write-guard.mjs
@@ -13,7 +13,17 @@
  * When MPL is active: guards Edit/Write on source files + warns on dangerous Bash
  */
 
-import { dirname, join, extname, resolve as resolvePath, basename } from 'path';
+import { dirname, join, extname, resolve as resolvePath, basename, posix as posixPath } from 'path';
+
+// Claude r20 on PR #249 [security]: POSIX path resolution collapses
+// `//` and `/./` segments at write time. The orchestrator can plant
+// `.mpl//mpl/decomposition.yaml` or `.mpl/./state.json` and the
+// protected-file regex (which requires single slashes) misses it.
+// Normalize the file_path before every protected-file regex check.
+function normalizeFilePath(p) {
+  if (typeof p !== 'string' || !p) return p;
+  return posixPath.normalize(p);
+}
 import { existsSync, realpathSync } from 'fs';
 import { fileURLToPath, pathToFileURL } from 'url';
 
@@ -623,7 +633,7 @@ async function main() {
     // direct-Write decomposition.yaml — the post-isMplActive
     // writer-identity check never runs. Apply the same pre-active
     // guard shape used by the state.json early-return.
-    if (earlyFilePath && DECOMPOSITION_FILE_REGEX.test(earlyFilePath) && isMplDir) {
+    if (earlyFilePath && DECOMPOSITION_FILE_REGEX.test(normalizeFilePath(earlyFilePath)) && isMplDir) {
       const earlyState = readState(cwd) || {};
       const earlyCallerTranscript = typeof data.transcript_path === 'string'
         ? data.transcript_path
@@ -653,7 +663,7 @@ async function main() {
       }
     }
 
-    if (earlyFilePath && STATE_FILE_REGEX.test(earlyFilePath) && isMplDir) {
+    if (earlyFilePath && STATE_FILE_REGEX.test(normalizeFilePath(earlyFilePath)) && isMplDir) {
       const reason =
         `[MPL #236 A1] Refused direct ${toolName} of .mpl/state.json: only ` +
         `mpl-write-guard's internal writeState may modify the orchestrator ` +
@@ -762,6 +772,82 @@ async function main() {
             reason,
             resumeInstruction:
               `Dispatch Agent(subagent_type='mpl-decomposer'); do not write decomposition.yaml from Bash.`,
+            retryContext: { command: earlyCommand },
+          });
+          console.log(JSON.stringify({
+            continue: false,
+            decision: 'block',
+            reason,
+          }));
+          return;
+        }
+      }
+    }
+  }
+
+  // Codex r20 on PR #249 [security]: also gate Bash writes to
+  // .mpl/state.json BEFORE the isMplActive short-circuit. Without
+  // this, the deactivation-chain class re-opens for Bash:
+  // current_phase=completed lets a Bash redirect write a forged
+  // decomposer_dispatch into state.json. Mirrors the decomp guard
+  // above and the r13 state.json Write/Edit guard.
+  if (isBashTool && process.env.MPL_FORCE_PURGE !== '1') {
+    const earlyCommand = (data.tool_input || data.toolInput || {}).command || '';
+    if (earlyCommand && existsSync(join(cwd, '.mpl'))) {
+      const normalizedEarly = normalizeShellCommand(earlyCommand);
+      const SAFE_READS_EARLY = new Set([
+        'cat', 'ls', 'head', 'tail', 'wc', 'file', 'stat', 'du', 'df',
+        'grep', 'rg', 'ag', 'ack', 'jq', 'yq',
+        'less', 'more', 'sort', 'uniq', 'tac', 'nl',
+        'diff', 'comm', 'sdiff',
+        'echo', 'printf', 'pwd', 'type', 'which',
+      ]);
+      let stateMention = /\.mpl\/state\.json/.test(normalizedEarly);
+      let symlinkWritesToState = false;
+      if (!stateMention) {
+        const stateTargetReEarly = /(?:[\d&]?>{1,2}\s*|\btee\b(?:\s+-\S+)*\s+|\bdd\b[^|;&]*\bof=\s*)([^\s|;&]+)/g;
+        for (const m of normalizedEarly.matchAll(stateTargetReEarly)) {
+          const targetAbs = resolvePath(cwd, m[1]);
+          let candidate = null;
+          try { candidate = realpathSync(targetAbs); }
+          catch {
+            try { candidate = join(realpathSync(dirname(targetAbs)), basename(targetAbs)); }
+            catch { /* skip */ }
+          }
+          if (candidate && /\.mpl\/state\.json$/.test(candidate)) {
+            stateMention = true;
+            symlinkWritesToState = true;
+            break;
+          }
+        }
+      }
+      if (stateMention) {
+        const segmentsEarly = normalizedEarly.split(/[|;&]+/).map((s) => s.trim()).filter(Boolean);
+        const allSafeEarly = segmentsEarly.length > 0 && segmentsEarly.every((seg) => {
+          const h = (seg.match(/^(\w+)/) || ['', ''])[1].toLowerCase();
+          return SAFE_READS_EARLY.has(h);
+        });
+        const writesEarly = (
+          /[\d&]?>{1,2}[^|;&\n]*\.mpl\/state\.json/.test(normalizedEarly) ||
+          /\btee\b[^|;&]*\.mpl\/state\.json/.test(normalizedEarly) ||
+          /\bdd\b[^|;&]*\bof=[^|;&]*\.mpl\/state\.json/.test(normalizedEarly)
+        );
+        if (!allSafeEarly || writesEarly || symlinkWritesToState) {
+          const reason =
+            `[MPL #236 A1] Refused Bash write to .mpl/state.json: only ` +
+            `mpl-write-guard's internal writeState may modify the orchestrator ` +
+            `state file. Bash writes (including those allowed by a deactivated ` +
+            `MPL state) bypass the writer-identity gate and would let any caller ` +
+            `forge decomposer_dispatch / first_transcript_seen / other capability ` +
+            `fields. Set MPL_FORCE_PURGE=1 for a one-shot manual reset.`;
+          recordBlockedHook(cwd, {
+            hookId: HOOK_ID,
+            phaseId: (readState(cwd) || {}).current_phase,
+            artifact: '.mpl/state.json',
+            code: 'state_json_bash_write',
+            reason,
+            resumeInstruction:
+              `Route the change through writeState(); set MPL_FORCE_PURGE=1 only for a one-shot manual reset.`,
             retryContext: { command: earlyCommand },
           });
           console.log(JSON.stringify({
@@ -1017,7 +1103,7 @@ ensure you have the correct target path. The command will proceed, but please ve
   // inside another subagent — is blocked. The block precedes the
   // generic `isAllowedPath` (.mpl/* is otherwise an allowlisted
   // orchestrator path) so the writer identity wins.
-  if (DECOMPOSITION_FILE_REGEX.test(filePath)) {
+  if (DECOMPOSITION_FILE_REGEX.test(normalizeFilePath(filePath))) {
     const callerTranscript = typeof data.transcript_path === 'string'
       ? data.transcript_path
       : (typeof data.transcriptPath === 'string' ? data.transcriptPath : null);

--- a/hooks/mpl-write-guard.mjs
+++ b/hooks/mpl-write-guard.mjs
@@ -177,6 +177,30 @@ function isDangerousBashCommand(command) {
 // Resolving each token via path.resolve(cwd, token) normalizes those
 // forms to a single canonical absolute path that we can compare
 // against the resolved protected roots.
+// Expand bash brace patterns within each whitespace-separated token,
+// repeating until no more `{…}` groups remain (10-round backstop for
+// pathological nesting). Cartesian: `{a,b}{c,d}` → `ac ad bc bd`.
+function expandShellBraces(text) {
+  let tokens = text.split(/\s+/);
+  for (let iter = 0; iter < 10; iter++) {
+    let changed = false;
+    const next = [];
+    for (const t of tokens) {
+      const m = t.match(/^([^{}]*)\{([^{}]+)\}(.*)$/);
+      if (m && m[2].includes(',')) {
+        const [, pre, body, post] = m;
+        for (const p of body.split(',')) next.push(`${pre}${p}${post}`);
+        changed = true;
+      } else {
+        next.push(t);
+      }
+    }
+    tokens = next;
+    if (!changed) break;
+  }
+  return tokens.join(' ');
+}
+
 function matchesProtectedDelete(command, cwd) {
   if (!command || typeof command !== 'string') return null;
   // Strip leading wrapper before checking the head — `sudo rm -rf …`
@@ -189,25 +213,45 @@ function matchesProtectedDelete(command, cwd) {
     return null;
   }
 
-  // Pre-normalize:
+  // Pre-normalize the command to the form a real shell would execute,
+  // so substring + token checks see the same path the OS sees.
+  // Layered from "most decoded" to "least decoded":
+  //   - Codex r5 on PR #249 [data-integrity]: Bash ANSI-C quoting
+  //     ($'…') decodes hex (\xHH), octal (\OOO), and Unicode (\uHHHH /
+  //     \UHHHHHHHH) escapes. `rm -rf $'.mpl\x2fmpl'` deletes `.mpl/mpl`.
+  //     Decode these escapes to characters BEFORE the generic
+  //     backslash strip so they don't get clobbered to `x2f`.
   //   - Codex r4 on PR #249 [data-integrity]: POSIX shells remove
-  //     backslash escapes before exec — `rm -rf .mpl\/mpl` deletes
-  //     `.mpl/mpl`. Strip every `\X` → `X` first so backslash-escape
-  //     forgery collapses to the same literal a real shell would see.
-  //   - Codex r3 on PR #249 [data-integrity]: POSIX shells concatenate
-  //     adjacent quote fragments. `.mpl/""mpl` and `.mpl"/"mpl` both
-  //     resolve to `.mpl/mpl` at execution time. Strip every `"`, `'`,
-  //     backtick character so quote-concatenation forgery collapses to
-  //     the same literal a real shell would see.
-  //   - Codex r2 on PR #249 [logic]: a real shell normalizes runs of
-  //     `/` after expansion (`$PWD/.mpl//mpl` deletes `.mpl/mpl`).
+  //     generic backslash escapes — `rm -rf .mpl\/mpl` deletes
+  //     `.mpl/mpl`. After ANSI-C decoding, strip every remaining
+  //     `\X` → `X`.
+  //   - Codex r3 on PR #249 [data-integrity]: shells concatenate
+  //     adjacent quote fragments — `.mpl/""mpl` and `.mpl"/"mpl`
+  //     resolve to `.mpl/mpl`. Strip every `"`, `'`, backtick.
+  //   - Codex r2 on PR #249 [logic]: shells normalize runs of `/`
+  //     after expansion (`$PWD/.mpl//mpl` deletes `.mpl/mpl`).
   //     Collapse repeated slashes to one.
-  // All three transforms preserve token-boundary whitespace, so
-  // downstream tokenization still works.
+  // All transforms preserve token-boundary whitespace.
   normalized = normalized
+    .replace(/\\x([0-9a-fA-F]{2})/g, (_, h) => String.fromCharCode(parseInt(h, 16)))
+    .replace(/\\u([0-9a-fA-F]{4})/g, (_, h) => String.fromCharCode(parseInt(h, 16)))
+    .replace(/\\U([0-9a-fA-F]{8})/g, (_, h) => {
+      const cp = parseInt(h, 16);
+      try { return String.fromCodePoint(cp); } catch { return ''; }
+    })
+    .replace(/\\([0-7]{1,3})/g, (_, oct) => String.fromCharCode(parseInt(oct, 8)))
     .replace(/\\([\s\S])/g, '$1')
     .replace(/["'`]/g, '')
     .replace(/\/+/g, '/');
+
+  // Claude r5 on PR #249 [data-integrity]: Bash brace expansion
+  // (`.mpl/{mpl,contracts}` → `.mpl/mpl .mpl/contracts`, cartesian
+  // `{a,b}{c,d}` → `ac ad bc bd`) was a new class outside the
+  // previously-closed list. Expand braces here so the literal target
+  // appears in one of the expanded tokens and the substring + token
+  // checks fire normally. Iterative leftmost-brace expansion handles
+  // nested + cartesian forms; we cap at 10 iterations as a backstop.
+  normalized = expandShellBraces(normalized);
 
   // Claude r1 on PR #249 [logic] (concrete repros): shell-expansion
   // forms (`$PWD`, `$(pwd)`), parenthesized subshells, variable

--- a/hooks/mpl-write-guard.mjs
+++ b/hooks/mpl-write-guard.mjs
@@ -577,6 +577,41 @@ async function main() {
   // --- Bash dangerous command check (T-01, v3.8) + #236 A3 ---
   if (isBashTool) {
     const command = toolInput.command || '';
+    // Claude r11 on PR #249 [security]: Claude r9's
+    // decomposer_dispatch forgery guard only covered Write/Edit.
+    // A Bash command like
+    //   `echo '{"decomposer_dispatch":…}' > .mpl/state.json`
+    //   `tee .mpl/state.json <<EOF …`
+    //   `dd of=.mpl/state.json …`
+    //   `node -e 'fs.writeFileSync(".mpl/state.json", …)'`
+    // can still plant the flag through the Bash tool surface.
+    // Refuse any Bash command that mentions BOTH `.mpl/state.json`
+    // AND `decomposer_dispatch`. The MPL hook is the only legitimate
+    // writer of that key — no shell command should ever co-mention
+    // them.
+    if (/\.mpl\/state\.json/.test(command) && /decomposer_dispatch/.test(command)) {
+      const reason =
+        `[MPL #236 A1] Refused Bash that mentions both .mpl/state.json AND ` +
+        `decomposer_dispatch — only mpl-write-guard itself may plant that flag. ` +
+        `Allowing this would let the orchestrator forge the decomposition.yaml ` +
+        `writer-identity check.`;
+      recordBlockedHook(cwd, {
+        hookId: HOOK_ID,
+        phaseId: (readState(cwd) || {}).current_phase,
+        artifact: '.mpl/state.json',
+        code: 'decomposer_dispatch_forgery',
+        reason,
+        resumeInstruction:
+          `Remove the decomposer_dispatch reference from the Bash command. The hook will populate it on Agent(subagent_type='mpl-decomposer') dispatch.`,
+        retryContext: { command },
+      });
+      console.log(JSON.stringify({
+        continue: false,
+        decision: 'block',
+        reason,
+      }));
+      return;
+    }
     // #236 A3: protected-path delete — hard-block regardless of safe-cleanup
     // allowlist. Override via env MPL_FORCE_PURGE=1 set by the operator.
     const protectedTarget = matchesProtectedDelete(command, cwd);

--- a/hooks/mpl-write-guard.mjs
+++ b/hooks/mpl-write-guard.mjs
@@ -275,7 +275,15 @@ function normalizeShellCommand(command) {
     .replace(/\\([0-7]{1,3})/g, (_, oct) => String.fromCharCode(parseInt(oct, 8)))
     .replace(/\\([\s\S])/g, '$1')
     .replace(/["'`]/g, '')
-    .replace(/\/+/g, '/');
+    .replace(/\/+/g, '/')
+    // Codex r21 [security]: collapse `/./` segments. POSIX collapses
+    // these at path-resolution time, so `.mpl/./state.json` and
+    // `.mpl/./mpl/decomposition.yaml` are equivalent to the canonical
+    // form. Iterate until no more match (handles `/././`).
+    .replace(/\/(?:\.\/)+/g, '/')
+    // Collapse `/X/../` traversal forms once (covers .mpl/foo/../state.json).
+    // This is a heuristic — full traversal resolution is out of scope.
+    .replace(/\/[^/]+\/\.\.\//g, '/');
   normalized = expandShellBraces(normalized);
   normalized = expandSimpleVars(normalized);
   return normalized;

--- a/hooks/mpl-write-guard.mjs
+++ b/hooks/mpl-write-guard.mjs
@@ -366,13 +366,40 @@ function matchesProtectedDelete(command, cwd) {
     // gzip earlier in the chain.
     normalized.split(/[;|&\n]+/).some((seg) => {
       if (!/\b(gzip|bzip2|xz|zstd)\b/.test(seg)) return false;
-      // Codex r26 [security]: `-k`/`--keep` only counts as an option
-      // when it appears BEFORE `--` (POSIX end-of-options sentinel).
-      // After `--` any `-k` is a literal filename. So `gzip -- .mpl/mpl/-k`
-      // still deletes the protected file. Split the segment at `--` and
-      // only inspect the pre-options portion for the keep flag.
-      const beforeDoubleDash = seg.split(/\s--(?:\s|$)/)[0];
-      return !/(?:-k|--keep)\b/.test(beforeDoubleDash);
+      // Claude r27 [security] (generalizes Codex r26): `-k`/`--keep`
+      // must be a STANDALONE option token, not a substring of an
+      // operand path. Otherwise `gzip .mpl/mpl/-k` and similar
+      // filename-ends-in-`-k` paths suppress the destructive check
+      // even without a POSIX `--` end-of-options sentinel — the
+      // segment-wide `/(?:-k|--keep)\b/` matched the filename tail.
+      //
+      // Tokenize on whitespace; only consider tokens after the
+      // compressor verb and BEFORE a literal `--` token. A keep flag
+      // is one of:
+      //   - exactly `-k`
+      //   - exactly `--keep`
+      //   - `--keep=…` (long option with value)
+      //   - `-Xk[Y…]` (combined short-flag bundle including `k`)
+      const tokens = seg.trim().split(/\s+/);
+      let pastVerb = false;
+      let hasKeep = false;
+      for (const t of tokens) {
+        if (!pastVerb) {
+          if (/^(gzip|bzip2|xz|zstd)$/.test(t)) pastVerb = true;
+          continue;
+        }
+        if (t === '--') break;
+        if (
+          t === '-k' ||
+          t === '--keep' ||
+          /^--keep=/.test(t) ||
+          /^-[a-zA-Z]*k[a-zA-Z]*$/.test(t)
+        ) {
+          hasKeep = true;
+          break;
+        }
+      }
+      return !hasKeep;
     }) ||
     // Codex r10 on PR #249 [data-integrity]: interpreter one-liners
     // (`node -e "require('fs').rmSync('.mpl/mpl')"`, `python -c

--- a/hooks/mpl-write-guard.mjs
+++ b/hooks/mpl-write-guard.mjs
@@ -713,24 +713,34 @@ async function main() {
     // uses). Read-only operations against state.json (`cat .mpl/
     // state.json`, `ls .mpl/state.json`) still pass.
     const stateJsonMention = /\.mpl\/state\.json/.test(normalizedCommand);
-    const hasWriteVerb = (
-      /\brm\b/.test(normalizedCommand) ||
-      /\bfind\b.*-delete\b/.test(normalizedCommand) ||
-      /\bmv\b/.test(normalizedCommand) ||
-      /\bshred\b/.test(normalizedCommand) ||
-      /\bunlink\b/.test(normalizedCommand) ||
-      /\btruncate\b/.test(normalizedCommand) ||
-      /\bcp\b/.test(normalizedCommand) ||
-      /\btee\b/.test(normalizedCommand) ||
-      /\bdd\b.*\bof=/.test(normalizedCommand) ||
-      /\btar\b.*--remove-files\b/.test(normalizedCommand) ||
-      /\brsync\b.*--remove-source-files\b/.test(normalizedCommand) ||
-      /\b(node|deno|bun|python\d?|ruby|perl|php|lua|tclsh|osascript|awk|sed)\b/.test(normalizedCommand) ||
-      /(?:^|[\s;|&])\d?>{1,2}/.test(normalizedCommand) ||
-      /(?:^|[\s;|&])&>{1,2}/.test(normalizedCommand) ||
-      /\bbase64\b/.test(normalizedCommand) // codex r13: catches the base64 decode path explicitly
+    // Codex r14 on PR #249 [security]: a verb allowlist is unbounded.
+    // Structural rule: state.json is presumed-write UNLESS the head
+    // verb is in SAFE_READ_HEADS AND the command does not redirect /
+    // tee / dd-of into state.json. This catches pipeline forms like
+    // `printf X | base64 -d > .mpl/state.json` (head safe but redirect
+    // target is state.json) AND novel writer utilities (install / pax /
+    // cpio / touch / mktemp / etc., head not safe-read).
+    const SAFE_READ_HEADS = new Set([
+      'cat', 'ls', 'head', 'tail', 'wc', 'file', 'stat', 'du', 'df',
+      'grep', 'rg', 'ag', 'ack',
+      'jq', 'yq',
+      'find', // -delete is already rejected upstream as destructive
+      'less', 'more',
+      'sort', 'uniq', 'tac', 'nl',
+      'diff', 'comm', 'sdiff',
+      'echo', 'printf', 'pwd', 'type', 'which',
+    ]);
+    const headVerbMatch = normalizedCommand.match(/^(\w+)/);
+    const headVerb = headVerbMatch ? headVerbMatch[1].toLowerCase() : '';
+    const isSafeRead = SAFE_READ_HEADS.has(headVerb);
+    // Detect redirect/tee/dd targeting state.json anywhere in the
+    // command (catches pipe-then-redirect forms).
+    const writesToStateJson = (
+      /[\d&]?>{1,2}[^|;&\n]*\.mpl\/state\.json/.test(normalizedCommand) ||
+      /\btee\b[^|;&]*\.mpl\/state\.json/.test(normalizedCommand) ||
+      /\bdd\b[^|;&]*\bof=[^|;&]*\.mpl\/state\.json/.test(normalizedCommand)
     );
-    if (stateJsonMention && hasWriteVerb && process.env.MPL_FORCE_PURGE !== '1') {
+    if (stateJsonMention && (!isSafeRead || writesToStateJson) && process.env.MPL_FORCE_PURGE !== '1') {
       const reason =
         `[MPL #236 A1] Refused Bash write to .mpl/state.json: only ` +
         `mpl-write-guard's internal writeState may modify the orchestrator ` +

--- a/hooks/mpl-write-guard.mjs
+++ b/hooks/mpl-write-guard.mjs
@@ -177,6 +177,36 @@ function isDangerousBashCommand(command) {
 // Resolving each token via path.resolve(cwd, token) normalizes those
 // forms to a single canonical absolute path that we can compare
 // against the resolved protected roots.
+// Codex r7 on PR #249 [data-integrity]: substitute simple variable
+// assignments. `p=.mpl; rm -rf ${p}/mpl` reaches the shell as
+// `rm -rf .mpl/mpl`. Collect every leading `name=value` from each
+// statement (`;`/`&&`/`||`/newline split), then replace `$name` and
+// `${name}` references throughout the command. Supports `export name=…`
+// prefix and quoted values; values stop at the first whitespace
+// (`name="multi word"` is uncommon in protected-path bypass shapes).
+function expandSimpleVars(text) {
+  const vars = new Map();
+  const segments = text.split(/(?:;|&&|\|\||\n)/);
+  for (const seg of segments) {
+    let s = seg.trimStart().replace(/^export\s+/, '');
+    const m = s.match(/^([a-zA-Z_][a-zA-Z0-9_]*)=("([^"]*)"|'([^']*)'|(\S+))/);
+    if (m) {
+      const value = m[3] !== undefined ? m[3]
+        : m[4] !== undefined ? m[4]
+        : (m[5] ?? '');
+      vars.set(m[1], value);
+    }
+  }
+  if (vars.size === 0) return text;
+  let out = text;
+  for (const [name, value] of vars) {
+    const esc = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    out = out.replace(new RegExp(`\\$\\{${esc}\\}`, 'g'), value);
+    out = out.replace(new RegExp(`\\$${esc}\\b`, 'g'), value);
+  }
+  return out;
+}
+
 // Expand bash brace patterns within each whitespace-separated token,
 // repeating until no more `{…}` groups remain (10-round backstop for
 // pathological nesting). Cartesian: `{a,b}{c,d}` → `ac ad bc bd`.
@@ -206,12 +236,27 @@ function matchesProtectedDelete(command, cwd) {
   // Strip leading wrapper before checking the head — `sudo rm -rf …`
   // must still trip.
   let normalized = command.replace(/^\s*(sudo|time|nice|env)\s+/, '').trim();
-  // Identify rm-family / find -delete calls. Multi-command lines
-  // (`a; rm -rf X`, `a && rm -rf X`) still parse because we scan the
-  // whole command for `rm` or `find ... -delete`.
-  if (!/\brm\b/.test(normalized) && !/\bfind\b.*-delete\b/.test(normalized)) {
-    return null;
-  }
+  // Identify destructive operations against the protected paths. Each
+  // of these is a way to remove or wipe a path that the mpl-cancel
+  // SKILL forbids — `rm` is the obvious one, but `mv` away,
+  // redirect-truncate (`> file`), `shred`, `unlink`, `truncate`, and
+  // `cp /dev/null …` are equally destructive.
+  //
+  // Claude r7 on PR #249 [data-integrity]: pre-r7 the entry gate was
+  // only `rm`/`find -delete`, so the non-rm forms above silently
+  // passed.
+  const isDestructive = (
+    /\brm\b/.test(normalized) ||
+    /\bfind\b.*-delete\b/.test(normalized) ||
+    /\bmv\b/.test(normalized) ||
+    /\bshred\b/.test(normalized) ||
+    /\bunlink\b/.test(normalized) ||
+    /\btruncate\b/.test(normalized) ||
+    /\bcp\b.*\/dev\/null/.test(normalized) ||
+    /(^|[\s;|&])>{1,2}\s/.test(normalized) ||
+    /(^|[\s;|&])&>{1}\s/.test(normalized)
+  );
+  if (!isDestructive) return null;
 
   // Pre-normalize the command to the form a real shell would execute,
   // so substring + token checks see the same path the OS sees.
@@ -252,6 +297,7 @@ function matchesProtectedDelete(command, cwd) {
   // checks fire normally. Iterative leftmost-brace expansion handles
   // nested + cartesian forms; we cap at 10 iterations as a backstop.
   normalized = expandShellBraces(normalized);
+  normalized = expandSimpleVars(normalized);
 
   // Claude r1 on PR #249 [logic] (concrete repros): shell-expansion
   // forms (`$PWD`, `$(pwd)`), parenthesized subshells, variable
@@ -279,7 +325,7 @@ function matchesProtectedDelete(command, cwd) {
     // Skip flag tokens; they can't be paths.
     if (token.startsWith('-')) continue;
     // Skip known program names so we don't false-match `rm` itself.
-    if (/^(rm|find|sudo|time|nice|env|cd|pushd|popd|mkdir)$/i.test(token)) continue;
+    if (/^(rm|find|sudo|time|nice|env|cd|pushd|popd|mkdir|mv|shred|unlink|truncate|cp|export)$/i.test(token)) continue;
 
     // Codex r6 on PR #249 [data-integrity]: shell pathname expansion
     // (glob metachars `*`, `?`, `[…]`) lets a command operand expand

--- a/hooks/mpl-write-guard.mjs
+++ b/hooks/mpl-write-guard.mjs
@@ -62,6 +62,17 @@ const HOOK_ID = 'mpl-write-guard';
 // via a state-based dispatch flag set when the orchestrator dispatches
 // Agent(subagent_type='mpl-decomposer') and cleared on Stop.
 const DECOMPOSITION_FILE_REGEX = /(^|\/)\.mpl\/mpl\/decomposition\.ya?ml$/;
+
+// Claude r9 on PR #249 [security]: the orchestrator can Write
+// `.mpl/state.json` (it sits inside the `/\.mpl\//` allowlist), and
+// the writer-identity check at A1 trusted whatever
+// `state.decomposer_dispatch.parent_transcript_path` value it found
+// — so the orchestrator could plant a `parent_transcript_path !=
+// its own transcript`, then write decomposition.yaml. Reject any
+// Write/Edit to .mpl/state.json whose payload introduces or mutates
+// `decomposer_dispatch.*` — only the hook itself may set those keys.
+const STATE_FILE_REGEX = /(^|\/)\.mpl\/state\.json$/;
+const DECOMPOSER_DISPATCH_FIELD_REGEX = /"decomposer_dispatch"\s*:/;
 const DECOMPOSER_SUBAGENT_TYPES = new Set([
   'mpl-decomposer',
   'mpl:mpl-decomposer',
@@ -258,6 +269,16 @@ function matchesProtectedDelete(command, cwd) {
     // `tee FILE` opens FILE for write and overwrites it.
     /\btee\b/.test(normalized) ||
     /\bdd\b.*\bof=/.test(normalized) ||
+    // Codex r10 on PR #249 [data-integrity]: interpreter one-liners
+    // (`node -e "require('fs').rmSync('.mpl/mpl')"`, `python -c
+    // "shutil.rmtree('.mpl/mpl')"`) can destroy protected paths
+    // without invoking any shell-level destructive verb. Treat any
+    // common interpreter as a possible-destructive entry; the
+    // substring/token checks then catch the protected target literal
+    // inside the eval body. Pure read-only interpreter use (`node
+    // script.js` without mentioning a protected path) is not blocked
+    // because neither the substring nor the token check would match.
+    /\b(node|deno|bun|python\d?|ruby|perl|php|lua|tclsh|osascript|awk|sed)\b/.test(normalized) ||
     // Codex r8 on PR #249 [data-integrity]: POSIX shell redirection
     // does not require whitespace after `>`/`>>`/`&>`. `echo x
     // >.mpl/mpl/foo` truncates the protected file. Allow optional
@@ -611,6 +632,52 @@ ensure you have the correct target path. The command will proceed, but please ve
 
   const state = readState(cwd) || {};
   const dogfood = isDogfoodMode(cwd);
+
+  // Claude r9 on PR #249 [security]: reject any Write/Edit to
+  // .mpl/state.json whose payload introduces or mutates the
+  // `decomposer_dispatch.*` key. Only this hook is allowed to set
+  // the dispatch flag; an orchestrator that plants a forged flag
+  // could otherwise unlock the A1 writer-identity check and Write
+  // decomposition.yaml from its own transcript.
+  if (STATE_FILE_REGEX.test(filePath)) {
+    const payload = (() => {
+      const t = data.tool_input || data.toolInput || {};
+      const parts = [];
+      if (typeof t.content === 'string') parts.push(t.content);
+      if (typeof t.new_string === 'string') parts.push(t.new_string);
+      if (typeof t.newString === 'string') parts.push(t.newString);
+      if (Array.isArray(t.edits)) {
+        for (const e of t.edits) {
+          if (e?.new_string) parts.push(String(e.new_string));
+          if (e?.newString) parts.push(String(e.newString));
+        }
+      }
+      return parts.join('\n');
+    })();
+    if (DECOMPOSER_DISPATCH_FIELD_REGEX.test(payload)) {
+      const reason =
+        `[MPL #236 A1] Refused to Write/Edit decomposer_dispatch into ` +
+        `.mpl/state.json: only mpl-write-guard itself may set that key. ` +
+        `Planting it from outside would let the orchestrator forge the ` +
+        `decomposition.yaml writer-identity flag.`;
+      recordBlockedHook(cwd, {
+        hookId: HOOK_ID,
+        phaseId: state?.current_phase,
+        artifact: filePath,
+        code: 'decomposer_dispatch_forgery',
+        reason,
+        resumeInstruction:
+          `Remove the decomposer_dispatch field from the .mpl/state.json patch; the hook will populate it on Agent(subagent_type='mpl-decomposer') dispatch.`,
+        retryContext: { file_path: filePath },
+      });
+      console.log(JSON.stringify({
+        continue: false,
+        decision: 'block',
+        reason,
+      }));
+      return;
+    }
+  }
 
   // #236 A1: decomposition.yaml may ONLY be Written/Edited by the
   // mpl-decomposer subagent. The hook detects this via a dispatch

--- a/hooks/mpl-write-guard.mjs
+++ b/hooks/mpl-write-guard.mjs
@@ -301,9 +301,20 @@ function normalizeShellCommand(command) {
 
 function matchesProtectedDelete(command, cwd) {
   if (!command || typeof command !== 'string') return null;
-  // Strip leading wrapper before checking the head — `sudo rm -rf …`
-  // must still trip.
-  let normalized = command.replace(/^\s*(sudo|time|nice|env)\s+/, '').trim();
+  // Codex r27 on PR #249 [data-integrity]: full shell normalization
+  // must run BEFORE the destructive-verb gate, otherwise quote- /
+  // backslash-concatenated command words bypass the literal `\brm\b` /
+  // `\bgzip\b` etc. regex even though the shell strips the quotes and
+  // executes the destructive verb. Examples:
+  //   `r"m" -rf .mpl/mpl`     → shell executes `rm -rf .mpl/mpl`
+  //   `g"zip" .mpl/mpl/foo`   → shell executes `gzip .mpl/mpl/foo` (delete-by-default)
+  //   `g\zip .mpl/mpl/foo`    → shell executes `gzip …` (backslash-strip)
+  // `normalizeShellCommand` already performs sudo/time/nice/env strip,
+  // ANSI-C decode, backslash strip, quote strip, slash collapse,
+  // `/./` collapse, iterated `/X/../` collapse, brace expand, and
+  // simple var expand — exactly the transforms the destructive-verb
+  // regexes need to see.
+  let normalized = normalizeShellCommand(command);
   // Identify destructive operations against the protected paths. Each
   // of these is a way to remove or wipe a path that the mpl-cancel
   // SKILL forbids — `rm` is the obvious one, but `mv` away,
@@ -382,46 +393,12 @@ function matchesProtectedDelete(command, cwd) {
   );
   if (!isDestructive) return null;
 
-  // Pre-normalize the command to the form a real shell would execute,
-  // so substring + token checks see the same path the OS sees.
-  // Layered from "most decoded" to "least decoded":
-  //   - Codex r5 on PR #249 [data-integrity]: Bash ANSI-C quoting
-  //     ($'…') decodes hex (\xHH), octal (\OOO), and Unicode (\uHHHH /
-  //     \UHHHHHHHH) escapes. `rm -rf $'.mpl\x2fmpl'` deletes `.mpl/mpl`.
-  //     Decode these escapes to characters BEFORE the generic
-  //     backslash strip so they don't get clobbered to `x2f`.
-  //   - Codex r4 on PR #249 [data-integrity]: POSIX shells remove
-  //     generic backslash escapes — `rm -rf .mpl\/mpl` deletes
-  //     `.mpl/mpl`. After ANSI-C decoding, strip every remaining
-  //     `\X` → `X`.
-  //   - Codex r3 on PR #249 [data-integrity]: shells concatenate
-  //     adjacent quote fragments — `.mpl/""mpl` and `.mpl"/"mpl`
-  //     resolve to `.mpl/mpl`. Strip every `"`, `'`, backtick.
-  //   - Codex r2 on PR #249 [logic]: shells normalize runs of `/`
-  //     after expansion (`$PWD/.mpl//mpl` deletes `.mpl/mpl`).
-  //     Collapse repeated slashes to one.
-  // All transforms preserve token-boundary whitespace.
-  normalized = normalized
-    .replace(/\\x([0-9a-fA-F]{2})/g, (_, h) => String.fromCharCode(parseInt(h, 16)))
-    .replace(/\\u([0-9a-fA-F]{4})/g, (_, h) => String.fromCharCode(parseInt(h, 16)))
-    .replace(/\\U([0-9a-fA-F]{8})/g, (_, h) => {
-      const cp = parseInt(h, 16);
-      try { return String.fromCodePoint(cp); } catch { return ''; }
-    })
-    .replace(/\\([0-7]{1,3})/g, (_, oct) => String.fromCharCode(parseInt(oct, 8)))
-    .replace(/\\([\s\S])/g, '$1')
-    .replace(/["'`]/g, '')
-    .replace(/\/+/g, '/');
-
-  // Claude r5 on PR #249 [data-integrity]: Bash brace expansion
-  // (`.mpl/{mpl,contracts}` → `.mpl/mpl .mpl/contracts`, cartesian
-  // `{a,b}{c,d}` → `ac ad bc bd`) was a new class outside the
-  // previously-closed list. Expand braces here so the literal target
-  // appears in one of the expanded tokens and the substring + token
-  // checks fire normally. Iterative leftmost-brace expansion handles
-  // nested + cartesian forms; we cap at 10 iterations as a backstop.
-  normalized = expandShellBraces(normalized);
-  normalized = expandSimpleVars(normalized);
+  // (Codex r27 [data-integrity]: shell normalization already ran above
+  // before the destructive-verb gate — `normalizeShellCommand`
+  // performs ANSI-C decode, backslash strip, quote strip, slash
+  // collapse, `/./` + `/X/../` collapse, brace + simple-var expand.
+  // The path-matching code below operates on the same normalized
+  // string the gate used.)
 
   // Claude r1 on PR #249 [logic] (concrete repros): shell-expansion
   // forms (`$PWD`, `$(pwd)`), parenthesized subshells, variable

--- a/hooks/mpl-write-guard.mjs
+++ b/hooks/mpl-write-guard.mjs
@@ -341,6 +341,11 @@ function matchesProtectedDelete(command, cwd) {
     // tree, removing files not in the source. Same destructive shape
     // as --remove-source-files but against the destination operand.
     /\brsync\b.*--delete(?:-before|-during|-delay|-after)?\b/.test(normalized) ||
+    // Claude r23 [security]: `git clean -fdx` / `-fdX` deletes
+    // untracked + ignored files. .mpl/ is typically gitignored, so
+    // -x sweeps the entire .mpl/ tree. Treat git clean with any -*x*
+    // / -*X* flag as destructive against the workspace.
+    /\bgit\s+clean\b.*-\S*[xX]/.test(normalized) ||
     // Codex r10 on PR #249 [data-integrity]: interpreter one-liners
     // (`node -e "require('fs').rmSync('.mpl/mpl')"`, `python -c
     // "shutil.rmtree('.mpl/mpl')"`) can destroy protected paths
@@ -409,6 +414,27 @@ function matchesProtectedDelete(command, cwd) {
   // operator escape hatch already documented in the block reason.
   for (const target of PROTECTED_DELETE_TARGETS) {
     if (normalized.includes(target)) return target;
+  }
+
+  // Codex r23 [security]: runtime-constructed paths via
+  // command-substitution + decoder bypass the literal substring
+  // check (`p=$(base64 -d ...); rm -rf "$p"`). Conservatively block
+  // destructive commands that combine a decoder primitive
+  // (base64 / xxd / openssl base64 -d) with command-substitution
+  // operand syntax. MPL_FORCE_PURGE=1 escape applies.
+  const hasDecoder = /\bbase64\b|\bxxd\b|\bopenssl\s+base64\b/.test(normalized);
+  const hasCmdSub = /\$\(|`/.test(normalized);
+  if (hasDecoder && hasCmdSub) {
+    return PROTECTED_DELETE_TARGETS[0];
+  }
+
+  // Claude r23 [security]: `git clean -*x*` sweeps cwd-wide, deleting
+  // untracked + (with -x) ignored files. .mpl/ is typically gitignored.
+  // Block unconditionally when this verb is present in the command —
+  // the operator override via MPL_FORCE_PURGE is the documented
+  // escape for legitimate "reset my repo" flows.
+  if (/\bgit\s+clean\b.*-\S*[xX]/.test(normalized)) {
+    return PROTECTED_DELETE_TARGETS[0];
   }
 
   const resolvedRoots = PROTECTED_DELETE_TARGETS.map((target) => ({

--- a/hooks/mpl-write-guard.mjs
+++ b/hooks/mpl-write-guard.mjs
@@ -280,6 +280,38 @@ function matchesProtectedDelete(command, cwd) {
     if (token.startsWith('-')) continue;
     // Skip known program names so we don't false-match `rm` itself.
     if (/^(rm|find|sudo|time|nice|env|cd|pushd|popd|mkdir)$/i.test(token)) continue;
+
+    // Codex r6 on PR #249 [data-integrity]: shell pathname expansion
+    // (glob metachars `*`, `?`, `[…]`) lets a command operand expand
+    // at execution time to a protected path without the literal
+    // appearing in the hook input. E.g. `rm -rf .mpl/m*` expands to
+    // `rm -rf .mpl/mpl` (and `.mpl/memory`). When a token contains
+    // glob meta, the literal prefix (before the first metachar) is
+    // resolved; if the glob COULD reasonably expand into a path that
+    // equals OR shares a path with a protected root, block. Same
+    // ancestor-match logic as below.
+    const globIdx = token.search(/[*?[]/);
+    if (globIdx >= 0) {
+      const literalPrefix = token.slice(0, globIdx);
+      let absPrefix;
+      try { absPrefix = resolvePath(cwd, literalPrefix); }
+      catch { continue; }
+      for (const { target, abs: rootAbs } of resolvedRoots) {
+        // For glob tokens, any protected root whose abs path STARTS
+        // WITH the literal prefix is a possible expansion — the glob
+        // metachar (`*`/`?`/`[…]`) could fill the rest. `.mpl/m*` →
+        // absPrefix `.mpl/m`; `.mpl/mpl` starts with `.mpl/m` → block.
+        // Also include the inverse: `.mpl/sub/*` whose absPrefix is
+        // already deeper than `.mpl/mpl` could expand to a descendant.
+        if (
+          absPrefix === rootAbs ||
+          absPrefix.startsWith(rootAbs + '/') ||
+          rootAbs.startsWith(absPrefix)
+        ) return target;
+      }
+      continue;
+    }
+
     let abs;
     try { abs = resolvePath(cwd, token); }
     catch { continue; }

--- a/hooks/mpl-write-guard.mjs
+++ b/hooks/mpl-write-guard.mjs
@@ -656,22 +656,53 @@ async function main() {
     // substring check, so quote-concat / backslash-escape / ANSI-C /
     // slash-collapse forms of `.mpl/state.json` can't bypass.
     const normalizedCommand = normalizeShellCommand(command);
-    if (/\.mpl\/state\.json/.test(normalizedCommand) &&
-        (/decomposer_dispatch/.test(normalizedCommand) ||
-         /first_transcript_seen/.test(normalizedCommand))) {
+    // Codex r13 on PR #249 [security]: an encoded write (e.g. base64
+    // -d > .mpl/state.json) can plant decomposer_dispatch without the
+    // literal field name appearing in the Bash command. The right
+    // structural fix is to refuse ANY Bash command that writes to
+    // .mpl/state.json — the hook itself uses writeState() (not Bash)
+    // so legit hook operation is unaffected. MPL_FORCE_PURGE=1 is the
+    // documented escape hatch for legitimate manual state edits.
+    //
+    // Detection: command mentions `.mpl/state.json` (in normalized
+    // form) AND has any destructive verb / redirect / interpreter
+    // (the same `isDestructive` indicator matchesProtectedDelete
+    // uses). Read-only operations against state.json (`cat .mpl/
+    // state.json`, `ls .mpl/state.json`) still pass.
+    const stateJsonMention = /\.mpl\/state\.json/.test(normalizedCommand);
+    const hasWriteVerb = (
+      /\brm\b/.test(normalizedCommand) ||
+      /\bfind\b.*-delete\b/.test(normalizedCommand) ||
+      /\bmv\b/.test(normalizedCommand) ||
+      /\bshred\b/.test(normalizedCommand) ||
+      /\bunlink\b/.test(normalizedCommand) ||
+      /\btruncate\b/.test(normalizedCommand) ||
+      /\bcp\b/.test(normalizedCommand) ||
+      /\btee\b/.test(normalizedCommand) ||
+      /\bdd\b.*\bof=/.test(normalizedCommand) ||
+      /\btar\b.*--remove-files\b/.test(normalizedCommand) ||
+      /\brsync\b.*--remove-source-files\b/.test(normalizedCommand) ||
+      /\b(node|deno|bun|python\d?|ruby|perl|php|lua|tclsh|osascript|awk|sed)\b/.test(normalizedCommand) ||
+      /(?:^|[\s;|&])\d?>{1,2}/.test(normalizedCommand) ||
+      /(?:^|[\s;|&])&>{1,2}/.test(normalizedCommand) ||
+      /\bbase64\b/.test(normalizedCommand) // codex r13: catches the base64 decode path explicitly
+    );
+    if (stateJsonMention && hasWriteVerb && process.env.MPL_FORCE_PURGE !== '1') {
       const reason =
-        `[MPL #236 A1] Refused Bash that mentions both .mpl/state.json AND ` +
-        `decomposer_dispatch — only mpl-write-guard itself may plant that flag. ` +
-        `Allowing this would let the orchestrator forge the decomposition.yaml ` +
-        `writer-identity check.`;
+        `[MPL #236 A1] Refused Bash write to .mpl/state.json: only ` +
+        `mpl-write-guard's internal writeState may modify the orchestrator ` +
+        `state file. Allowing this would let any caller forge ` +
+        `decomposer_dispatch / first_transcript_seen / other capability ` +
+        `fields. If you really need to edit state manually, set ` +
+        `MPL_FORCE_PURGE=1 in the same shell.`;
       recordBlockedHook(cwd, {
         hookId: HOOK_ID,
         phaseId: (readState(cwd) || {}).current_phase,
         artifact: '.mpl/state.json',
-        code: 'decomposer_dispatch_forgery',
+        code: 'state_json_bash_write',
         reason,
         resumeInstruction:
-          `Remove the decomposer_dispatch reference from the Bash command. The hook will populate it on Agent(subagent_type='mpl-decomposer') dispatch.`,
+          `Use the orchestrator's state-write tool path (or the Read+Edit tool if appropriate); set MPL_FORCE_PURGE=1 only if a manual reset is intended.`,
         retryContext: { command },
       });
       console.log(JSON.stringify({

--- a/hooks/mpl-write-guard.mjs
+++ b/hooks/mpl-write-guard.mjs
@@ -13,7 +13,7 @@
  * When MPL is active: guards Edit/Write on source files + warns on dangerous Bash
  */
 
-import { dirname, join, extname } from 'path';
+import { dirname, join, extname, resolve as resolvePath } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -166,24 +166,67 @@ function isDangerousBashCommand(command) {
 
 // #236 A3: does `command` attempt to remove any PROTECTED_DELETE_TARGETS
 // path (or one of its descendants)? Returns the matched target on hit,
-// null otherwise. Matches the canonical `rm` family — `rm`, `rm -r*`,
-// `rm -f*`, `rm --force`, and the wrapped `find ... -delete` form.
-// The check is conservative — over-matching is acceptable because the
-// MPL_FORCE_PURGE escape hatch exists for legitimate cleanup.
-function matchesProtectedDelete(command) {
+// null otherwise. Matches the canonical `rm` family and the wrapped
+// `find ... -delete` form, and resolves each path token against the
+// workspace `cwd` so workspace-absolute paths (`/abs/.../MPL/.mpl/mpl`)
+// and `..`/`.` traversal forms still match.
+//
+// Codex r1 retry on PR #249: the original token-prefix regex missed
+// `rm -rf /Users/.../MPL/.mpl/mpl` because the protected substring
+// appeared mid-path (no whitespace/quote boundary just before it).
+// Resolving each token via path.resolve(cwd, token) normalizes those
+// forms to a single canonical absolute path that we can compare
+// against the resolved protected roots.
+function matchesProtectedDelete(command, cwd) {
   if (!command || typeof command !== 'string') return null;
-  // Strip leading `sudo ` etc. before checking the head — `sudo rm -rf .mpl/mpl`
+  // Strip leading wrapper before checking the head — `sudo rm -rf …`
   // must still trip.
   const normalized = command.replace(/^\s*(sudo|time|nice|env)\s+/, '').trim();
-  // Identify rm calls — `rm`, `rm -*`, `\brm\b` inside a pipeline, etc.
+  // Identify rm-family / find -delete calls. Multi-command lines
+  // (`a; rm -rf X`, `a && rm -rf X`) still parse because we scan the
+  // whole command for `rm` or `find ... -delete`.
   if (!/\brm\b/.test(normalized) && !/\bfind\b.*-delete\b/.test(normalized)) {
     return null;
   }
+
+  // Claude r1 on PR #249 [logic] (concrete repros): shell-expansion
+  // forms (`$PWD`, `$(pwd)`), parenthesized subshells (`(cd … && rm
+  // -rf …)`), `pushd … && rm -rf …` splits, and shell-variable
+  // operands all defeat literal token resolution. Defense-in-depth:
+  // ALSO match the protected substring anywhere in the command. This
+  // over-blocks on incidental mentions, but `MPL_FORCE_PURGE=1` is
+  // already the operator escape hatch — over-blocking is the safe
+  // direction for a destructive op.
   for (const target of PROTECTED_DELETE_TARGETS) {
-    // Whole target OR `target/` prefix to catch descendants.
-    const escaped = target.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    const re = new RegExp(`(^|[\\s'"])(\\./)?${escaped}(/|\\b|['"])`);
-    if (re.test(normalized)) return target;
+    if (normalized.includes(target)) return target;
+  }
+
+  const resolvedRoots = PROTECTED_DELETE_TARGETS.map((target) => ({
+    target,
+    abs: resolvePath(cwd, target),
+  }));
+
+  // Tokenize on whitespace AND `;`/`&&`/`||`/`|`/`(`/`)` so a
+  // multi-command line + subshell surfaces every operand. We don't
+  // honour quoting precisely — strip leading/trailing quote and
+  // paren chars and check each token.
+  const tokens = normalized
+    .split(/[\s;|&()]+/)
+    .map((t) => t.replace(/^[\\$"'`]+/, '').replace(/[\\"'`)]+$/, ''))
+    .filter(Boolean);
+
+  for (const token of tokens) {
+    // Skip flag tokens; they can't be paths.
+    if (token.startsWith('-')) continue;
+    // Skip known program names so we don't false-match `rm` itself.
+    if (/^(rm|find|sudo|time|nice|env|cd|pushd|popd|mkdir)$/i.test(token)) continue;
+    // path.resolve handles `./`, `../`, abs, and trailing `/`.
+    let abs;
+    try { abs = resolvePath(cwd, token); }
+    catch { continue; }
+    for (const { target, abs: rootAbs } of resolvedRoots) {
+      if (abs === rootAbs || abs.startsWith(rootAbs + '/')) return target;
+    }
   }
   return null;
 }
@@ -191,24 +234,46 @@ function matchesProtectedDelete(command) {
 // #236 A1: record state.decomposer_dispatch when the orchestrator
 // dispatches Agent(subagent_type='mpl-decomposer'). Used by the
 // decomposition.yaml writer-identity check below.
-function recordDecomposerDispatch(cwd) {
+//
+// Codex r1 retry on PR #249: an ambient time-only flag let the
+// orchestrator itself write decomposition.yaml within the TTL
+// window. The fix is to also pin the PARENT (orchestrator) transcript
+// path at dispatch time, then on a later write require the calling
+// transcript to be DIFFERENT from the dispatcher's — a subagent's
+// transcript is always a distinct file.
+function recordDecomposerDispatch(cwd, parentTranscriptPath) {
   try {
     writeState(cwd, {
       decomposer_dispatch: {
         dispatched_at: new Date().toISOString(),
+        parent_transcript_path: parentTranscriptPath || null,
       },
     });
   } catch { /* best-effort */ }
 }
 
-// #236 A1: is a decomposer subagent currently expected to be running?
-// True when state.decomposer_dispatch.dispatched_at is within the TTL.
-function isDecomposerDispatchActive(cwd, state) {
+// #236 A1: is the current write coming from the decomposer subagent?
+//   - dispatch flag must be set,
+//   - within the TTL,
+//   - AND the calling transcript_path must DIFFER from the recorded
+//     parent (orchestrator) transcript_path. A same-transcript write
+//     is the orchestrator itself, which the contract forbids.
+//
+// When parent_transcript_path was not recorded (legacy state), we
+// fail closed — the writer-identity check cannot be satisfied without
+// a parent reference, so the write is rejected.
+function isDecomposerDispatchActive(state, callerTranscriptPath) {
   const flag = state?.decomposer_dispatch;
   if (!flag || typeof flag.dispatched_at !== 'string') return false;
   const ts = Date.parse(flag.dispatched_at);
   if (Number.isNaN(ts)) return false;
-  return (Date.now() - ts) <= DECOMPOSER_DISPATCH_TTL_MS;
+  if ((Date.now() - ts) > DECOMPOSER_DISPATCH_TTL_MS) return false;
+  const parent = typeof flag.parent_transcript_path === 'string'
+    ? flag.parent_transcript_path
+    : null;
+  if (!parent) return false;
+  if (!callerTranscriptPath || typeof callerTranscriptPath !== 'string') return false;
+  return callerTranscriptPath !== parent;
 }
 
 function isAllowedPath(filePath, opts = {}) {
@@ -268,7 +333,14 @@ async function main() {
   if (isTaskTool) {
     const sub = String(toolInput.subagent_type || toolInput.subagentType || '');
     if (DECOMPOSER_SUBAGENT_TYPES.has(sub)) {
-      recordDecomposerDispatch(cwd);
+      // The transcript_path on a PreToolUse Task dispatch is the
+      // DISPATCHING agent's transcript (the orchestrator's). Pin it
+      // so the writer-identity check can reject any future write
+      // arriving with the same transcript_path.
+      const parentTranscript = typeof data.transcript_path === 'string'
+        ? data.transcript_path
+        : (typeof data.transcriptPath === 'string' ? data.transcriptPath : null);
+      recordDecomposerDispatch(cwd, parentTranscript);
     }
     console.log(JSON.stringify({ continue: true, suppressOutput: true }));
     return;
@@ -279,7 +351,7 @@ async function main() {
     const command = toolInput.command || '';
     // #236 A3: protected-path delete — hard-block regardless of safe-cleanup
     // allowlist. Override via env MPL_FORCE_PURGE=1 set by the operator.
-    const protectedTarget = matchesProtectedDelete(command);
+    const protectedTarget = matchesProtectedDelete(command, cwd);
     if (protectedTarget && process.env.MPL_FORCE_PURGE !== '1') {
       const reason =
         `[MPL #236 A3] Refused destructive write to protected path "${protectedTarget}". ` +
@@ -348,7 +420,10 @@ ensure you have the correct target path. The command will proceed, but please ve
   // generic `isAllowedPath` (.mpl/* is otherwise an allowlisted
   // orchestrator path) so the writer identity wins.
   if (DECOMPOSITION_FILE_REGEX.test(filePath)) {
-    if (!isDecomposerDispatchActive(cwd, state)) {
+    const callerTranscript = typeof data.transcript_path === 'string'
+      ? data.transcript_path
+      : (typeof data.transcriptPath === 'string' ? data.transcriptPath : null);
+    if (!isDecomposerDispatchActive(state, callerTranscript)) {
       const reason =
         `[MPL #236 A1] Refused direct ${toolName} of decomposition.yaml: ` +
         `the orchestrator must NOT write this file. Only the mpl-decomposer ` +

--- a/hooks/mpl-write-guard.mjs
+++ b/hooks/mpl-write-guard.mjs
@@ -353,9 +353,16 @@ function matchesProtectedDelete(command, cwd) {
     // Claude r25 [security]: scan per-statement — `-k`/`--keep`
     // anywhere else in the command doesn't suppress an unkeyed
     // gzip earlier in the chain.
-    normalized.split(/[;|&\n]+/).some((seg) =>
-      /\b(gzip|bzip2|xz|zstd)\b/.test(seg) && !/(?:-k|--keep)\b/.test(seg),
-    ) ||
+    normalized.split(/[;|&\n]+/).some((seg) => {
+      if (!/\b(gzip|bzip2|xz|zstd)\b/.test(seg)) return false;
+      // Codex r26 [security]: `-k`/`--keep` only counts as an option
+      // when it appears BEFORE `--` (POSIX end-of-options sentinel).
+      // After `--` any `-k` is a literal filename. So `gzip -- .mpl/mpl/-k`
+      // still deletes the protected file. Split the segment at `--` and
+      // only inspect the pre-options portion for the keep flag.
+      const beforeDoubleDash = seg.split(/\s--(?:\s|$)/)[0];
+      return !/(?:-k|--keep)\b/.test(beforeDoubleDash);
+    }) ||
     // Codex r10 on PR #249 [data-integrity]: interpreter one-liners
     // (`node -e "require('fs').rmSync('.mpl/mpl')"`, `python -c
     // "shutil.rmtree('.mpl/mpl')"`) can destroy protected paths

--- a/hooks/mpl-write-guard.mjs
+++ b/hooks/mpl-write-guard.mjs
@@ -72,7 +72,12 @@ const HOOK_ID = 'mpl-write-guard';
 // (commands/mpl-run-decompose.md:16). We detect the writer identity
 // via a state-based dispatch flag set when the orchestrator dispatches
 // Agent(subagent_type='mpl-decomposer') and cleared on Stop.
-const DECOMPOSITION_FILE_REGEX = /(^|\/)\.mpl\/mpl\/decomposition\.ya?ml$/;
+// Claude r21 [security]: macOS APFS / Windows NTFS are case-insensitive
+// by default. `.MPL/MPL/decomposition.yaml` opens the same inode as
+// the lowercase form. Use case-insensitive regex so the orchestrator
+// can't bypass via uppercase. All regex literals are lowercase ASCII
+// so the `i` flag is structurally safe.
+const DECOMPOSITION_FILE_REGEX = /(^|\/)\.mpl\/mpl\/decomposition\.ya?ml$/i;
 
 // Claude r9 on PR #249 [security]: the orchestrator can Write
 // `.mpl/state.json` (it sits inside the `/\.mpl\//` allowlist), and
@@ -82,7 +87,7 @@ const DECOMPOSITION_FILE_REGEX = /(^|\/)\.mpl\/mpl\/decomposition\.ya?ml$/;
 // its own transcript`, then write decomposition.yaml. Reject any
 // Write/Edit to .mpl/state.json whose payload introduces or mutates
 // `decomposer_dispatch.*` — only the hook itself may set those keys.
-const STATE_FILE_REGEX = /(^|\/)\.mpl\/state\.json$/;
+const STATE_FILE_REGEX = /(^|\/)\.mpl\/state\.json$/i;
 const DECOMPOSER_DISPATCH_FIELD_REGEX = /"decomposer_dispatch"\s*:/;
 // Codex r12 + Claude r12 [security]: also protect first_transcript_seen
 // from forgery — that key is the bootstrap of the dispatcher-identity
@@ -280,10 +285,15 @@ function normalizeShellCommand(command) {
     // these at path-resolution time, so `.mpl/./state.json` and
     // `.mpl/./mpl/decomposition.yaml` are equivalent to the canonical
     // form. Iterate until no more match (handles `/././`).
-    .replace(/\/(?:\.\/)+/g, '/')
-    // Collapse `/X/../` traversal forms once (covers .mpl/foo/../state.json).
-    // This is a heuristic — full traversal resolution is out of scope.
-    .replace(/\/[^/]+\/\.\.\//g, '/');
+    .replace(/\/(?:\.\/)+/g, '/');
+  // Claude r22 [security]: iterate `/X/../` collapse until no more
+  // matches. Multi-level traversal `.mpl/a/b/../../state.json` was
+  // depth-only-one with the single-pass r21 fix.
+  let prevNormalized;
+  do {
+    prevNormalized = normalized;
+    normalized = normalized.replace(/\/[^/]+\/\.\.(?:\/|$)/g, '/');
+  } while (normalized !== prevNormalized);
   normalized = expandShellBraces(normalized);
   normalized = expandSimpleVars(normalized);
   return normalized;
@@ -326,6 +336,11 @@ function matchesProtectedDelete(command, cwd) {
     // their source operand after the copy completes.
     /\btar\b.*--remove-files\b/.test(normalized) ||
     /\brsync\b.*--remove-source-files\b/.test(normalized) ||
+    // Codex r22 [security]: `rsync --delete` (and variants
+    // --delete-before/-during/-delay/-after) prunes the destination
+    // tree, removing files not in the source. Same destructive shape
+    // as --remove-source-files but against the destination operand.
+    /\brsync\b.*--delete(?:-before|-during|-delay|-after)?\b/.test(normalized) ||
     // Codex r10 on PR #249 [data-integrity]: interpreter one-liners
     // (`node -e "require('fs').rmSync('.mpl/mpl')"`, `python -c
     // "shutil.rmtree('.mpl/mpl')"`) can destroy protected paths
@@ -707,8 +722,12 @@ async function main() {
   if (isBashTool && process.env.MPL_FORCE_PURGE !== '1') {
     const earlyCommand = (data.tool_input || data.toolInput || {}).command || '';
     if (earlyCommand && existsSync(join(cwd, '.mpl'))) {
-      const normalizedEarly = normalizeShellCommand(earlyCommand);
-      let decompMention = /\.mpl\/mpl\/decomposition\.ya?ml/.test(normalizedEarly);
+      // Claude r21 [security]: lowercase for case-insensitive filesystem
+      // protection. macOS APFS / Windows NTFS open `.MPL/...` against
+      // the same inode as `.mpl/...`. All subsequent regexes match
+      // lowercase ASCII so lowercasing the input is structurally safe.
+      const normalizedEarly = normalizeShellCommand(earlyCommand).toLowerCase();
+      let decompMention = /\.mpl\/mpl\/decomposition\.ya?ml/i.test(normalizedEarly);
       // Claude r17 [security]: also resolve redirect/tee/dd-of target
       // paths through symlinks. A pre-existing symlink whose target
       // resolves to `.mpl/mpl/...` defeats the literal substring check.
@@ -735,7 +754,7 @@ async function main() {
             try { candidate = join(realpathSync(dirname(targetAbs)), basename(targetAbs)); }
             catch { /* parent doesn't exist — skip */ }
           }
-          if (candidate && /\.mpl\/mpl\/decomposition\.ya?ml$/.test(candidate)) {
+          if (candidate && /\.mpl\/mpl\/decomposition\.ya?ml$/i.test(candidate)) {
             decompMention = true;
             symlinkWritesToDecomp = true;
             break;
@@ -802,7 +821,11 @@ async function main() {
   if (isBashTool && process.env.MPL_FORCE_PURGE !== '1') {
     const earlyCommand = (data.tool_input || data.toolInput || {}).command || '';
     if (earlyCommand && existsSync(join(cwd, '.mpl'))) {
-      const normalizedEarly = normalizeShellCommand(earlyCommand);
+      // Claude r21 [security]: lowercase for case-insensitive filesystem
+      // protection. macOS APFS / Windows NTFS open `.MPL/...` against
+      // the same inode as `.mpl/...`. All subsequent regexes match
+      // lowercase ASCII so lowercasing the input is structurally safe.
+      const normalizedEarly = normalizeShellCommand(earlyCommand).toLowerCase();
       const SAFE_READS_EARLY = new Set([
         'cat', 'ls', 'head', 'tail', 'wc', 'file', 'stat', 'du', 'df',
         'grep', 'rg', 'ag', 'ack', 'jq', 'yq',
@@ -822,7 +845,7 @@ async function main() {
             try { candidate = join(realpathSync(dirname(targetAbs)), basename(targetAbs)); }
             catch { /* skip */ }
           }
-          if (candidate && /\.mpl\/state\.json$/.test(candidate)) {
+          if (candidate && /\.mpl\/state\.json$/i.test(candidate)) {
             stateMention = true;
             symlinkWritesToState = true;
             break;
@@ -931,7 +954,9 @@ async function main() {
     // layered shell decode as matchesProtectedDelete BEFORE the
     // substring check, so quote-concat / backslash-escape / ANSI-C /
     // slash-collapse forms of `.mpl/state.json` can't bypass.
-    const normalizedCommand = normalizeShellCommand(command);
+    // Claude r21 [security]: lowercase for case-insensitive filesystem
+    // protection (macOS APFS / Windows NTFS).
+    const normalizedCommand = normalizeShellCommand(command).toLowerCase();
     // Codex r13 on PR #249 [security]: an encoded write (e.g. base64
     // -d > .mpl/state.json) can plant decomposer_dispatch without the
     // literal field name appearing in the Bash command. The right
@@ -1000,7 +1025,7 @@ async function main() {
           try { candidate = join(realpathSync(dirname(targetAbs)), basename(targetAbs)); }
           catch { /* skip */ }
         }
-        if (candidate && /\.mpl\/state\.json$/.test(candidate)) {
+        if (candidate && /\.mpl\/state\.json$/i.test(candidate)) {
           symlinkWritesToStateJson = true;
           writesToStateJson = true;
           break;

--- a/hooks/mpl-write-guard.mjs
+++ b/hooks/mpl-write-guard.mjs
@@ -696,11 +696,13 @@ async function main() {
       // resolves to `.mpl/mpl/...` defeats the literal substring check.
       let symlinkWritesToDecomp = false;
       if (!decompMention) {
-        const targetMatch = normalizedEarly.match(
-          /(?:[\d&]?>{1,2}|\btee\b[^|;&]*|\bdd\b[^|;&]*\bof=)\s*([^\s|;&]+)/,
-        );
-        if (targetMatch) {
-          const target = targetMatch[1];
+        // Claude r18 [security]: iterate EVERY redirect/tee/dd-of
+        // target in the command, not just the first. A multi-statement
+        // line with a benign first redirect followed by a symlink-
+        // through-protected second redirect would otherwise slip.
+        const targetRe = /(?:[\d&]?>{1,2}|\btee\b[^|;&]*|\bdd\b[^|;&]*\bof=)\s*([^\s|;&]+)/g;
+        for (const m of normalizedEarly.matchAll(targetRe)) {
+          const target = m[1];
           const targetAbs = resolvePath(cwd, target);
           try {
             const realParent = realpathSync(dirname(targetAbs));
@@ -708,6 +710,7 @@ async function main() {
             if (/\.mpl\/mpl\/decomposition\.ya?ml$/.test(candidate)) {
               decompMention = true;
               symlinkWritesToDecomp = true;
+              break;
             }
           } catch { /* parent doesn't exist — skip realpath */ }
         }
@@ -859,12 +862,32 @@ async function main() {
     const isSafeRead = SAFE_READ_HEADS.has(headVerb);
     // Detect redirect/tee/dd targeting state.json anywhere in the
     // command (catches pipe-then-redirect forms).
-    const writesToStateJson = (
+    let writesToStateJson = (
       /[\d&]?>{1,2}[^|;&\n]*\.mpl\/state\.json/.test(normalizedCommand) ||
       /\btee\b[^|;&]*\.mpl\/state\.json/.test(normalizedCommand) ||
       /\bdd\b[^|;&]*\bof=[^|;&]*\.mpl\/state\.json/.test(normalizedCommand)
     );
-    if (stateJsonMention && (!isSafeRead || writesToStateJson) && process.env.MPL_FORCE_PURGE !== '1') {
+    // Claude r18 [security] (symmetric to decomp fix): iterate ALL
+    // redirect/tee/dd-of targets and realpath-check each so symlink-
+    // through-state.json forms (single or multi-statement) are caught.
+    let symlinkWritesToStateJson = false;
+    if (!stateJsonMention) {
+      const stateTargetRe = /(?:[\d&]?>{1,2}|\btee\b[^|;&]*|\bdd\b[^|;&]*\bof=)\s*([^\s|;&]+)/g;
+      for (const m of normalizedCommand.matchAll(stateTargetRe)) {
+        const target = m[1];
+        const targetAbs = resolvePath(cwd, target);
+        try {
+          const realParent = realpathSync(dirname(targetAbs));
+          const candidate = join(realParent, basename(targetAbs));
+          if (/\.mpl\/state\.json$/.test(candidate)) {
+            symlinkWritesToStateJson = true;
+            writesToStateJson = true;
+            break;
+          }
+        } catch { /* parent doesn't exist — skip */ }
+      }
+    }
+    if ((stateJsonMention || symlinkWritesToStateJson) && (!isSafeRead || writesToStateJson) && process.env.MPL_FORCE_PURGE !== '1') {
       const reason =
         `[MPL #236 A1] Refused Bash write to .mpl/state.json: only ` +
         `mpl-write-guard's internal writeState may modify the orchestrator ` +

--- a/hooks/mpl-write-guard.mjs
+++ b/hooks/mpl-write-guard.mjs
@@ -346,6 +346,10 @@ function matchesProtectedDelete(command, cwd) {
     // -x sweeps the entire .mpl/ tree. Treat git clean with any -*x*
     // / -*X* flag as destructive against the workspace.
     /\bgit\s+clean\b.*-\S*[xX]/.test(normalized) ||
+    // Claude r24 [security]: gzip / bzip2 / xz / zstd delete their
+    // input file by default (unless `-k`/`--keep` is set). Treat
+    // them as destructive against the operand path.
+    /\b(gzip|bzip2|xz|zstd)\b(?!.*(?:-k|--keep))/.test(normalized) ||
     // Codex r10 on PR #249 [data-integrity]: interpreter one-liners
     // (`node -e "require('fs').rmSync('.mpl/mpl')"`, `python -c
     // "shutil.rmtree('.mpl/mpl')"`) can destroy protected paths
@@ -498,10 +502,16 @@ function matchesProtectedDelete(command, cwd) {
       // `.mpl/contracts`, `.mpl/memory`. `find . -delete` destroys
       // every file under cwd including protected ones. The pre-fix
       // check only caught descendants of a root, not roots-of-the-root.
+      //
+      // Refinement after r24 regression: the ancestor match must
+      // only fire when the operand is INSIDE the workspace cwd —
+      // otherwise `cd /tmp && …` (with cwd `/tmp/X`) trips because
+      // `/tmp` is a filesystem-level ancestor of `/tmp/X/.mpl/mpl`.
+      const cwdAbs = resolvePath(cwd);
       if (
         abs === rootAbs ||
         abs.startsWith(rootAbs + '/') ||
-        rootAbs.startsWith(abs + '/')
+        (rootAbs.startsWith(abs + '/') && (abs === cwdAbs || abs.startsWith(cwdAbs + '/')))
       ) return target;
     }
   }
@@ -753,7 +763,19 @@ async function main() {
       // the same inode as `.mpl/...`. All subsequent regexes match
       // lowercase ASCII so lowercasing the input is structurally safe.
       const normalizedEarly = normalizeShellCommand(earlyCommand).toLowerCase();
-      let decompMention = /\.mpl\/mpl\/decomposition\.ya?ml/i.test(normalizedEarly);
+      // Codex r24 [security]: detect `cd …` followed by a redirect/tee/
+      // dd-of to a bare basename matching a protected file. Static
+      // checks can't model directory changes, so a command like
+      // `cd .$(printf mpl)/mpl && printf forged > decomposition.yaml`
+      // would otherwise slip — after the cd, `decomposition.yaml` is
+      // resolved against the new cwd. Treat the combination as a
+      // protected write.
+      const hasCdCmdSub = /\bcd\b[^;|&\n]*\$\(/.test(normalizedEarly) ||
+                          /\bcd\b[^;|&\n]*`/.test(normalizedEarly);
+      const hasCdBareDecompWrite = /\bcd\b[\s\S]*&&[\s\S]*(?:>{1,2}|\btee\b|\bdd\b[^;|&]*\bof=)\s*decomposition\.ya?ml\b/i.test(normalizedEarly);
+      const cdConstructedDecomp = hasCdCmdSub && /(?:>{1,2}|\btee\b|\bdd\b[^;|&]*\bof=)\s*decomposition\.ya?ml\b/i.test(normalizedEarly);
+      let decompMention = /\.mpl\/mpl\/decomposition\.ya?ml/i.test(normalizedEarly)
+                          || hasCdBareDecompWrite || cdConstructedDecomp;
       // Claude r17 [security]: also resolve redirect/tee/dd-of target
       // paths through symlinks. A pre-existing symlink whose target
       // resolves to `.mpl/mpl/...` defeats the literal substring check.
@@ -859,7 +881,14 @@ async function main() {
         'diff', 'comm', 'sdiff',
         'echo', 'printf', 'pwd', 'type', 'which',
       ]);
-      let stateMention = /\.mpl\/state\.json/.test(normalizedEarly);
+      // Codex r24 [security]: detect cd-into-constructed-mpl + bare
+      // state.json write.
+      const cdCmdSubState = /\bcd\b[^;|&\n]*\$\(/.test(normalizedEarly) ||
+                            /\bcd\b[^;|&\n]*`/.test(normalizedEarly);
+      const hasCdBareStateWrite = /\bcd\b[\s\S]*&&[\s\S]*(?:>{1,2}|\btee\b|\bdd\b[^;|&]*\bof=)\s*state\.json\b/i.test(normalizedEarly);
+      const cdConstructedState = cdCmdSubState && /(?:>{1,2}|\btee\b|\bdd\b[^;|&]*\bof=)\s*state\.json\b/i.test(normalizedEarly);
+      let stateMention = /\.mpl\/state\.json/.test(normalizedEarly)
+                         || hasCdBareStateWrite || cdConstructedState;
       let symlinkWritesToState = false;
       if (!stateMention) {
         const stateTargetReEarly = /(?:[\d&]?>{1,2}\s*|\btee\b(?:\s+-\S+)*\s+|\bdd\b[^|;&]*\bof=\s*)([^\s|;&]+)/g;

--- a/hooks/mpl-write-guard.mjs
+++ b/hooks/mpl-write-guard.mjs
@@ -349,7 +349,13 @@ function matchesProtectedDelete(command, cwd) {
     // Claude r24 [security]: gzip / bzip2 / xz / zstd delete their
     // input file by default (unless `-k`/`--keep` is set). Treat
     // them as destructive against the operand path.
-    /\b(gzip|bzip2|xz|zstd)\b(?!.*(?:-k|--keep))/.test(normalized) ||
+    //
+    // Claude r25 [security]: scan per-statement — `-k`/`--keep`
+    // anywhere else in the command doesn't suppress an unkeyed
+    // gzip earlier in the chain.
+    normalized.split(/[;|&\n]+/).some((seg) =>
+      /\b(gzip|bzip2|xz|zstd)\b/.test(seg) && !/(?:-k|--keep)\b/.test(seg),
+    ) ||
     // Codex r10 on PR #249 [data-integrity]: interpreter one-liners
     // (`node -e "require('fs').rmSync('.mpl/mpl')"`, `python -c
     // "shutil.rmtree('.mpl/mpl')"`) can destroy protected paths

--- a/hooks/mpl-write-guard.mjs
+++ b/hooks/mpl-write-guard.mjs
@@ -13,8 +13,8 @@
  * When MPL is active: guards Edit/Write on source files + warns on dangerous Bash
  */
 
-import { dirname, join, extname, resolve as resolvePath } from 'path';
-import { existsSync } from 'fs';
+import { dirname, join, extname, resolve as resolvePath, basename } from 'path';
+import { existsSync, realpathSync } from 'fs';
 import { fileURLToPath, pathToFileURL } from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -298,6 +298,11 @@ function matchesProtectedDelete(command, cwd) {
     // `tee FILE` opens FILE for write and overwrites it.
     /\btee\b/.test(normalized) ||
     /\bdd\b.*\bof=/.test(normalized) ||
+    // Claude r17 on PR #249 [security]: `ln -s SRC DST` creating a
+    // symlink whose source is a protected root/descendant lets a
+    // later redirect-write reach the protected file through
+    // indirection. Catch the creation step itself.
+    /\bln\b/.test(normalized) ||
     // Codex r11 on PR #249 [data-integrity]: `tar --remove-files` and
     // `rsync --remove-source-files` are destructive — both delete
     // their source operand after the copy completes.
@@ -392,7 +397,7 @@ function matchesProtectedDelete(command, cwd) {
     // Skip flag tokens; they can't be paths.
     if (token.startsWith('-')) continue;
     // Skip known program names so we don't false-match `rm` itself.
-    if (/^(rm|find|sudo|time|nice|env|cd|pushd|popd|mkdir|mv|shred|unlink|truncate|cp|export|tee|dd|tar|rsync|echo|cat|printf)$/i.test(token)) continue;
+    if (/^(rm|find|sudo|time|nice|env|cd|pushd|popd|mkdir|mv|shred|unlink|truncate|cp|export|tee|dd|tar|rsync|echo|cat|printf|ln)$/i.test(token)) continue;
 
     // Codex r6 on PR #249 [data-integrity]: shell pathname expansion
     // (glob metachars `*`, `?`, `[…]`) lets a command operand expand
@@ -685,7 +690,28 @@ async function main() {
     const earlyCommand = (data.tool_input || data.toolInput || {}).command || '';
     if (earlyCommand && existsSync(join(cwd, '.mpl'))) {
       const normalizedEarly = normalizeShellCommand(earlyCommand);
-      const decompMention = /\.mpl\/mpl\/decomposition\.ya?ml/.test(normalizedEarly);
+      let decompMention = /\.mpl\/mpl\/decomposition\.ya?ml/.test(normalizedEarly);
+      // Claude r17 [security]: also resolve redirect/tee/dd-of target
+      // paths through symlinks. A pre-existing symlink whose target
+      // resolves to `.mpl/mpl/...` defeats the literal substring check.
+      let symlinkWritesToDecomp = false;
+      if (!decompMention) {
+        const targetMatch = normalizedEarly.match(
+          /(?:[\d&]?>{1,2}|\btee\b[^|;&]*|\bdd\b[^|;&]*\bof=)\s*([^\s|;&]+)/,
+        );
+        if (targetMatch) {
+          const target = targetMatch[1];
+          const targetAbs = resolvePath(cwd, target);
+          try {
+            const realParent = realpathSync(dirname(targetAbs));
+            const candidate = join(realParent, basename(targetAbs));
+            if (/\.mpl\/mpl\/decomposition\.ya?ml$/.test(candidate)) {
+              decompMention = true;
+              symlinkWritesToDecomp = true;
+            }
+          } catch { /* parent doesn't exist — skip realpath */ }
+        }
+      }
       if (decompMention) {
         const headM = normalizedEarly.match(/^(\w+)/);
         const head = headM ? headM[1].toLowerCase() : '';
@@ -701,7 +727,7 @@ async function main() {
           /\btee\b[^|;&]*\.mpl\/mpl\/decomposition\.ya?ml/.test(normalizedEarly) ||
           /\bdd\b[^|;&]*\bof=[^|;&]*\.mpl\/mpl\/decomposition\.ya?ml/.test(normalizedEarly)
         );
-        if (!SAFE_READS.has(head) || writesToDecomp) {
+        if (!SAFE_READS.has(head) || writesToDecomp || symlinkWritesToDecomp) {
           const reason =
             `[MPL #236 A1] Refused Bash write to .mpl/mpl/decomposition.yaml: ` +
             `only the mpl-decomposer subagent may emit this file. Bash writes ` +

--- a/hooks/mpl-write-guard.mjs
+++ b/hooks/mpl-write-guard.mjs
@@ -716,8 +716,6 @@ async function main() {
         }
       }
       if (decompMention) {
-        const headM = normalizedEarly.match(/^(\w+)/);
-        const head = headM ? headM[1].toLowerCase() : '';
         const SAFE_READS = new Set([
           'cat', 'ls', 'head', 'tail', 'wc', 'file', 'stat', 'du', 'df',
           'grep', 'rg', 'ag', 'ack', 'jq', 'yq',
@@ -725,12 +723,22 @@ async function main() {
           'diff', 'comm', 'sdiff',
           'echo', 'printf', 'pwd', 'type', 'which',
         ]);
+        // Codex r19 [security]: check EVERY pipeline / statement
+        // segment's head verb, not just the first. `printf forged |
+        // sponge .mpl/mpl/decomposition.yaml` has a safe-read head
+        // (`printf`) but a downstream writer (`sponge`) that
+        // overwrites the protected file.
+        const segments = normalizedEarly.split(/[|;&]+/).map((s) => s.trim()).filter(Boolean);
+        const allSegmentsSafe = segments.every((seg) => {
+          const segHead = (seg.match(/^(\w+)/) || ['', ''])[1].toLowerCase();
+          return SAFE_READS.has(segHead);
+        });
         const writesToDecomp = (
           /[\d&]?>{1,2}[^|;&\n]*\.mpl\/mpl\/decomposition\.ya?ml/.test(normalizedEarly) ||
           /\btee\b[^|;&]*\.mpl\/mpl\/decomposition\.ya?ml/.test(normalizedEarly) ||
           /\bdd\b[^|;&]*\bof=[^|;&]*\.mpl\/mpl\/decomposition\.ya?ml/.test(normalizedEarly)
         );
-        if (!SAFE_READS.has(head) || writesToDecomp || symlinkWritesToDecomp) {
+        if (!allSegmentsSafe || writesToDecomp || symlinkWritesToDecomp) {
           const reason =
             `[MPL #236 A1] Refused Bash write to .mpl/mpl/decomposition.yaml: ` +
             `only the mpl-decomposer subagent may emit this file. Bash writes ` +
@@ -857,9 +865,15 @@ async function main() {
       'diff', 'comm', 'sdiff',
       'echo', 'printf', 'pwd', 'type', 'which',
     ]);
-    const headVerbMatch = normalizedCommand.match(/^(\w+)/);
-    const headVerb = headVerbMatch ? headVerbMatch[1].toLowerCase() : '';
-    const isSafeRead = SAFE_READ_HEADS.has(headVerb);
+    // Codex r19 [security]: check EVERY pipeline / statement segment's
+    // head verb, not just the first. `printf forged | sponge
+    // .mpl/state.json` has a safe-read head but a downstream writer.
+    const segmentsStateGuard = normalizedCommand
+      .split(/[|;&]+/).map((s) => s.trim()).filter(Boolean);
+    const isSafeRead = segmentsStateGuard.length > 0 && segmentsStateGuard.every((seg) => {
+      const segHead = (seg.match(/^(\w+)/) || ['', ''])[1].toLowerCase();
+      return SAFE_READ_HEADS.has(segHead);
+    });
     // Detect redirect/tee/dd targeting state.json anywhere in the
     // command (catches pipe-then-redirect forms).
     let writesToStateJson = (

--- a/hooks/mpl-write-guard.mjs
+++ b/hooks/mpl-write-guard.mjs
@@ -73,6 +73,11 @@ const DECOMPOSITION_FILE_REGEX = /(^|\/)\.mpl\/mpl\/decomposition\.ya?ml$/;
 // `decomposer_dispatch.*` — only the hook itself may set those keys.
 const STATE_FILE_REGEX = /(^|\/)\.mpl\/state\.json$/;
 const DECOMPOSER_DISPATCH_FIELD_REGEX = /"decomposer_dispatch"\s*:/;
+// Codex r12 + Claude r12 [security]: also protect first_transcript_seen
+// from forgery — that key is the bootstrap of the dispatcher-identity
+// chain. If the orchestrator plants this field, the codex r12
+// mitigation falls. Same guard shape as decomposer_dispatch.
+const FIRST_TRANSCRIPT_FIELD_REGEX = /"first_transcript_seen"\s*:/;
 const DECOMPOSER_SUBAGENT_TYPES = new Set([
   'mpl-decomposer',
   'mpl:mpl-decomposer',
@@ -240,6 +245,29 @@ function expandShellBraces(text) {
     if (!changed) break;
   }
   return tokens.join(' ');
+}
+
+// Claude r12 on PR #249 [security]: extract the shell-normalization
+// chain so other Bash defenses (decomposer_dispatch forgery) can
+// reuse it. Without normalization, quote-concat / backslash-escape /
+// ANSI-C / slash-collapse forms of `.mpl/state.json` bypassed the
+// raw substring check at the dispatch-forgery guard.
+function normalizeShellCommand(command) {
+  let normalized = command.replace(/^\s*(sudo|time|nice|env)\s+/, '').trim();
+  normalized = normalized
+    .replace(/\\x([0-9a-fA-F]{2})/g, (_, h) => String.fromCharCode(parseInt(h, 16)))
+    .replace(/\\u([0-9a-fA-F]{4})/g, (_, h) => String.fromCharCode(parseInt(h, 16)))
+    .replace(/\\U([0-9a-fA-F]{8})/g, (_, h) => {
+      const cp = parseInt(h, 16);
+      try { return String.fromCodePoint(cp); } catch { return ''; }
+    })
+    .replace(/\\([0-7]{1,3})/g, (_, oct) => String.fromCharCode(parseInt(oct, 8)))
+    .replace(/\\([\s\S])/g, '$1')
+    .replace(/["'`]/g, '')
+    .replace(/\/+/g, '/');
+  normalized = expandShellBraces(normalized);
+  normalized = expandSimpleVars(normalized);
+  return normalized;
 }
 
 function matchesProtectedDelete(command, cwd) {
@@ -443,6 +471,26 @@ function recordDecomposerDispatch(cwd, parentTranscriptPath) {
   } catch { /* best-effort */ }
 }
 
+// Codex r12 on PR #249 [security]: the A1 dispatch gate trusted any
+// Task caller as the dispatch parent. A non-orchestrator agent
+// (phase-runner, etc.) could dispatch mpl-decomposer and the
+// orchestrator could then become the first "child" writer.
+//
+// Mitigation: bind the dispatcher-role to the FIRST transcript
+// observed in the session. The first tool call records
+// state.first_transcript_seen; subsequent Task(subagent_type=
+// 'mpl-decomposer') calls only record dispatch when the caller's
+// transcript matches that first observed transcript. Nested
+// dispatchers fail the match and are refused.
+function recordFirstTranscript(cwd, transcriptPath) {
+  if (!transcriptPath || typeof transcriptPath !== 'string') return;
+  try {
+    const state = readState(cwd) || {};
+    if (typeof state.first_transcript_seen === 'string' && state.first_transcript_seen) return;
+    writeState(cwd, { first_transcript_seen: transcriptPath });
+  } catch { /* best-effort */ }
+}
+
 // #236 A1: is the current write coming from the decomposer subagent?
 //   - dispatch flag must be set,
 //   - within the TTL,
@@ -553,6 +601,17 @@ async function main() {
   }
 
   const toolInput = data.tool_input || data.toolInput || {};
+  const callerTranscriptPath = typeof data.transcript_path === 'string'
+    ? data.transcript_path
+    : (typeof data.transcriptPath === 'string' ? data.transcriptPath : null);
+
+  // Codex r12 on PR #249 [security]: record the FIRST transcript
+  // observed in the session on EVERY tool call (Bash / Write / Task /
+  // etc.) — this binds the dispatcher-role to whichever transcript
+  // appears first, which is typically the orchestrator. Subsequent
+  // mpl-decomposer dispatches from OTHER transcripts (nested
+  // phase-runner, etc.) are then refused.
+  recordFirstTranscript(cwd, callerTranscriptPath);
 
   // --- #236 A1 part 1: record decomposer dispatch when the orchestrator
   // calls Agent(subagent_type='mpl-decomposer'). The state flag is
@@ -561,14 +620,17 @@ async function main() {
   if (isTaskTool) {
     const sub = String(toolInput.subagent_type || toolInput.subagentType || '');
     if (DECOMPOSER_SUBAGENT_TYPES.has(sub)) {
-      // The transcript_path on a PreToolUse Task dispatch is the
-      // DISPATCHING agent's transcript (the orchestrator's). Pin it
-      // so the writer-identity check can reject any future write
-      // arriving with the same transcript_path.
-      const parentTranscript = typeof data.transcript_path === 'string'
-        ? data.transcript_path
-        : (typeof data.transcriptPath === 'string' ? data.transcriptPath : null);
-      recordDecomposerDispatch(cwd, parentTranscript);
+      const sessState = readState(cwd) || {};
+      const firstSeen = typeof sessState.first_transcript_seen === 'string'
+        ? sessState.first_transcript_seen
+        : null;
+      // Codex r12 [security]: only the first-seen (orchestrator-role)
+      // transcript may dispatch mpl-decomposer. Any other caller's
+      // dispatch is refused (no dispatch flag recorded → no
+      // decomposition.yaml write window opens).
+      if (firstSeen && callerTranscriptPath && firstSeen === callerTranscriptPath) {
+        recordDecomposerDispatch(cwd, callerTranscriptPath);
+      }
     }
     console.log(JSON.stringify({ continue: true, suppressOutput: true }));
     return;
@@ -589,7 +651,14 @@ async function main() {
     // AND `decomposer_dispatch`. The MPL hook is the only legitimate
     // writer of that key — no shell command should ever co-mention
     // them.
-    if (/\.mpl\/state\.json/.test(command) && /decomposer_dispatch/.test(command)) {
+    // Claude r12 [security]: normalize the command through the same
+    // layered shell decode as matchesProtectedDelete BEFORE the
+    // substring check, so quote-concat / backslash-escape / ANSI-C /
+    // slash-collapse forms of `.mpl/state.json` can't bypass.
+    const normalizedCommand = normalizeShellCommand(command);
+    if (/\.mpl\/state\.json/.test(normalizedCommand) &&
+        (/decomposer_dispatch/.test(normalizedCommand) ||
+         /first_transcript_seen/.test(normalizedCommand))) {
       const reason =
         `[MPL #236 A1] Refused Bash that mentions both .mpl/state.json AND ` +
         `decomposer_dispatch — only mpl-write-guard itself may plant that flag. ` +
@@ -694,7 +763,7 @@ ensure you have the correct target path. The command will proceed, but please ve
       }
       return parts.join('\n');
     })();
-    if (DECOMPOSER_DISPATCH_FIELD_REGEX.test(payload)) {
+    if (DECOMPOSER_DISPATCH_FIELD_REGEX.test(payload) || FIRST_TRANSCRIPT_FIELD_REGEX.test(payload)) {
       const reason =
         `[MPL #236 A1] Refused to Write/Edit decomposer_dispatch into ` +
         `.mpl/state.json: only mpl-write-guard itself may set that key. ` +

--- a/hooks/mpl-write-guard.mjs
+++ b/hooks/mpl-write-guard.mjs
@@ -181,7 +181,7 @@ function matchesProtectedDelete(command, cwd) {
   if (!command || typeof command !== 'string') return null;
   // Strip leading wrapper before checking the head — `sudo rm -rf …`
   // must still trip.
-  const normalized = command.replace(/^\s*(sudo|time|nice|env)\s+/, '').trim();
+  let normalized = command.replace(/^\s*(sudo|time|nice|env)\s+/, '').trim();
   // Identify rm-family / find -delete calls. Multi-command lines
   // (`a; rm -rf X`, `a && rm -rf X`) still parse because we scan the
   // whole command for `rm` or `find ... -delete`.
@@ -189,23 +189,27 @@ function matchesProtectedDelete(command, cwd) {
     return null;
   }
 
+  // Pre-normalize:
+  //   - Codex r3 on PR #249 [data-integrity]: POSIX shells concatenate
+  //     adjacent quote fragments. `.mpl/""mpl` and `.mpl"/"mpl` both
+  //     resolve to `.mpl/mpl` at execution time. Strip every `"`, `'`,
+  //     backtick character so quote-concatenation forgery collapses to
+  //     the same literal a real shell would see.
+  //   - Codex r2 on PR #249 [logic]: a real shell normalizes runs of
+  //     `/` after expansion (`$PWD/.mpl//mpl` deletes `.mpl/mpl`).
+  //     Collapse repeated slashes to one.
+  // Both transforms preserve token-boundary whitespace, so downstream
+  // tokenization still works.
+  normalized = normalized.replace(/["'`]/g, '').replace(/\/+/g, '/');
+
   // Claude r1 on PR #249 [logic] (concrete repros): shell-expansion
-  // forms (`$PWD`, `$(pwd)`), parenthesized subshells (`(cd … && rm
-  // -rf …)`), `pushd … && rm -rf …` splits, and shell-variable
+  // forms (`$PWD`, `$(pwd)`), parenthesized subshells, variable
   // operands all defeat literal token resolution. Defense-in-depth:
-  // ALSO match the protected substring anywhere in the command. This
-  // over-blocks on incidental mentions, but `MPL_FORCE_PURGE=1` is
-  // already the operator escape hatch — over-blocking is the safe
-  // direction for a destructive op.
-  //
-  // Codex r2 on PR #249 [logic]: a real shell normalizes runs of `/`
-  // after expansion (`$PWD/.mpl//mpl` deletes `.mpl/mpl` just fine).
-  // Collapse repeated slashes in the normalized command before the
-  // substring check so the defense is invariant under redundant-slash
-  // forgery.
-  const slashCollapsed = normalized.replace(/\/+/g, '/');
+  // ALSO match the protected substring anywhere in the command.
+  // Over-blocks on incidental mentions — `MPL_FORCE_PURGE=1` is the
+  // operator escape hatch already documented in the block reason.
   for (const target of PROTECTED_DELETE_TARGETS) {
-    if (slashCollapsed.includes(target)) return target;
+    if (normalized.includes(target)) return target;
   }
 
   const resolvedRoots = PROTECTED_DELETE_TARGETS.map((target) => ({
@@ -214,12 +218,10 @@ function matchesProtectedDelete(command, cwd) {
   }));
 
   // Tokenize on whitespace AND `;`/`&&`/`||`/`|`/`(`/`)` so a
-  // multi-command line + subshell surfaces every operand. We don't
-  // honour quoting precisely — strip leading/trailing quote and
-  // paren chars and check each token.
+  // multi-command line + subshell surfaces every operand.
   const tokens = normalized
     .split(/[\s;|&()]+/)
-    .map((t) => t.replace(/^[\\$"'`]+/, '').replace(/[\\"'`)]+$/, ''))
+    .map((t) => t.replace(/^[\\$]+/, '').replace(/[\\)]+$/, ''))
     .filter(Boolean);
 
   for (const token of tokens) {
@@ -227,12 +229,20 @@ function matchesProtectedDelete(command, cwd) {
     if (token.startsWith('-')) continue;
     // Skip known program names so we don't false-match `rm` itself.
     if (/^(rm|find|sudo|time|nice|env|cd|pushd|popd|mkdir)$/i.test(token)) continue;
-    // path.resolve handles `./`, `../`, abs, and trailing `/`.
     let abs;
     try { abs = resolvePath(cwd, token); }
     catch { continue; }
     for (const { target, abs: rootAbs } of resolvedRoots) {
-      if (abs === rootAbs || abs.startsWith(rootAbs + '/')) return target;
+      // Claude r2 on PR #249 [security]: also match ANCESTORS of
+      // protected roots. `rm -rf .mpl` destroys `.mpl/mpl`,
+      // `.mpl/contracts`, `.mpl/memory`. `find . -delete` destroys
+      // every file under cwd including protected ones. The pre-fix
+      // check only caught descendants of a root, not roots-of-the-root.
+      if (
+        abs === rootAbs ||
+        abs.startsWith(rootAbs + '/') ||
+        rootAbs.startsWith(abs + '/')
+      ) return target;
     }
   }
   return null;
@@ -254,6 +264,13 @@ function recordDecomposerDispatch(cwd, parentTranscriptPath) {
       decomposer_dispatch: {
         dispatched_at: new Date().toISOString(),
         parent_transcript_path: parentTranscriptPath || null,
+        // Claude r3 on PR #249 [contract-break]: re-dispatch must
+        // reset the lock — without an explicit null, writeState's
+        // deepMerge preserves the previous child_transcript_path,
+        // so the new decomposer's write (with a fresh transcript)
+        // is wrongly rejected even though it IS the legitimate
+        // freshly-dispatched subagent.
+        child_transcript_path: null,
       },
     });
   } catch { /* best-effort */ }

--- a/hooks/mpl-write-guard.mjs
+++ b/hooks/mpl-write-guard.mjs
@@ -269,6 +269,11 @@ function matchesProtectedDelete(command, cwd) {
     // `tee FILE` opens FILE for write and overwrites it.
     /\btee\b/.test(normalized) ||
     /\bdd\b.*\bof=/.test(normalized) ||
+    // Codex r11 on PR #249 [data-integrity]: `tar --remove-files` and
+    // `rsync --remove-source-files` are destructive — both delete
+    // their source operand after the copy completes.
+    /\btar\b.*--remove-files\b/.test(normalized) ||
+    /\brsync\b.*--remove-source-files\b/.test(normalized) ||
     // Codex r10 on PR #249 [data-integrity]: interpreter one-liners
     // (`node -e "require('fs').rmSync('.mpl/mpl')"`, `python -c
     // "shutil.rmtree('.mpl/mpl')"`) can destroy protected paths

--- a/hooks/mpl-write-guard.mjs
+++ b/hooks/mpl-write-guard.mjs
@@ -14,6 +14,7 @@
  */
 
 import { dirname, join, extname, resolve as resolvePath } from 'path';
+import { existsSync } from 'fs';
 import { fileURLToPath, pathToFileURL } from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -592,8 +593,50 @@ async function main() {
     return;
   }
 
-  // Check if MPL is active
   const cwd = data.cwd || data.directory || process.cwd();
+
+  // Claude r13 on PR #249 [security]: refuse direct Write/Edit to
+  // .mpl/state.json BEFORE the isMplActive short-circuit. Without
+  // this, an attacker can deactivate MPL via a benign-looking
+  // state.json write, then forge dispatch fields in a second write
+  // while the hook short-circuits, then write decomposition.yaml
+  // from the orchestrator's own transcript.
+  if (isWriteTool && process.env.MPL_FORCE_PURGE !== '1') {
+    const earlyFilePath = (data.tool_input || data.toolInput || {}).file_path
+      || (data.tool_input || data.toolInput || {}).filePath
+      || '';
+    // isMplDir: workspace has the .mpl/ directory (regardless of
+    // current_phase). This guards the deactivation chain even when
+    // current_phase has been flipped to completed/cancelled.
+    const isMplDir = existsSync(join(cwd, '.mpl'));
+    if (earlyFilePath && STATE_FILE_REGEX.test(earlyFilePath) && isMplDir) {
+      const reason =
+        `[MPL #236 A1] Refused direct ${toolName} of .mpl/state.json: only ` +
+        `mpl-write-guard's internal writeState may modify the orchestrator ` +
+        `state file. Direct Write/Edit can be chained (deactivate MPL → ` +
+        `forge decomposer_dispatch → write decomposition.yaml) to bypass ` +
+        `the A1 writer-identity gate. Use mpl_state_write / writeState, OR ` +
+        `set MPL_FORCE_PURGE=1 in the same shell for a one-shot manual edit.`;
+      recordBlockedHook(cwd, {
+        hookId: HOOK_ID,
+        phaseId: (readState(cwd) || {}).current_phase,
+        artifact: earlyFilePath,
+        code: 'state_json_direct_write',
+        reason,
+        resumeInstruction:
+          `Route the change through writeState() / mpl_state_write. Set MPL_FORCE_PURGE=1 only for a one-shot manual reset.`,
+        retryContext: { file_path: earlyFilePath, tool: toolName },
+      });
+      console.log(JSON.stringify({
+        continue: false,
+        decision: 'block',
+        reason,
+      }));
+      return;
+    }
+  }
+
+  // Check if MPL is active
   if (!isMplActive(cwd)) {
     // MPL inactive: no interference
     console.log(JSON.stringify({ continue: true, suppressOutput: true }));
@@ -779,45 +822,8 @@ ensure you have the correct target path. The command will proceed, but please ve
   // the dispatch flag; an orchestrator that plants a forged flag
   // could otherwise unlock the A1 writer-identity check and Write
   // decomposition.yaml from its own transcript.
-  if (STATE_FILE_REGEX.test(filePath)) {
-    const payload = (() => {
-      const t = data.tool_input || data.toolInput || {};
-      const parts = [];
-      if (typeof t.content === 'string') parts.push(t.content);
-      if (typeof t.new_string === 'string') parts.push(t.new_string);
-      if (typeof t.newString === 'string') parts.push(t.newString);
-      if (Array.isArray(t.edits)) {
-        for (const e of t.edits) {
-          if (e?.new_string) parts.push(String(e.new_string));
-          if (e?.newString) parts.push(String(e.newString));
-        }
-      }
-      return parts.join('\n');
-    })();
-    if (DECOMPOSER_DISPATCH_FIELD_REGEX.test(payload) || FIRST_TRANSCRIPT_FIELD_REGEX.test(payload)) {
-      const reason =
-        `[MPL #236 A1] Refused to Write/Edit decomposer_dispatch into ` +
-        `.mpl/state.json: only mpl-write-guard itself may set that key. ` +
-        `Planting it from outside would let the orchestrator forge the ` +
-        `decomposition.yaml writer-identity flag.`;
-      recordBlockedHook(cwd, {
-        hookId: HOOK_ID,
-        phaseId: state?.current_phase,
-        artifact: filePath,
-        code: 'decomposer_dispatch_forgery',
-        reason,
-        resumeInstruction:
-          `Remove the decomposer_dispatch field from the .mpl/state.json patch; the hook will populate it on Agent(subagent_type='mpl-decomposer') dispatch.`,
-        retryContext: { file_path: filePath },
-      });
-      console.log(JSON.stringify({
-        continue: false,
-        decision: 'block',
-        reason,
-      }));
-      return;
-    }
-  }
+  // (state.json Write/Edit guard moved to the top of main() to run
+  // BEFORE the isMplActive short-circuit — see Claude r13.)
 
   // #236 A1: decomposition.yaml may ONLY be Written/Edited by the
   // mpl-decomposer subagent. The hook detects this via a dispatch

--- a/hooks/mpl-write-guard.mjs
+++ b/hooks/mpl-write-guard.mjs
@@ -47,8 +47,42 @@ const { loadConfig } = await import(
 const { recordBlockedHook, clearBlockedHook } = await import(
   pathToFileURL(join(__dirname, 'lib', 'mpl-blocked-hook.mjs')).href
 );
+// #236: state-based subagent dispatch tracking so the decomposition.yaml
+// writer-identity check can verify it's the decomposer subagent.
+// (readState already imported above with isMplActive.)
+const { writeState } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-state.mjs')).href
+);
 
 const HOOK_ID = 'mpl-write-guard';
+
+// #236 A1: orchestrator MUST NOT directly Write/Edit
+// `.mpl/mpl/decomposition.yaml`. Only the mpl-decomposer agent may
+// (commands/mpl-run-decompose.md:16). We detect the writer identity
+// via a state-based dispatch flag set when the orchestrator dispatches
+// Agent(subagent_type='mpl-decomposer') and cleared on Stop.
+const DECOMPOSITION_FILE_REGEX = /(^|\/)\.mpl\/mpl\/decomposition\.ya?ml$/;
+const DECOMPOSER_SUBAGENT_TYPES = new Set([
+  'mpl-decomposer',
+  'mpl:mpl-decomposer',
+]);
+// Dispatch flag lifetime in ms — a real decompose run typically
+// completes in a few minutes; 30 min is a conservative ceiling.
+const DECOMPOSER_DISPATCH_TTL_MS = 30 * 60 * 1000;
+
+// #236 A3: skill mpl-cancel declares these paths NEVER deletable.
+// The dangerous-bash check used to allowlist `rm -rf .mpl` as "safe
+// cleanup" — that allowed the exact destructive op the SKILL forbids.
+// Fix: every rm against any of these (or any descendant) is hard-blocked
+// regardless of the safe-cleanup allowlist. Override via env var
+// MPL_FORCE_PURGE=1 — operators initiating a real reset can set this
+// in the same shell.
+const PROTECTED_DELETE_TARGETS = [
+  '.mpl/mpl',
+  '.mpl/contracts',
+  '.mpl/memory',
+  'docs/learnings',
+];
 
 // Dogfood mode (P0-3, #111): when developing the MPL plugin against itself,
 // `/MPL/` paths must be treated like ordinary source — orchestrator should
@@ -106,7 +140,13 @@ const DANGEROUS_BASH_PATTERNS = [
   /\bchmod\s+777\b/,                                  // chmod 777
 ];
 
-// Safe cleanup patterns that look dangerous but are common/expected
+// Safe cleanup patterns that look dangerous but are common/expected.
+// #236 A3 removed `.mpl` from this set — it conflicted with the
+// mpl-cancel SKILL contract that explicitly forbids deleting any of
+// `.mpl/mpl/**`, `.mpl/contracts/*.json`, `.mpl/memory/`, and
+// `docs/learnings/`. The protected-delete check (matchesProtectedDelete)
+// runs BEFORE the dangerous-bash check now and hard-blocks regardless
+// of this allowlist.
 const SAFE_CLEANUP_PATTERNS = [
   /\brm\s+(-[a-zA-Z]*f[a-zA-Z]*\s+|.*--force\s+)(\.\/)?node_modules/,
   /\brm\s+(-[a-zA-Z]*f[a-zA-Z]*\s+|.*--force\s+)(\.\/)?\.next/,
@@ -115,7 +155,6 @@ const SAFE_CLEANUP_PATTERNS = [
   /\brm\s+(-[a-zA-Z]*f[a-zA-Z]*\s+|.*--force\s+)(\.\/)?\.cache/,
   /\brm\s+(-[a-zA-Z]*f[a-zA-Z]*\s+|.*--force\s+)(\.\/)?coverage/,
   /\brm\s+(-[a-zA-Z]*f[a-zA-Z]*\s+|.*--force\s+)(\.\/)?__pycache__/,
-  /\brm\s+(-[a-zA-Z]*f[a-zA-Z]*\s+|.*--force\s+)(\.\/)?\.mpl/,
 ];
 
 function isDangerousBashCommand(command) {
@@ -123,6 +162,53 @@ function isDangerousBashCommand(command) {
   // Check safe cleanup first (allowlist takes priority)
   if (SAFE_CLEANUP_PATTERNS.some(p => p.test(command))) return false;
   return DANGEROUS_BASH_PATTERNS.some(p => p.test(command));
+}
+
+// #236 A3: does `command` attempt to remove any PROTECTED_DELETE_TARGETS
+// path (or one of its descendants)? Returns the matched target on hit,
+// null otherwise. Matches the canonical `rm` family — `rm`, `rm -r*`,
+// `rm -f*`, `rm --force`, and the wrapped `find ... -delete` form.
+// The check is conservative — over-matching is acceptable because the
+// MPL_FORCE_PURGE escape hatch exists for legitimate cleanup.
+function matchesProtectedDelete(command) {
+  if (!command || typeof command !== 'string') return null;
+  // Strip leading `sudo ` etc. before checking the head — `sudo rm -rf .mpl/mpl`
+  // must still trip.
+  const normalized = command.replace(/^\s*(sudo|time|nice|env)\s+/, '').trim();
+  // Identify rm calls — `rm`, `rm -*`, `\brm\b` inside a pipeline, etc.
+  if (!/\brm\b/.test(normalized) && !/\bfind\b.*-delete\b/.test(normalized)) {
+    return null;
+  }
+  for (const target of PROTECTED_DELETE_TARGETS) {
+    // Whole target OR `target/` prefix to catch descendants.
+    const escaped = target.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const re = new RegExp(`(^|[\\s'"])(\\./)?${escaped}(/|\\b|['"])`);
+    if (re.test(normalized)) return target;
+  }
+  return null;
+}
+
+// #236 A1: record state.decomposer_dispatch when the orchestrator
+// dispatches Agent(subagent_type='mpl-decomposer'). Used by the
+// decomposition.yaml writer-identity check below.
+function recordDecomposerDispatch(cwd) {
+  try {
+    writeState(cwd, {
+      decomposer_dispatch: {
+        dispatched_at: new Date().toISOString(),
+      },
+    });
+  } catch { /* best-effort */ }
+}
+
+// #236 A1: is a decomposer subagent currently expected to be running?
+// True when state.decomposer_dispatch.dispatched_at is within the TTL.
+function isDecomposerDispatchActive(cwd, state) {
+  const flag = state?.decomposer_dispatch;
+  if (!flag || typeof flag.dispatched_at !== 'string') return false;
+  const ts = Date.parse(flag.dispatched_at);
+  if (Number.isNaN(ts)) return false;
+  return (Date.now() - ts) <= DECOMPOSER_DISPATCH_TTL_MS;
 }
 
 function isAllowedPath(filePath, opts = {}) {
@@ -153,8 +239,14 @@ async function main() {
 
   const toolName = data.tool_name || data.toolName || '';
 
-  // Only intercept Edit, Write, MultiEdit, and Bash tools
-  if (!['Edit', 'Write', 'MultiEdit', 'edit', 'write', 'multiEdit', 'multiedit', 'Bash', 'bash'].includes(toolName)) {
+  // Tool sets we care about. Task/Agent only used for the decomposer
+  // dispatch flag (A1); Bash for the safety + protected-delete check
+  // (A3); Edit/Write/MultiEdit for the source-file / phase-scope /
+  // decomposition-writer checks.
+  const isWriteTool = ['Edit', 'Write', 'MultiEdit', 'edit', 'write', 'multiEdit', 'multiedit'].includes(toolName);
+  const isBashTool = ['Bash', 'bash'].includes(toolName);
+  const isTaskTool = ['Task', 'Agent', 'task', 'agent'].includes(toolName);
+  if (!isWriteTool && !isBashTool && !isTaskTool) {
     console.log(JSON.stringify({ continue: true, suppressOutput: true }));
     return;
   }
@@ -169,9 +261,50 @@ async function main() {
 
   const toolInput = data.tool_input || data.toolInput || {};
 
-  // --- Bash dangerous command check (T-01, v3.8) ---
-  if (['Bash', 'bash'].includes(toolName)) {
+  // --- #236 A1 part 1: record decomposer dispatch when the orchestrator
+  // calls Agent(subagent_type='mpl-decomposer'). The state flag is
+  // consumed by the decomposition.yaml writer-identity check below
+  // when the decomposer subsequently calls Write/Edit.
+  if (isTaskTool) {
+    const sub = String(toolInput.subagent_type || toolInput.subagentType || '');
+    if (DECOMPOSER_SUBAGENT_TYPES.has(sub)) {
+      recordDecomposerDispatch(cwd);
+    }
+    console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+    return;
+  }
+
+  // --- Bash dangerous command check (T-01, v3.8) + #236 A3 ---
+  if (isBashTool) {
     const command = toolInput.command || '';
+    // #236 A3: protected-path delete — hard-block regardless of safe-cleanup
+    // allowlist. Override via env MPL_FORCE_PURGE=1 set by the operator.
+    const protectedTarget = matchesProtectedDelete(command);
+    if (protectedTarget && process.env.MPL_FORCE_PURGE !== '1') {
+      const reason =
+        `[MPL #236 A3] Refused destructive write to protected path "${protectedTarget}". ` +
+        `Command: \`${command}\`. The mpl-cancel skill (skills/mpl-cancel/SKILL.md) forbids ` +
+        `deleting any of: ${PROTECTED_DELETE_TARGETS.join(', ')} (decomposition / contracts / ` +
+        `cross-session memory / learnings). If you are running a real reset, set MPL_FORCE_PURGE=1 ` +
+        `in the same shell, OR invoke /mpl:mpl-cancel which performs an auditable cleanup.`;
+      const state = readState(cwd) || {};
+      recordBlockedHook(cwd, {
+        hookId: HOOK_ID,
+        phaseId: state?.current_phase,
+        artifact: protectedTarget,
+        code: 'protected_path_delete',
+        reason,
+        resumeInstruction:
+          `Either run /mpl:mpl-cancel (auditable cleanup that preserves intended state) or set MPL_FORCE_PURGE=1 in the same shell if you really want this rm to proceed, then retry.`,
+        retryContext: { command, target: protectedTarget },
+      });
+      console.log(JSON.stringify({
+        continue: false,
+        decision: 'block',
+        reason,
+      }));
+      return;
+    }
     if (isDangerousBashCommand(command)) {
       const message = `[MPL SAFETY WARNING] Potentially dangerous command detected:
   ${command}
@@ -204,6 +337,45 @@ ensure you have the correct target path. The command will proceed, but please ve
 
   const state = readState(cwd) || {};
   const dogfood = isDogfoodMode(cwd);
+
+  // #236 A1: decomposition.yaml may ONLY be Written/Edited by the
+  // mpl-decomposer subagent. The hook detects this via a dispatch
+  // flag set when the orchestrator calls Agent(subagent_type=
+  // 'mpl-decomposer') above; the flag has a 30-min TTL so a stale
+  // marker can't permanently unlock the path. Any Write/Edit to
+  // decomposition.yaml without an active dispatch — even from
+  // inside another subagent — is blocked. The block precedes the
+  // generic `isAllowedPath` (.mpl/* is otherwise an allowlisted
+  // orchestrator path) so the writer identity wins.
+  if (DECOMPOSITION_FILE_REGEX.test(filePath)) {
+    if (!isDecomposerDispatchActive(cwd, state)) {
+      const reason =
+        `[MPL #236 A1] Refused direct ${toolName} of decomposition.yaml: ` +
+        `the orchestrator must NOT write this file. Only the mpl-decomposer ` +
+        `subagent may emit it (commands/mpl-run-decompose.md). Dispatch via ` +
+        `Agent(subagent_type='mpl-decomposer', prompt='...') and let it write.`;
+      recordBlockedHook(cwd, {
+        hookId: HOOK_ID,
+        phaseId: state?.current_phase,
+        artifact: filePath,
+        code: 'decomposition_writer_violation',
+        reason,
+        resumeInstruction:
+          `Dispatch Agent(subagent_type='mpl-decomposer') and let it produce decomposition.yaml; do not Edit/Write it directly.`,
+        retryContext: { file_path: filePath, tool: toolName },
+      });
+      console.log(JSON.stringify({
+        continue: false,
+        decision: 'block',
+        reason,
+      }));
+      return;
+    }
+    // Decomposer dispatch is active — allow + clear any stale envelope.
+    clearBlockedHook(cwd, { hookId: HOOK_ID, artifact: filePath });
+    console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+    return;
+  }
 
   // Check if path is allowed for orchestrator (honours dogfood mode).
   if (isAllowedPath(filePath, { dogfood })) {

--- a/hooks/mpl-write-guard.mjs
+++ b/hooks/mpl-write-guard.mjs
@@ -253,6 +253,11 @@ function matchesProtectedDelete(command, cwd) {
     /\bunlink\b/.test(normalized) ||
     /\btruncate\b/.test(normalized) ||
     /\bcp\b.*\/dev\/null/.test(normalized) ||
+    // Codex r9 on PR #249 [data-integrity]: writer utilities that
+    // create/overwrite their path operand are destructive too.
+    // `tee FILE` opens FILE for write and overwrites it.
+    /\btee\b/.test(normalized) ||
+    /\bdd\b.*\bof=/.test(normalized) ||
     // Codex r8 on PR #249 [data-integrity]: POSIX shell redirection
     // does not require whitespace after `>`/`>>`/`&>`. `echo x
     // >.mpl/mpl/foo` truncates the protected file. Allow optional
@@ -332,7 +337,7 @@ function matchesProtectedDelete(command, cwd) {
     // Skip flag tokens; they can't be paths.
     if (token.startsWith('-')) continue;
     // Skip known program names so we don't false-match `rm` itself.
-    if (/^(rm|find|sudo|time|nice|env|cd|pushd|popd|mkdir|mv|shred|unlink|truncate|cp|export)$/i.test(token)) continue;
+    if (/^(rm|find|sudo|time|nice|env|cd|pushd|popd|mkdir|mv|shred|unlink|truncate|cp|export|tee|dd|tar|rsync|echo|cat|printf)$/i.test(token)) continue;
 
     // Codex r6 on PR #249 [data-integrity]: shell pathname expansion
     // (glob metachars `*`, `?`, `[…]`) lets a command operand expand


### PR DESCRIPTION
## What

Two write-guard tightenings per #236 acceptance criteria:

- **A1** — `mpl-write-guard.mjs` now requires `mpl-decomposer` subagent identity for `.mpl/mpl/decomposition.yaml` writes. The hook records a state dispatch flag when the orchestrator calls `Agent(subagent_type='mpl-decomposer')`; subsequent Write/Edit on decomposition.yaml is allowed only while that flag is active and within a 30-min TTL. Orchestrator hand-writes (or any non-decomposer agent) → block + envelope (`decomposition_writer_violation`).
- **A3** — `.mpl` removed from the safe-cleanup allowlist. New `matchesProtectedDelete` hard-blocks `rm`-family commands targeting `.mpl/mpl`, `.mpl/contracts`, `.mpl/memory`, `docs/learnings` (per `skills/mpl-cancel/SKILL.md`). Operator override via `MPL_FORCE_PURGE=1` env var.

`docs/design.md` Hook System table updated to reflect the new Task/Agent matcher.

## Why

Per `docs/findings/2026-05-28-prompt-gate-restore-divergence.md` §A1 + §A3 — both prompt-only rules previously had no mechanical guard. The decomposition.yaml content check only verified a `generated_by:` marker string (trivially forgeable). The dangerous-bash check actively allowlisted `rm -rf .mpl` as "safe cleanup", directly contradicting the mpl-cancel SKILL.

## Acceptance criteria

- [x] Orchestrator Write/Edit of decomposition.yaml is blocked at PreToolUse with an envelope referencing mpl-decomposer as the only allowed writer.
- [x] `rm -rf .mpl/mpl/phases/phase-1/` is blocked at PreToolUse with an envelope explaining the protected-path rule.
- [x] Legitimate `mpl-decomposer` subagent dispatch → `Write decomposition.yaml` still works (dispatch flag active path).
- [x] `MPL_FORCE_PURGE=1` override works for legitimate cleanup.
- [x] Tests cover both block cases + the legitimate-cancel pass case + the decomposer-write pass case.
- [x] Existing tests stay green (1399 → 1411).

## Out of scope

- **A2** (HA-01 vague delegation prompt heuristic) — Non-Goal per #236 spec; needs design pass on false-positive tolerance.
- Other A-category warn/telemetry items — separate issue (#238).

## Test plan

- [x] `node --test hooks/__tests__/*.test.mjs` — 1411/1411 pass.
- [x] `node --test hooks/__tests__/mpl-issue-236-write-guard-tighten.test.mjs` — 12/12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)