### PR TITLE
Close residual I12 forgery surface from PR #244 r10 (#245)

### DIFF
--- a/hooks/__tests__/mpl-issue-245-i12-residual.test.mjs
+++ b/hooks/__tests__/mpl-issue-245-i12-residual.test.mjs
@@ -1,0 +1,138 @@
+/**
+ * #245 — Residual I12 forgery surface from PR #244.
+ *
+ * AC coverage:
+ *   (1) Trailing keyword arg promotes the entry to hard3: fixed by
+ *       picking the family from the subcommand, not the whole canonical.
+ *       `npm test playwright` → hard2 (not hard3).
+ *   (2) Subshell expansion (`$( … )`, backticks, `<( … )`, `>( … )`)
+ *       embedded a separate command whose keyword forged hard3.
+ *       Fixed by cutting at the opener in `stripNonExecutedSuffix`.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { classifyGateCommand } from '../lib/mpl-gate-classify.mjs';
+
+// ---------------------------------------------------------------------------
+// (1) Trailing keyword arg → family from subcommand, not whole canonical
+// ---------------------------------------------------------------------------
+
+test('#245 (1) [data-integrity]: `npm test playwright` classifies as hard2, not hard3', () => {
+  assert.equal(classifyGateCommand('npm test playwright'), 'hard2_coverage');
+});
+
+test('#245 (1) [data-integrity]: family resolves from subcommand for every npm-family head', () => {
+  for (const head of ['npm', 'pnpm', 'yarn']) {
+    assert.equal(
+      classifyGateCommand(`${head} test playwright`),
+      'hard2_coverage',
+      `${head} test playwright must be hard2`,
+    );
+    assert.equal(
+      classifyGateCommand(`${head} test e2e`),
+      'hard2_coverage',
+      `${head} test e2e must be hard2 (positional arg, not script)`,
+    );
+    assert.equal(
+      classifyGateCommand(`${head} test cypress wdio contract`),
+      'hard2_coverage',
+      `${head} test with multiple HARD3 keywords as positional args must be hard2`,
+    );
+  }
+});
+
+test('#245 (1) [data-integrity]: cargo/go trailing keyword args do not promote', () => {
+  assert.equal(classifyGateCommand('cargo test playwright'), 'hard2_coverage');
+  assert.equal(classifyGateCommand('cargo build playwright'), 'hard1_baseline');
+  assert.equal(classifyGateCommand('go test e2e'), 'hard2_coverage');
+  assert.equal(classifyGateCommand('go build e2e'), 'hard1_baseline');
+  assert.equal(classifyGateCommand('go vet playwright'), 'hard1_baseline');
+});
+
+test('#245 (1): npm run X still classifies by the script name (X), not whole canonical', () => {
+  // `npm run e2e` is the legitimate hard3 form — script name IS the
+  // family signal. The fix must preserve this.
+  assert.equal(classifyGateCommand('npm run e2e'), 'hard3_resilience');
+  assert.equal(classifyGateCommand('pnpm run cypress'), 'hard3_resilience');
+  // `npm run lint` / `npm run build` resolve normally.
+  assert.equal(classifyGateCommand('npm run lint'), 'hard1_baseline');
+  assert.equal(classifyGateCommand('pnpm run build'), 'hard1_baseline');
+  // `npm run test` is the test script.
+  assert.equal(classifyGateCommand('npm run test'), 'hard2_coverage');
+});
+
+test('#245 (1): bare subcommand without args still resolves to the correct family', () => {
+  assert.equal(classifyGateCommand('npm test'), 'hard2_coverage');
+  assert.equal(classifyGateCommand('npm lint'), 'hard1_baseline');
+  assert.equal(classifyGateCommand('npm build'), 'hard1_baseline');
+  assert.equal(classifyGateCommand('cargo test'), 'hard2_coverage');
+  assert.equal(classifyGateCommand('cargo clippy'), 'hard1_baseline');
+  assert.equal(classifyGateCommand('go test'), 'hard2_coverage');
+  assert.equal(classifyGateCommand('go build'), 'hard1_baseline');
+});
+
+test('#245 (1): npx with non-runner first positional still rejects (unchanged)', () => {
+  // The runner head check is still strict — `npx cowsay playwright`
+  // doesn't classify because cowsay isn't a runner script.
+  assert.equal(classifyGateCommand('npx cowsay playwright'), null);
+});
+
+test('#245 (1): npx with runner script positional classifies normally (unchanged)', () => {
+  assert.equal(classifyGateCommand('npx playwright test'), 'hard3_resilience');
+  assert.equal(classifyGateCommand('npx jest'), 'hard2_coverage');
+  assert.equal(classifyGateCommand('npx eslint .'), 'hard1_baseline');
+});
+
+// ---------------------------------------------------------------------------
+// (2) Subshell expansion stripped before family regex
+// ---------------------------------------------------------------------------
+
+test('#245 (2) [data-integrity]: $(...) subshell expansion does not promote hard tier', () => {
+  assert.equal(
+    classifyGateCommand('npm test $(echo playwright)'),
+    'hard2_coverage',
+    'subshell argument output must not match HARD3 keyword',
+  );
+  assert.equal(
+    classifyGateCommand('cargo build $(echo e2e)'),
+    'hard1_baseline',
+  );
+});
+
+test('#245 (2) [data-integrity]: backtick command substitution does not promote hard tier', () => {
+  assert.equal(
+    classifyGateCommand('npm test `echo playwright`'),
+    'hard2_coverage',
+  );
+  assert.equal(
+    classifyGateCommand('go build `echo e2e`'),
+    'hard1_baseline',
+  );
+});
+
+test('#245 (2) [data-integrity]: process substitution `<( … )` / `>( … )` does not promote', () => {
+  assert.equal(
+    classifyGateCommand('npm test <(echo playwright)'),
+    'hard2_coverage',
+  );
+  assert.equal(
+    classifyGateCommand('npm test >(echo cypress)'),
+    'hard2_coverage',
+  );
+});
+
+test('#245 (2): legitimate trailing `$` in a positional arg unaffected', () => {
+  // `$` alone (no `(` following) is not a subshell opener. The strip
+  // only cuts at `$(` specifically.
+  assert.equal(classifyGateCommand('npm test $foo'), 'hard2_coverage');
+});
+
+test('#245 (1+2) combined: subshell + trailing positional do not promote', () => {
+  // Belt and suspenders — both fixes apply on the same canonical.
+  assert.equal(
+    classifyGateCommand('npm test $(echo cypress) e2e wdio'),
+    'hard2_coverage',
+  );
+});

--- a/hooks/lib/mpl-gate-classify.mjs
+++ b/hooks/lib/mpl-gate-classify.mjs
@@ -393,9 +393,24 @@ function classifyRunnerHead(head, canonical) {
     if (NPM_EXEC_SUBCOMMANDS.has(sub)) {
       i++;
     } else if (NPM_GATE_SUBCOMMANDS_REGEX.has(sub)) {
-      // `npm test` / `npm run lint` etc. — the anchored HARD1/HARD2
-      // regex can classify safely. Fall through.
-      return undefined;
+      // #245 (1) [data-integrity]: previously fell through to
+      // `matchFamilyRegex(safeCanonical)`, which scans HARD3
+      // keywords across the whole canonical first. That let a
+      // trailing positional arg containing an e2e keyword
+      // (`npm test playwright`, `pnpm test cypress`) promote the
+      // entry to hard3 even though the npm-subcommand `test` was
+      // the actual gate shape. Fix: re-classify against a
+      // synthesized canonical of just `head subcommand
+      // [run-script]`, dropping every trailing positional arg
+      // before the family regex sees it. `npm run e2e` still
+      // resolves to hard3 because the run-script IS the family
+      // signal in that form; `npm test playwright` resolves to
+      // hard2 because `playwright` is a positional test arg.
+      let synthesized = `${head} ${sub}`;
+      if (sub === 'run' && tokens[i + 1]) {
+        synthesized += ` ${String(tokens[i + 1]).toLowerCase()}`;
+      }
+      return matchFamilyRegex(synthesized);
     } else {
       // Anything else (install/add/version/audit/publish/init/an
       // arbitrary binary name placed where the subcommand goes …) is
@@ -412,13 +427,21 @@ function classifyRunnerHead(head, canonical) {
     i = skipFlagsAt(tokens, i, new Set());
     if (i >= tokens.length) return null;
     const sub = tokens[i].toLowerCase();
-    if (CARGO_GATE_SUBCOMMANDS.has(sub)) return undefined; // fall through to anchored regex
+    if (CARGO_GATE_SUBCOMMANDS.has(sub)) {
+      // #245 (1) [data-integrity]: same trailing-keyword fix as npm.
+      // `cargo test playwright` resolves to hard2, not hard3.
+      return matchFamilyRegex(`${head} ${sub}`);
+    }
     return null; // cargo install/doc/run/etc. → not gate evidence
   } else if (head === 'go') {
     i = skipFlagsAt(tokens, i, new Set());
     if (i >= tokens.length) return null;
     const sub = tokens[i].toLowerCase();
-    if (GO_GATE_SUBCOMMANDS.has(sub)) return undefined;
+    if (GO_GATE_SUBCOMMANDS.has(sub)) {
+      // #245 (1) [data-integrity]: same trailing-keyword fix as npm.
+      // `go build e2e` resolves to hard1, not hard3.
+      return matchFamilyRegex(`${head} ${sub}`);
+    }
     return null;
   } else if (head !== 'npx' && head !== 'pnpx') {
     return undefined;
@@ -674,9 +697,20 @@ function stripNonExecutedSuffix(command) {
   let cut = command.length;
   // Redirect targets / shell comments — not executed.
   // Control operators — separate command boundaries.
+  // #245 (2) [data-integrity]: subshell openers — `$( … )`, backticks,
+  // process substitution `<( … )` / `>( … )` — embed a SEPARATE
+  // command whose output becomes a positional arg of the gate
+  // command. `npm test $(echo playwright)` previously survived the
+  // strip and the family regex matched `\bplaywright\b` against the
+  // unexpanded canonical, forging hard3. Cut at the opener so the
+  // family regex only sees `npm test` and resolves to hard2.
+  // (We don't try to match closing `)` / `` ` `` — once the opener
+  // is in the canonical, everything to its right is non-executed
+  // gate content for our purposes.)
   for (const op of [
     '#', '>>', '>', '<<', '<', '2>', '&>', '|&',
     ';', '\n', '\r', '&&', '||', '|', '&',
+    '$(', '<(', '>(', '`',
   ]) {
     const idx = command.indexOf(op);
     if (idx !== -1 && idx < cut) cut = idx;


### PR DESCRIPTION
Closes #245 — two same-class forgery paths flagged advisory in PR #244 round 10.

## What

**(1)** `classifyRunnerHead` no longer falls through to a whole-canonical regex scan after matching a known gate subcommand. Instead, it builds a synthesized `head subcommand [run-script]` canonical and runs `matchFamilyRegex` against that. Trailing positional args (test selectors, file paths, glob args) are dropped before the family regex sees them.

| Input | Before | After |
|---|---|---|
| `npm test playwright` | hard3 ⛔ | hard2 ✅ |
| `pnpm test cypress` | hard3 ⛔ | hard2 ✅ |
| `cargo test playwright` | hard3 ⛔ | hard2 ✅ |
| `go build e2e` | hard3 ⛔ | hard1 ✅ |
| `npm run e2e` | hard3 ✅ | hard3 ✅ (unchanged — script name IS the signal) |
| `npm run lint` | hard1 ✅ | hard1 ✅ (unchanged) |

**(2)** `stripNonExecutedSuffix` now cuts at the four subshell openers `$(`, `` ` ``, `<(`, `>(` in addition to the existing control / redirect / comment cutters. Once an opener appears, the right side is non-executed gate content — the inner command's keywords no longer reach the family regex.

| Input | Before | After |
|---|---|---|
| `npm test $(echo playwright)` | hard3 ⛔ | hard2 ✅ |
| `npm test \`echo playwright\`` | hard3 ⛔ | hard2 ✅ |
| `npm test <(echo cypress)` | hard3 ⛔ | hard2 ✅ |

## Why

Per #245 issue body. Both cases were identified in PR #244 r10 as the same structural class re-defended through r3-r9 (eval flags, quoting forms, runner-script positions, global flags, cargo/go subcommand allow-list). The issue body documented them as advisory so #244 could land; this PR closes them.

## Acceptance Criteria

- [x] (1) `npm test playwright` / `cargo test playwright` / `go build e2e` / `pnpm test playwright` no longer classify as hard3.
- [x] (2) Subshell expansion forms (`$(...)`, backticks, `<(...)`, `>(...)`) cannot promote hard tier via embedded keywords.
- [x] Legitimate `npm run e2e` / `npx playwright test` / `cargo clippy` paths still classify correctly.

## Test plan

- [x] 12 new tests in `hooks/__tests__/mpl-issue-245-i12-residual.test.mjs`.
- [x] 1543/1543 hook tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)