### PR TITLE
Close #225 consumption side — brief is the test-agent primary contract

### DIFF
--- a/agents/mpl-test-agent.md
+++ b/agents/mpl-test-agent.md
@@ -38,17 +38,62 @@ disallowedTools: Task
 
   <Execution_Flow>
     ### Step 1: Understand Context
-    - Read the phase's verification_plan (A/S-items for this phase)
-    - Read the interface_contract (what this phase produces/requires)
-    - Read the implemented code to understand the public API (but test the contract, not internals)
-    - Identify the project's test framework and conventions
+
+    **PRIMARY EXECUTION CONTRACT (#225)** — read `.mpl/mpl/phases/{phase_id}/test-agent-brief.yaml`
+    FIRST. The brief is the canonical, deterministically-generated runbook for
+    this phase. It carries every input you need, already de-duplicated and
+    placeholder-rejected by the producer (`hooks/lib/mpl-decomposition-postprocess.mjs`)
+    and validated by the gate (`hooks/mpl-require-test-agent-brief.mjs`):
+
+    - `target_implementation_files` — files the Phase Runner just modified;
+      anchor your test files against these.
+    - `interface_contracts[]` — the `{symbol, path}` surface you must verify.
+      Test the contract, NOT internal implementation details.
+    - `a_item_coverage[]` / `s_item_coverage[]` — every A/S item the phase
+      committed to in decomposition. Each entry has an `id` and a
+      `test_target` description; you owe one assertion per entry.
+    - `required_test_commands[]` — the exact commands you must execute (the
+      producer pulls these from the decomposer's `s_items[].test_command`
+      / `a_items[].command` when present, and from the language default
+      otherwise). Use these verbatim in `commands_run[]`.
+    - `forbidden_conditions[]` — patterns your tests MUST NOT contain
+      (mocks of the unit under test, placeholder assertions like
+      `expect(true).toBe(true)`, etc.). These trip the gate at PostToolUse
+      if you violate them.
+    - `probing_targets[]` (optional) — adversarial test targets pulled from
+      `decomposition.yaml.phase.probing_hints`. Treat as mandatory test
+      targets per HA-03 below, not as suggestions.
+    - `expected_evidence_shape` — the JSON shape you MUST emit in your
+      final message. The Output_Schema block below mirrors this — use the
+      brief's shape as the authoritative reference.
+
+    Read the brief ONCE at the start of the phase. Do not re-infer these
+    fields from `decomposition.yaml` — the producer has already extracted
+    them and the brief gate has already rejected placeholder shapes. If the
+    brief and the decomposition disagree, the brief wins (the brief is the
+    derived runbook; the decomposition is the source the producer
+    interpreted).
+
+    **TRANSITIONAL FALLBACK** — the brief gate's `block` mode (default
+    since #225 cutover) guarantees the file exists before you are dispatched.
+    If the file is genuinely missing (gate set to `warn` / `off` in
+    `.mpl/config/test-agent-brief-enforcement.json`), fall back to reading
+    the decomposition fields named in the dispatch prompt: `verification_plan`
+    (A/S items), `interface_contract`, and the modified-files list. Do not
+    skip A/S items in this path — the brief omission does not relax the
+    coverage requirement.
+
+    After the brief (or fallback fields):
+    - Read the implemented code to understand the public API. Test the
+      contract, not internals.
+    - Identify the project's test framework and conventions.
 
     #### F-26 Gherkin AC Input (Optional)
 
     If `.mpl/pm/requirements-{hash}.md` exists, use Gherkin AC as pre-seeded test scenarios:
     1. Extract `gherkin` field from the `acceptance_criteria` section
     2. Convert Given-When-Then to test function skeletons
-    3. If file does not exist, maintain existing behavior (based on A/S-items from verification_plan)
+    3. If file does not exist, maintain existing behavior (based on A/S-items from the brief / verification_plan)
 
     ### Step 2: Design Tests
     - For each A-item: translate the command/criterion into a test case

--- a/commands/mpl-run-execute.md
+++ b/commands/mpl-run-execute.md
@@ -687,19 +687,45 @@ can_pipeline_verification =
   AND next scheduler tier does not read phase_id contract_files
   AND phase_id is not immediately entering phase3-gate or phase5-finalize
 
-// Dispatch Test Agent (required by decomposition field)
+// Dispatch Test Agent (required by decomposition field).
+//
+// #225 dispatch contract: pre-load the BRIEF PATH and let mpl-test-agent
+// drive itself from `.mpl/mpl/phases/{phase_id}/test-agent-brief.yaml`.
+// The brief is the deterministically-generated runbook the
+// mpl-decomposition-postprocess hook produces from decomposition.yaml,
+// and the brief gate (mpl-require-test-agent-brief) defaults to `block`
+// — so by the time we reach this dispatch, the file is guaranteed to
+// exist and to have passed the placeholder/coverage validator.
+//
+// Do NOT pre-stuff the prompt with phase_verification_plan,
+// phase_definition.interface_contract, or the domain_test_requirements
+// table — those fields all live inside the brief, the agent reads them
+// once from a single canonical source, and re-asserting them inline
+// invites the brief and the prompt to drift. Carry only what the brief
+// does NOT cover: the impact-file list (so the agent can anchor its
+// tests without re-parsing the decomposition).
 test_handle_or_result = Task(subagent_type="mpl-test-agent", model="sonnet",
      prompt="""
      ## Phase: {phase_id} - {phase_name}
-     ## Phase Domain: {phase_definition.phase_domain}
-     ### Verification Plan (A/S-items for this phase)
-     {phase_verification_plan}
-     ### Interface Contract
-     {phase_definition.interface_contract}
-     ### Implemented Code
+
+     ### Primary execution contract (#225)
+     Read `.mpl/mpl/phases/{phase_id}/test-agent-brief.yaml` first. It is
+     the canonical runbook for this phase: `target_implementation_files`,
+     `interface_contracts`, `a_item_coverage`, `s_item_coverage`,
+     `required_test_commands`, `forbidden_conditions`, `probing_targets`,
+     `expected_evidence_shape`. Use those fields verbatim — the producer
+     already extracted them from decomposition.yaml and the brief gate
+     already rejected placeholder shapes.
+
+     ### Implemented Code (this phase)
      {list of files created/modified by the Phase Runner}
-     ### Domain-Specific Test Requirements
-     {domain_test_requirements[domain]}
+
+     ### Transitional fallback
+     If the brief file is genuinely missing (gate set to `warn`/`off` in
+     `.mpl/config/test-agent-brief-enforcement.json`), fall back to
+     `decomposition.yaml.phases[{phase_id}]`: `verification_plan`,
+     `interface_contract`, `phase_domain`, `probing_hints`. Coverage
+     requirements (every A/S item, every produces symbol) are unchanged.
 
      Write and run tests for this phase's implementation.
      ALL S-items MUST have corresponding executable tests.

--- a/docs/schemas/test-agent-brief.md
+++ b/docs/schemas/test-agent-brief.md
@@ -152,16 +152,19 @@ History: PR #224 (Codex r2 [contract-break]) introduced the config
 with a `warn` default because the brief producer was deferred. PR for
 #225 ships the producer and flips the default to `block`.
 
-## Still-deferred follow-ups
+## Consumption side (#225 follow-up — shipped)
 
-The #225 cutover delivers the producer + flips to block-mode. Still
-deferred (separate issues):
+Both items previously listed under "Still-deferred follow-ups" are now in tree:
 
-- Updates to `mpl-test-agent`'s system prompt to declare the brief as
-  its primary execution contract.
-- Executor dispatch path changes that pre-load the brief into the
-  test-agent prompt instead of assembling scattered decomposition
-  fields ad hoc.
-
-These are consumption-side changes — the brief itself is now
-guaranteed to exist for every required phase.
+- `agents/mpl-test-agent.md` Step 1 declares the brief path as the agent's
+  PRIMARY EXECUTION CONTRACT. The agent reads the brief once and uses its
+  fields (`target_implementation_files`, `interface_contracts`,
+  `a_item_coverage`, `s_item_coverage`, `required_test_commands`,
+  `forbidden_conditions`, `probing_targets`, `expected_evidence_shape`)
+  verbatim. Decomposition re-inference is the transitional-fallback path
+  only (gate set to `warn`/`off`).
+- `commands/mpl-run-execute.md` Step 4 dispatch pre-loads the brief path
+  into the test-agent prompt and removes the ad-hoc inline assembly of
+  `phase_verification_plan` / `interface_contract` /
+  `domain_test_requirements`. The orchestrator carries only the impact-
+  file list inline; everything else lives in the brief.

--- a/hooks/__tests__/mpl-issue-225-brief-consumption.test.mjs
+++ b/hooks/__tests__/mpl-issue-225-brief-consumption.test.mjs
@@ -1,0 +1,120 @@
+/**
+ * #225 consumption-side — brief is the primary execution contract.
+ *
+ * The producer + block-mode cutover landed in PR #226 (commit 6b98f44).
+ * This file covers the remaining acceptance criteria the producer cutover
+ * deferred:
+ *
+ *   - mpl-test-agent documents the brief as primary; legacy decomposition
+ *     fields are explicitly the transitional fallback.
+ *   - Executor dispatch in commands/mpl-run-execute.md references the brief
+ *     path in the dispatched prompt and no longer pre-stuffs the legacy
+ *     phase_verification_plan / interface_contract / domain_test_requirements
+ *     blocks ad hoc.
+ *
+ * These are prompt-text invariants — regressing them silently would let the
+ * dispatch drift back to scattered-field assembly while the brief gate
+ * keeps blocking phases that don't have a brief. Test against the live
+ * files so the docs drift detector catches it on the next change.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const REPO_ROOT = join(dirname(__filename), '..', '..');
+
+function readDoc(rel) {
+  return readFileSync(join(REPO_ROOT, rel), 'utf-8');
+}
+
+test('#225: mpl-test-agent.md declares the brief as the primary execution contract', () => {
+  const text = readDoc('agents/mpl-test-agent.md');
+  // The brief path MUST appear in Step 1 — the agent reads it FIRST.
+  assert.match(text, /\.mpl\/mpl\/phases\/\{phase_id\}\/test-agent-brief\.yaml/);
+  // Step 1 must explicitly mark the brief as primary, not optional.
+  assert.match(text, /PRIMARY EXECUTION CONTRACT/);
+  // The legacy decomposition-field path must be tagged as a fallback,
+  // not as the default. Producer-block-mode means the brief is present.
+  assert.match(text, /TRANSITIONAL FALLBACK/);
+});
+
+test('#225: mpl-test-agent.md lists every brief field the agent must consume', () => {
+  const text = readDoc('agents/mpl-test-agent.md');
+  // The Step 1 contract must enumerate the brief's load-bearing fields by
+  // name so a drift in the schema produces a visible test failure here
+  // before it ships.
+  for (const field of [
+    'target_implementation_files',
+    'interface_contracts',
+    'a_item_coverage',
+    's_item_coverage',
+    'required_test_commands',
+    'forbidden_conditions',
+    'probing_targets',
+    'expected_evidence_shape',
+  ]) {
+    assert.match(
+      text,
+      new RegExp(`\\b${field}\\b`),
+      `mpl-test-agent.md Step 1 must name ${field} so the agent reads it from the brief`,
+    );
+  }
+});
+
+test('#225: mpl-run-execute.md test-agent dispatch references the brief path', () => {
+  const text = readDoc('commands/mpl-run-execute.md');
+  // The dispatch prompt must include the brief path so the test-agent
+  // reads it on entry. The path is a template (`{phase_id}` interpolated
+  // by the orchestrator), so we look for the literal template.
+  assert.match(text, /\.mpl\/mpl\/phases\/\{phase_id\}\/test-agent-brief\.yaml/);
+});
+
+test('#225: mpl-run-execute.md no longer pre-stuffs the legacy ad-hoc blocks in the dispatch prompt', () => {
+  const text = readDoc('commands/mpl-run-execute.md');
+  // Locate the test-agent dispatch block and assert the legacy
+  // template placeholders are gone from that block. The brief now
+  // carries the same data — duplicating it inline invites drift.
+  const dispatchMatch = text.match(/Task\(subagent_type="mpl-test-agent"[\s\S]*?run_in_background=can_pipeline_verification\)/);
+  assert.ok(dispatchMatch, 'mpl-test-agent dispatch block must be present');
+  const dispatch = dispatchMatch[0];
+  // Old ad-hoc blocks that the brief replaces:
+  assert.doesNotMatch(dispatch, /\{phase_verification_plan\}/,
+    'dispatch must not interpolate {phase_verification_plan} ad hoc — the brief carries A/S items');
+  assert.doesNotMatch(dispatch, /\{phase_definition\.interface_contract\}/,
+    'dispatch must not interpolate {phase_definition.interface_contract} — the brief carries interface_contracts');
+  assert.doesNotMatch(dispatch, /\{domain_test_requirements\[domain\]\}/,
+    'dispatch must not interpolate {domain_test_requirements[domain]} — the brief carries forbidden_conditions / probing_targets');
+});
+
+test('#225: dispatch retains the impact-file list inline (anchor for the test-agent)', () => {
+  // The brief's `target_implementation_files` mirrors this, but the
+  // executor still passes the impact-file list inline so the test-agent
+  // can cross-check against the actual Phase Runner output.
+  const text = readDoc('commands/mpl-run-execute.md');
+  const dispatchMatch = text.match(/Task\(subagent_type="mpl-test-agent"[\s\S]*?run_in_background=can_pipeline_verification\)/);
+  assert.ok(dispatchMatch);
+  assert.match(
+    dispatchMatch[0],
+    /files created\/modified by the Phase Runner/,
+    'dispatch must still pass the Phase Runner impact-file list inline',
+  );
+});
+
+test('#225: docs/schemas/test-agent-brief.md notes the consumption side as shipped', () => {
+  const text = readDoc('docs/schemas/test-agent-brief.md');
+  // The schema doc previously listed mpl-test-agent + executor dispatch
+  // under "Still-deferred follow-ups". After the #225 consumption-side
+  // PR they must move to a "shipped" section so the next reader knows
+  // they're done.
+  // Match the heading shape (`## Still-deferred follow-ups`), not the
+  // literal string — the new "Consumption side (shipped)" section may
+  // still reference the old heading name in its body prose.
+  assert.doesNotMatch(text, /^##\s+Still-deferred follow-ups\s*$/m,
+    'schema doc must move both items out of the deferred section after #225 ships');
+  assert.match(text, /^##\s+Consumption side.*shipped/m,
+    'schema doc must record that both consumption-side items are now in tree');
+});


### PR DESCRIPTION
## Summary

Closes #225.

PR #226 (commit 6b98f44) shipped the brief producer and flipped enforcement to `block` by default. Two acceptance-criteria items remained explicitly deferred in `docs/schemas/test-agent-brief.md` under "Still-deferred follow-ups" — both ship here.

## What

- **`agents/mpl-test-agent.md`** — Step 1 now opens with a **PRIMARY EXECUTION CONTRACT** section pointing at `.mpl/mpl/phases/{phase_id}/test-agent-brief.yaml`. The agent is told to read the brief once and use every load-bearing field verbatim (`target_implementation_files`, `interface_contracts`, `a_item_coverage`, `s_item_coverage`, `required_test_commands`, `forbidden_conditions`, `probing_targets`, `expected_evidence_shape`). Re-inference from `decomposition.yaml` is the **TRANSITIONAL FALLBACK** path only — used when the brief gate is set to `warn`/`off` in `.mpl/config/test-agent-brief-enforcement.json`.
- **`commands/mpl-run-execute.md` Step 4** — the test-agent dispatch prompt no longer interpolates `{phase_verification_plan}`, `{phase_definition.interface_contract}`, or `{domain_test_requirements[domain]}` inline. The brief carries the same data and re-asserting them inline invites the prompt and the brief to drift. The dispatch keeps only the Phase Runner impact-file list inline so the agent can cross-check actual outputs against the brief's `target_implementation_files`.
- **`docs/schemas/test-agent-brief.md`** — the "Still-deferred follow-ups" section is replaced with "Consumption side (#225 follow-up — shipped)" so the schema doc reflects the closed state.
- **`hooks/__tests__/mpl-issue-225-brief-consumption.test.mjs`** — new prompt-text invariants: brief path appears in both the agent definition and the dispatch prompt, every brief field is named in Step 1, the dispatch no longer carries the legacy ad-hoc blocks, and the impact-file anchor stays inline. A future drift back to scattered-field assembly will fail CI here.

## Why

`mpl-require-test-agent-brief` has been `block` by default since the #225 producer cutover, so the brief is guaranteed to exist for every required phase. Without a primary-contract declaration the agent kept re-inferring intent from the decomposition, defeating the producer's purpose. Closing the consumption side makes the brief the single source of truth and the decomposer's surface stays unchanged.

## Test plan

- [x] `node --test hooks/__tests__/mpl-issue-225-brief-consumption.test.mjs` → 6/6 pass
- [x] `node --test hooks/__tests__/*.test.mjs` → 1562/1562 pass (no regression in #224 brief-validator suite, the postprocess writer suite, or any other hook test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)