### PR TITLE
Add quality-signal telemetry surface for prompt-only quality rules (#238)

### DIFF
--- a/agents/mpl-doctor.md
+++ b/agents/mpl-doctor.md
@@ -358,6 +358,35 @@ disallowedTools: Write, Edit, Task
     [d] inverse audit (scripts/agents/commands): ✓ clean   or ⚠️ {n} hit(s) outside F3 runtime scope
     Result: PASS / WARN ({m} advisories) / FAIL (any blocker above)
     ```
+
+    ### Category 16: Quality Signals (#238)
+    - **Scope**: `.mpl/mpl/quality-signals.jsonl`
+    - Read the append-only log of soft-signal records emitted by
+      prompt-only quality rules (HA-01 vague delegation, seed
+      ambiguity-notes gap, etc.). Each line is one JSON record:
+      `{ rule, severity, ts, phase, agent, evidence }`.
+    - Aggregate per-rule counts and surface a top-N table. NEVER fails
+      the diagnostic — these are advisory signals, not state
+      corruption. A high count just means the rule is firing often
+      and warrants prompt-tuning attention.
+    - PASS — log file absent (no signals yet) OR all rule counts
+      below the advisory threshold (default: 10 per rule per run).
+    - WARN — any rule count ≥ threshold, OR log file malformed
+      (some lines unparseable). Surface the top 5 rules by count.
+    - FAIL — never (telemetry surface, no blocking).
+
+    **Output format for Category 16**:
+    ```
+    ### Quality Signals (#238)
+    Log: .mpl/mpl/quality-signals.jsonl ({N} records)
+
+    Top rules by hit count:
+      HA-01                       {n}   — vague delegation in Task prompts
+      seed-ambiguity-notes        {n}   — uncertainty without ambiguity_notes
+      …
+
+    Result: PASS / WARN (high-volume rules surfaced)
+    ```
   </Diagnostic_Categories>
 
   <Output_Schema>
@@ -387,6 +416,7 @@ disallowedTools: Write, Edit, Task
     | 10 | MCP Server | {PASS|WARN|FAIL} | {tools or "not available"} |
     | 11 | Documentation | {PASS|WARN|FAIL} | {brief} |
     | 12 | Measurement Integrity Audit | {PASS|WARN|FAIL} | AD-0006/0007/0008 (audit mode only) |
+    | 16 | Quality Signals | {PASS|WARN} | {N} records, top rule: {rule}={count} (or "no signals yet") |
 
     ## Tool Availability Detail
 

--- a/agents/mpl-doctor.md
+++ b/agents/mpl-doctor.md
@@ -365,27 +365,34 @@ disallowedTools: Write, Edit, Task
       prompt-only quality rules (HA-01 vague delegation, seed
       ambiguity-notes gap, etc.). Each line is one JSON record:
       `{ rule, severity, ts, phase, agent, evidence }`.
-    - Aggregate per-rule counts and surface a top-N table. NEVER fails
-      the diagnostic — these are advisory signals, not state
-      corruption. A high count just means the rule is firing often
-      and warrants prompt-tuning attention.
-    - PASS — log file absent (no signals yet) OR all rule counts
-      below the advisory threshold (default: 10 per rule per run).
-    - WARN — any rule count ≥ threshold, OR log file malformed
-      (some lines unparseable). Surface the top 5 rules by count.
+    - Use `readQualitySignals(cwd)` from
+      `hooks/lib/mpl-quality-signals.mjs`, which returns
+      `{ records, malformed }`. The `malformed` count is the number of
+      non-empty lines that failed to parse — surface this directly so
+      a corrupted log triggers a WARN instead of silently degrading.
+    - Aggregate per-rule counts via `summarizeQualitySignals(records)`
+      and surface a top-N table. NEVER fails the diagnostic — these
+      are advisory signals, not state corruption. A high count just
+      means the rule is firing often and warrants prompt-tuning
+      attention.
+    - PASS — log file absent (no signals yet) OR (malformed === 0 AND
+      every rule count below the advisory threshold; default: 10 per
+      rule per run).
+    - WARN — `malformed >= 1`, OR any rule count ≥ threshold. Surface
+      the top 5 rules by count AND the malformed-line count when > 0.
     - FAIL — never (telemetry surface, no blocking).
 
     **Output format for Category 16**:
     ```
     ### Quality Signals (#238)
-    Log: .mpl/mpl/quality-signals.jsonl ({N} records)
+    Log: .mpl/mpl/quality-signals.jsonl ({N} records, {M} malformed lines)
 
     Top rules by hit count:
       HA-01                       {n}   — vague delegation in Task prompts
       seed-ambiguity-notes        {n}   — uncertainty without ambiguity_notes
       …
 
-    Result: PASS / WARN (high-volume rules surfaced)
+    Result: PASS / WARN (high-volume rules / malformed lines surfaced)
     ```
   </Diagnostic_Categories>
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -450,7 +450,7 @@ All Discoveries are recorded in `.mpl/discoveries.md`.
 
 ## 7. Hook System
 
-`hooks/hooks.json` is the live SSOT for hook registration. MPL maintains pipeline integrity with 39 registered hook commands:
+`hooks/hooks.json` is the live SSOT for hook registration. MPL maintains pipeline integrity with 40 registered hook commands:
 
 | Hook | Event / matcher | Purpose | Introduced |
 |----|--------|------|------------|
@@ -472,6 +472,7 @@ All Discoveries are recorded in `.mpl/discoveries.md`.
 | `mpl-require-phase-evidence` | PreToolUse: Edit/Write/MultiEdit | Require phase Evidence Latches before completion artifacts or completion state writes. | v0.18.3 guard stream |
 | `mpl-baseline-guard` | PreToolUse: Edit/Write/MultiEdit | Protect `.mpl/mpl/baseline.yaml` after creation unless an explicit renewal sentinel exists. | v0.17.0 P2 stream (#59) |
 | `mpl-ambiguity-gate` | PreToolUse: Task/Agent | Block decomposer dispatch until ambiguity and user-contract readiness gates pass. | v0.11.2; UC readiness v0.16.0 |
+| `mpl-soft-signal-emit` | PreToolUse: Task/Agent | Emit quality-signal telemetry records (HA-01 vague delegation, etc.) to `.mpl/mpl/quality-signals.jsonl`. Never blocks. | #238 |
 | `mpl-require-chain-assignment` | PreToolUse: Task/Agent | Require `chain-assignment.yaml` before seed-generator dispatch when chain seed is enabled. | v0.17.0 P1-4d |
 | `mpl-tool-tracker` | PostToolUse: Bash/Edit/Write/MultiEdit/Task/Agent/Read/Grep/Glob/TodoWrite/NotebookEdit/WebFetch/WebSearch/SlashCommand/BashOutput/KillShell/ExitPlanMode/mcp__.* | Stamp `state.last_tool_at` for hang detection and telemetry freshness. | v0.18.1 |
 | `mpl-gate-recorder` | PostToolUse: Bash/Task/Agent | Record structured gate, E2E, sprint, and test-agent PASS evidence from real tool results. | v0.15.0; blocked-hook cleanup v0.18.3/v0.18.4 |

--- a/hooks/__tests__/mpl-issue-238-quality-signals.test.mjs
+++ b/hooks/__tests__/mpl-issue-238-quality-signals.test.mjs
@@ -322,6 +322,18 @@ test('#238 e2e: soft-signal-emit hook is a no-op outside MPL workspaces', () => 
   }
 });
 
+test('#238 codex r4 [contract-break]: mpl-doctor skill dispatch wires Category 16 into default mode', () => {
+  // Codex r4: the skill (skills/mpl-doctor/SKILL.md) is the actual
+  // command-path entry. If the dispatch prompt says only "Categories
+  // 1-12" then the agent prompt's Category 16 is unreachable from
+  // /mpl:mpl-doctor, defeating the AC. Contract: the dispatch must
+  // reference Category 16 (the user-facing telemetry surface).
+  const skillPath = join(import.meta.dirname, '..', '..', 'skills', 'mpl-doctor', 'SKILL.md');
+  const text = readFileSync(skillPath, 'utf-8');
+  assert.ok(/Category\s*16/i.test(text), 'SKILL.md must reference Category 16 in dispatch');
+  assert.ok(/quality-signals\.jsonl/.test(text), 'SKILL.md must point at .mpl/mpl/quality-signals.jsonl');
+});
+
 test('#238 codex r2 [contract-break] e2e: soft-signal-emit hook accepts camelCase payload shape', () => {
   // Codex r2: sibling hooks normalize both `tool_name` and `toolName`.
   // The new hook initially read only snake_case, silently losing

--- a/hooks/__tests__/mpl-issue-238-quality-signals.test.mjs
+++ b/hooks/__tests__/mpl-issue-238-quality-signals.test.mjs
@@ -80,8 +80,9 @@ test('#238: recordQualitySignal creates the log file and appends one record per 
       cwd,
     );
 
-    const records = readQualitySignals(cwd);
+    const { records, malformed } = readQualitySignals(cwd);
     assert.equal(records.length, 2);
+    assert.equal(malformed, 0);
     assert.equal(records[0].rule, 'HA-01');
     assert.equal(records[0].severity, 'warn');
     assert.equal(records[0].agent, 'mpl-decomposer');
@@ -110,7 +111,11 @@ test('#238: summarizeQualitySignals counts and sorts by descending rule frequenc
   assert.deepEqual(counts, { 'HA-01': 3, 'seed-ambiguity-notes': 2 });
 });
 
-test('#238: readQualitySignals skips malformed lines without throwing', () => {
+test('#238 codex r1 [contract-break]: readQualitySignals reports malformed-line count (so doctor Category 16 can WARN)', () => {
+  // Codex r1: Category 16's "WARN when log has malformed lines"
+  // promise required a reader contract that surfaces the malformed
+  // count, not silently skips. Test: a log with 2 valid + 1 bad line
+  // returns records.length=2 AND malformed=1.
   const cwd = freshWorkspace();
   try {
     const path = signalsLogPath(cwd);
@@ -118,10 +123,21 @@ test('#238: readQualitySignals skips malformed lines without throwing', () => {
       path,
       '{"rule":"HA-01"}\nnot-json\n{"rule":"seed-ambiguity-notes"}\n',
     );
-    const records = readQualitySignals(cwd);
+    const { records, malformed } = readQualitySignals(cwd);
     assert.equal(records.length, 2);
+    assert.equal(malformed, 1);
     assert.equal(records[0].rule, 'HA-01');
     assert.equal(records[1].rule, 'seed-ambiguity-notes');
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('#238 codex r1 [contract-break]: readQualitySignals returns {records:[], malformed:0} for an absent log', () => {
+  const cwd = freshWorkspace();
+  try {
+    const result = readQualitySignals(cwd);
+    assert.deepEqual(result, { records: [], malformed: 0 });
   } finally {
     rmSync(cwd, { recursive: true, force: true });
   }
@@ -216,8 +232,9 @@ test('#238 e2e: soft-signal-emit hook writes HA-01 record for vague Task prompt 
       },
     });
     assert.equal(decision.continue, true, 'must never block');
-    const records = readQualitySignals(cwd);
+    const { records, malformed } = readQualitySignals(cwd);
     assert.equal(records.length, 1);
+    assert.equal(malformed, 0);
     assert.equal(records[0].rule, 'HA-01');
     assert.equal(records[0].agent, 'mpl-decomposer');
     assert.equal(records[0].evidence.matched_phrase, '이전 결과 참고');
@@ -239,7 +256,7 @@ test('#238 e2e: soft-signal-emit hook stays silent on a well-scoped prompt', () 
       },
     });
     assert.equal(decision.continue, true);
-    assert.equal(readQualitySignals(cwd).length, 0);
+    assert.equal(readQualitySignals(cwd).records.length, 0);
   } finally {
     rmSync(cwd, { recursive: true, force: true });
   }

--- a/hooks/__tests__/mpl-issue-238-quality-signals.test.mjs
+++ b/hooks/__tests__/mpl-issue-238-quality-signals.test.mjs
@@ -1,0 +1,279 @@
+/**
+ * #238 — soft-signal telemetry surface for prompt-only quality rules.
+ *
+ * Acceptance criteria coverage (from the issue body):
+ *   - `.mpl/mpl/quality-signals.jsonl` accumulates entries when target
+ *     rules fire.
+ *   - Tests cover at least HA-01 prompt detection + ambiguity_notes
+ *     presence check.
+ *   - No blocking behavior change for any listed rule.
+ *
+ * Out of scope (deferred to follow-up):
+ *   - A4 mpl-validate-output JSON-fence telemetry
+ *   - A5 test_command finalize elevation
+ *   - A6 probing hints zero-coverage detection
+ *   - A8 HA-02 BEGIN/END region mirror
+ *   - A9 Retry-2 reflection
+ *   - A10 Interviewer comparison table
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execSync } from 'child_process';
+import { mkdtempSync, rmSync, mkdirSync, readFileSync, writeFileSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import {
+  signalsLogPath,
+  recordQualitySignal,
+  readQualitySignals,
+  summarizeQualitySignals,
+  detectHa01,
+  detectSeedAmbiguityNotesGap,
+} from '../lib/mpl-quality-signals.mjs';
+
+const HOOKS_DIR = join(import.meta.dirname, '..');
+
+function freshWorkspace() {
+  const cwd = mkdtempSync(join(tmpdir(), 'mpl-238-'));
+  mkdirSync(join(cwd, '.mpl', 'mpl'), { recursive: true });
+  writeFileSync(
+    join(cwd, '.mpl', 'state.json'),
+    JSON.stringify({ current_phase: 'phase-1' }),
+  );
+  return cwd;
+}
+
+function runHook(scriptRelPath, payload) {
+  const script = join(HOOKS_DIR, scriptRelPath);
+  const json = JSON.stringify(payload);
+  const out = execSync(`node "${script}"`, {
+    input: json,
+    stdio: ['pipe', 'pipe', 'pipe'],
+    timeout: 5000,
+  }).toString();
+  return JSON.parse(out.trim());
+}
+
+// ---------------------------------------------------------------------------
+// recordQualitySignal — append-only writes + schema fields
+// ---------------------------------------------------------------------------
+
+test('#238: recordQualitySignal creates the log file and appends one record per call', () => {
+  const cwd = freshWorkspace();
+  try {
+    const path = signalsLogPath(cwd);
+    assert.equal(existsSync(path), false, 'log starts absent');
+
+    assert.equal(
+      recordQualitySignal(
+        { rule: 'HA-01', agent: 'mpl-decomposer', evidence: { matched_phrase: '알아서 판단' } },
+        cwd,
+      ),
+      true,
+    );
+    assert.equal(existsSync(path), true);
+
+    recordQualitySignal(
+      { rule: 'seed-ambiguity-notes', evidence: { matched: 'TBD' } },
+      cwd,
+    );
+
+    const records = readQualitySignals(cwd);
+    assert.equal(records.length, 2);
+    assert.equal(records[0].rule, 'HA-01');
+    assert.equal(records[0].severity, 'warn');
+    assert.equal(records[0].agent, 'mpl-decomposer');
+    assert.equal(records[0].phase, 'phase-1');
+    assert.equal(typeof records[0].ts, 'string');
+    assert.ok(records[0].ts.includes('T'));
+    assert.equal(records[1].rule, 'seed-ambiguity-notes');
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('#238: recordQualitySignal returns false on missing rule or cwd (fail-soft)', () => {
+  assert.equal(recordQualitySignal({}, '/tmp/whatever'), false);
+  assert.equal(recordQualitySignal({ rule: 'X' }, ''), false);
+});
+
+test('#238: summarizeQualitySignals counts and sorts by descending rule frequency', () => {
+  const counts = summarizeQualitySignals([
+    { rule: 'HA-01' },
+    { rule: 'seed-ambiguity-notes' },
+    { rule: 'HA-01' },
+    { rule: 'HA-01' },
+    { rule: 'seed-ambiguity-notes' },
+  ]);
+  assert.deepEqual(counts, { 'HA-01': 3, 'seed-ambiguity-notes': 2 });
+});
+
+test('#238: readQualitySignals skips malformed lines without throwing', () => {
+  const cwd = freshWorkspace();
+  try {
+    const path = signalsLogPath(cwd);
+    writeFileSync(
+      path,
+      '{"rule":"HA-01"}\nnot-json\n{"rule":"seed-ambiguity-notes"}\n',
+    );
+    const records = readQualitySignals(cwd);
+    assert.equal(records.length, 2);
+    assert.equal(records[0].rule, 'HA-01');
+    assert.equal(records[1].rule, 'seed-ambiguity-notes');
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// HA-01 detector
+// ---------------------------------------------------------------------------
+
+test('#238 [HA-01]: detects Korean vague-delegation phrases case-insensitively', () => {
+  assert.deepEqual(
+    detectHa01('Phase 3 작업: 이전 결과 참고해서 마무리해줘.'),
+    { phrase: '이전 결과 참고', offset: '"Phase 3 작업: '.length - 1 },
+  );
+  assert.equal(detectHa01('알아서 판단해주세요')?.phrase, '알아서 판단');
+  assert.equal(detectHa01('알아서 처리')?.phrase, '알아서 처리');
+  assert.equal(detectHa01('적절히 판단해서')?.phrase, '적절히 판단');
+});
+
+test('#238 [HA-01]: detects English vague-delegation phrases', () => {
+  assert.equal(detectHa01('Use your judgement here.')?.phrase, 'use your judgement');
+  assert.equal(detectHa01('Adapt as appropriate.')?.phrase, 'as appropriate');
+  assert.equal(detectHa01('Just figure it out.')?.phrase, 'figure it out');
+});
+
+test('#238 [HA-01]: no match returns null', () => {
+  assert.equal(detectHa01('Decompose the goal into 3 phases with concrete acceptance criteria.'), null);
+  assert.equal(detectHa01(''), null);
+  assert.equal(detectHa01(null), null);
+});
+
+// ---------------------------------------------------------------------------
+// Seed ambiguity-notes gap detector
+// ---------------------------------------------------------------------------
+
+test('#238 [seed-ambiguity-notes]: TBD/unclear without ambiguity_notes fires the signal', () => {
+  const yaml = `phase_seed:
+  goal: "Implement TBD endpoint"
+  acceptance_criteria:
+    - "returns 200"
+`;
+  const result = detectSeedAmbiguityNotesGap(yaml);
+  assert.ok(result, 'should detect');
+  assert.equal(result.reason, 'uncertainty-without-ambiguity-notes');
+  assert.equal(result.matched, 'TBD');
+});
+
+test('#238 [seed-ambiguity-notes]: Korean uncertainty vocabulary triggers the signal', () => {
+  const yaml = `phase_seed:
+  goal: "정확한 동작 모르겠음, 추정으로 진행"
+  acceptance_criteria:
+    - "기본 케이스"
+`;
+  const result = detectSeedAmbiguityNotesGap(yaml);
+  assert.ok(result);
+  assert.equal(result.reason, 'uncertainty-without-ambiguity-notes');
+});
+
+test('#238 [seed-ambiguity-notes]: presence of ambiguity_notes suppresses the signal', () => {
+  const yaml = `phase_seed:
+  goal: "Implement TBD endpoint"
+  ambiguity_notes:
+    - "Boundary unclear: which auth tier applies"
+  acceptance_criteria:
+    - "returns 200"
+`;
+  assert.equal(detectSeedAmbiguityNotesGap(yaml), null);
+});
+
+test('#238 [seed-ambiguity-notes]: no uncertainty vocabulary → no signal', () => {
+  const yaml = `phase_seed:
+  goal: "Implement /healthz endpoint"
+  acceptance_criteria:
+    - "returns 200 OK"
+`;
+  assert.equal(detectSeedAmbiguityNotesGap(yaml), null);
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end: mpl-soft-signal-emit hook never blocks + writes record on HA-01
+// ---------------------------------------------------------------------------
+
+test('#238 e2e: soft-signal-emit hook writes HA-01 record for vague Task prompt and never blocks', () => {
+  const cwd = freshWorkspace();
+  try {
+    const decision = runHook('mpl-soft-signal-emit.mjs', {
+      cwd,
+      tool_name: 'Task',
+      tool_input: {
+        subagent_type: 'mpl-decomposer',
+        prompt: 'Decompose this. 이전 결과 참고해서 알아서 판단.',
+      },
+    });
+    assert.equal(decision.continue, true, 'must never block');
+    const records = readQualitySignals(cwd);
+    assert.equal(records.length, 1);
+    assert.equal(records[0].rule, 'HA-01');
+    assert.equal(records[0].agent, 'mpl-decomposer');
+    assert.equal(records[0].evidence.matched_phrase, '이전 결과 참고');
+    assert.ok(records[0].evidence.prompt_preview.includes('이전 결과 참고'));
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('#238 e2e: soft-signal-emit hook stays silent on a well-scoped prompt', () => {
+  const cwd = freshWorkspace();
+  try {
+    const decision = runHook('mpl-soft-signal-emit.mjs', {
+      cwd,
+      tool_name: 'Task',
+      tool_input: {
+        subagent_type: 'mpl-decomposer',
+        prompt: 'Decompose the goal of adding /healthz endpoint into 3 phases with concrete acceptance criteria.',
+      },
+    });
+    assert.equal(decision.continue, true);
+    assert.equal(readQualitySignals(cwd).length, 0);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('#238 e2e: soft-signal-emit hook is a no-op outside MPL workspaces', () => {
+  const cwd = mkdtempSync(join(tmpdir(), 'mpl-238-no-mpl-'));
+  try {
+    const decision = runHook('mpl-soft-signal-emit.mjs', {
+      cwd,
+      tool_name: 'Task',
+      tool_input: {
+        subagent_type: 'mpl-decomposer',
+        prompt: '이전 결과 참고해서 알아서 판단.',
+      },
+    });
+    assert.equal(decision.continue, true);
+    assert.equal(existsSync(signalsLogPath(cwd)), false);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('#238 e2e: soft-signal-emit hook ignores non-Task tools', () => {
+  const cwd = freshWorkspace();
+  try {
+    const decision = runHook('mpl-soft-signal-emit.mjs', {
+      cwd,
+      tool_name: 'Bash',
+      tool_input: { command: '이전 결과 참고' },
+    });
+    assert.equal(decision.continue, true);
+    assert.equal(existsSync(signalsLogPath(cwd)), false);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});

--- a/hooks/__tests__/mpl-issue-238-quality-signals.test.mjs
+++ b/hooks/__tests__/mpl-issue-238-quality-signals.test.mjs
@@ -207,6 +207,48 @@ test('#238 [seed-ambiguity-notes]: presence of ambiguity_notes suppresses the si
   assert.equal(detectSeedAmbiguityNotesGap(yaml), null);
 });
 
+test('#238 codex r3 [logic]: empty ambiguity_notes block followed by sibling key still emits the signal', () => {
+  // Codex r3 [logic]: the previous regex `\s+[-\w]` could swallow the
+  // newline before the SIBLING key (same indent) and treat it as the
+  // ambiguity_notes child, hiding the gap. Fix: indentation-aware
+  // check requires the next non-blank line to be STRICTLY deeper.
+  const emptyBlock = `phase_seed:
+  goal: TBD endpoint
+  ambiguity_notes:
+  acceptance_criteria:
+    - returns 200
+`;
+  const result = detectSeedAmbiguityNotesGap(emptyBlock);
+  assert.ok(result, 'empty ambiguity_notes + sibling key must still fire signal');
+  assert.equal(result.matched, 'TBD');
+
+  // Sanity: empty block at end-of-string (no following sibling).
+  const emptyEof = `phase_seed:
+  goal: TBD
+  ambiguity_notes:
+`;
+  assert.ok(detectSeedAmbiguityNotesGap(emptyEof));
+
+  // Sanity: inline scalar form counts as populated.
+  const inlineScalar = `phase_seed:
+  goal: TBD endpoint
+  ambiguity_notes: "Boundary unclear"
+  acceptance_criteria:
+    - x
+`;
+  assert.equal(detectSeedAmbiguityNotesGap(inlineScalar), null);
+
+  // Sanity: block with deeper child (list bullet) counts as populated.
+  const blockChild = `phase_seed:
+  goal: TBD endpoint
+  ambiguity_notes:
+    - Boundary unclear
+  acceptance_criteria:
+    - x
+`;
+  assert.equal(detectSeedAmbiguityNotesGap(blockChild), null);
+});
+
 test('#238 [seed-ambiguity-notes]: no uncertainty vocabulary → no signal', () => {
   const yaml = `phase_seed:
   goal: "Implement /healthz endpoint"

--- a/hooks/__tests__/mpl-issue-238-quality-signals.test.mjs
+++ b/hooks/__tests__/mpl-issue-238-quality-signals.test.mjs
@@ -207,6 +207,52 @@ test('#238 [seed-ambiguity-notes]: presence of ambiguity_notes suppresses the si
   assert.equal(detectSeedAmbiguityNotesGap(yaml), null);
 });
 
+test('#238 codex r6 [logic]: block-scalar openers (|, >, |-, >+, |2 ...) require deeper child content', () => {
+  // Codex r6: `ambiguity_notes: |` is NOT inline content — the
+  // block-scalar opener says "payload follows on deeper lines". An
+  // empty block scalar (`|` followed by a sibling key at same indent)
+  // was being treated as populated, suppressing the signal. Even
+  // worse, a populated block scalar (`|\n    real text`) was ALSO
+  // being silenced because the Form-1 inline branch returned true
+  // before Form 2 could verify the deeper child content.
+  //
+  // After the fix: block scalar opener falls through to Form 2, which
+  // requires a strictly-deeper non-comment line.
+  const cwd = freshWorkspace(); // also doubles as syntax sanity for the test
+  try {
+    // Empty block scalars must fire.
+    for (const opener of ['|', '|-', '|+', '>', '>-', '>+', '|2', '>4']) {
+      const yaml = `phase_seed:
+  goal: TBD endpoint
+  ambiguity_notes: ${opener}
+  acceptance_criteria:
+    - x
+`;
+      const result = detectSeedAmbiguityNotesGap(yaml);
+      assert.ok(result, `expected signal for empty block scalar opener: ${opener}`);
+      assert.equal(result.matched, 'TBD');
+    }
+
+    // Populated block scalars must NOT fire (deeper content present).
+    for (const opener of ['|', '|-', '>', '>-']) {
+      const yaml = `phase_seed:
+  goal: TBD endpoint
+  ambiguity_notes: ${opener}
+    Boundary unclear; needs operator confirmation.
+  acceptance_criteria:
+    - x
+`;
+      assert.equal(
+        detectSeedAmbiguityNotesGap(yaml),
+        null,
+        `expected NO signal for populated block scalar: ${opener}`,
+      );
+    }
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
 test('#238 claude r6 [logic]: YAML-canonical Null/NULL + whitespace variants do NOT suppress signal', () => {
   // Claude r6 (generalizes Codex r5): YAML 1.2 canonical nulls are
   // `null|Null|NULL|~`; empty flow forms accept whitespace inside

--- a/hooks/__tests__/mpl-issue-238-quality-signals.test.mjs
+++ b/hooks/__tests__/mpl-issue-238-quality-signals.test.mjs
@@ -207,6 +207,53 @@ test('#238 [seed-ambiguity-notes]: presence of ambiguity_notes suppresses the si
   assert.equal(detectSeedAmbiguityNotesGap(yaml), null);
 });
 
+test('#238 claude r6 [logic]: YAML-canonical Null/NULL + whitespace variants do NOT suppress signal', () => {
+  // Claude r6 (generalizes Codex r5): YAML 1.2 canonical nulls are
+  // `null|Null|NULL|~`; empty flow forms accept whitespace inside
+  // (`[ ]`, `{ }`); quoted scalars with whitespace-only content
+  // (`" "`, `' '`) are also semantically empty. The r5 fix only
+  // covered the lowercase + zero-whitespace forms.
+  const placeholders = [
+    'null', 'Null', 'NULL', '~',
+    '[]', '[ ]', '[   ]',
+    '{}', '{ }', '{   }',
+    '""', '" "', '"   "',
+    "''", "' '", "'   '",
+  ];
+  for (const value of placeholders) {
+    const yaml = `phase_seed:
+  goal: TBD endpoint
+  ambiguity_notes: ${value}
+  acceptance_criteria:
+    - x
+`;
+    const result = detectSeedAmbiguityNotesGap(yaml);
+    assert.ok(result, `expected signal for ambiguity_notes: ${value}`);
+    assert.equal(result.matched, 'TBD');
+  }
+
+  // Sanity: real content (incl. YAML-non-null tokens) still suppresses.
+  for (const value of [
+    '"Boundary unclear"',
+    'Nil',          // YAML 1.2 does NOT treat `Nil` as null — it's a string
+    'unclear',
+    '[ a ]',
+    '{ foo: bar }',
+  ]) {
+    const yaml = `phase_seed:
+  goal: TBD endpoint
+  ambiguity_notes: ${value}
+  acceptance_criteria:
+    - x
+`;
+    assert.equal(
+      detectSeedAmbiguityNotesGap(yaml),
+      null,
+      `expected NO signal for real content ambiguity_notes: ${value}`,
+    );
+  }
+});
+
 test('#238 codex r5 [logic]: inline empty placeholders (null/~/[]/{}/empty quotes) do NOT suppress the signal', () => {
   // Codex r5: an agent can syntactically present the escape-hatch
   // field but semantically empty it — `ambiguity_notes: []`,

--- a/hooks/__tests__/mpl-issue-238-quality-signals.test.mjs
+++ b/hooks/__tests__/mpl-issue-238-quality-signals.test.mjs
@@ -207,6 +207,43 @@ test('#238 [seed-ambiguity-notes]: presence of ambiguity_notes suppresses the si
   assert.equal(detectSeedAmbiguityNotesGap(yaml), null);
 });
 
+test('#238 codex r5 [logic]: inline empty placeholders (null/~/[]/{}/empty quotes) do NOT suppress the signal', () => {
+  // Codex r5: an agent can syntactically present the escape-hatch
+  // field but semantically empty it — `ambiguity_notes: []`,
+  // `: null`, `: ~`, `: ""`, `: ''`, `: {}` — and the previous Form-1
+  // check treated any inline non-whitespace as populated, silently
+  // hiding the very invention pattern the rule was meant to surface.
+  for (const value of ['[]', 'null', '~', '""', "''", '{}']) {
+    const yaml = `phase_seed:
+  goal: TBD endpoint
+  ambiguity_notes: ${value}
+  acceptance_criteria:
+    - returns 200
+`;
+    const result = detectSeedAmbiguityNotesGap(yaml);
+    assert.ok(result, `expected signal for ambiguity_notes: ${value}`);
+    assert.equal(result.matched, 'TBD');
+  }
+
+  // Sanity: a real inline scalar still suppresses.
+  const inlineScalar = `phase_seed:
+  goal: TBD endpoint
+  ambiguity_notes: "Boundary unclear"
+  acceptance_criteria:
+    - x
+`;
+  assert.equal(detectSeedAmbiguityNotesGap(inlineScalar), null);
+
+  // Sanity: empty placeholder followed by inline comment still empty.
+  const placeholderWithComment = `phase_seed:
+  goal: TBD endpoint
+  ambiguity_notes: null # explicitly empty
+  acceptance_criteria:
+    - x
+`;
+  assert.ok(detectSeedAmbiguityNotesGap(placeholderWithComment));
+});
+
 test('#238 codex r3 [logic]: empty ambiguity_notes block followed by sibling key still emits the signal', () => {
   // Codex r3 [logic]: the previous regex `\s+[-\w]` could swallow the
   // newline before the SIBLING key (same indent) and treat it as the

--- a/hooks/__tests__/mpl-issue-238-quality-signals.test.mjs
+++ b/hooks/__tests__/mpl-issue-238-quality-signals.test.mjs
@@ -280,6 +280,31 @@ test('#238 e2e: soft-signal-emit hook is a no-op outside MPL workspaces', () => 
   }
 });
 
+test('#238 codex r2 [contract-break] e2e: soft-signal-emit hook accepts camelCase payload shape', () => {
+  // Codex r2: sibling hooks normalize both `tool_name` and `toolName`.
+  // The new hook initially read only snake_case, silently losing
+  // HA-01 signals on a camelCase harness delivery.
+  const cwd = freshWorkspace();
+  try {
+    const decision = runHook('mpl-soft-signal-emit.mjs', {
+      cwd,
+      toolName: 'Task',
+      toolInput: {
+        subagent_type: 'mpl-decomposer',
+        prompt: 'Decompose this. 이전 결과 참고해서 알아서 판단.',
+      },
+    });
+    assert.equal(decision.continue, true, 'must never block');
+    const { records, malformed } = readQualitySignals(cwd);
+    assert.equal(records.length, 1, 'HA-01 record must be appended even on camelCase payload');
+    assert.equal(malformed, 0);
+    assert.equal(records[0].rule, 'HA-01');
+    assert.equal(records[0].agent, 'mpl-decomposer');
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
 test('#238 e2e: soft-signal-emit hook ignores non-Task tools', () => {
   const cwd = freshWorkspace();
   try {

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -186,6 +186,16 @@
         "hooks": [
           {
             "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/mpl-soft-signal-emit.mjs\"",
+            "timeout": 3
+          }
+        ]
+      },
+      {
+        "matcher": "Task|Agent",
+        "hooks": [
+          {
+            "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/mpl-require-chain-assignment.mjs\"",
             "timeout": 3
           }

--- a/hooks/lib/mpl-hook-trace.mjs
+++ b/hooks/lib/mpl-hook-trace.mjs
@@ -57,6 +57,7 @@ const PURPOSES = {
   'mpl-require-phase-evidence': 'phase evidence guard',
   'mpl-baseline-guard': 'baseline immutability/hash guard',
   'mpl-ambiguity-gate': 'ambiguity score gate before decomposer dispatch',
+  'mpl-soft-signal-emit': 'soft-signal telemetry emitter (HA-01 vague delegation etc.) — never blocks',
   'mpl-require-chain-assignment': 'chain assignment guard before seed generation',
   'mpl-tool-tracker': 'last-tool telemetry',
   'mpl-gate-recorder': 'gate/test-agent evidence recorder',

--- a/hooks/lib/mpl-quality-signals.mjs
+++ b/hooks/lib/mpl-quality-signals.mjs
@@ -243,14 +243,16 @@ function hasNonEmptyAmbiguityNotes(yamlText) {
       // Strip a possible inline `# comment` first — anything after a
       // whitespace-preceded `#` is a comment, not content.
       const noComment = rest.replace(/\s+#.*$/, '').trim();
-      // Codex r5 [logic]: empty placeholders such as `[]`, `{}`,
-      // `null`, `~`, `""`, `''` are YAML-valid "no value" markers.
-      // The escape-hatch field is syntactically present but
-      // semantically empty — treating it as populated lets the agent
-      // suppress the gap signal with a placeholder, which is exactly
-      // the inversion this telemetry is meant to surface.
-      const INLINE_EMPTY = new Set(['null', '~', '[]', '{}', '""', "''"]);
-      if (noComment.length > 0 && !INLINE_EMPTY.has(noComment)) return true;
+      // Codex r5 / Claude r6 [logic]: empty placeholders are YAML
+      // "no value" markers that must NOT count as populated.
+      // - YAML 1.2 canonical nulls: `null` / `Null` / `NULL` / `~`
+      // - empty flow sequence/mapping: `[]` / `[ ]` / `{}` / `{ }`
+      // - empty / whitespace-only quoted scalars: `""` / `" "` / `''` / `' '`
+      // Treating any of these as populated lets the agent suppress
+      // the gap signal with a placeholder — the exact inversion this
+      // telemetry is meant to surface.
+      const INLINE_EMPTY_RE = /^(?:null|~|\[\s*\]|\{\s*\}|"\s*"|'\s*')$/i;
+      if (noComment.length > 0 && !INLINE_EMPTY_RE.test(noComment)) return true;
     }
     // Form 2: block opener — scan forward for the first non-blank,
     // non-comment line. If its indent > headerIndent AND it begins

--- a/hooks/lib/mpl-quality-signals.mjs
+++ b/hooks/lib/mpl-quality-signals.mjs
@@ -208,12 +208,59 @@ const UNCERTAINTY_TOKENS = [
 
 export function detectSeedAmbiguityNotesGap(yamlText) {
   if (!yamlText || typeof yamlText !== 'string') return null;
-  // If the seed already provides a non-empty ambiguity_notes block,
-  // the escape hatch was used — no signal.
-  if (/^\s*ambiguity_notes\s*:\s*\S/m.test(yamlText)) return null;
-  if (/^\s*ambiguity_notes\s*:\s*\n\s+[-\w]/m.test(yamlText)) return null;
+  if (hasNonEmptyAmbiguityNotes(yamlText)) return null;
   const re = new RegExp(`(?:${UNCERTAINTY_TOKENS.join('|')})`, 'i');
   const m = yamlText.match(re);
   if (!m) return null;
   return { reason: 'uncertainty-without-ambiguity-notes', matched: m[0] };
+}
+
+/**
+ * Indentation-aware check: does the YAML contain a populated
+ * `ambiguity_notes:` block?
+ *
+ * Populated means EITHER:
+ *   1. inline scalar on the same line: `ambiguity_notes: "TBD"` (non-blank after `:`).
+ *   2. block opener with a child line indented STRICTLY deeper than
+ *      the `ambiguity_notes:` line, where the first such non-blank
+ *      child starts with `-` (list item) or `\w` (sub-key).
+ *
+ * An empty `ambiguity_notes:` followed by a sibling key at the SAME
+ * indent (codex r3 [logic] repro) is NOT populated — the previous
+ * `\s+[-\w]` regex collapsed the newline + sibling indent into one
+ * `\s+` run and incorrectly treated the sibling as the child.
+ */
+function hasNonEmptyAmbiguityNotes(yamlText) {
+  const lines = yamlText.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const m = line.match(/^(\s*)ambiguity_notes\s*:(.*)$/);
+    if (!m) continue;
+    const headerIndent = m[1].length;
+    const rest = m[2];
+    // Form 1: inline scalar.
+    if (rest.trim().length > 0) {
+      // Strip a possible inline `# comment` — any non-whitespace token
+      // before `#` counts as a value.
+      const noComment = rest.replace(/\s+#.*$/, '').trim();
+      if (noComment.length > 0) return true;
+    }
+    // Form 2: block opener — scan forward for the first non-blank,
+    // non-comment line. If its indent > headerIndent AND it begins
+    // with a list bullet or word-char (sub-key), the block is populated.
+    for (let j = i + 1; j < lines.length; j++) {
+      const next = lines[j];
+      if (!next.trim()) continue;
+      if (/^\s*#/.test(next)) continue;
+      const indentMatch = next.match(/^(\s*)/);
+      const indent = indentMatch ? indentMatch[1].length : 0;
+      if (indent <= headerIndent) return false; // sibling or shallower → empty block
+      // Indented deeper → only counts as content if it actually
+      // introduces a list item or mapping (not a stray inline
+      // continuation that's never valid as a child here).
+      return /^\s*(-|\w)/.test(next);
+    }
+    return false; // EOF after the header → empty
+  }
+  return false;
 }

--- a/hooks/lib/mpl-quality-signals.mjs
+++ b/hooks/lib/mpl-quality-signals.mjs
@@ -1,0 +1,202 @@
+/**
+ * Quality-signal telemetry surface.
+ *
+ * Some MUSTs / SHOULDs in MPL agent prompts are real quality concerns
+ * but pattern-matching them is heuristic and the false-positive rate is
+ * meaningful. Blocking on them would over-enforce; ignoring them loses
+ * the signal entirely. This module is the middle path: append a
+ * structured record per soft-signal hit to `.mpl/mpl/quality-signals.jsonl`
+ * so violations are countable across runs, surfaced in `mpl-doctor`,
+ * and reviewable without blocking the pipeline.
+ *
+ * See:
+ *   - `docs/findings/2026-05-28-enforcement-relaxation-plan.md` §A
+ *   - Issue #238
+ *
+ * Per-record schema:
+ *   { rule, severity, ts, phase, agent, evidence }
+ *
+ * - `rule`     — stable identifier (e.g. "HA-01", "seed-ambiguity-notes")
+ * - `severity` — "warn" (default) | "info"
+ * - `ts`       — ISO-8601 UTC timestamp
+ * - `phase`    — current_phase from state.json, or null
+ * - `agent`    — subagent_type / tool_name that triggered the signal
+ * - `evidence` — rule-specific structured payload (e.g. matched phrase + offset)
+ *
+ * This module is fail-soft: any IO error appending the record is
+ * swallowed (the calling hook should not be blocked on telemetry).
+ */
+
+import { existsSync, mkdirSync, appendFileSync, readFileSync } from 'fs';
+import { join, dirname } from 'path';
+
+const SIGNALS_REL = ['.mpl', 'mpl', 'quality-signals.jsonl'];
+
+export function signalsLogPath(cwd) {
+  return join(cwd, ...SIGNALS_REL);
+}
+
+function readCurrentPhase(cwd) {
+  try {
+    const statePath = join(cwd, '.mpl', 'state.json');
+    if (!existsSync(statePath)) return null;
+    const state = JSON.parse(readFileSync(statePath, 'utf-8'));
+    return state?.current_phase ?? state?.execution?.current_phase ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Append a quality-signal record. Returns true if the record was
+ * written, false if any IO error swallowed the write.
+ *
+ * @param {object} record
+ * @param {string} record.rule        Stable rule id (e.g. "HA-01")
+ * @param {string} [record.severity]  "warn" (default) | "info"
+ * @param {string} [record.agent]     subagent_type / tool_name
+ * @param {object} [record.evidence]  Rule-specific structured payload
+ * @param {string} [record.ts]        ISO timestamp (defaults to now)
+ * @param {string} cwd                Workspace root
+ */
+export function recordQualitySignal(record, cwd) {
+  if (!record || !record.rule || !cwd) return false;
+  try {
+    const path = signalsLogPath(cwd);
+    mkdirSync(dirname(path), { recursive: true });
+    const payload = {
+      rule: String(record.rule),
+      severity: record.severity || 'warn',
+      ts: record.ts || new Date().toISOString(),
+      phase: record.phase ?? readCurrentPhase(cwd),
+      agent: record.agent ?? null,
+      evidence: record.evidence ?? null,
+    };
+    appendFileSync(path, JSON.stringify(payload) + '\n');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Read all signal records as an array. Malformed lines are skipped.
+ * Returns [] if the log doesn't exist.
+ */
+export function readQualitySignals(cwd) {
+  const path = signalsLogPath(cwd);
+  if (!existsSync(path)) return [];
+  try {
+    const text = readFileSync(path, 'utf-8');
+    const out = [];
+    for (const line of text.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        out.push(JSON.parse(trimmed));
+      } catch {
+        /* skip malformed */
+      }
+    }
+    return out;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Aggregate signal records into per-rule counts.
+ * Returns { [rule]: count } sorted by descending count.
+ */
+export function summarizeQualitySignals(signals) {
+  const counts = new Map();
+  for (const rec of signals || []) {
+    if (!rec || !rec.rule) continue;
+    counts.set(rec.rule, (counts.get(rec.rule) || 0) + 1);
+  }
+  return Object.fromEntries(
+    [...counts.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0])),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Rule-specific detectors
+// ---------------------------------------------------------------------------
+
+/**
+ * HA-01: vague delegation prompt.
+ *
+ * Detects orchestrator-emitted Task/Agent prompts that delegate without
+ * passing the work-load specifically. The rule lives only in the
+ * `mpl-decomposer` / `mpl-phase-runner` agent prompts; here we surface
+ * the pattern as a soft signal so the operator can audit how often
+ * agents are dispatched with under-specified prompts.
+ *
+ * Returns the matched phrase + offset when a match is found, or null.
+ * The match is case-insensitive and tolerant of surrounding whitespace.
+ */
+const HA01_PHRASES = [
+  // Korean — common patterns observed in the 3-layer audit
+  '이전 결과 참고',
+  '이전 결과를 참고',
+  '알아서 판단',
+  '알아서 처리',
+  '적절히 판단',
+  '적당히 판단',
+  '필요하면 추가',
+  // English equivalents the audit doc cites
+  'use your judgment',
+  'use your judgement',
+  'figure it out',
+  'as appropriate',
+  'as you see fit',
+];
+
+export function detectHa01(promptText) {
+  if (!promptText || typeof promptText !== 'string') return null;
+  const lower = promptText.toLowerCase();
+  for (const phrase of HA01_PHRASES) {
+    const idx = lower.indexOf(phrase.toLowerCase());
+    if (idx >= 0) {
+      return { phrase, offset: idx };
+    }
+  }
+  return null;
+}
+
+/**
+ * Seed Generator "No invention" / `ambiguity_notes` check.
+ *
+ * The Seed Generator prompt requires that when the agent is uncertain
+ * about a phase boundary, it MUST surface that uncertainty in an
+ * `ambiguity_notes` block rather than inventing acceptance criteria.
+ * The signal here: when the produced seed YAML mentions uncertainty
+ * vocabulary (TBD / unclear / 모르겠음 / 추정 etc.) but provides no
+ * `ambiguity_notes` field, the agent has likely invented instead of
+ * surfacing the gap.
+ *
+ * Returns { reason, matched } when the soft-signal fires, or null.
+ */
+const UNCERTAINTY_TOKENS = [
+  '\\bTBD\\b',
+  '\\bTODO\\b',
+  '\\bunclear\\b',
+  '\\bunknown\\b',
+  '\\bestimate(?:d)?\\b',
+  '추정',
+  '모르겠',
+  '불확실',
+  '확실하지\\s*않',
+];
+
+export function detectSeedAmbiguityNotesGap(yamlText) {
+  if (!yamlText || typeof yamlText !== 'string') return null;
+  // If the seed already provides a non-empty ambiguity_notes block,
+  // the escape hatch was used — no signal.
+  if (/^\s*ambiguity_notes\s*:\s*\S/m.test(yamlText)) return null;
+  if (/^\s*ambiguity_notes\s*:\s*\n\s+[-\w]/m.test(yamlText)) return null;
+  const re = new RegExp(`(?:${UNCERTAINTY_TOKENS.join('|')})`, 'i');
+  const m = yamlText.match(re);
+  if (!m) return null;
+  return { reason: 'uncertainty-without-ambiguity-notes', matched: m[0] };
+}

--- a/hooks/lib/mpl-quality-signals.mjs
+++ b/hooks/lib/mpl-quality-signals.mjs
@@ -252,7 +252,23 @@ function hasNonEmptyAmbiguityNotes(yamlText) {
       // the gap signal with a placeholder — the exact inversion this
       // telemetry is meant to surface.
       const INLINE_EMPTY_RE = /^(?:null|~|\[\s*\]|\{\s*\}|"\s*"|'\s*')$/i;
-      if (noComment.length > 0 && !INLINE_EMPTY_RE.test(noComment)) return true;
+      // Codex r6 [logic]: a block-scalar opener (`|`, `>`, with
+      // optional chomping `+`/`-` and indentation digit) is NOT
+      // inline content — the actual payload lives on the deeper
+      // child lines. Fall through to Form 2 so the child scan can
+      // verify that at least one deeper non-comment line is present.
+      // Without this, both `ambiguity_notes: |` (truly empty) AND
+      // `ambiguity_notes: |\n  Boundary unclear` (populated) were
+      // hitting the inline path — the empty case incorrectly
+      // suppressed the signal.
+      const BLOCK_SCALAR_RE = /^[|>][+-]?\d?$/;
+      if (
+        noComment.length > 0 &&
+        !INLINE_EMPTY_RE.test(noComment) &&
+        !BLOCK_SCALAR_RE.test(noComment)
+      ) {
+        return true;
+      }
     }
     // Form 2: block opener — scan forward for the first non-blank,
     // non-comment line. If its indent > headerIndent AND it begins

--- a/hooks/lib/mpl-quality-signals.mjs
+++ b/hooks/lib/mpl-quality-signals.mjs
@@ -80,28 +80,45 @@ export function recordQualitySignal(record, cwd) {
 }
 
 /**
- * Read all signal records as an array. Malformed lines are skipped.
- * Returns [] if the log doesn't exist.
+ * Read the quality-signal log.
+ *
+ * Returns `{ records, malformed }`:
+ *   - `records`   — array of parsed records, in file order.
+ *   - `malformed` — count of non-empty lines that failed to parse as JSON.
+ *
+ * Returns `{ records: [], malformed: 0 }` if the log file does not exist
+ * (no signals yet — not an error).
+ *
+ * The `malformed` count is load-bearing for mpl-doctor Category 16
+ * (#238): doctor must distinguish "log is clean" from "log has
+ * unparseable lines" to surface the WARN the category promises.
+ * Silently dropping malformed lines would hide the very condition the
+ * diagnostic is meant to catch (codex r1 [contract-break] finding).
  */
 export function readQualitySignals(cwd) {
   const path = signalsLogPath(cwd);
-  if (!existsSync(path)) return [];
+  if (!existsSync(path)) return { records: [], malformed: 0 };
+  let text;
   try {
-    const text = readFileSync(path, 'utf-8');
-    const out = [];
-    for (const line of text.split('\n')) {
-      const trimmed = line.trim();
-      if (!trimmed) continue;
-      try {
-        out.push(JSON.parse(trimmed));
-      } catch {
-        /* skip malformed */
-      }
-    }
-    return out;
+    text = readFileSync(path, 'utf-8');
   } catch {
-    return [];
+    // IO error on a present file is itself a degraded read condition;
+    // surface it as a malformed signal so doctor warns rather than
+    // reporting "clean".
+    return { records: [], malformed: 1 };
   }
+  const records = [];
+  let malformed = 0;
+  for (const line of text.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      records.push(JSON.parse(trimmed));
+    } catch {
+      malformed += 1;
+    }
+  }
+  return { records, malformed };
 }
 
 /**

--- a/hooks/lib/mpl-quality-signals.mjs
+++ b/hooks/lib/mpl-quality-signals.mjs
@@ -240,10 +240,17 @@ function hasNonEmptyAmbiguityNotes(yamlText) {
     const rest = m[2];
     // Form 1: inline scalar.
     if (rest.trim().length > 0) {
-      // Strip a possible inline `# comment` — any non-whitespace token
-      // before `#` counts as a value.
+      // Strip a possible inline `# comment` first — anything after a
+      // whitespace-preceded `#` is a comment, not content.
       const noComment = rest.replace(/\s+#.*$/, '').trim();
-      if (noComment.length > 0) return true;
+      // Codex r5 [logic]: empty placeholders such as `[]`, `{}`,
+      // `null`, `~`, `""`, `''` are YAML-valid "no value" markers.
+      // The escape-hatch field is syntactically present but
+      // semantically empty — treating it as populated lets the agent
+      // suppress the gap signal with a placeholder, which is exactly
+      // the inversion this telemetry is meant to surface.
+      const INLINE_EMPTY = new Set(['null', '~', '[]', '{}', '""', "''"]);
+      if (noComment.length > 0 && !INLINE_EMPTY.has(noComment)) return true;
     }
     // Form 2: block opener — scan forward for the first non-blank,
     // non-comment line. If its indent > headerIndent AND it begins

--- a/hooks/mpl-soft-signal-emit.mjs
+++ b/hooks/mpl-soft-signal-emit.mjs
@@ -51,13 +51,18 @@ async function main() {
     return;
   }
 
-  const toolName = data.tool_name || '';
+  // Codex r2 [contract-break]: sibling hooks (`mpl-validate-seed`,
+  // `mpl-ambiguity-gate`, etc.) accept both snake_case AND camelCase
+  // payload shapes. Reading only `data.tool_name` would silently drop
+  // HA-01 signals when the harness delivers `toolName` / `toolInput`,
+  // breaking the doctor count.
+  const toolName = data.tool_name || data.toolName || '';
   if (toolName !== 'Task' && toolName !== 'Agent') {
     console.log(JSON.stringify({ continue: true, suppressOutput: true }));
     return;
   }
 
-  const toolInput = data.tool_input || {};
+  const toolInput = data.tool_input || data.toolInput || {};
   const subagentType = toolInput.subagent_type || toolInput.subagentType || '';
   const prompt = toolInput.prompt || toolInput.description || '';
 

--- a/hooks/mpl-soft-signal-emit.mjs
+++ b/hooks/mpl-soft-signal-emit.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+/**
+ * MPL Soft-Signal Emitter (PreToolUse: Task|Agent)
+ *
+ * Emits quality-signal telemetry records for prompt-only quality rules
+ * that should never block but should be countable across runs.
+ *
+ * Currently surfaces:
+ *   - HA-01: vague delegation prompt
+ *     (e.g. "이전 결과 참고", "알아서 판단", "use your judgement")
+ *     Detected on every Task/Agent invocation that carries a prompt.
+ *
+ * Append-only sink: `.mpl/mpl/quality-signals.jsonl`. Surfaced in
+ * `mpl-doctor` Category 16. NEVER blocks (continue: true always).
+ *
+ * See:
+ *   - Issue #238
+ *   - `docs/findings/2026-05-28-enforcement-relaxation-plan.md` §A2
+ */
+
+import { dirname, join } from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const { isMplActive } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-state.mjs')).href
+);
+const { readStdin } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'stdin.mjs')).href
+);
+const { detectHa01, recordQualitySignal } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-quality-signals.mjs')).href
+);
+
+async function main() {
+  const input = await readStdin();
+
+  let data;
+  try {
+    data = JSON.parse(input);
+  } catch {
+    console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+    return;
+  }
+
+  const cwd = data.cwd || data.directory || process.cwd();
+  if (!isMplActive(cwd)) {
+    console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+    return;
+  }
+
+  const toolName = data.tool_name || '';
+  if (toolName !== 'Task' && toolName !== 'Agent') {
+    console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+    return;
+  }
+
+  const toolInput = data.tool_input || {};
+  const subagentType = toolInput.subagent_type || toolInput.subagentType || '';
+  const prompt = toolInput.prompt || toolInput.description || '';
+
+  const ha01 = detectHa01(prompt);
+  if (ha01) {
+    recordQualitySignal(
+      {
+        rule: 'HA-01',
+        severity: 'warn',
+        agent: subagentType || toolName,
+        evidence: {
+          matched_phrase: ha01.phrase,
+          offset: ha01.offset,
+          prompt_preview: prompt.slice(Math.max(0, ha01.offset - 40), ha01.offset + 80),
+        },
+      },
+      cwd,
+    );
+  }
+
+  console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+}
+
+const isMain = import.meta.url === pathToFileURL(process.argv[1] || '').href;
+if (isMain) {
+  main().catch(() => {
+    // Fail-soft: never block on telemetry IO.
+    console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+  });
+}

--- a/hooks/mpl-validate-seed.mjs
+++ b/hooks/mpl-validate-seed.mjs
@@ -34,6 +34,9 @@ const { readStdin } = await import(
 const { collectFileWrites, isFileWriteTool } = await import(
   pathToFileURL(join(__dirname, 'lib', 'tool-input.mjs')).href
 );
+const { detectSeedAmbiguityNotesGap, recordQualitySignal } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-quality-signals.mjs')).href
+);
 
 // ---------------------------------------------------------------------------
 // YAML extraction (regex-based, no external parser — MPL minimal deps)
@@ -456,6 +459,22 @@ Do NOT proceed to Phase Runner until a valid Phase Seed is produced.
   // Detect boundary phase context
   const promptText = toolInput.prompt || toolInput.description || '';
   const hasContracts = hasContractFilesContext(promptText);
+
+  // #238 [soft-signal]: seed contains uncertainty vocabulary but no
+  // ambiguity_notes — the Seed Generator likely invented criteria
+  // instead of using the escape hatch. Telemetry-only, never blocks.
+  const ambiguityGap = detectSeedAmbiguityNotesGap(yamlText);
+  if (ambiguityGap) {
+    recordQualitySignal(
+      {
+        rule: 'seed-ambiguity-notes',
+        severity: 'warn',
+        agent: toolName,
+        evidence: ambiguityGap,
+      },
+      cwd,
+    );
+  }
 
   // Validate seed
   const result = validateSeed(yamlText, { hasContractFiles: hasContracts });

--- a/skills/mpl-doctor/SKILL.md
+++ b/skills/mpl-doctor/SKILL.md
@@ -22,8 +22,8 @@ Record the MPL root path for all subsequent checks.
 
 Invocation mode decides which categories run:
 
-- `/mpl:mpl-doctor` (default) → Categories 1-12 (installation health)
-- `/mpl:mpl-doctor audit` → Categories 1-12 + **Category 13 Measurement Integrity Audit** (AD-0006, v0.15.0). Requires a finalized pipeline (`.mpl/state.json.finalize_done == true`); otherwise Category 13 returns "NOT APPLICABLE".
+- `/mpl:mpl-doctor` (default) → Categories 1-12 (installation health) **and Category 16 (Quality Signals, #238)**. Category 16 is always run because the soft-signal log is a per-workspace runtime artifact whose freshness only matters when doctor is actually invoked.
+- `/mpl:mpl-doctor audit` → adds **Category 13 Measurement Integrity Audit** (AD-0006, v0.15.0). Requires a finalized pipeline (`.mpl/state.json.finalize_done == true`); otherwise Category 13 returns "NOT APPLICABLE".
 
 Delegate to the `mpl-doctor` agent:
 
@@ -33,7 +33,7 @@ audit_mode = (arguments include "audit") ? "yes" : "no"
 Task(
   subagent_type="mpl-doctor",
   model="haiku",
-  prompt=f"Run MPL diagnostics on the plugin at {MPL_ROOT}. Check Categories 1-12 (installation health). audit_mode={audit_mode}. If audit_mode=yes AND .mpl/state.json.finalize_done==true, ALSO run Category 13 Measurement Integrity Audit (AD-0006 [a]-[g] checks) against the completed pipeline. Working dir: {CWD}."
+  prompt=f"Run MPL diagnostics on the plugin at {MPL_ROOT}. Check Categories 1-12 (installation health) AND Category 16 (Quality Signals — read .mpl/mpl/quality-signals.jsonl via hooks/lib/mpl-quality-signals.mjs, surface per-rule counts and malformed-line count; PASS when clean, WARN on malformed>=1 or high-volume rule). audit_mode={audit_mode}. If audit_mode=yes AND .mpl/state.json.finalize_done==true, ALSO run Category 13 Measurement Integrity Audit (AD-0006 [a]-[g] checks) against the completed pipeline. Working dir: {CWD}."
 )
 ```
 


### PR DESCRIPTION
Closes #238 (acceptance-criteria scope; A4/A5/A6/A8/A9/A10 deferred via follow-up).

## What

Adds a structured telemetry sink for prompt-only quality rules that are heuristic and would over-enforce if turned into blocking hooks. Records append to `.mpl/mpl/quality-signals.jsonl`; mpl-doctor surfaces per-rule counts in a new Category 16.

Implements only the rules the AC explicitly required:
- **HA-01 — vague delegation prompt** (`hooks/mpl-soft-signal-emit.mjs` PreToolUse Task|Agent; emits a record when a Task/Agent prompt contains "이전 결과 참고", "알아서 판단", "use your judgement", etc.).
- **Seed ambiguity-notes gap** (`hooks/mpl-validate-seed.mjs`; emits a record when seed YAML contains uncertainty vocabulary — TBD/unclear/추정/모르겠음 — without an `ambiguity_notes` block).

## Why

`docs/findings/2026-05-28-enforcement-relaxation-plan.md` §A flagged 8 rules as "telemetry tier" — countable signal without blocking. The current state is binary (block or invisible); this is the middle path.

## Acceptance Criteria (from #238)

- [x] `.mpl/mpl/quality-signals.jsonl` exists and accumulates entries when target rules fire.
- [x] mpl-doctor (Category 16) shows per-rule signal counts.
- [x] No blocking behavior change for any listed rule.
- [x] Tests cover HA-01 prompt detection + ambiguity_notes presence check.

## Out of scope (follow-up)

Per the standing "intent을 넘어가는 이슈는 follow-up으로" rule:
- A4 mpl-validate-output JSON-fence telemetry
- A5 test_command finalize-time block elevation + config flag
- A6 probing hints → adversarial test zero-coverage detection
- A8 HA-02 BEGIN/END region mirror divergence
- A9 Retry-2 reflection presence
- A10 Interviewer comparison-table substring telemetry

## Test plan

- [x] 15 new tests in `hooks/__tests__/mpl-issue-238-quality-signals.test.mjs` (lib + e2e hook behavior).
- [x] 1475/1475 hook tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)