### PR TITLE
Close non-runner head trailing-keyword forgery in I12 classifier (#256)

### DIFF
--- a/hooks/__tests__/mpl-issue-256-non-runner-canonical.test.mjs
+++ b/hooks/__tests__/mpl-issue-256-non-runner-canonical.test.mjs
@@ -1,0 +1,176 @@
+/**
+ * #256 — Residual I12 forgery surface for NON-RUNNER gate heads.
+ *
+ * PR #245 fixed the trailing-keyword shape for runner heads
+ * (npm/pnpm/yarn/cargo/go via `classifyRunnerHead`). The structurally
+ * same-class hole remained for the rest of `STRICT_GATE_HEAD_ALLOWLIST`:
+ * heads whose binary name IS the family signal (tsc/eslint/vitest/jest/
+ * mocha/ruff/mypy/playwright/cypress/wdio). Their fallback ran
+ * `matchFamilyRegex(safeCanonical)` against the whole canonical, so a
+ * trailing HARD3 keyword promoted the entry. ANSI-C `$'...'` and
+ * parameter expansion `${...}` wrapped the same forgery into different
+ * quoting forms.
+ *
+ * AC coverage:
+ *   (A) Trailing positional keyword arg → family from the head itself.
+ *       `tsc playwright` → hard1_baseline (not hard3_resilience).
+ *   (B) Quote / expansion wrappers carry no signal.
+ *       `tsc $'playwright'` → hard1_baseline.
+ *       `tsc ${FOO}playwright` → hard1_baseline.
+ *       `eslint $"cypress"` → hard1_baseline.
+ *
+ * The fix synthesizes a canonical of just the head before
+ * `matchFamilyRegex` for the head-as-signal set.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { classifyGateCommand } from '../lib/mpl-gate-classify.mjs';
+
+// ---------------------------------------------------------------------------
+// (A) Trailing keyword arg on non-runner heads
+// ---------------------------------------------------------------------------
+
+test('#256 (A) [data-integrity]: `tsc playwright` classifies as hard1_baseline, not hard3_resilience', () => {
+  assert.equal(classifyGateCommand('tsc playwright'), 'hard1_baseline');
+});
+
+test('#256 (A) [data-integrity]: `eslint cypress` classifies as hard1_baseline, not hard3_resilience', () => {
+  assert.equal(classifyGateCommand('eslint cypress'), 'hard1_baseline');
+});
+
+test('#256 (A) [data-integrity]: `vitest playwright` classifies as hard2_coverage, not hard3_resilience', () => {
+  assert.equal(classifyGateCommand('vitest playwright'), 'hard2_coverage');
+});
+
+test('#256 (A) [data-integrity]: `jest cypress` classifies as hard2_coverage, not hard3_resilience', () => {
+  assert.equal(classifyGateCommand('jest cypress'), 'hard2_coverage');
+});
+
+test('#256 (A) [data-integrity]: `mocha e2e` classifies as hard2_coverage, not hard3_resilience', () => {
+  assert.equal(classifyGateCommand('mocha e2e'), 'hard2_coverage');
+});
+
+test('#256 (A): every head-as-signal binary rejects HARD3 keyword leakage', () => {
+  // Each head's positional arg may contain a foreign-family keyword
+  // (file path, test selector, plugin name). The head's family must
+  // win regardless of the arg.
+  const cases = [
+    // Hard 1
+    ['tsc', 'hard1_baseline'],
+    ['eslint', 'hard1_baseline'],
+    ['ruff', 'hard1_baseline'],
+    ['mypy', 'hard1_baseline'],
+    // Hard 2
+    ['vitest', 'hard2_coverage'],
+    ['jest', 'hard2_coverage'],
+    ['pytest', 'hard2_coverage'],
+    ['mocha', 'hard2_coverage'],
+    // Hard 3 (head is the e2e runner itself — trailing args still ignored)
+    ['playwright', 'hard3_resilience'],
+    ['cypress', 'hard3_resilience'],
+    ['wdio', 'hard3_resilience'],
+  ];
+  for (const [head, expected] of cases) {
+    // Trailing arg with a HARD3 keyword that does NOT belong to this head.
+    assert.equal(
+      classifyGateCommand(`${head} playwright`),
+      expected,
+      `${head} playwright must be ${expected}, not hard3 via trailing keyword`,
+    );
+    // Trailing arg with hard2 keyword.
+    assert.equal(
+      classifyGateCommand(`${head} jest`),
+      expected,
+      `${head} jest must be ${expected}, not hard2 via trailing keyword`,
+    );
+  }
+});
+
+// ---------------------------------------------------------------------------
+// (B) ANSI-C quoting + parameter expansion + locale translation
+// ---------------------------------------------------------------------------
+
+test("#256 (B) [data-integrity]: `tsc $'playwright'` (ANSI-C) classifies as hard1_baseline", () => {
+  assert.equal(classifyGateCommand("tsc $'playwright'"), 'hard1_baseline');
+});
+
+test('#256 (B) [data-integrity]: `tsc ${FOO}playwright` (parameter expansion) classifies as hard1_baseline', () => {
+  assert.equal(classifyGateCommand('tsc ${FOO}playwright'), 'hard1_baseline');
+});
+
+test('#256 (B) [data-integrity]: `eslint $"cypress"` (locale translation) classifies as hard1_baseline', () => {
+  assert.equal(classifyGateCommand('eslint $"cypress"'), 'hard1_baseline');
+});
+
+test('#256 (B): every head-as-signal binary survives ANSI-C / parameter-expansion wrapping of HARD3 keywords', () => {
+  const wrappers = [
+    (kw) => `$'${kw}'`,           // ANSI-C
+    (kw) => `\${FOO}${kw}`,       // parameter expansion (literal $ in source)
+    (kw) => `$"${kw}"`,           // locale translation
+    (kw) => `'${kw}'`,            // single-quoted
+    (kw) => `"${kw}"`,            // double-quoted
+  ];
+  const cases = [
+    ['tsc', 'hard1_baseline'],
+    ['eslint', 'hard1_baseline'],
+    ['vitest', 'hard2_coverage'],
+    ['jest', 'hard2_coverage'],
+  ];
+  for (const [head, expected] of cases) {
+    for (const wrap of wrappers) {
+      const cmd = `${head} ${wrap('playwright')}`;
+      assert.equal(
+        classifyGateCommand(cmd),
+        expected,
+        `${cmd} must be ${expected}, not hard3 via wrapper-quoted keyword`,
+      );
+    }
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Regression — legitimate invocations still classify correctly
+// ---------------------------------------------------------------------------
+
+test('#256 regression: bare head invocations stay correctly classified', () => {
+  assert.equal(classifyGateCommand('tsc'), 'hard1_baseline');
+  assert.equal(classifyGateCommand('eslint'), 'hard1_baseline');
+  assert.equal(classifyGateCommand('vitest'), 'hard2_coverage');
+  assert.equal(classifyGateCommand('jest'), 'hard2_coverage');
+  assert.equal(classifyGateCommand('mocha'), 'hard2_coverage');
+  assert.equal(classifyGateCommand('pytest'), 'hard2_coverage');
+  assert.equal(classifyGateCommand('playwright'), 'hard3_resilience');
+  assert.equal(classifyGateCommand('cypress'), 'hard3_resilience');
+});
+
+test('#256 regression: head with config-file arg classifies by the head, not by the arg path', () => {
+  // `tsc -p tsconfig.json` and `eslint src/` are the everyday legit
+  // shapes — they must still classify by the head.
+  assert.equal(classifyGateCommand('tsc -p tsconfig.json'), 'hard1_baseline');
+  assert.equal(classifyGateCommand('eslint src/'), 'hard1_baseline');
+  assert.equal(classifyGateCommand('vitest run'), 'hard2_coverage');
+  assert.equal(classifyGateCommand('jest --ci'), 'hard2_coverage');
+  assert.equal(classifyGateCommand('mocha test/foo.spec.js'), 'hard2_coverage');
+  assert.equal(classifyGateCommand('playwright test'), 'hard3_resilience');
+});
+
+test('#256 regression: #244 / #245 runner-head behavior is preserved', () => {
+  // The fix touches only the non-runner fall-through; runner heads
+  // (npm/pnpm/yarn/cargo/go/npx/pnpx) still route through
+  // classifyRunnerHead. Spot-check the prior invariants.
+  assert.equal(classifyGateCommand('npm test playwright'), 'hard2_coverage');
+  assert.equal(classifyGateCommand('npm run e2e'), 'hard3_resilience');
+  assert.equal(classifyGateCommand('cargo test playwright'), 'hard2_coverage');
+  assert.equal(classifyGateCommand('npx playwright test'), 'hard3_resilience');
+  assert.equal(classifyGateCommand('npx cowsay playwright'), null);
+});
+
+test('#256 regression: unrecognized heads still return null', () => {
+  // Heads not in the allowlist remain unclassified, regardless of any
+  // trailing keyword.
+  assert.equal(classifyGateCommand('biome playwright'), null);
+  assert.equal(classifyGateCommand('deno playwright'), null);
+  assert.equal(classifyGateCommand('bun playwright'), null);
+});

--- a/hooks/lib/mpl-gate-classify.mjs
+++ b/hooks/lib/mpl-gate-classify.mjs
@@ -275,6 +275,34 @@ export function allowedGateHeads(cwd) {
   return merged;
 }
 
+// #256: built-in non-runner heads whose BINARY NAME is itself the
+// family signal — `tsc`/`eslint`/`vitest`/`jest`/`mocha`/`ruff`/`mypy`/
+// `playwright`/`cypress`/`wdio`. Before this set, the fallback
+// `matchFamilyRegex(safeCanonical)` scanned the WHOLE canonical for
+// HARD3 keywords first, so a trailing positional arg containing an e2e
+// keyword (`tsc playwright`, `eslint cypress`, `vitest playwright`,
+// `mocha e2e`, etc.) promoted the entry to hard3 even though the head
+// already determined the family. ANSI-C `$'...'` and parameter
+// expansion `${VAR}...` wrap arbitrary text into the same shape
+// (`tsc $'playwright'`, `tsc ${FOO}playwright`) and bypassed the
+// classifier the same way. Synthesizing a canonical of just the head
+// before matchFamilyRegex closes both shapes: positional args no longer
+// leak into the keyword scan, and quoting/expansion is irrelevant
+// because the text after the head never reaches the regex.
+//
+// Members are exactly the strict allowlist minus runner heads (which
+// are routed through classifyRunnerHead instead). Each binary appears
+// as a `\b<head>\b` literal in one of HARD1/HARD2/HARD3_PATTERNS, so
+// matchFamilyRegex(head) is unambiguous.
+const STRICT_HEAD_AS_FAMILY_SIGNAL = Object.freeze(new Set([
+  // Hard 1
+  'tsc', 'eslint', 'ruff', 'mypy',
+  // Hard 2
+  'vitest', 'jest', 'pytest', 'mocha',
+  // Hard 3
+  'playwright', 'cypress', 'wdio',
+]));
+
 // Codex r8 on PR #244 [contract-break]: runner-head argument forgery.
 // `npx`/`pnpx`/`npm exec` allow arbitrary scripts after the head; the
 // family regex naively scanned the whole command, so `npx cowsay
@@ -582,6 +610,14 @@ export function classifyGateCommand(command, { cwd } = {}) {
   const familyFallback = () => {
     const runnerVerdict = classifyRunnerHead(head, safeCanonical);
     if (runnerVerdict !== undefined) return runnerVerdict;
+    // #256: head-as-signal binaries — synthesize a canonical of just the
+    // head before the family regex so trailing positional args (e.g.
+    // `tsc playwright`, `vitest cypress`) and quote/expansion wrappers
+    // (`tsc $'playwright'`, `tsc ${FOO}playwright`) cannot leak HARD3
+    // keywords into the keyword scan and forge a family promotion.
+    if (STRICT_HEAD_AS_FAMILY_SIGNAL.has(head)) {
+      return matchFamilyRegex(head);
+    }
     return matchFamilyRegex(safeCanonical);
   };
   if (structured?.has(head)) {


### PR DESCRIPTION
## Summary

Closes #256.

Extends the PR #244 / #245 synthesized-canonical pattern from runner heads (npm/pnpm/yarn/cargo/go/npx/pnpx) to the remaining `STRICT_GATE_HEAD_ALLOWLIST` heads whose binary name IS the family signal — `tsc`/`eslint`/`vitest`/`jest`/`mocha`/`ruff`/`mypy`/`playwright`/`cypress`/`wdio`.

## What

Before this PR, the non-runner branch of `classifyGateCommand` (after `classifyRunnerHead` returns `undefined`) fell straight to `matchFamilyRegex(safeCanonical)`, which scanned HARD3 keywords across the whole canonical. Two structurally-related leak shapes:

- **(A) Trailing positional keyword arg:** `tsc playwright`, `eslint cypress`, `vitest playwright`, `jest cypress`, `mocha e2e` all promoted to `hard3_resilience` via the trailing keyword, even though the head's binary name already determined the family.
- **(B) ANSI-C / parameter expansion / locale-translation quoting:** `tsc $'playwright'`, `tsc ${FOO}playwright`, `eslint $"cypress"` shared the same forgery surface because the wrapper text reached the family regex unmodified.

Fix: after `classifyRunnerHead` returns `undefined`, if the head is a `STRICT_HEAD_AS_FAMILY_SIGNAL` member, run `matchFamilyRegex(head)` — only the head itself, no trailing args. Both (A) and (B) close in the same change because the post-head text never reaches the regex.

## Why

Same I12-evidence-forgery class as PRs #219 / #244 / #245. Manual `state.gate_results` writes must classify by their actual binary, not by an attacker-controllable trailing-arg or quoting wrapper. Each head in the new set already appears as a `\b<head>\b` literal in exactly one of `HARD1/HARD2/HARD3_PATTERNS`, so `matchFamilyRegex(head)` is unambiguous.

Per #245's bounded-scope rationale, this is a focused follow-up: the synthesized-canonical pattern is generalized to the remaining same-class shape without expanding scope to recorder-vs-strict semantics (#232) or canonical `failure_code` separation (#230).

## Test plan

- [x] `node --test hooks/__tests__/mpl-issue-256-non-runner-canonical.test.mjs` → 14/14 pass
- [x] `node --test hooks/__tests__/*.test.mjs` → 1570/1570 pass (no regression in #244/#245 runner-head suite or any other gate-classify path)
- [x] Each repro from the issue body now resolves to its correct family
- [x] Bare-head and config-file-arg legit shapes still classify correctly
- [x] Unrecognized heads (`biome`, `deno`, `bun` without config) still return `null`

🤖 Generated with [Claude Code](https://claude.com/claude-code)