### PR TITLE
Wire C2 reviewer_required + C3 batch_test + C6 Hard 1 evidence-aware (#251)

### DIFF
--- a/agents/mpl-decomposer.md
+++ b/agents/mpl-decomposer.md
@@ -559,6 +559,38 @@ disallowedTools: Bash,Task,WebFetch,WebSearch,NotebookEdit
           # When test_agent_required is true, this can be omitted OR used to pre-brief
           # the test-agent dispatch (e.g., "focus on boundary invariants of X").
 
+        # #239 C2 / #251: F-40 dispatch mirror for adversarial reviewer.
+        # OPTIONAL per phase (default: true). When false, the executor
+        # skips `mpl-adversarial-reviewer` dispatch for the phase.
+        # `hooks/mpl-require-reviewer.mjs` enforces that
+        # `reviewer_rationale` is non-empty whenever `reviewer_required`
+        # is false — same shape as `test_agent_required` /
+        # `test_agent_rationale`.
+        reviewer_required: boolean
+          # Default: true. Only set false for phases where independent
+          # adversarial review adds no signal:
+          #   - pure documentation edits (docs/*.md only, no src changes)
+          #   - infra/config phases with no code path
+          #   - schema-migration phases that are mechanical regenerations
+          # The skip is logged as a `reviewer-skipped` record in
+          # `.mpl/mpl/quality-signals.jsonl` (#238) so over-use is measurable.
+        reviewer_rationale: string
+          # REQUIRED when reviewer_required is false. Explain why
+          # adversarial review is unnecessary. Anti-patterns (blanket
+          # "trivial" / "no time") accepted by the hook but counted
+          # toward over-use telemetry.
+
+        # #239 C3 / #251: per-phase batch-test opt-in.
+        # OPTIONAL (default: false). When true, Phase Runner Rule 4
+        # allows batched implement-then-verify across TODOs in the
+        # phase instead of the strict per-TODO-test cadence. Set true
+        # automatically when `phase_domain` ∈ {refactor, schema_migration}
+        # where TODOs are co-dependent (rename + update callers + fix
+        # interface) and per-TODO isolation is impractical.
+        # Propagates to `phase_seed.batch_test` at seed generation time
+        # so the Phase Runner sees it in the seed YAML.
+        batch_test: boolean
+
     execution_tiers:
       # REQUIRED scheduler contract (v0.18.5). Executor consumes this directly.
       # Sort by tier ascending. Every phase id must appear exactly once.

--- a/agents/mpl-seed-generator.md
+++ b/agents/mpl-seed-generator.md
@@ -135,6 +135,12 @@ disallowedTools: Write,Edit,Bash,Task,WebFetch,WebSearch,NotebookEdit
     phases:
       phase-{id}:
         goal: string
+        # #239 C3 / #251: propagate `batch_test` from the decomposer's
+        # per-phase field so Phase Runner Rule 4 sees the same flag.
+        # OPTIONAL (default false). Set true when the decomposer's
+        # phase entry has batch_test:true (auto-derived when
+        # `phase_domain ∈ {refactor, schema_migration}`).
+        batch_test: boolean
         acceptance_criteria: [string]  # sourced from design-intent + machine-verifiable refinement
         todo_structure:
           - id: string

--- a/commands/mpl-run-execute-gates.md
+++ b/commands/mpl-run-execute-gates.md
@@ -170,15 +170,31 @@ for each { cmd, name } in build_commands:
 // "tooling requested" — the default decomposer mode demands
 // lint/type/build.
 NON_TOOLING_EVIDENCE = ["goal_trace", "manual", "external_audit", "documentation"]
-completed_phases = state.execution.phase_details
+
+// **Source of truth (codex r3 fix)**: `evidence_required` lives on the
+// decomposition's per-phase block, NOT on `state.execution.phase_details`
+// (which only stores id/name/status/pp/retry/result). An earlier draft
+// read `phase.evidence_required` off phase_details — that read always
+// returned undefined, so `phase_evidence = []`, `all_non_tooling = false`,
+// and the skip path was dead code on every real run. Fix: re-read
+// `.mpl/mpl/decomposition.yaml` at Hard 1 time and JOIN completed phase
+// ids back to the decomposition entry to extract `evidence_required`.
+decomposition = readDecompositionYaml(cwd)  // `.mpl/mpl/decomposition.yaml`
+decomp_phase_by_id = Map(decomposition.phases.map(p => [p.id, p]))
+completed_phase_ids = state.execution.phase_details
   .filter(p => p.status == "completed")
-all_non_tooling = completed_phases.every(phase => {
+  .map(p => p.id)
+completed_decomp_phases = completed_phase_ids
+  .map(id => decomp_phase_by_id.get(id))
+  .filter(p => p != null)  // drop phases missing from decomposition (shouldn't happen)
+
+all_non_tooling = completed_decomp_phases.every(phase => {
   phase_evidence = phase.evidence_required or []
   return phase_evidence.length > 0 and
          phase_evidence.every(e => NON_TOOLING_EVIDENCE.includes(e))
 })
-requests_tooling = not all_non_tooling
-skip_justifying_phases = completed_phases
+requests_tooling = not all_non_tooling or completed_decomp_phases.length == 0
+skip_justifying_phases = completed_decomp_phases
   .filter(phase => (phase.evidence_required or []).every(e => NON_TOOLING_EVIDENCE.includes(e)) and (phase.evidence_required or []).length > 0)
   .map(phase => phase.id)
 

--- a/commands/mpl-run-execute-gates.md
+++ b/commands/mpl-run-execute-gates.md
@@ -184,9 +184,27 @@ decomp_phase_by_id = Map(decomposition.phases.map(p => [p.id, p]))
 completed_phase_ids = state.execution.phase_details
   .filter(p => p.status == "completed")
   .map(p => p.id)
+
+// **Fail-closed on resolution mismatch (codex r4 fix)**: a stale or
+// partially-rewritten decomposition.yaml can be missing some completed
+// phase ids (e.g., a recomposition removed a code-bearing phase while
+// retaining a docs/manual phase with non-tooling evidence). Silently
+// filtering out the missing ids would let `all_non_tooling` resolve
+// to true purely because the remaining resolvable entries happened to
+// be docs/manual — a fail-OPEN path at the exact source-of-truth
+// boundary this gate is meant to harden. Detect the mismatch BEFORE
+// the every() check; if any completed phase id has no decomposition
+// entry, FAIL Hard 1 with the unresolved id list and do not enter
+// the skip path.
+missing_completed_phase_ids = completed_phase_ids
+  .filter(id => not decomp_phase_by_id.has(id))
+if missing_completed_phase_ids.length > 0:
+  announce: "[MPL] Hard 1 FAIL: {missing_completed_phase_ids.length} completed phase(s) absent from decomposition.yaml: {missing_completed_phase_ids.join(', ')}. Re-sync the decomposition before retrying Hard 1; cannot determine evidence_required for the missing phases (failing closed)."
+  → enter fix loop (target: restore the missing phase entries in decomposition.yaml)
+  // STOP — do NOT evaluate all_non_tooling on a partial set.
+
 completed_decomp_phases = completed_phase_ids
   .map(id => decomp_phase_by_id.get(id))
-  .filter(p => p != null)  // drop phases missing from decomposition (shouldn't happen)
 
 all_non_tooling = completed_decomp_phases.every(phase => {
   phase_evidence = phase.evidence_required or []

--- a/commands/mpl-run-execute-gates.md
+++ b/commands/mpl-run-execute-gates.md
@@ -138,14 +138,14 @@ for each { cmd, name } in build_commands:
 // Defensive check: if NO verification ran at all, fail rather than auto-pass.
 // Same principle as AD-02 for Hard 3 — missing precondition ≠ free pass.
 //
-// #239 C6 / #251: when the phase's `evidence_required` list contains
-// ONLY non-tooling evidence types (`goal_trace`, `manual`, etc.),
-// Hard 1 skips the tooling demand and reports PASS via those evidence
-// types instead. This unblocks docs-only / prompt-only / pure-evidence
-// phases that legitimately have no lint/type/build surface.
+// #239 C6 / #251: when EVERY completed phase's `evidence_required`
+// list contains ONLY non-tooling evidence types (`goal_trace`,
+// `manual`, etc.), Hard 1 skips the tooling demand and reports PASS
+// via those evidence types instead. This unblocks docs-only /
+// prompt-only / pure-evidence runs that legitimately have no
+// lint/type/build surface anywhere.
 //
-// CLOSED LIST of non-tooling evidence types (Hard 1 skips when the
-// `evidence_required` list contains ONLY these):
+// CLOSED LIST of non-tooling evidence types:
 //   `goal_trace`, `manual`, `external_audit`, `documentation`.
 //
 // EVERYTHING ELSE counts as tooling — including `command` (Bash with
@@ -156,12 +156,31 @@ for each { cmd, name } in build_commands:
 // machine-backed evidence token does not silently slip through Hard 1
 // just because the executor prompt forgot to list it.
 //
-// An empty `evidence_required` array is treated as "tooling requested"
-// — the default decomposer mode demands lint/type/build.
-phase_evidence = phase.evidence_required or []
+// **Aggregation rule (codex r2 fix)**: Hard 1 runs ONCE for the whole
+// pipeline after every phase completes. A single docs phase declaring
+// `evidence_required: [goal_trace]` MUST NOT suppress the tooling
+// demand when other completed phases changed code. So the skip path
+// requires that **every** completed phase whose impact actually
+// touched code (i.e., not the pure-Phase 0 readme phases) is
+// non-tooling-only. If ANY code-bearing completed phase requests
+// tooling (or has an empty/absent `evidence_required`, which defaults
+// to tooling-requested), Hard 1 demands tools.
+//
+// An empty `evidence_required` on a phase is treated as
+// "tooling requested" — the default decomposer mode demands
+// lint/type/build.
 NON_TOOLING_EVIDENCE = ["goal_trace", "manual", "external_audit", "documentation"]
-requests_tooling = phase_evidence.length == 0 or
-                   phase_evidence.some(e => not NON_TOOLING_EVIDENCE.includes(e))
+completed_phases = state.execution.phase_details
+  .filter(p => p.status == "completed")
+all_non_tooling = completed_phases.every(phase => {
+  phase_evidence = phase.evidence_required or []
+  return phase_evidence.length > 0 and
+         phase_evidence.every(e => NON_TOOLING_EVIDENCE.includes(e))
+})
+requests_tooling = not all_non_tooling
+skip_justifying_phases = completed_phases
+  .filter(phase => (phase.evidence_required or []).every(e => NON_TOOLING_EVIDENCE.includes(e)) and (phase.evidence_required or []).length > 0)
+  .map(phase => phase.id)
 
 total_checks = lint_commands.length + build_commands.length + (diagnostics ? 1 : 0)
 if total_checks == 0:

--- a/commands/mpl-run-execute-gates.md
+++ b/commands/mpl-run-execute-gates.md
@@ -137,13 +137,34 @@ for each { cmd, name } in build_commands:
 
 // Defensive check: if NO verification ran at all, fail rather than auto-pass.
 // Same principle as AD-02 for Hard 3 — missing precondition ≠ free pass.
+//
+// #239 C6 / #251: when the phase's `evidence_required` list excludes
+// every tooling-based evidence type — i.e., it requests ONLY
+// non-tooling evidence such as `[goal_trace]` — Hard 1 skips the
+// tooling demand and reports PASS via `[goal_trace]` evidence instead.
+// This unblocks docs-only / prompt-only / pure-evidence phases that
+// legitimately have no lint/type/build surface.
+//
+// Tooling evidence types (Hard 1 honors): `lint`, `type_check`, `build`,
+// `lsp_diagnostics`, `tooling`.
+// Non-tooling evidence types (Hard 1 skips when ONLY these requested):
+// `goal_trace`, `manual`, `external_audit`, `documentation`.
+phase_evidence = phase.evidence_required or []
+TOOLING_EVIDENCE = ["lint", "type_check", "build", "lsp_diagnostics", "tooling"]
+requests_tooling = phase_evidence.length == 0 or
+                   phase_evidence.some(e => TOOLING_EVIDENCE.includes(e))
+
 total_checks = lint_commands.length + build_commands.length + (diagnostics ? 1 : 0)
 if total_checks == 0:
-  announce: "[MPL] Hard 1 FAIL: No lint, type check, or build tool profile detected. Cannot verify code quality with zero tools."
-  → enter fix loop (target: add build/lint configuration)
-
-Hard 1 passes when: all lint tools + type check + all build tools succeed AND at least one check ran.
-Report: `[MPL] Hard 1: Build + Lint + Type PASSED ({total_checks} checks).`
+  if not requests_tooling:
+    announce: "[MPL] Hard 1 SKIPPED: phase.evidence_required={phase_evidence} excludes tooling-based evidence. Tracking evidence via {phase_evidence} types instead."
+    → mark Hard 1 PASS with `evidence_required` reason; proceed to Hard 2
+  else:
+    announce: "[MPL] Hard 1 FAIL: No lint, type check, or build tool profile detected. Cannot verify code quality with zero tools."
+    → enter fix loop (target: add build/lint configuration)
+else:
+  Hard 1 passes when: all lint tools + type check + all build tools succeed AND at least one check ran.
+  Report: `[MPL] Hard 1: Build + Lint + Type PASSED ({total_checks} checks).`
 
 #### Hard 2: Full Test Suite + Regression + Intent Invariants ($0, mechanical, binary)
 

--- a/commands/mpl-run-execute-gates.md
+++ b/commands/mpl-run-execute-gates.md
@@ -138,26 +138,35 @@ for each { cmd, name } in build_commands:
 // Defensive check: if NO verification ran at all, fail rather than auto-pass.
 // Same principle as AD-02 for Hard 3 — missing precondition ≠ free pass.
 //
-// #239 C6 / #251: when the phase's `evidence_required` list excludes
-// every tooling-based evidence type — i.e., it requests ONLY
-// non-tooling evidence such as `[goal_trace]` — Hard 1 skips the
-// tooling demand and reports PASS via `[goal_trace]` evidence instead.
-// This unblocks docs-only / prompt-only / pure-evidence phases that
-// legitimately have no lint/type/build surface.
+// #239 C6 / #251: when the phase's `evidence_required` list contains
+// ONLY non-tooling evidence types (`goal_trace`, `manual`, etc.),
+// Hard 1 skips the tooling demand and reports PASS via those evidence
+// types instead. This unblocks docs-only / prompt-only / pure-evidence
+// phases that legitimately have no lint/type/build surface.
 //
-// Tooling evidence types (Hard 1 honors): `lint`, `type_check`, `build`,
-// `lsp_diagnostics`, `tooling`.
-// Non-tooling evidence types (Hard 1 skips when ONLY these requested):
-// `goal_trace`, `manual`, `external_audit`, `documentation`.
+// CLOSED LIST of non-tooling evidence types (Hard 1 skips when the
+// `evidence_required` list contains ONLY these):
+//   `goal_trace`, `manual`, `external_audit`, `documentation`.
+//
+// EVERYTHING ELSE counts as tooling — including `command` (Bash with
+// `exit_code: 0`), `test_agent`, `lint`, `type_check`, `build`,
+// `lsp_diagnostics`, `tooling`, and any other token a future
+// decomposer might add. The classifier is intentionally a non-tooling
+// allowlist (codex r1 fix), NOT a tooling allowlist, so a newly-added
+// machine-backed evidence token does not silently slip through Hard 1
+// just because the executor prompt forgot to list it.
+//
+// An empty `evidence_required` array is treated as "tooling requested"
+// — the default decomposer mode demands lint/type/build.
 phase_evidence = phase.evidence_required or []
-TOOLING_EVIDENCE = ["lint", "type_check", "build", "lsp_diagnostics", "tooling"]
+NON_TOOLING_EVIDENCE = ["goal_trace", "manual", "external_audit", "documentation"]
 requests_tooling = phase_evidence.length == 0 or
-                   phase_evidence.some(e => TOOLING_EVIDENCE.includes(e))
+                   phase_evidence.some(e => not NON_TOOLING_EVIDENCE.includes(e))
 
 total_checks = lint_commands.length + build_commands.length + (diagnostics ? 1 : 0)
 if total_checks == 0:
   if not requests_tooling:
-    announce: "[MPL] Hard 1 SKIPPED: phase.evidence_required={phase_evidence} excludes tooling-based evidence. Tracking evidence via {phase_evidence} types instead."
+    announce: "[MPL] Hard 1 SKIPPED: phase.evidence_required={phase_evidence} contains only non-tooling evidence. Tracking evidence via {phase_evidence} types instead."
     → mark Hard 1 PASS with `evidence_required` reason; proceed to Hard 2
   else:
     announce: "[MPL] Hard 1 FAIL: No lint, type check, or build tool profile detected. Cannot verify code quality with zero tools."

--- a/commands/mpl-run-execute.md
+++ b/commands/mpl-run-execute.md
@@ -457,7 +457,7 @@ result = Task(subagent_type="mpl-phase-runner", model=phase_model,
      1. Scope discipline: Only work within this phase's scope.
      2. Impact awareness: Impact section lists files to touch. Out-of-scope -> create Discovery.
      3. Direct implementation: Implement code changes DIRECTLY using Edit/Write/Bash. You are the implementer — all code changes happen directly in Phase Runner.
-     4. Incremental testing: After each TODO, immediately test the affected module. Fix failures before moving to the next TODO. Do NOT batch all implementation before testing.
+     4. Incremental testing: After each TODO, immediately test the affected module. Fix failures before moving to the next TODO. Do NOT batch all implementation before testing. **Exception (#239 C3 / #251)**: when the phase's seed sets `batch_test: true` (auto-set by the Seed Generator when `phase_domain ∈ {refactor, schema_migration}`), batched implement-then-verify is allowed — the TODOs are co-dependent (e.g., rename + update every caller + fix interface) and per-TODO isolation would create an invalid intermediate state. Verify once after all TODOs land. Set this flag for refactor/migration phases ONLY when intermediate states would not compile / would dirty the test suite.
      5. Cumulative verification: Run ALL tests (current + prior phases) at phase end. Record pass_rate.
      6. Discovery reporting: Unexpected findings -> Discovery with PP conflict assessment.
      7. PD Override: Changing past decisions -> explicit PD Override request.
@@ -868,11 +868,35 @@ keeping actual additions at ~80-100K.
       announce: "[MPL] Regression suite: {regression_suite.total_assertions} assertions accumulated across {regression_suite.accumulated_tests.length} phases"
     ```
 
-12. **Adversarial Review (P0-A redesign, #103)** — dispatch the reviewer
-    before the dependency frontier can consume this phase. In v0.18.6, this may
-    run in the background under the same `can_pipeline_verification` predicate
-    used for Test Agent; it MUST join before a dependent phase, Gate entry, or
-    finalize:
+12. **Adversarial Review (P0-A redesign, #103; #239 C2 / #251)** — dispatch the
+    reviewer before the dependency frontier can consume this phase. In v0.18.6,
+    this may run in the background under the same `can_pipeline_verification`
+    predicate used for Test Agent; it MUST join before a dependent phase, Gate
+    entry, or finalize.
+
+    **Skip path (#239 C2 / #251)**: when the phase's decomposition entry sets
+    `reviewer_required: false`, skip the dispatch entirely AND record a
+    `reviewer-skipped` telemetry signal so over-use is measurable:
+    ```
+    if phase_definition.reviewer_required == false:
+      # Pre-condition: hooks/mpl-require-reviewer.mjs already enforced
+      # that reviewer_rationale is a non-empty string. The dispatch is
+      # legitimately optional for pure-docs / mechanical-migration phases.
+      recordQualitySignal({
+        rule: "reviewer-skipped",
+        severity: "warn",
+        evidence: {
+          phase_id: phase.id,
+          phase_domain: phase_definition.phase_domain,
+          reviewer_rationale: phase_definition.reviewer_rationale
+        }
+      }, cwd)
+      // Treat the phase's adversarial step as PASS with no score
+      // contribution. mpl-quality-gate.mjs handles the absent JSON.
+      proceed to step 13
+    ```
+
+    Default path (`reviewer_required: true` or absent):
     ```
     reviewer_handle_or_result = Task({
       subagent_type: "mpl-adversarial-reviewer",

--- a/commands/mpl-run-execute.md
+++ b/commands/mpl-run-execute.md
@@ -879,21 +879,31 @@ keeping actual additions at ~80-100K.
     `reviewer-skipped` telemetry signal so over-use is measurable:
     ```
     if phase_definition.reviewer_required == false:
-      # Pre-condition: hooks/mpl-require-reviewer.mjs already enforced
-      # that reviewer_rationale is a non-empty string. The dispatch is
-      # legitimately optional for pure-docs / mechanical-migration phases.
-      recordQualitySignal({
-        rule: "reviewer-skipped",
-        severity: "warn",
-        evidence: {
-          phase_id: phase.id,
-          phase_domain: phase_definition.phase_domain,
-          reviewer_rationale: phase_definition.reviewer_rationale
-        }
-      }, cwd)
-      // Treat the phase's adversarial step as PASS with no score
-      // contribution. mpl-quality-gate.mjs handles the absent JSON.
-      proceed to step 13
+      # codex r2 defense-in-depth: hooks/mpl-require-reviewer.mjs is
+      # the authoring-time guard, but a pre-existing decomposition,
+      # a hook IO failure (fail-soft), or a decomposition restored
+      # from disk with hooks disabled can still arrive here with
+      # reviewer_required:false AND empty/missing rationale. The
+      # executor MUST verify the invariant at dispatch time, not
+      # trust the hook precondition. Whitespace-only rationale is
+      # treated as missing (claude r1 advisory).
+      rationale = (phase_definition.reviewer_rationale or "").trim()
+      if rationale.length == 0:
+        announce: "[MPL #239 C2 / #251] Reviewer skip rejected for {phase.id}: reviewer_required:false but reviewer_rationale missing/blank. Forcing reviewer dispatch."
+        // fall through to the default dispatch path below
+      else:
+        recordQualitySignal({
+          rule: "reviewer-skipped",
+          severity: "warn",
+          evidence: {
+            phase_id: phase.id,
+            phase_domain: phase_definition.phase_domain,
+            reviewer_rationale: rationale
+          }
+        }, cwd)
+        // Treat the phase's adversarial step as PASS with no score
+        // contribution. mpl-quality-gate.mjs handles the absent JSON.
+        proceed to step 13
     ```
 
     Default path (`reviewer_required: true` or absent):

--- a/docs/design.md
+++ b/docs/design.md
@@ -450,7 +450,7 @@ All Discoveries are recorded in `.mpl/discoveries.md`.
 
 ## 7. Hook System
 
-`hooks/hooks.json` is the live SSOT for hook registration. MPL maintains pipeline integrity with 40 registered hook commands:
+`hooks/hooks.json` is the live SSOT for hook registration. MPL maintains pipeline integrity with 41 registered hook commands:
 
 | Hook | Event / matcher | Purpose | Introduced |
 |----|--------|------|------------|
@@ -469,6 +469,7 @@ All Discoveries are recorded in `.mpl/discoveries.md`.
 | `mpl-require-phase-contract-graph` | PreToolUse: Edit/Write/MultiEdit | Enforce graph metadata, evidence policy, resource locks, and valid phase dependencies in `decomposition.yaml`. | v0.18.3 guard stream; resource locks v0.18.5 |
 | `mpl-require-decomposition-delta` | PreToolUse: Edit/Write/MultiEdit | Require recomposition deltas for existing decomposition graph rewrites. | v0.18.3 guard stream |
 | `mpl-require-completed-phase-immutability` | PreToolUse: Edit/Write/MultiEdit | Prevent completed phase blocks from being mutated or removed during recomposition. | v0.18.3 guard stream |
+| `mpl-require-reviewer` | PreToolUse: Edit/Write/MultiEdit | Enforce non-empty `reviewer_rationale` when a phase declares `reviewer_required: false`. | #239 C2 / #251 |
 | `mpl-require-phase-evidence` | PreToolUse: Edit/Write/MultiEdit | Require phase Evidence Latches before completion artifacts or completion state writes. | v0.18.3 guard stream |
 | `mpl-baseline-guard` | PreToolUse: Edit/Write/MultiEdit | Protect `.mpl/mpl/baseline.yaml` after creation unless an explicit renewal sentinel exists. | v0.17.0 P2 stream (#59) |
 | `mpl-ambiguity-gate` | PreToolUse: Task/Agent | Block decomposer dispatch until ambiguity and user-contract readiness gates pass. | v0.11.2; UC readiness v0.16.0 |

--- a/docs/design.md
+++ b/docs/design.md
@@ -469,7 +469,6 @@ All Discoveries are recorded in `.mpl/discoveries.md`.
 | `mpl-require-phase-contract-graph` | PreToolUse: Edit/Write/MultiEdit | Enforce graph metadata, evidence policy, resource locks, and valid phase dependencies in `decomposition.yaml`. | v0.18.3 guard stream; resource locks v0.18.5 |
 | `mpl-require-decomposition-delta` | PreToolUse: Edit/Write/MultiEdit | Require recomposition deltas for existing decomposition graph rewrites. | v0.18.3 guard stream |
 | `mpl-require-completed-phase-immutability` | PreToolUse: Edit/Write/MultiEdit | Prevent completed phase blocks from being mutated or removed during recomposition. | v0.18.3 guard stream |
-| `mpl-require-reviewer` | PreToolUse: Edit/Write/MultiEdit | Enforce non-empty `reviewer_rationale` when a phase declares `reviewer_required: false`. | #239 C2 / #251 |
 | `mpl-require-phase-evidence` | PreToolUse: Edit/Write/MultiEdit | Require phase Evidence Latches before completion artifacts or completion state writes. | v0.18.3 guard stream |
 | `mpl-baseline-guard` | PreToolUse: Edit/Write/MultiEdit | Protect `.mpl/mpl/baseline.yaml` after creation unless an explicit renewal sentinel exists. | v0.17.0 P2 stream (#59) |
 | `mpl-ambiguity-gate` | PreToolUse: Task/Agent | Block decomposer dispatch until ambiguity and user-contract readiness gates pass. | v0.11.2; UC readiness v0.16.0 |
@@ -480,6 +479,7 @@ All Discoveries are recorded in `.mpl/discoveries.md`.
 | `mpl-fallback-grep` | PostToolUse: Edit/Write/MultiEdit | Run anti-pattern registry checks against edited files as a fallback static guard. | v0.18.1 |
 | `mpl-artifact-schema` | PostToolUse: Edit/Write/MultiEdit/mcp__.*__write.* | Validate MPL artifacts against required markdown headings and YAML key schemas. | v0.18.1 |
 | `mpl-decomposition-postprocess` | PostToolUse: Edit/Write/MultiEdit | Regenerate `.mpl/mpl/decomposition-derived.json` immediately after derived source artifacts change. | v0.18 Phase 5 diet |
+| `mpl-require-reviewer` | PostToolUse: Edit/Write/MultiEdit | Enforce non-empty `reviewer_rationale` when a phase declares `reviewer_required: false`. | #239 C2 / #251 |
 | `mpl-require-test-agent` | PostToolUse: Task/Agent | Block phase-runner completion until required test-agent PASS evidence or override exists. | v0.15.1; structured PASS hardening v0.18.3 |
 | `mpl-require-test-agent-brief` | PreToolUse: Task/Agent | Block `mpl-test-agent` dispatch when `test_agent_required: true` phase has no valid `test-agent-brief.yaml` runbook artifact. | #212 |
 | `mpl-quality-gate` | PostToolUse: Task/Agent | Consume adversarial reviewer quality scores and trigger retry/escalation decisions. | v0.18.1 |

--- a/hooks/__tests__/mpl-issue-251-c2c3c6-runtime.test.mjs
+++ b/hooks/__tests__/mpl-issue-251-c2c3c6-runtime.test.mjs
@@ -269,6 +269,30 @@ test('#251 C2 codex r3 [logic]: YAML block-scalar rationale (|, >) requires deep
   assert.deepEqual(findReviewerRationaleGaps(populatedFolded).offenders, []);
 });
 
+test('#251 C6 codex r4 [logic]: Hard 1 fails closed when completed phase id missing from decomposition', () => {
+  // Codex r4: silently filtering out completed phase ids that have
+  // no decomposition entry let `all_non_tooling` resolve to true
+  // purely because the remaining resolvable phases happened to be
+  // docs/manual. Fail-OPEN at the source-of-truth boundary. Fix:
+  // detect missing ids BEFORE the every() check and Hard 1 FAIL
+  // when the lists don't match.
+  const text = readPrompt('commands/mpl-run-execute-gates.md');
+  assert.match(
+    text,
+    /missing_completed_phase_ids|Hard 1 FAIL.*absent from decomposition\.yaml/i,
+    'Hard 1 must fail closed when completed phase id missing from decomposition',
+  );
+  // Stale silent-filter shape must be gone.
+  assert.ok(
+    !/\.filter\(p\s*=>\s*p\s*!=\s*null\)\s*\/\/\s*drop phases missing/i.test(text),
+    'silent drop of missing decomposition entries must be gone',
+  );
+  // The check must run BEFORE the all_non_tooling every() call.
+  const flow = text.match(/missing_completed_phase_ids[\s\S]*?all_non_tooling/);
+  assert.ok(flow, 'missing-id check must run before all_non_tooling evaluation');
+  assert.match(flow[0], /STOP[\s\S]*?do NOT evaluate all_non_tooling|enter fix loop/i);
+});
+
 test('#251 C6 codex r3 [logic]: Hard 1 reads evidence_required from decomposition.yaml, not phase_details', () => {
   // Codex r3: `evidence_required` lives on the decomposition per-phase
   // entry, NOT on `state.execution.phase_details` (which only carries

--- a/hooks/__tests__/mpl-issue-251-c2c3c6-runtime.test.mjs
+++ b/hooks/__tests__/mpl-issue-251-c2c3c6-runtime.test.mjs
@@ -144,6 +144,92 @@ test('#251 C2 e2e: hook lets a valid rationale through', () => {
   }
 });
 
+test('#251 C2 claude r1 [logic]: whitespace-only rationale is treated as missing', () => {
+  // Claude r1 advisory promoted to a [logic] regression: a phase
+  // with `reviewer_rationale: "   "` (whitespace-only) had no real
+  // author intent but slipped through the length-only check. Fix:
+  // trim before length check in findReviewerRationaleGaps.
+  const yaml = `phases:
+  - id: phase-1
+    reviewer_required: false
+    reviewer_rationale: "   "
+  - id: phase-2
+    reviewer_required: false
+    reviewer_rationale: "\\t\\n  "
+  - id: phase-3
+    reviewer_required: false
+    reviewer_rationale: "Pure docs, no code change"
+`;
+  const { offenders } = findReviewerRationaleGaps(yaml);
+  assert.ok(offenders.includes('phase-1'), 'spaces-only rationale must be flagged');
+  // phase-3 has real content → not flagged.
+  assert.ok(!offenders.includes('phase-3'), 'real content rationale must pass');
+});
+
+test('#251 C2 codex r2: executor skip path checks rationale presence (defense-in-depth)', () => {
+  // Codex r2: the executor must not blindly trust the PostToolUse
+  // hook's precondition — pre-existing decompositions, hook IO
+  // failures, restored-from-disk states can all arrive at dispatch
+  // time with reviewer_required:false AND empty rationale. The
+  // executor MUST verify at runtime and either reject the skip or
+  // force the reviewer dispatch.
+  const text = readPrompt('commands/mpl-run-execute.md');
+  // The skip block must include a rationale-blank check before
+  // emitting the telemetry and skipping.
+  // Anchor on the section heading and read forward until the trailing
+  // ``` fence that closes the skip-path code block.
+  const skipBlock = text.match(
+    /Skip path[^\n]*#239 C2[\s\S]*?\n```\n/,
+  );
+  assert.ok(skipBlock, 'Skip path block must exist');
+  // Must explicitly trim + zero-length check.
+  assert.match(
+    skipBlock[0],
+    /rationale\.length\s*==\s*0|trim\(\)\.length\s*==\s*0|blank/i,
+  );
+  // Must explicitly fall through to reviewer dispatch when blank.
+  assert.match(
+    skipBlock[0],
+    /Forcing reviewer dispatch|fall through to the default dispatch|reject.*skip/i,
+  );
+  // The codex r2 attribution must be in the comment so a future
+  // revert can be traced.
+  assert.match(skipBlock[0], /codex r2|defense-in-depth/i);
+});
+
+test('#251 C6 codex r2 [logic]: Hard 1 aggregates across ALL completed phases', () => {
+  // Codex r2: Hard 1 runs ONCE for the whole pipeline. The skip
+  // logic must check that EVERY completed phase has non-tooling-only
+  // evidence, not just the most recent / one-off phase. A mixed
+  // run (docs phase + code phase) must NOT let the docs phase
+  // suppress the tooling demand for the code phase.
+  const text = readPrompt('commands/mpl-run-execute-gates.md');
+
+  // Must use a per-completed-phase aggregation, not single-phase keying.
+  assert.match(
+    text,
+    /completed_phases|\.every\(|every completed phase|every phase in scope/i,
+    'Hard 1 skip must aggregate over completed phases, not a single phase',
+  );
+  // The skip path must surface which phase ids justified the skip
+  // so an operator can audit.
+  assert.match(
+    text,
+    /skip_justifying_phases|skip-justifying phases|which phase ids|phase ids that/i,
+    'Hard 1 skip must record which phase ids justified the skip',
+  );
+  // Stale single-phase classifier (top-level read of `phase.evidence_required`
+  // without aggregation) must be gone. The current shape reads it INSIDE
+  // `.every()`, which is fine.
+  const preAggregationShape = text.match(
+    /^phase_evidence\s*=\s*phase\.evidence_required[^\n]*\n[^\n]*\nrequests_tooling\s*=/m,
+  );
+  assert.ok(
+    !preAggregationShape,
+    'single-phase phase_evidence assignment followed by direct requests_tooling must be gone (codex r2 [logic])',
+  );
+});
+
 test('#251 C2 codex r1 [contract-break]: hook reads post-write disk state, not pre-write content', () => {
   // Codex r1: original hook was registered as PreToolUse but read
   // disk — the disk file is the PRE-write version, so a write that

--- a/hooks/__tests__/mpl-issue-251-c2c3c6-runtime.test.mjs
+++ b/hooks/__tests__/mpl-issue-251-c2c3c6-runtime.test.mjs
@@ -197,6 +197,112 @@ test('#251 C2 codex r2: executor skip path checks rationale presence (defense-in
   assert.match(skipBlock[0], /codex r2|defense-in-depth/i);
 });
 
+test('#251 C2 codex r3 [logic]: YAML block-scalar rationale (|, >) requires deeper non-blank body', () => {
+  // Codex r3: `reviewer_rationale: |` followed by a sibling key (or
+  // EOF, or whitespace-only body) made `extractScalar` return the
+  // literal `|` marker. After trim that was non-empty, so the gate
+  // passed even though the author intent was absent. Fix: detect
+  // block-scalar opener and collect deeper-indented content; empty
+  // body → empty rationale.
+  const empties = [
+    // EOF after opener
+    `phases:
+  - id: phase-1
+    reviewer_required: false
+    reviewer_rationale: |`,
+    // Sibling at same indent → no body
+    `phases:
+  - id: phase-1
+    reviewer_required: false
+    reviewer_rationale: |
+  - id: phase-2
+    reviewer_required: true
+`,
+    // Whitespace-only deeper body
+    `phases:
+  - id: phase-1
+    reviewer_required: false
+    reviewer_rationale: |
+
+
+`,
+    // Folded > marker, empty
+    `phases:
+  - id: phase-1
+    reviewer_required: false
+    reviewer_rationale: >`,
+    // With chomping indicators
+    `phases:
+  - id: phase-1
+    reviewer_required: false
+    reviewer_rationale: |-
+  - id: phase-2`,
+  ];
+  for (const yaml of empties) {
+    const { offenders } = findReviewerRationaleGaps(yaml);
+    assert.ok(
+      offenders.includes('phase-1'),
+      `expected block-scalar empty rationale to be flagged:\n${yaml}`,
+    );
+  }
+
+  // Sanity: real multi-line block-scalar body → not flagged.
+  const populated = `phases:
+  - id: phase-1
+    reviewer_required: false
+    reviewer_rationale: |
+      Boundary unclear; operator must confirm.
+      Multi-line rationale spans multiple lines.
+  - id: phase-2
+    reviewer_required: true
+`;
+  assert.deepEqual(findReviewerRationaleGaps(populated).offenders, []);
+
+  // Sanity: folded > with content → not flagged.
+  const populatedFolded = `phases:
+  - id: phase-1
+    reviewer_required: false
+    reviewer_rationale: >
+      folded rationale across
+      multiple lines becomes one paragraph
+`;
+  assert.deepEqual(findReviewerRationaleGaps(populatedFolded).offenders, []);
+});
+
+test('#251 C6 codex r3 [logic]: Hard 1 reads evidence_required from decomposition.yaml, not phase_details', () => {
+  // Codex r3: `evidence_required` lives on the decomposition per-phase
+  // entry, NOT on `state.execution.phase_details` (which only carries
+  // id/name/status/pp/retry/result). An earlier draft read it off
+  // phase_details — that read always returned undefined, so
+  // `phase_evidence = []`, `all_non_tooling = false`, and the skip
+  // path was dead code on every real run.
+  const text = readPrompt('commands/mpl-run-execute-gates.md');
+
+  // Must read decomposition.yaml at gate time.
+  assert.match(
+    text,
+    /readDecompositionYaml|decomposition\.yaml|decomposition\.phases/i,
+    'Hard 1 skip must read decomposition.yaml directly',
+  );
+
+  // Must JOIN completed phase ids back to the decomposition.
+  assert.match(
+    text,
+    /decomp_phase_by_id|join completed phase ids|join.*decomposition|completed_decomp_phases/i,
+    'Hard 1 must join completed phase ids back to decomposition entries',
+  );
+
+  // Stale read off phase_details.evidence_required must be gone.
+  assert.ok(
+    !/state\.execution\.phase_details[\s\S]{0,60}?\.evidence_required/.test(text),
+    'Hard 1 must not read evidence_required off state.execution.phase_details (codex r3)',
+  );
+
+  // The fix attribution must be in the comment so a future revert
+  // can be traced.
+  assert.match(text, /codex r3|dead code on every real run|source of truth/i);
+});
+
 test('#251 C6 codex r2 [logic]: Hard 1 aggregates across ALL completed phases', () => {
   // Codex r2: Hard 1 runs ONCE for the whole pipeline. The skip
   // logic must check that EVERY completed phase has non-tooling-only

--- a/hooks/__tests__/mpl-issue-251-c2c3c6-runtime.test.mjs
+++ b/hooks/__tests__/mpl-issue-251-c2c3c6-runtime.test.mjs
@@ -1,0 +1,282 @@
+/**
+ * #251 — Follow-up to #239 C2/C3/C6 runtime work.
+ *
+ * AC coverage:
+ *   - C2: docs phase with `reviewer_required: false` + non-empty
+ *     rationale → adversarial-reviewer not dispatched.
+ *   - C3: refactor phase with `batch_test: true` → per-TODO test
+ *     rule relaxed.
+ *   - C6: phase with `evidence_required: [goal_trace]` → Hard 1
+ *     skips tooling demand.
+ *
+ * Runtime tests cover the new hook + schema-field declarations +
+ * prompt wiring that downstream consumers will read.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execSync } from 'child_process';
+import {
+  mkdtempSync,
+  rmSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { findReviewerRationaleGaps } from '../mpl-require-reviewer.mjs';
+
+const REPO_ROOT = join(import.meta.dirname, '..', '..');
+const HOOKS_DIR = join(REPO_ROOT, 'hooks');
+
+function readPrompt(relPath) {
+  return readFileSync(join(REPO_ROOT, relPath), 'utf-8');
+}
+
+function freshWorkspace() {
+  const cwd = mkdtempSync(join(tmpdir(), 'mpl-251-'));
+  mkdirSync(join(cwd, '.mpl', 'mpl'), { recursive: true });
+  writeFileSync(
+    join(cwd, '.mpl', 'state.json'),
+    JSON.stringify({ current_phase: 'phase-1' }),
+  );
+  return cwd;
+}
+
+function runReviewerHook(cwd, payload) {
+  const json = JSON.stringify(payload);
+  const out = execSync(
+    `node "${join(HOOKS_DIR, 'mpl-require-reviewer.mjs')}"`,
+    {
+      input: json,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 5000,
+    },
+  ).toString();
+  return JSON.parse(out.trim());
+}
+
+// ---------------------------------------------------------------------------
+// C2 — reviewer_required + reviewer_rationale unit tests
+// ---------------------------------------------------------------------------
+
+test('#251 C2 [unit]: findReviewerRationaleGaps reports phases with reviewer_required:false but empty rationale', () => {
+  const yaml = `phases:
+  - id: phase-1
+    reviewer_required: false
+    reviewer_rationale: "Pure docs phase, no code change"
+  - id: phase-2
+    reviewer_required: false
+    reviewer_rationale: ""
+  - id: phase-3
+    reviewer_required: false
+  - id: phase-4
+    reviewer_required: true
+  - id: phase-5
+`;
+  const { offenders } = findReviewerRationaleGaps(yaml);
+  // phase-2 has empty rationale, phase-3 has no rationale.
+  // phase-1 has valid rationale → no offense.
+  // phase-4 / phase-5 have reviewer_required:true or absent → no offense.
+  assert.deepEqual(offenders.sort(), ['phase-2', 'phase-3']);
+});
+
+test('#251 C2 [unit]: quoted rationale string is treated as content', () => {
+  const yaml = `phases:
+  - id: phase-1
+    reviewer_required: false
+    reviewer_rationale: 'Single-quoted reason'
+  - id: phase-2
+    reviewer_required: false
+    reviewer_rationale: "Double-quoted reason"
+`;
+  const { offenders } = findReviewerRationaleGaps(yaml);
+  assert.deepEqual(offenders, []);
+});
+
+// ---------------------------------------------------------------------------
+// C2 — hook end-to-end behavior
+// ---------------------------------------------------------------------------
+
+test('#251 C2 e2e: hook blocks decomposition.yaml Write when reviewer_required:false has no rationale', () => {
+  const cwd = freshWorkspace();
+  try {
+    const decompPath = join(cwd, '.mpl', 'mpl', 'decomposition.yaml');
+    const yaml = `phases:
+  - id: phase-1
+    reviewer_required: false
+`;
+    writeFileSync(decompPath, yaml);
+    const decision = runReviewerHook(cwd, {
+      cwd,
+      tool_name: 'Write',
+      tool_input: { file_path: decompPath, content: yaml },
+    });
+    assert.equal(decision.continue, false);
+    assert.equal(decision.decision, 'block');
+    assert.match(decision.reason, /phase-1/);
+    assert.match(decision.reason, /reviewer_rationale/);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('#251 C2 e2e: hook lets a valid rationale through', () => {
+  const cwd = freshWorkspace();
+  try {
+    const decompPath = join(cwd, '.mpl', 'mpl', 'decomposition.yaml');
+    const yaml = `phases:
+  - id: phase-1
+    reviewer_required: false
+    reviewer_rationale: "Pure docs phase, no code surface"
+`;
+    writeFileSync(decompPath, yaml);
+    const decision = runReviewerHook(cwd, {
+      cwd,
+      tool_name: 'Write',
+      tool_input: { file_path: decompPath, content: yaml },
+    });
+    assert.equal(decision.continue, true);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('#251 C2 e2e: hook is silent on non-decomposition writes', () => {
+  const cwd = freshWorkspace();
+  try {
+    const decision = runReviewerHook(cwd, {
+      cwd,
+      tool_name: 'Write',
+      tool_input: { file_path: join(cwd, 'README.md'), content: 'hi' },
+    });
+    assert.equal(decision.continue, true);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('#251 C2 e2e: hook is silent outside MPL workspaces', () => {
+  const cwd = mkdtempSync(join(tmpdir(), 'mpl-251-no-mpl-'));
+  try {
+    const decision = runReviewerHook(cwd, {
+      cwd,
+      tool_name: 'Write',
+      tool_input: {
+        file_path: join(cwd, '.mpl', 'mpl', 'decomposition.yaml'),
+        content: 'phases:\n  - id: phase-1\n    reviewer_required: false\n',
+      },
+    });
+    assert.equal(decision.continue, true);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('#251 C2 e2e: hook accepts camelCase payload shape', () => {
+  // Sibling-hook convention from #238 codex r2.
+  const cwd = freshWorkspace();
+  try {
+    const decompPath = join(cwd, '.mpl', 'mpl', 'decomposition.yaml');
+    const yaml = `phases:
+  - id: phase-1
+    reviewer_required: false
+`;
+    writeFileSync(decompPath, yaml);
+    const decision = runReviewerHook(cwd, {
+      cwd,
+      toolName: 'Write',
+      toolInput: { file_path: decompPath, content: yaml },
+    });
+    assert.equal(decision.continue, false);
+    assert.equal(decision.decision, 'block');
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// C2 — schema declaration in decomposer prompt
+// ---------------------------------------------------------------------------
+
+test('#251 C2 schema: mpl-decomposer Output_Schema declares reviewer_required + reviewer_rationale', () => {
+  const text = readPrompt('agents/mpl-decomposer.md');
+  assert.match(text, /reviewer_required\s*:\s*boolean/);
+  assert.match(text, /reviewer_rationale\s*:\s*string/);
+  // Must mirror the test_agent_required idiom: default true, set false
+  // only for specific phase types.
+  assert.match(text, /Default[^\n]*true/i);
+  assert.match(text, /REQUIRED when reviewer_required is false/i);
+});
+
+test('#251 C2 wire: executor dispatch (commands/mpl-run-execute.md) honors reviewer_required:false', () => {
+  const text = readPrompt('commands/mpl-run-execute.md');
+  assert.match(text, /reviewer_required\s*==\s*false|reviewer_required:\s*false/);
+  assert.match(text, /reviewer-skipped/);
+  assert.match(text, /recordQualitySignal/);
+});
+
+// ---------------------------------------------------------------------------
+// C3 — batch_test schema + Phase Runner Rule 4 prompt wiring
+// ---------------------------------------------------------------------------
+
+test('#251 C3 schema: decomposer Output_Schema declares phase-level batch_test', () => {
+  const text = readPrompt('agents/mpl-decomposer.md');
+  const c3Block = text.match(/#239 C3[\s\S]{0,800}?batch_test\s*:\s*boolean/);
+  assert.ok(c3Block, 'mpl-decomposer.md must declare batch_test boolean under #239 C3');
+});
+
+test('#251 C3 schema: Seed Generator propagates batch_test to phase_seed', () => {
+  const text = readPrompt('agents/mpl-seed-generator.md');
+  assert.match(text, /batch_test\s*:\s*boolean/);
+  assert.match(text, /#239 C3|phase_domain\s*∈\s*\{refactor/i);
+});
+
+test('#251 C3 wire: Phase Runner Rule 4 relaxes per-TODO test when batch_test:true', () => {
+  const text = readPrompt('commands/mpl-run-execute.md');
+  const rule4 = text.match(/Incremental testing[\s\S]{0,800}?(?=\n\s*\d+\.|$)/);
+  assert.ok(rule4, 'Rule 4 block must exist');
+  assert.match(rule4[0], /batch_test:\s*true/);
+  assert.match(rule4[0], /Exception.*#239 C3|#239 C3.*Exception|batched implement-then-verify/i);
+});
+
+// ---------------------------------------------------------------------------
+// C6 — Hard 1 honors phase.evidence_required
+// ---------------------------------------------------------------------------
+
+test('#251 C6 wire: Hard 1 skips tooling demand when evidence_required excludes tooling', () => {
+  const text = readPrompt('commands/mpl-run-execute-gates.md');
+  // The gate logic must name the field and the skip path.
+  assert.match(text, /phase\.evidence_required|evidence_required/);
+  assert.match(text, /Hard 1 SKIPPED.*evidence_required|evidence_required.*Hard 1 SKIPPED|#239 C6/i);
+  // The tooling vs non-tooling distinction must be explicit.
+  assert.match(text, /TOOLING_EVIDENCE|tooling.based evidence/i);
+});
+
+test('#251 C6 wire: Hard 1 still fails when tooling is requested but no tools are present', () => {
+  // Sanity: the previous defensive check must still fire for the
+  // tooling-requested path.
+  const text = readPrompt('commands/mpl-run-execute-gates.md');
+  assert.match(
+    text,
+    /Hard 1 FAIL.*No lint, type check, or build tool/i,
+    'tooling-requested path must still hard-fail when no tools detected',
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Discoverability — hook table, PURPOSES map
+// ---------------------------------------------------------------------------
+
+test('#251: docs/design.md Hook System table includes mpl-require-reviewer', () => {
+  const text = readPrompt('docs/design.md');
+  assert.match(text, /`mpl-require-reviewer`/);
+  assert.match(text, /41 registered hook commands/);
+});
+
+test('#251: PURPOSES map (hooks/lib/mpl-hook-trace.mjs) has entry for mpl-require-reviewer', () => {
+  const text = readPrompt('hooks/lib/mpl-hook-trace.mjs');
+  assert.match(text, /'mpl-require-reviewer':\s*'[^']+'/);
+});

--- a/hooks/__tests__/mpl-issue-251-c2c3c6-runtime.test.mjs
+++ b/hooks/__tests__/mpl-issue-251-c2c3c6-runtime.test.mjs
@@ -144,6 +144,71 @@ test('#251 C2 e2e: hook lets a valid rationale through', () => {
   }
 });
 
+test('#251 C2 codex r1 [contract-break]: hook reads post-write disk state, not pre-write content', () => {
+  // Codex r1: original hook was registered as PreToolUse but read
+  // disk — the disk file is the PRE-write version, so a write that
+  // would introduce a rationale-less skip slipped through. Fix:
+  // register as PostToolUse (disk now reflects the post-write merged
+  // result). Regression test simulates the real PostToolUse path —
+  // disk has the post-write content, hook reads it, and blocks.
+  const cwd = freshWorkspace();
+  try {
+    const decompPath = join(cwd, '.mpl', 'mpl', 'decomposition.yaml');
+    // Pre-write state: VALID decomposition. Mirrors a baseline where
+    // the prior write put a non-empty rationale.
+    writeFileSync(
+      decompPath,
+      `phases:
+  - id: phase-1
+    reviewer_required: false
+    reviewer_rationale: "Pure docs phase, no code change"
+`,
+    );
+    // Now simulate the PostToolUse delivery — the write already
+    // committed to disk, and the on-disk content NOW has the bad
+    // shape (rationale removed). We materialize this by writing the
+    // bad bytes to disk BEFORE invoking the hook — that's what
+    // PostToolUse semantics actually deliver.
+    const badYaml = `phases:
+  - id: phase-1
+    reviewer_required: false
+`;
+    writeFileSync(decompPath, badYaml);
+    const decision = runReviewerHook(cwd, {
+      cwd,
+      tool_name: 'Edit',
+      tool_input: {
+        file_path: decompPath,
+        old_string: 'reviewer_rationale: "Pure docs phase, no code change"',
+        new_string: '',
+      },
+    });
+    assert.equal(decision.continue, false);
+    assert.equal(decision.decision, 'block');
+    assert.match(decision.reason, /phase-1/);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('#251 C2 codex r1: hook is registered as PostToolUse in hooks.json', () => {
+  // Lifecycle correctness: the hook semantics (re-read disk) match
+  // its registration. A future revert that moves it back to
+  // PreToolUse would silently regress the codex r1 finding.
+  const text = readPrompt('hooks/hooks.json');
+  // The hook must appear under PostToolUse, not PreToolUse.
+  const postToolUseBlock = text.match(/"PostToolUse"\s*:\s*\[([\s\S]*?)\n\s*\]\s*,?\s*\n\s*"Stop"/);
+  assert.ok(postToolUseBlock, 'PostToolUse block must exist in hooks.json');
+  assert.match(postToolUseBlock[1], /mpl-require-reviewer\.mjs/);
+  // And must NOT appear under PreToolUse.
+  const preToolUseBlock = text.match(/"PreToolUse"\s*:\s*\[([\s\S]*?)\n\s*\]\s*,\s*\n\s*"PostToolUse"/);
+  assert.ok(preToolUseBlock, 'PreToolUse block must exist in hooks.json');
+  assert.ok(
+    !/mpl-require-reviewer\.mjs/.test(preToolUseBlock[1]),
+    'mpl-require-reviewer must NOT be registered under PreToolUse',
+  );
+});
+
 test('#251 C2 e2e: hook is silent on non-decomposition writes', () => {
   const cwd = freshWorkspace();
   try {
@@ -251,8 +316,48 @@ test('#251 C6 wire: Hard 1 skips tooling demand when evidence_required excludes 
   // The gate logic must name the field and the skip path.
   assert.match(text, /phase\.evidence_required|evidence_required/);
   assert.match(text, /Hard 1 SKIPPED.*evidence_required|evidence_required.*Hard 1 SKIPPED|#239 C6/i);
-  // The tooling vs non-tooling distinction must be explicit.
-  assert.match(text, /TOOLING_EVIDENCE|tooling.based evidence/i);
+  // The non-tooling allowlist must be present.
+  assert.match(text, /NON_TOOLING_EVIDENCE|non.tooling allowlist/i);
+});
+
+test('#251 C6 codex r1 [contract-break]: Hard 1 classifier is a non-tooling allowlist (so `command` counts as tooling)', () => {
+  // Codex r1: an early draft used a tooling allowlist
+  // (lint/type_check/build/lsp_diagnostics/tooling). That gave a free
+  // pass to phases with `evidence_required: [command]` — a machine-
+  // backed Bash exit-code-0 token that IS tooling but wasn't in the
+  // list. Fix: inverted to a non-tooling allowlist
+  // (goal_trace / manual / external_audit / documentation). Anything
+  // outside that closed list — including `command`, `test_agent`,
+  // future-added tokens — counts as tooling and Hard 1 demands tools.
+  const text = readPrompt('commands/mpl-run-execute-gates.md');
+
+  // 1. The allowlist itself must be the non-tooling form, not the
+  //    tooling form. Reject the stale shape that listed `lint` etc.
+  assert.ok(
+    !/TOOLING_EVIDENCE\s*=\s*\[\s*["']lint["']/i.test(text),
+    'Hard 1 must NOT define a tooling allowlist (the codex r1 [contract-break] regression)',
+  );
+  assert.match(text, /NON_TOOLING_EVIDENCE\s*=\s*\[\s*["']goal_trace["']/i);
+
+  // 2. The closed list must NOT contain `command` (command IS tooling).
+  const allowlistMatch = text.match(
+    /NON_TOOLING_EVIDENCE\s*=\s*\[([^\]]*)\]/i,
+  );
+  assert.ok(allowlistMatch, 'NON_TOOLING_EVIDENCE allowlist must exist');
+  const allowlistBody = allowlistMatch[1];
+  for (const toolingToken of ['command', 'test_agent', 'lint', 'type_check', 'build']) {
+    assert.ok(
+      !new RegExp(`["']${toolingToken}["']`).test(allowlistBody),
+      `non-tooling allowlist must NOT contain "${toolingToken}" (it counts as tooling)`,
+    );
+  }
+
+  // 3. The classifier must explicitly call out that anything outside
+  //    the closed list counts as tooling.
+  assert.match(
+    text,
+    /EVERYTHING ELSE counts as tooling|anything outside.*counts as tooling|\bcommand\b.*counts as tooling/i,
+  );
 });
 
 test('#251 C6 wire: Hard 1 still fails when tooling is requested but no tools are present', () => {

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -156,6 +156,16 @@
         "hooks": [
           {
             "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/mpl-require-reviewer.mjs\"",
+            "timeout": 3
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/mpl-require-phase-evidence.mjs\"",
             "timeout": 3
           }

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -156,16 +156,6 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/mpl-require-reviewer.mjs\"",
-            "timeout": 3
-          }
-        ]
-      },
-      {
-        "matcher": "Edit|Write|MultiEdit",
-        "hooks": [
-          {
-            "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/mpl-require-phase-evidence.mjs\"",
             "timeout": 3
           }
@@ -270,6 +260,16 @@
             "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/mpl-decomposition-postprocess.mjs\"",
             "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/mpl-require-reviewer.mjs\"",
+            "timeout": 3
           }
         ]
       },

--- a/hooks/lib/mpl-hook-trace.mjs
+++ b/hooks/lib/mpl-hook-trace.mjs
@@ -58,6 +58,7 @@ const PURPOSES = {
   'mpl-baseline-guard': 'baseline immutability/hash guard',
   'mpl-ambiguity-gate': 'ambiguity score gate before decomposer dispatch',
   'mpl-soft-signal-emit': 'soft-signal telemetry emitter (HA-01 vague delegation etc.) — never blocks',
+  'mpl-require-reviewer': 'enforce reviewer_rationale non-empty when reviewer_required:false (#239 C2 / #251)',
   'mpl-require-chain-assignment': 'chain assignment guard before seed generation',
   'mpl-tool-tracker': 'last-tool telemetry',
   'mpl-gate-recorder': 'gate/test-agent evidence recorder',

--- a/hooks/mpl-require-reviewer.mjs
+++ b/hooks/mpl-require-reviewer.mjs
@@ -3,13 +3,26 @@
  * #239 C2 / #251 — `reviewer_required: false` requires a
  * non-empty `reviewer_rationale` on the same phase.
  *
- * PostToolUse on Edit|Write|MultiEdit. Activates only when the
- * tool wrote `.mpl/mpl/decomposition.yaml`. Parses each phase
- * block. If any phase declares `reviewer_required: false` AND
- * `reviewer_rationale` is missing OR an empty string, blocks
- * the write with a structured reason naming every offending
- * phase id. Pass-through in every other case (no MPL active,
- * other files, `reviewer_required: true` or absent).
+ * **PostToolUse** on Edit|Write|MultiEdit (codex r1
+ * [contract-break] fix). Activates only when the tool wrote
+ * `.mpl/mpl/decomposition.yaml`. After the write commits to disk,
+ * re-reads the file (disk is authoritative for PostToolUse),
+ * parses each phase block, and if any phase declares
+ * `reviewer_required: false` AND `reviewer_rationale` is missing
+ * OR an empty string, blocks the write with a structured reason
+ * naming every offending phase id. Pass-through in every other
+ * case (no MPL active, other files, `reviewer_required: true` or
+ * absent).
+ *
+ * Why PostToolUse and not PreToolUse: PreToolUse fires before the
+ * write commits. Edit/MultiEdit deliver only a patch fragment in
+ * `tool_input`, not the post-edit file content — validating the
+ * patch alone would either miss neighboring phase blocks (false
+ * negative) or require reconstructing the full post-edit text
+ * (brittle). PostToolUse on the disk state side-steps both
+ * problems: the merged result is exactly what the rest of the
+ * pipeline will read, so we validate the same bytes a downstream
+ * consumer would.
  *
  * Mirrors the contract shape already established for
  * `test_agent_required` / `test_agent_rationale` (#212 brief

--- a/hooks/mpl-require-reviewer.mjs
+++ b/hooks/mpl-require-reviewer.mjs
@@ -1,0 +1,224 @@
+#!/usr/bin/env node
+/**
+ * #239 C2 / #251 — `reviewer_required: false` requires a
+ * non-empty `reviewer_rationale` on the same phase.
+ *
+ * PostToolUse on Edit|Write|MultiEdit. Activates only when the
+ * tool wrote `.mpl/mpl/decomposition.yaml`. Parses each phase
+ * block. If any phase declares `reviewer_required: false` AND
+ * `reviewer_rationale` is missing OR an empty string, blocks
+ * the write with a structured reason naming every offending
+ * phase id. Pass-through in every other case (no MPL active,
+ * other files, `reviewer_required: true` or absent).
+ *
+ * Mirrors the contract shape already established for
+ * `test_agent_required` / `test_agent_rationale` (#212 brief
+ * gate + AD-0007 §test_agent_rationale).
+ *
+ * Telemetry: when the skip is legitimate (rationale non-empty),
+ * the executor's Step 12 emits a `reviewer-skipped` record to
+ * `.mpl/mpl/quality-signals.jsonl` (#238). This hook does not
+ * emit telemetry — it only enforces the rationale shape so
+ * the skip path is not silently abused.
+ */
+
+import { dirname, join } from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+import { existsSync, readFileSync } from 'fs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const isMain = import.meta.url === pathToFileURL(process.argv[1] || '').href;
+
+const { isMplActive } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-state.mjs')).href
+);
+const { readStdin } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'stdin.mjs')).href
+);
+const { collectFileWrites, isFileWriteTool } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'tool-input.mjs')).href
+);
+
+const HOOK_ID = 'mpl-require-reviewer';
+const DECOMPOSITION_REL = ['.mpl', 'mpl', 'decomposition.yaml'];
+
+function silent() {
+  console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+}
+
+function block(reason) {
+  console.log(
+    JSON.stringify({
+      continue: false,
+      decision: 'block',
+      reason,
+    }),
+  );
+}
+
+function parseYamlBoolean(value) {
+  if (typeof value !== 'string') return null;
+  const v = value.trim().toLowerCase().replace(/[#].*$/, '').trim();
+  if (v === 'true' || v === 'yes' || v === 'on') return true;
+  if (v === 'false' || v === 'no' || v === 'off') return false;
+  return null;
+}
+
+/**
+ * Strip a quoted-string scalar's surrounding quotes (single OR double)
+ * and return its inner text. For unquoted scalars, return the raw
+ * trimmed value with any trailing `#` comment removed.
+ */
+function extractScalar(raw) {
+  if (typeof raw !== 'string') return '';
+  let value = raw.trim();
+  // Drop trailing inline comment when outside quotes (heuristic — same
+  // shape as mpl-completed-phase-immutability `stripInlineYamlComment`).
+  const noCommentMatch = value.match(/^(?:(["']).*?\1|[^#]*)/);
+  if (noCommentMatch) value = noCommentMatch[0].trim();
+  if (
+    (value.startsWith('"') && value.endsWith('"')) ||
+    (value.startsWith("'") && value.endsWith("'"))
+  ) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
+/**
+ * Minimal per-phase parse: scan for `- id: phase-…` blocks, then
+ * within each block look for `reviewer_required:` and
+ * `reviewer_rationale:` at any indent (they're per-phase fields).
+ * Returns [{ id, reviewer_required, reviewer_rationale }, ...].
+ */
+function parsePhases(text) {
+  const phases = [];
+  const lines = String(text || '').split('\n');
+  let cur = null;
+  for (const rawLine of lines) {
+    const line = rawLine.replace(/\r$/, '');
+    const idMatch = line.match(/^\s*-\s+id\s*:\s*["']?(phase-[\w.-]+)["']?/);
+    if (idMatch) {
+      if (cur) phases.push(cur);
+      cur = { id: idMatch[1], reviewer_required: null, reviewer_rationale: null };
+      continue;
+    }
+    if (!cur) continue;
+    const reqMatch = line.match(/^\s+reviewer_required\s*:\s*(.+)$/);
+    if (reqMatch) {
+      cur.reviewer_required = parseYamlBoolean(reqMatch[1]);
+      continue;
+    }
+    const ratMatch = line.match(/^\s+reviewer_rationale\s*:\s*(.+)$/);
+    if (ratMatch) {
+      cur.reviewer_rationale = extractScalar(ratMatch[1]);
+      continue;
+    }
+  }
+  if (cur) phases.push(cur);
+  return phases;
+}
+
+/**
+ * Test-only export. The runtime entry below is intentionally not
+ * factored through this — it streams stdin and prints — but tests
+ * call this with pre-parsed YAML text.
+ *
+ * Returns { offenders: [phaseId, ...] }.
+ */
+export function findReviewerRationaleGaps(text) {
+  const offenders = [];
+  for (const phase of parsePhases(text)) {
+    if (phase.reviewer_required === false) {
+      const rationale = phase.reviewer_rationale;
+      if (rationale == null || rationale.length === 0) {
+        offenders.push(phase.id);
+      }
+    }
+  }
+  return { offenders };
+}
+
+async function main() {
+  const raw = await readStdin();
+  if (!raw.trim()) {
+    silent();
+    return;
+  }
+  let data;
+  try {
+    data = JSON.parse(raw);
+  } catch {
+    silent();
+    return;
+  }
+
+  const cwd = data.cwd || data.directory || process.cwd();
+  if (!isMplActive(cwd)) {
+    silent();
+    return;
+  }
+
+  const toolName = data.tool_name || data.toolName || '';
+  if (!isFileWriteTool(toolName)) {
+    silent();
+    return;
+  }
+
+  const toolInput = data.tool_input || data.toolInput || {};
+  const writes = collectFileWrites(toolInput);
+
+  // Find any write targeting decomposition.yaml.
+  const decompTail = `${DECOMPOSITION_REL.join('/')}`;
+  const decompHit = writes.find(
+    (w) => typeof w.filePath === 'string' && w.filePath.endsWith(decompTail),
+  );
+  if (!decompHit) {
+    silent();
+    return;
+  }
+
+  // Re-read the file from disk after the write — `tool_response` may
+  // not carry the full text on Edit/MultiEdit. Disk is authoritative
+  // for PostToolUse anyway.
+  const onDiskPath = join(cwd, ...DECOMPOSITION_REL);
+  let text = '';
+  if (existsSync(onDiskPath)) {
+    try {
+      text = readFileSync(onDiskPath, 'utf-8');
+    } catch {
+      silent();
+      return;
+    }
+  } else {
+    // Write may have been to a path that doesn't materialize as the
+    // canonical decomposition file (rare). Fall back to the tool input.
+    text = decompHit.text || '';
+  }
+
+  const { offenders } = findReviewerRationaleGaps(text);
+  if (offenders.length === 0) {
+    silent();
+    return;
+  }
+
+  const list = offenders.map((id) => `  - ${id}`).join('\n');
+  block(
+    `[MPL #239 C2 / #251] Phase(s) declared \`reviewer_required: false\` ` +
+      `without a non-empty \`reviewer_rationale\`:\n${list}\n\n` +
+      `When a phase opts out of adversarial review, an authoring note ` +
+      `is REQUIRED so the skip is auditable. Add a non-empty ` +
+      `\`reviewer_rationale\` string to each phase above, or set ` +
+      `\`reviewer_required: true\` (default). Blanket strings like ` +
+      `"trivial" are accepted but tracked in \`.mpl/mpl/quality-signals.jsonl\` ` +
+      `(#238) for over-use telemetry.`,
+  );
+}
+
+if (isMain) {
+  main().catch(() => {
+    // Fail-soft: never break the pipeline on hook IO error.
+    silent();
+  });
+}

--- a/hooks/mpl-require-reviewer.mjs
+++ b/hooks/mpl-require-reviewer.mjs
@@ -102,32 +102,79 @@ function extractScalar(raw) {
 /**
  * Minimal per-phase parse: scan for `- id: phase-…` blocks, then
  * within each block look for `reviewer_required:` and
- * `reviewer_rationale:` at any indent (they're per-phase fields).
+ * `reviewer_rationale:` at any indent.
+ *
+ * Codex r3 [logic] fix: `reviewer_rationale:` may use a YAML block
+ * scalar opener (`|` or `>`, optionally with chomping indicator
+ * `+`/`-` and explicit indentation digit). The body lives on deeper-
+ * indented lines; the marker itself is not content. For these forms
+ * we collect every line strictly deeper than the `reviewer_rationale:`
+ * line until indent returns to that level or shallower, then join
+ * and trim. An empty body → empty rationale.
+ *
+ * Inline scalar form (`reviewer_rationale: "real text"`) keeps the
+ * existing path through `extractScalar`.
+ *
  * Returns [{ id, reviewer_required, reviewer_rationale }, ...].
  */
 function parsePhases(text) {
   const phases = [];
-  const lines = String(text || '').split('\n');
+  const lines = String(text || '').split('\n').map((l) => l.replace(/\r$/, ''));
   let cur = null;
-  for (const rawLine of lines) {
-    const line = rawLine.replace(/\r$/, '');
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i];
     const idMatch = line.match(/^\s*-\s+id\s*:\s*["']?(phase-[\w.-]+)["']?/);
     if (idMatch) {
       if (cur) phases.push(cur);
       cur = { id: idMatch[1], reviewer_required: null, reviewer_rationale: null };
+      i++;
       continue;
     }
-    if (!cur) continue;
+    if (!cur) {
+      i++;
+      continue;
+    }
     const reqMatch = line.match(/^\s+reviewer_required\s*:\s*(.+)$/);
     if (reqMatch) {
       cur.reviewer_required = parseYamlBoolean(reqMatch[1]);
+      i++;
       continue;
     }
-    const ratMatch = line.match(/^\s+reviewer_rationale\s*:\s*(.+)$/);
+    const ratMatch = line.match(/^(\s+)reviewer_rationale\s*:\s*(.+)$/);
     if (ratMatch) {
-      cur.reviewer_rationale = extractScalar(ratMatch[1]);
+      const headerIndent = ratMatch[1].length;
+      const rest = ratMatch[2];
+      // Strip inline `# comment` before classifying the scalar form.
+      const noComment = rest.replace(/\s+#.*$/, '').trim();
+      // Block-scalar opener? `|`, `>`, with optional chomping and indent
+      // digit. The opener itself is NOT content — collect deeper-indented
+      // lines until indent backs up to headerIndent or shallower.
+      if (/^[|>][+-]?\d?$/.test(noComment)) {
+        const bodyLines = [];
+        let j = i + 1;
+        while (j < lines.length) {
+          const next = lines[j];
+          if (!next.trim()) {
+            bodyLines.push('');
+            j++;
+            continue;
+          }
+          const indentMatch = next.match(/^(\s*)/);
+          const indent = indentMatch ? indentMatch[1].length : 0;
+          if (indent <= headerIndent) break;
+          bodyLines.push(next.slice(headerIndent + 1));
+          j++;
+        }
+        cur.reviewer_rationale = bodyLines.join('\n');
+        i = j;
+        continue;
+      }
+      cur.reviewer_rationale = extractScalar(rest);
+      i++;
       continue;
     }
+    i++;
   }
   if (cur) phases.push(cur);
   return phases;

--- a/hooks/mpl-require-reviewer.mjs
+++ b/hooks/mpl-require-reviewer.mjs
@@ -145,7 +145,12 @@ export function findReviewerRationaleGaps(text) {
   for (const phase of parsePhases(text)) {
     if (phase.reviewer_required === false) {
       const rationale = phase.reviewer_rationale;
-      if (rationale == null || rationale.length === 0) {
+      // Claude r1 advisory: whitespace-only rationale ("   ") is
+      // semantically missing — author intent is absent even though
+      // the string is technically non-empty. Trim before length check.
+      const trimmed =
+        rationale == null ? '' : String(rationale).trim();
+      if (trimmed.length === 0) {
         offenders.push(phase.id);
       }
     }


### PR DESCRIPTION
Closes #251 — follow-up runtime work for #239 (C1+C4 landed in #252).

## What

**C2** — `reviewer_required: bool` mirror of `test_agent_required`:
- Per-phase optional field on decomposer Output_Schema (default true; required `reviewer_rationale` non-empty string when false).
- Executor Step 12 (`commands/mpl-run-execute.md:871`) skips `mpl-adversarial-reviewer` dispatch when `reviewer_required:false` and logs a `reviewer-skipped` record to the #238 quality-signals surface for over-use telemetry.
- New PreToolUse hook `hooks/mpl-require-reviewer.mjs` enforces non-empty `reviewer_rationale` whenever a phase declares `reviewer_required:false`. Blocks the decomposition.yaml write otherwise.

**C3** — `batch_test: bool`:
- Per-phase optional field on decomposer (default false; auto-true when `phase_domain ∈ {refactor, schema_migration}`).
- Propagates to `phase_seed.batch_test` so the Phase Runner sees it.
- `commands/mpl-run-execute.md:460` Rule 4 relaxed: when `batch_test:true`, batched implement-then-verify replaces per-TODO test cadence.

**C6** — Hard 1 honors `phase.evidence_required`:
- `commands/mpl-run-execute-gates.md:138` Hard 1 now classifies the phase's `evidence_required` list against a `TOOLING_EVIDENCE` set. When the list contains ONLY non-tooling types (`goal_trace`, `manual`, `external_audit`, `documentation`), Hard 1 emits `Hard 1 SKIPPED` with the declared evidence reason and proceeds to Hard 2 instead of hard-failing on "no tools detected".

## Why

Per `docs/findings/2026-05-29-over-enforcement-audit.md` §C. Each item was a mandate that the audit found over-blocking on legitimate paths (pure-docs phases, refactor co-dependent TODOs, evidence-only phases) while the actual enforcement either didn't exist (C2) or was too rigid (C3, C6).

## Acceptance Criteria

- [x] C2: docs phase with `reviewer_required: false` + non-empty rationale → adversarial-reviewer skip path documented and hook enforces rationale presence.
- [x] C3: refactor phase with `batch_test: true` → per-TODO test rule relaxed in Rule 4 + Seed Generator propagation declared.
- [x] C6: phase with `evidence_required: [goal_trace]` → Hard 1 skips tooling demand.

## Test plan

- [x] 16 new tests in `hooks/__tests__/mpl-issue-251-c2c3c6-runtime.test.mjs` (8 C2 unit/e2e/wire, 3 C3 schema/wire, 2 C6 wire, 3 discoverability).
- [x] 1508/1508 hook tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)