### PR TITLE
Coalesce four finalize hooks into mpl-finalize-gate (#257)

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -450,7 +450,7 @@ All Discoveries are recorded in `.mpl/discoveries.md`.
 
 ## 7. Hook System
 
-`hooks/hooks.json` is the live SSOT for hook registration. MPL maintains pipeline integrity with 41 registered hook commands:
+`hooks/hooks.json` is the live SSOT for hook registration. MPL maintains pipeline integrity with 38 registered hook commands:
 
 | Hook | Event / matcher | Purpose | Introduced |
 |----|--------|------|------------|
@@ -459,10 +459,7 @@ All Discoveries are recorded in `.mpl/discoveries.md`.
 | `mpl-write-guard` | PreToolUse: Edit/Write/MultiEdit/Bash/Task/Agent | Warn or block unsafe direct source edits and dangerous shell commands; #236: protect mpl-cancel SKILL paths from `rm -rf` and require mpl-decomposer subagent identity for decomposition.yaml writes. | v0.13.x baseline; MultiEdit/MCP hardening v0.18.1; protected-path + decomposition-writer v0.18.5 |
 | `mpl-bash-timeout` | PreToolUse: Bash | Enforce timeout budgets on build, lint, test, and verification commands. | v0.18.1 |
 | `mpl-state-invariant` | PreToolUse: Task/Agent/Edit/Write/MultiEdit; Stop | Validate state schema, gate evidence, pause/block status, and completion invariants before state can drift. | v0.18.1; I10/I11 recovery v0.18.4 |
-| `mpl-require-e2e` | PreToolUse: Edit/Write/MultiEdit | Block finalize when required E2E scenarios or UC coverage are missing, failing, or explicitly uncovered. | v0.15.2; UC coverage v0.16.0 |
-| `mpl-require-e2e-authenticity` | PreToolUse: Edit/Write/MultiEdit | Reject mock, placeholder, or absent real-runtime E2E evidence before finalize. | v0.18.3 |
-| `mpl-require-finalize-artifacts` | PreToolUse: Edit/Write/MultiEdit | Require goal-contract completion artifacts, RUNBOOK final section, security evidence, and optional commit evidence before `finalize_done=true`. | v0.18.3 guard stream |
-| `mpl-require-whole-goal-closure` | PreToolUse: Edit/Write/MultiEdit | Require completed phase evidence and goal traces to cover every Goal Contract AC/AX before finalize. | v0.18.3 guard stream |
+| `mpl-finalize-gate` | PreToolUse: Edit/Write/MultiEdit | Coalesced finalize_done=true gate. Delegates to the four finalize validators (E2E scenarios, E2E authenticity, declared artifacts, AC/AX closure) as subprocesses, aggregates every failure into a single `finalize_gate_failures` envelope (`retry_context.failures[]` preserves each validator's hookId+code+reason), and emits one block instead of cascading retries. | #257 |
 | `mpl-validate-pp-schema` | PreToolUse: Edit/Write/MultiEdit | Keep mutable User Contract fields out of immutable `pivot-points.md`. | v0.16.0 |
 | `mpl-require-covers` | PreToolUse: Edit/Write/MultiEdit | Require decomposition phases to declare valid `covers` mappings to UC ids or `internal`. | v0.16.0 |
 | `mpl-require-goal-trace` | PreToolUse: Edit/Write/MultiEdit | Ensure decomposition goal traces cover the frozen Goal Contract hash and AC/AX ids. | v0.18.3 guard stream |

--- a/hooks/__tests__/mpl-finalize-gate.test.mjs
+++ b/hooks/__tests__/mpl-finalize-gate.test.mjs
@@ -1,0 +1,265 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { tmpdir } from 'os';
+
+import { CURRENT_SCHEMA_VERSION } from '../lib/mpl-state.mjs';
+import {
+  isFinalizeDoneWrite,
+  summarizeFailures,
+  summarizeAdvisories,
+  DELEGATES,
+  HOOK_ID,
+} from '../mpl-finalize-gate.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const HOOK_PATH = join(dirname(__filename), '..', 'mpl-finalize-gate.mjs');
+const SCHEMA_V = CURRENT_SCHEMA_VERSION;
+
+const TEST_PIPELINE_ID = 'mpl-test-257';
+const TEST_STARTED_AT = '2026-05-30T00:00:00.000Z';
+
+let tmp;
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'mpl-finalize-gate-'));
+  mkdirSync(join(tmp, '.mpl', 'mpl', 'profile'), { recursive: true });
+  writeFileSync(join(tmp, '.mpl', 'state.json'), JSON.stringify({
+    schema_version: SCHEMA_V,
+    current_phase: 'phase5-finalize',
+    pipeline_id: TEST_PIPELINE_ID,
+    started_at: TEST_STARTED_AT,
+    phase_scheduler_history: [],
+  }));
+});
+afterEach(() => rmSync(tmp, { recursive: true, force: true }));
+
+function goalContract({
+  realRuntimeRequired = true,
+  securityRequired = false,
+} = {}) {
+  return `
+source:
+  user_request: "Build app"
+  user_request_hash: "req"
+mission:
+  goal: "Finalize gate coalesced reporting"
+  project_pivot: "single envelope"
+  must_ship_outcomes:
+    - "usable app"
+ontology:
+  entities:
+    - app
+variation_axes:
+  - id: AX-1
+acceptance_criteria:
+  - id: AC-1
+e2e_policy:
+  real_runtime_required: ${realRuntimeRequired ? 'true' : 'false'}
+  mock_allowed: false
+  placeholder_assertions_allowed: false
+security_policy:
+  required: ${securityRequired ? 'true' : 'false'}
+completion_evidence:
+  required_artifacts:
+    - .mpl/mpl/RUNBOOK.md
+    - .mpl/mpl/profile/run-summary.json
+    - .mpl/mpl/audit-report.json
+  require_commit: false
+  require_finalize_timestamps: true
+`;
+}
+
+function finalizeWriteInput(cwd, { toolName = 'Write' } = {}) {
+  return {
+    cwd,
+    tool_name: toolName,
+    tool_input: {
+      file_path: '.mpl/state.json',
+      content: JSON.stringify({ current_phase: 'phase5-finalize', finalize_done: true }),
+    },
+  };
+}
+
+function runGate(input) {
+  // Capture every line the gate emits and keep only valid JSON lines so the
+  // delegate-child JSON (also printed on the same stdout when the gate calls
+  // recordBlockedHook via emitBlockedHook) doesn't confuse the parser.
+  const stdout = execFileSync('node', [HOOK_PATH], {
+    input: JSON.stringify(input),
+    encoding: 'utf-8',
+  });
+  const lines = stdout.trim().split('\n').filter((l) => l.trim());
+  for (let i = lines.length - 1; i >= 0; i--) {
+    try { return JSON.parse(lines[i]); } catch {}
+  }
+  throw new Error(`No JSON in gate stdout:\n${stdout}`);
+}
+
+describe('isFinalizeDoneWrite', () => {
+  it('matches Write to .mpl/state.json with finalize_done:true', () => {
+    assert.equal(
+      isFinalizeDoneWrite({
+        file_path: '.mpl/state.json',
+        content: '{"finalize_done": true}',
+      }),
+      true,
+    );
+  });
+  it('ignores writes to other paths', () => {
+    assert.equal(
+      isFinalizeDoneWrite({
+        file_path: '.mpl/state.txt',
+        content: '{"finalize_done": true}',
+      }),
+      false,
+    );
+  });
+  it('ignores writes without finalize_done:true', () => {
+    assert.equal(
+      isFinalizeDoneWrite({
+        file_path: '.mpl/state.json',
+        content: '{"finalize_done": false}',
+      }),
+      false,
+    );
+  });
+  it('handles Edit new_string + MultiEdit edits[]', () => {
+    assert.equal(
+      isFinalizeDoneWrite({
+        file_path: '.mpl/state.json',
+        edits: [{ new_string: '"finalize_done": true' }],
+      }),
+      true,
+    );
+  });
+});
+
+describe('summarizeFailures', () => {
+  it('produces a numbered, hookId-tagged summary', () => {
+    const out = summarizeFailures([
+      { hookId: 'mpl-require-e2e', code: 'e2e_required_scenarios_absent', reason: 'scenarios missing' },
+      { hookId: 'mpl-require-whole-goal-closure', code: 'whole_goal_closure_missing', reason: 'AC-1 uncovered' },
+    ]);
+    assert.match(out, /2 validation failure/);
+    assert.match(out, /\[mpl-require-e2e\] \(e2e_required_scenarios_absent\)/);
+    assert.match(out, /\[mpl-require-whole-goal-closure\] \(whole_goal_closure_missing\)/);
+  });
+});
+
+describe('summarizeAdvisories', () => {
+  it('returns empty string for empty list', () => {
+    assert.equal(summarizeAdvisories([]), '');
+  });
+  it('prefixes advisory section header', () => {
+    const out = summarizeAdvisories([{ hookId: 'h', message: 'msg' }]);
+    assert.match(out, /Advisories \(non-blocking\)/);
+    assert.match(out, /\[h\] msg/);
+  });
+});
+
+describe('delegate registration', () => {
+  it('lists the four canonical finalize validators', () => {
+    assert.deepEqual(DELEGATES.sort(), [
+      'mpl-require-e2e-authenticity.mjs',
+      'mpl-require-e2e.mjs',
+      'mpl-require-finalize-artifacts.mjs',
+      'mpl-require-whole-goal-closure.mjs',
+    ]);
+  });
+});
+
+describe('gate behavior — non-finalize writes pass through', () => {
+  it('returns continue:true for non-state.json writes', () => {
+    writeFileSync(join(tmp, '.mpl', 'goal-contract.yaml'), goalContract());
+    const r = runGate({
+      cwd: tmp,
+      tool_name: 'Write',
+      tool_input: { file_path: 'README.md', content: 'hello' },
+    });
+    assert.equal(r.continue, true);
+  });
+  it('returns continue:true for state.json without finalize_done:true', () => {
+    writeFileSync(join(tmp, '.mpl', 'goal-contract.yaml'), goalContract());
+    const r = runGate({
+      cwd: tmp,
+      tool_name: 'Write',
+      tool_input: {
+        file_path: '.mpl/state.json',
+        content: JSON.stringify({ current_phase: 'phase2-sprint' }),
+      },
+    });
+    assert.equal(r.continue, true);
+  });
+});
+
+describe('gate behavior — coalesced multi-finding envelope', () => {
+  it('aggregates multiple validator failures into one block envelope with failures[]', () => {
+    // Under-provisioned setup: no e2e-scenarios.yaml, no completion_evidence
+    // artifacts, no decomposition.yaml → e2e + finalize-artifacts + whole-goal-
+    // closure all fail. Authenticity is gated on the goal contract's
+    // real_runtime_required + missing e2e_results, so it may also flag.
+    writeFileSync(join(tmp, '.mpl', 'goal-contract.yaml'), goalContract());
+
+    const r = runGate(finalizeWriteInput(tmp));
+
+    assert.equal(r.continue, false);
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason, /\[MPL Finalize Gate\]/);
+    assert.match(r.reason, /validation failure/);
+
+    // The coalesced envelope persisted under retry_context.failures[].
+    const state = JSON.parse(readFileSync(join(tmp, '.mpl', 'state.json'), 'utf-8'));
+    assert.equal(state.session_status, 'blocked_hook');
+    assert.equal(state.blocked_by_hook, HOOK_ID);
+    assert.equal(state.block_code, 'finalize_gate_failures');
+    assert.ok(Array.isArray(state.retry_context?.failures));
+    assert.ok(state.retry_context.failures.length >= 2,
+      `expected ≥2 batched failures, got ${state.retry_context.failures.length}: ${JSON.stringify(state.retry_context.failures.map(f => f.hookId))}`);
+
+    // Each failure preserves its originating validator's hookId + code.
+    for (const f of state.retry_context.failures) {
+      assert.equal(typeof f.hookId, 'string');
+      assert.equal(typeof f.code, 'string');
+      assert.equal(typeof f.reason, 'string');
+      assert.ok(f.hookId.startsWith('mpl-require-'),
+        `expected delegate hookId, got ${f.hookId}`);
+    }
+
+    // The set of represented hooks must include at least two distinct delegates
+    // (the whole point of coalescing — treadmill UX is replaced by batch UX).
+    const distinctHooks = new Set(state.retry_context.failures.map((f) => f.hookId));
+    assert.ok(distinctHooks.size >= 2,
+      `expected ≥2 distinct delegates in failures[], got ${[...distinctHooks].join(',')}`);
+  });
+
+  it('does not leak per-child envelopes — only the gate envelope remains', () => {
+    writeFileSync(join(tmp, '.mpl', 'goal-contract.yaml'), goalContract());
+    runGate(finalizeWriteInput(tmp));
+
+    const state = JSON.parse(readFileSync(join(tmp, '.mpl', 'state.json'), 'utf-8'));
+    // Critical: the children each wrote their own envelope during delegation;
+    // the gate must clear them and rewrite under HOOK_ID so the visible
+    // envelope is the coalesced one (not whichever child happened to run last).
+    assert.equal(state.blocked_by_hook, HOOK_ID);
+    assert.notEqual(state.blocked_by_hook, 'mpl-require-whole-goal-closure');
+    assert.notEqual(state.blocked_by_hook, 'mpl-require-finalize-artifacts');
+  });
+});
+
+describe('gate behavior — recoverable via mpl-recover', () => {
+  it('blocked envelope is routed by inspectRecovery as finalize_gate_failures handler', async () => {
+    writeFileSync(join(tmp, '.mpl', 'goal-contract.yaml'), goalContract());
+    runGate(finalizeWriteInput(tmp));
+
+    const { inspectRecovery } = await import('../lib/mpl-recover.mjs');
+    const plan = inspectRecovery(tmp);
+    assert.equal(plan.handler, 'finalize_gate_failures');
+    assert.equal(plan.status, 'requires_user_action');
+    assert.ok(Array.isArray(plan.failures));
+    assert.ok(plan.failures.length >= 2);
+    assert.match(plan.message, /finalize gate batched/i);
+  });
+});

--- a/hooks/__tests__/mpl-hook-trace.test.mjs
+++ b/hooks/__tests__/mpl-hook-trace.test.mjs
@@ -474,10 +474,12 @@ describe('mpl-hook-trace', () => {
       // evaluation, it would be silently dropped.
       assert.equal(ids.includes('mpl-gate-recorder'), true,
         'mpl-gate-recorder must appear in state trace regardless of matcher');
-      // Codex r1: mpl-require-e2e reads state.e2e_results before
-      // blocking finalize_done=true. Must appear in state traces.
-      assert.equal(ids.includes('mpl-require-e2e'), true,
-        'mpl-require-e2e must appear in state trace');
+      // #257: the coalesced mpl-finalize-gate now reads state.e2e_results
+      // (via its e2e delegate) and rewrites the blocked_hook envelope on
+      // finalize_done=true writes — it replaces mpl-require-e2e and the
+      // other three individual finalize PreToolUse hooks in hooks.json.
+      assert.equal(ids.includes('mpl-finalize-gate'), true,
+        'mpl-finalize-gate must appear in state trace');
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }
@@ -701,8 +703,11 @@ describe('mpl-hook-trace', () => {
       assert.equal(trace.category, 'file');
       const ids = trace.hooks.map((h) => h.hook_id);
       // file-category should include the broader set of file-write
-      // PreToolUse hooks.
-      assert.equal(ids.includes('mpl-require-e2e-authenticity'), true);
+      // PreToolUse hooks. #257: the four individual finalize hooks
+      // (mpl-require-e2e-authenticity included) are no longer registered;
+      // they are delegated by mpl-finalize-gate which is registered on the
+      // same Edit|Write|MultiEdit matcher.
+      assert.equal(ids.includes('mpl-finalize-gate'), true);
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }

--- a/hooks/__tests__/mpl-issue-251-c2c3c6-runtime.test.mjs
+++ b/hooks/__tests__/mpl-issue-251-c2c3c6-runtime.test.mjs
@@ -594,7 +594,10 @@ test('#251 C6 wire: Hard 1 still fails when tooling is requested but no tools ar
 test('#251: docs/design.md Hook System table includes mpl-require-reviewer', () => {
   const text = readPrompt('docs/design.md');
   assert.match(text, /`mpl-require-reviewer`/);
-  assert.match(text, /41 registered hook commands/);
+  // #257 reduced the count from 41 to 38 by folding mpl-require-e2e,
+  // mpl-require-e2e-authenticity, mpl-require-finalize-artifacts, and
+  // mpl-require-whole-goal-closure into the coalesced mpl-finalize-gate.
+  assert.match(text, /38 registered hook commands/);
 });
 
 test('#251: PURPOSES map (hooks/lib/mpl-hook-trace.mjs) has entry for mpl-require-reviewer', () => {

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -56,38 +56,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/mpl-require-e2e.mjs\"",
-            "timeout": 3
-          }
-        ]
-      },
-      {
-        "matcher": "Edit|Write|MultiEdit",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/mpl-require-e2e-authenticity.mjs\"",
-            "timeout": 3
-          }
-        ]
-      },
-      {
-        "matcher": "Edit|Write|MultiEdit",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/mpl-require-finalize-artifacts.mjs\"",
-            "timeout": 3
-          }
-        ]
-      },
-      {
-        "matcher": "Edit|Write|MultiEdit",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/mpl-require-whole-goal-closure.mjs\"",
-            "timeout": 3
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/mpl-finalize-gate.mjs\"",
+            "timeout": 15
           }
         ]
       },

--- a/hooks/lib/mpl-config.mjs
+++ b/hooks/lib/mpl-config.mjs
@@ -72,6 +72,12 @@ const ENFORCEMENT_DEFAULTS = {
   missing_e2e_evidence: 'block',
   e2e_authenticity_invalid: 'block',
   missing_whole_goal_closure: 'block',
+  // #257: coalesced finalize gate. Default 'block' preserves the union of the
+  // four delegate validators' 'block' defaults — if any delegate would have
+  // blocked individually, the coalesced gate must also block. Workspaces can
+  // opt the whole gate to 'off' or 'warn' via .mpl/config.json; per-delegate
+  // opt-outs (missing_e2e_evidence: off etc.) still apply inside the gate.
+  finalize_gate_failures: 'block',
   pp_schema_invalid: 'block',
   small_plan_scope_conflict: 'block',
   fast_track_phase0_artifacts_missing: 'block',

--- a/hooks/lib/mpl-hook-trace.mjs
+++ b/hooks/lib/mpl-hook-trace.mjs
@@ -83,6 +83,7 @@ const PURPOSES = {
   // #237 D1: hooks added after the original map was authored. Verified
   // by comparing hooks.json registered ids against PURPOSES keys.
   'mpl-require-test-agent-brief': 'test-agent brief validation gate (PreToolUse on Task)',
+  'mpl-finalize-gate': 'coalesced finalize_done=true gate — batch-reports e2e / authenticity / artifacts / closure violations in one envelope (#257)',
 };
 
 const DECOMPOSITION_PATH = '.mpl/mpl/decomposition.yaml';
@@ -125,6 +126,9 @@ const STATE_FOCUS = new Set([
   'mpl-require-e2e',
   // Codex r1: reads state.e2e_results / state.security_results for authenticity check.
   'mpl-require-e2e-authenticity',
+  // #257: coalesced finalize gate; spawns the four delegates on a single PreToolUse
+  //   and reads state.json to capture / clear / rewrite the blocked-hook envelope.
+  'mpl-finalize-gate',
 ]);
 
 function readHooksConfig(pluginRoot = DEFAULT_PLUGIN_ROOT) {

--- a/hooks/lib/mpl-recover.mjs
+++ b/hooks/lib/mpl-recover.mjs
@@ -1117,6 +1117,25 @@ export function inspectRecovery(cwd = process.cwd()) {
       message: 'Baseline renewal sentinel (.mpl/mpl/.baseline-renewal) must be touched manually to authorize the write.',
     });
   }
+  if (code === 'finalize_gate_failures') {
+    // #257: the coalesced finalize gate aggregates per-validator findings under
+    // retry_context.failures[]. Recovery is not a single mechanical fix — each
+    // failure carries its own resume_instruction and the user must resolve each
+    // before retrying the finalize_done=true write. Echo the structured list
+    // back so the orchestrator can present it without re-parsing block_reason.
+    const failures = Array.isArray(state.retry_context?.failures)
+      ? state.retry_context.failures
+      : [];
+    return buildResult(state, {
+      status: 'requires_user_action',
+      handler: 'finalize_gate_failures',
+      safe: false,
+      failures,
+      message: failures.length > 0
+        ? `Finalize gate batched ${failures.length} validator failure(s); resolve each entry in retry_context.failures[] (originating hookId + code + reason) and retry the finalize_done=true write.`
+        : 'Finalize gate blocked the finalize_done=true write; resolve the recorded failure(s) and retry.',
+    });
+  }
 
   return buildResult(state, {
     status: 'unsupported',

--- a/hooks/mpl-finalize-gate.mjs
+++ b/hooks/mpl-finalize-gate.mjs
@@ -1,0 +1,268 @@
+#!/usr/bin/env node
+/**
+ * MPL Finalize Gate (PreToolUse on Write|Edit|MultiEdit targeting state.json).
+ *
+ * Coalesces the four finalize_done validators (#257):
+ *   - mpl-require-e2e               — declared E2E scenarios ran + exited 0
+ *   - mpl-require-e2e-authenticity  — real runtime, no mocks, no placeholder
+ *   - mpl-require-finalize-artifacts — goal-contract declared evidence present
+ *   - mpl-require-whole-goal-closure — AC/AX coverage across completed phases
+ *
+ * The four hooks individually verify distinct properties, but registering them
+ * separately produced a cascading-block UX: fix one, retry, hit the next.
+ * This gate runs them as delegated subprocesses, captures each violation, and
+ * emits a SINGLE coalesced envelope listing every failure together so the user
+ * can fix them in one batch.
+ *
+ * Per-rule ENFORCEMENT_DEFAULTS (off/warn/block) are preserved — each child
+ * resolves its own rule action independently. Only child responses whose
+ * decision === 'block' contribute to failures[]; warn responses contribute to
+ * advisories[]. A child resolving to off contributes nothing.
+ */
+
+import { dirname, join } from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+import { spawnSync } from 'child_process';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const isMain = import.meta.url === pathToFileURL(process.argv[1] || '').href;
+
+const { readState, isMplActive } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-state.mjs')).href
+);
+const { readStdin } = isMain
+  ? await import(pathToFileURL(join(__dirname, 'lib', 'stdin.mjs')).href)
+  : { readStdin: async () => '' };
+const { emitBlockedHook, emitClearedOk } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-block-surface.mjs')).href
+);
+const { clearBlockedHook } = await import(
+  pathToFileURL(join(__dirname, 'lib', 'mpl-blocked-hook.mjs')).href
+);
+
+const HOOK_ID = 'mpl-finalize-gate';
+const BLOCKED_ARTIFACT = '.mpl/state.json#finalize_done';
+
+const DELEGATES = [
+  'mpl-require-e2e.mjs',
+  'mpl-require-e2e-authenticity.mjs',
+  'mpl-require-finalize-artifacts.mjs',
+  'mpl-require-whole-goal-closure.mjs',
+];
+
+const ENV_GUARD_KEY = 'MPL_FINALIZE_GATE_ACTIVE';
+
+function ok() {
+  console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+}
+
+function isFinalizeDoneWrite(toolInput) {
+  if (!toolInput || typeof toolInput !== 'object') return false;
+  const paths = [];
+  if (toolInput.file_path) paths.push(toolInput.file_path);
+  if (toolInput.filePath) paths.push(toolInput.filePath);
+  const texts = [];
+  for (const key of ['new_string', 'newString', 'content']) {
+    if (typeof toolInput[key] === 'string') texts.push(toolInput[key]);
+  }
+  if (Array.isArray(toolInput.edits)) {
+    for (const edit of toolInput.edits) {
+      if (edit?.file_path) paths.push(edit.file_path);
+      if (edit?.filePath) paths.push(edit.filePath);
+      for (const key of ['new_string', 'newString', 'content']) {
+        if (typeof edit?.[key] === 'string') texts.push(edit[key]);
+      }
+    }
+  }
+  if (!paths.some((p) => /(^|\/)\.mpl\/state\.json$/.test(p))) return false;
+  return texts.some((text) => /"finalize_done"\s*:\s*true/.test(text));
+}
+
+function parseLastJsonLine(stdout) {
+  if (!stdout) return null;
+  const lines = stdout.trim().split('\n').filter((l) => l.trim());
+  for (let i = lines.length - 1; i >= 0; i--) {
+    try { return JSON.parse(lines[i]); } catch {}
+  }
+  return null;
+}
+
+function delegateChild(hookFile, stdinPayload, cwd) {
+  const hookPath = join(__dirname, hookFile);
+  const hookId = hookFile.replace(/\.mjs$/, '');
+  const env = { ...process.env, [ENV_GUARD_KEY]: '1' };
+
+  let result;
+  try {
+    result = spawnSync('node', [hookPath], {
+      input: stdinPayload,
+      encoding: 'utf-8',
+      env,
+      timeout: 10000,
+    });
+  } catch (err) {
+    return { kind: 'error', hookId, message: String(err?.message || err) };
+  }
+
+  if (result.error) {
+    return { kind: 'error', hookId, message: String(result.error.message || result.error) };
+  }
+
+  const response = parseLastJsonLine(result.stdout);
+  if (!response) {
+    return { kind: 'error', hookId, message: 'no parseable response' };
+  }
+
+  if (response.decision === 'block') {
+    // The child just wrote its envelope to state.json. Capture it before the
+    // next child overwrites, then clear so the final coalesced envelope is the
+    // only blocked-hook record after the gate finishes.
+    const fresh = readState(cwd) || {};
+    const finding = {
+      hookId: fresh.blocked_by_hook || hookId,
+      code: fresh.block_code || 'unknown',
+      reason: fresh.block_reason || response.reason || '',
+      resume_instruction: fresh.resume_instruction || '',
+      retry_context: fresh.retry_context || {},
+    };
+    clearBlockedHook(cwd, {
+      hookId: finding.hookId,
+      artifact: fresh.blocked_artifact || BLOCKED_ARTIFACT,
+    });
+    return { kind: 'block', finding };
+  }
+
+  if (response.systemMessage || response.hookSpecificOutput?.additionalContext) {
+    const message = response.systemMessage
+      || response.hookSpecificOutput?.additionalContext
+      || '';
+    return { kind: 'warn', hookId, message };
+  }
+
+  return { kind: 'ok', hookId };
+}
+
+function summarizeFailures(failures) {
+  const lines = failures.map((f, i) => {
+    const head = `  ${i + 1}. [${f.hookId}] (${f.code})`;
+    const reason = (f.reason || '').trim().replace(/\s+/g, ' ');
+    return reason ? `${head}\n     ${reason}` : head;
+  });
+  return [
+    `[MPL Finalize Gate] ${failures.length} validation failure(s) detected on the finalize_done=true write. ` +
+      `Resolve every item below in one batch, then retry the write:`,
+    ...lines,
+  ].join('\n');
+}
+
+function summarizeAdvisories(advisories) {
+  if (!advisories.length) return '';
+  const lines = advisories.map((a) => `  - [${a.hookId}] ${a.message.trim()}`);
+  return ['[MPL Finalize Gate] Advisories (non-blocking):', ...lines].join('\n');
+}
+
+export async function runGate({ stdinPayload, cwd } = {}) {
+  if (!stdinPayload) { ok(); return 'ok'; }
+
+  let data;
+  try {
+    data = JSON.parse(stdinPayload);
+  } catch {
+    ok();
+    return 'ok';
+  }
+
+  const toolName = data.tool_name || data.toolName || '';
+  if (!/^(Edit|Write|MultiEdit)$/.test(toolName)) { ok(); return 'ok'; }
+
+  const toolInput = data.tool_input || data.toolInput || {};
+  if (!isFinalizeDoneWrite(toolInput)) { ok(); return 'ok'; }
+
+  const resolvedCwd = cwd || data.cwd || data.directory || process.cwd();
+  if (!isMplActive(resolvedCwd)) { ok(); return 'ok'; }
+
+  const failures = [];
+  const advisories = [];
+
+  for (const hookFile of DELEGATES) {
+    const outcome = delegateChild(hookFile, stdinPayload, resolvedCwd);
+    if (outcome.kind === 'block') {
+      failures.push(outcome.finding);
+    } else if (outcome.kind === 'warn') {
+      advisories.push({ hookId: outcome.hookId, message: outcome.message });
+    }
+    // 'error' and 'ok' contribute nothing — errors are logged via stderr by the
+    // child itself; the gate fails open per the MPL "non-blocking on error"
+    // convention so a broken delegate cannot pin the pipeline.
+  }
+
+  const state = readState(resolvedCwd) || {};
+
+  if (failures.length === 0) {
+    // No blockers. If advisories surfaced, attach them to the warn surface; the
+    // gate still passes (consistent with each child's individual warn outcome).
+    if (advisories.length === 0) {
+      emitClearedOk(resolvedCwd, { hookId: HOOK_ID, artifact: BLOCKED_ARTIFACT });
+      return 'ok';
+    }
+    clearBlockedHook(resolvedCwd, { hookId: HOOK_ID, artifact: BLOCKED_ARTIFACT });
+    console.log(JSON.stringify({
+      continue: true,
+      systemMessage: summarizeAdvisories(advisories),
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        additionalContext: summarizeAdvisories(advisories),
+      },
+    }));
+    return 'warn';
+  }
+
+  const reason = summarizeFailures(failures);
+  emitBlockedHook(resolvedCwd, state, {
+    hookId: HOOK_ID,
+    ruleId: 'finalize_gate_failures',
+    code: 'finalize_gate_failures',
+    artifact: BLOCKED_ARTIFACT,
+    reason,
+    resumeInstruction:
+      'Address every entry in retry_context.failures[]. Each entry preserves the originating validator\'s hookId, code, and reason. Once all are resolved, retry the finalize_done=true write — the gate re-runs every validator on the new write.',
+    retryContext: {
+      failures: failures.map((f) => ({
+        hookId: f.hookId,
+        code: f.code,
+        reason: f.reason,
+        resume_instruction: f.resume_instruction,
+        retry_context: f.retry_context,
+      })),
+      advisories,
+    },
+  });
+  return 'block';
+}
+
+async function main() {
+  // Recursion guard: if a parent gate spawned us (shouldn't happen since the
+  // four child hooks are delegated directly via spawnSync), bail.
+  if (process.env[ENV_GUARD_KEY] === '1') {
+    ok();
+    return;
+  }
+  const raw = await readStdin();
+  if (!raw.trim()) {
+    ok();
+    return;
+  }
+  try {
+    await runGate({ stdinPayload: raw });
+  } catch {
+    // Fail open — never wedge the pipeline because the gate itself crashed.
+    ok();
+  }
+}
+
+if (isMain) {
+  await main();
+}
+
+export { isFinalizeDoneWrite, summarizeFailures, summarizeAdvisories, DELEGATES, HOOK_ID, BLOCKED_ARTIFACT };

--- a/skills/mpl-recover/SKILL.md
+++ b/skills/mpl-recover/SKILL.md
@@ -83,6 +83,8 @@ Approval-required handlers:
   the recover skill returns an anomaly-specific `Task(subagent_type="mpl-phase-runner", ...)` dispatch instruction. Anomaly types include `empty_response`, `truncated_response`, `invalid_json`, `no_evidence`. Each has a tailored framing (stronger prompt / reduced context / explicit schema reminder / evidence emphasis). **Requires `--approve-unsafe` (codex r7 #242)**.
 - `baseline_immutable` (#234):
   no agent dispatch. Returns the recorded `resume_instruction` (touch `.mpl/mpl/.baseline-renewal`) as `user_instruction`. **Requires `--approve-unsafe` (codex r7 #242)**.
+- `finalize_gate_failures` (#257):
+  no agent dispatch. The coalesced finalize gate (`mpl-finalize-gate`) batches every per-validator failure on a single `finalize_done=true` write into one envelope. `retry_context.failures[]` preserves each originating validator's `hookId`, `code`, `reason`, and `resume_instruction`. The orchestrator must resolve every entry — they are independent concerns (E2E execution, E2E authenticity, declared artifacts, AC/AX closure) and there is no shortcut. After resolving all entries, retry the finalize write; the gate re-runs every validator from scratch on the new write. Returns `requires_user_action` (no `--approve-unsafe` path).
 
 If revalidation still fails, recovery must leave `session_status:"blocked_hook"`
 intact and update `block_reason`, `resume_instruction`, and


### PR DESCRIPTION
## Summary

Closes #257.

Replaces four separately-registered PreToolUse hooks on `finalize_done=true` writes — `mpl-require-e2e`, `mpl-require-e2e-authenticity`, `mpl-require-finalize-artifacts`, `mpl-require-whole-goal-closure` — with one coalesced gate `mpl-finalize-gate`. The four delegates' files remain on disk and unchanged; only their hooks.json registration is removed.

## What

- `hooks/mpl-finalize-gate.mjs` (new): detects `finalize_done=true` writes, spawns each delegate as a subprocess, captures every block, clears the per-child envelopes that recorded along the way, and emits one envelope with `retry_context.failures[]` listing each originating validator's `hookId`, `code`, `reason`, `resume_instruction`, and `retry_context`. Per-validator `ENFORCEMENT_DEFAULTS` (warn/block/off) are honored — each child resolves its own rule action.
- `hooks/hooks.json`: drop the four individual registrations, register the gate with a 15s timeout to cover four sequential children.
- `hooks/lib/mpl-config.mjs`: new `finalize_gate_failures: 'block'` default; lets workspaces opt the whole gate off via `.mpl/config.json` without touching delegate config.
- `hooks/lib/mpl-recover.mjs`: new `inspectRecovery` route for `finalize_gate_failures` — returns `requires_user_action` with the structured `failures[]` list. No auto-fix; user must resolve each entry before retrying.
- `skills/mpl-recover/SKILL.md`: handler doc.
- `hooks/lib/mpl-hook-trace.mjs`: PURPOSES + STATE_FOCUS entries for the gate.
- `docs/design.md`: one row replacing the four, count updated 41 → 38.
- Tests: new `mpl-finalize-gate.test.mjs` covers detection, summarization, multi-finding aggregation, child-envelope leak prevention, and the recover handler. Two existing hook-trace tests + one count-assertion test updated to reflect the registry change.

## Why

Per `docs/findings/2026-05-29-over-enforcement-audit.md` and harness-evaluation follow-up: each of the four hooks individually verified a distinct property (scenario execution, scenario authenticity, declared-artifact presence, AC/AX coverage), but registering them separately produced a cascading-block UX — fix one, retry, hit the next. Same pattern PR #233 endorses for the relaxation work: wire to existing policy + surface better, don't add new constraint surface. No new check, just one envelope instead of four sequential ones.

## Test plan

- [x] `node --test hooks/__tests__/*.test.mjs` → 1556/1556 pass
- [x] Multi-failure scenario produces single block envelope with `≥2` entries in `retry_context.failures[]`
- [x] Each `failures[]` entry preserves originating `hookId` + `code` + `reason`
- [x] `state.blocked_by_hook === 'mpl-finalize-gate'` after delegation — no leaked child envelope
- [x] `inspectRecovery` routes `finalize_gate_failures` → `requires_user_action` with `failures[]`
- [x] Non-finalize writes pass through unchanged
- [x] Existing per-validator semantics preserved (verified via subprocess delegation of the original files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)