### PR TITLE
Canonical failure_code separation for parallel_failed waves (#230)

### DIFF
--- a/commands/mpl-run-execute.md
+++ b/commands/mpl-run-execute.md
@@ -157,6 +157,26 @@ for each (wave, wave_index) in enumerate(waves):
     // Pool setup, worker dispatch, or per-phase execution failed before the
     // wave completed. Emit a distinct mode so finalize does not count this
     // as parallel execution.
+    //
+    // #230: emit a canonical `failure_code` alongside the free-form
+    // `failure_reason` message. The aggregator surfaces `failure_codes`
+    // as an independent axis from `rejection_reasons`, and the finalize
+    // gate requires each code to appear verbatim in `no_parallel_explanation`.
+    // Free-form `failure_reason` no longer feeds the gate's required-
+    // token set (paraphrase-bypass), it stays only for operator
+    // readability. Allowlisted codes (hooks/lib/mpl-scheduler-failure-codes.mjs):
+    //   - 'worktree_setup_error'  — pool / worktree creation failed BEFORE
+    //                               any worker dispatch
+    //   - 'worker_dispatch_error' — worker spawn / dispatch failed
+    //   - 'wave_execution_error'  — one or more workers failed inside the wave
+    //   - 'merge_error'           — sequential merge after workers completed failed
+    //   - 'unknown_runtime_error' — catch-all; use only when the error
+    //                               cannot be classified
+    // Codes outside the allowlist are silently dropped by the aggregator
+    // and the gate will surface
+    // `scheduler:no_parallel_explanation_missing_failure_code:expected=<code>`
+    // until a recognized code is recorded.
+    failure_code = classify_wave_failure(err)  // one of the canonical codes above
     record_scheduler_event({
       pipeline_id: state.pipeline_id,
       run_started_at: state.started_at,
@@ -171,6 +191,7 @@ for each (wave, wave_index) in enumerate(waves):
       worker_cap: max_phase_workers,
       rejection_reasons_by_phase: ready_but_blocked_reason,
       worktree_slots: [],
+      failure_code: failure_code,
       failure_reason: err.message
     })
     raise

--- a/commands/mpl-run-finalize.md
+++ b/commands/mpl-run-finalize.md
@@ -819,8 +819,19 @@ scheduler = {
   tiers_with_partial_rejection: <list of tier ids>,
   rejection_reasons: union of event.rejection_reasons and the values of
                      event.rejection_reasons_by_phase across all events
-                     (deduplicated), plus event.failure_reason values for
-                     parallel_failed waves,
+                     (deduplicated). #230: event.failure_reason free-form
+                     prose is NO LONGER unioned here — the runtime cause
+                     of a parallel_failed wave is now carried by the
+                     canonical `failure_codes` field below.
+  failure_codes:     sorted list of canonical `event.failure_code` values
+                     from `parallel_failed` events (allowlist:
+                     `worker_dispatch_error`, `worktree_setup_error`,
+                     `wave_execution_error`, `merge_error`,
+                     `unknown_runtime_error`). Each code MUST appear
+                     verbatim in `no_parallel_explanation` independently
+                     of `rejection_reasons` — a wave with both a
+                     pre-attempt planning token and a runtime failure
+                     must name both.
   affected_tier_ids: sorted list of expected_parallel_tiers that did not
                      reach selected_mode == "parallel", that the
                      no_parallel_explanation MUST reference by id,
@@ -879,6 +890,21 @@ scheduler = {
     `waves_parallel_rejected_without_reason`, and
     `waves_parallel_failed_without_reason` counters to decide which
     degraded tokens to include.
+
+    **Canonical failure_codes (#230) — required per code:** EVERY token
+    in `failure_codes` MUST appear verbatim in the explanation
+    (snake_case / hyphen / space variants accepted, case-insensitive).
+    This is an independent axis from `rejection_reasons` — a wave with
+    a pre-attempt planning rejection AND a runtime failure must name
+    both. Examples:
+
+      OK:    "tier 2 lost parallelism: file_overlap deferred phase-3 then
+             the wave hit worker_dispatch_error"
+      OK:    "tier 1 worktree-setup-error before any worker dispatched"
+      BLOCK: "tier 2 had file_overlap"   (computed failure_codes named
+                                          worker_dispatch_error — missing)
+      BLOCK: "tier 1 worker dispatch failed"  (paraphrase; needs the
+                                               canonical worker_dispatch_error)
 }
 ```
 

--- a/hooks/__tests__/mpl-issue-230-failure-code-canonical.test.mjs
+++ b/hooks/__tests__/mpl-issue-230-failure-code-canonical.test.mjs
@@ -1,0 +1,576 @@
+/**
+ * #230 — Canonical `failure_code` separation + per-event runtime cause.
+ *
+ * Before this issue, `parallel_failed` events carried only a free-form
+ * `failure_reason: err.message` and the scheduler aggregator unioned
+ * that string into `rejection_reasons`. Two attack shapes survived
+ * #214's vocabulary gate:
+ *
+ *  (1) Paraphrase bypass — an explanation could repeat the free-form
+ *      `failure_reason` verbatim and pass the canonical-vocabulary
+ *      check, even though `"worker dispatch failed"` is exactly the
+ *      kind of paraphrase #214 was meant to block.
+ *
+ *  (2) Masked runtime cause — a `parallel_failed` event with both
+ *      pre-attempt `rejection_reasons_by_phase` AND a runtime
+ *      `failure_reason` could be explained by the planning token
+ *      alone, hiding the runtime failure.
+ *
+ * The fix introduces a canonical `failure_code` enum on
+ * parallel_failed events; the aggregator surfaces it under
+ * `failure_codes` SEPARATELY from `rejection_reasons`; the finalize
+ * gate requires EVERY computed code to appear verbatim in
+ * `no_parallel_explanation` independently of the rejection-reason
+ * axis.
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { tmpdir } from 'os';
+
+import { CURRENT_SCHEMA_VERSION } from '../lib/mpl-state.mjs';
+
+import {
+  FAILURE_CODE_ALLOWLIST,
+  isCanonicalFailureCode,
+} from '../lib/mpl-scheduler-failure-codes.mjs';
+import {
+  aggregateScheduler,
+  explanationRequiredFromAggregate,
+} from '../lib/mpl-scheduler-aggregate.mjs';
+
+const PIPELINE_ID = 'mpl-230-test';
+const STARTED_AT = '2026-05-30T00:00:00.000Z';
+
+function decompositionYaml() {
+  return `
+recompose_count: 0
+execution_tiers:
+  - tier: 1
+    parallel: true
+    phases: [phase-1, phase-2]
+phases:
+  - id: phase-1
+  - id: phase-2
+`;
+}
+
+function writeWorkspace(tmp, events) {
+  mkdirSync(join(tmp, '.mpl', 'mpl', 'profile'), { recursive: true });
+  writeFileSync(join(tmp, '.mpl', 'mpl', 'decomposition.yaml'), decompositionYaml());
+  writeFileSync(
+    join(tmp, '.mpl', 'mpl', 'profile', 'phase-scheduler.jsonl'),
+    events.map((e) => JSON.stringify({
+      pipeline_id: PIPELINE_ID,
+      run_started_at: STARTED_AT,
+      recompose_count: 0,
+      ...e,
+    })).join('\n') + '\n',
+  );
+}
+
+function fakeState() {
+  return {
+    pipeline_id: PIPELINE_ID,
+    started_at: STARTED_AT,
+    phase_scheduler_history: [],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Allowlist surface
+// ---------------------------------------------------------------------------
+
+describe('#230 allowlist', () => {
+  it('exposes the five canonical failure codes', () => {
+    assert.deepEqual(
+      [...FAILURE_CODE_ALLOWLIST].sort(),
+      [
+        'merge_error',
+        'unknown_runtime_error',
+        'wave_execution_error',
+        'worker_dispatch_error',
+        'worktree_setup_error',
+      ],
+    );
+  });
+  it('isCanonicalFailureCode accepts allowlisted codes only', () => {
+    assert.equal(isCanonicalFailureCode('worker_dispatch_error'), true);
+    assert.equal(isCanonicalFailureCode('worktree_setup_error'), true);
+    assert.equal(isCanonicalFailureCode('worker dispatch failed'), false);
+    assert.equal(isCanonicalFailureCode(''), false);
+    assert.equal(isCanonicalFailureCode(null), false);
+    assert.equal(isCanonicalFailureCode(undefined), false);
+    assert.equal(isCanonicalFailureCode(42), false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Aggregator
+// ---------------------------------------------------------------------------
+
+describe('#230 aggregator', () => {
+  let tmp;
+  beforeEach(() => { tmp = mkdtempSync(join(tmpdir(), 'mpl-230-agg-')); });
+  afterEach(() => rmSync(tmp, { recursive: true, force: true }));
+
+  it('surfaces canonical failure_code in failure_codes[] (not in rejection_reasons)', () => {
+    writeWorkspace(tmp, [
+      {
+        tier: 1, wave_index: 0,
+        timestamp: '2026-05-30T00:01:00.000Z',
+        phases: ['phase-1', 'phase-2'],
+        selected_mode: 'parallel_failed',
+        parallel_requested: true,
+        worker_cap: 2,
+        worktree_slots: [],
+        failure_code: 'worker_dispatch_error',
+        failure_reason: 'worker dispatch failed: ENOENT spawning node',
+      },
+    ]);
+    const agg = aggregateScheduler(tmp, fakeState());
+    assert.deepEqual(agg.failure_codes, ['worker_dispatch_error']);
+    // The free-form failure_reason must NOT enter rejection_reasons —
+    // that's the paraphrase-bypass surface #230 closes.
+    assert.equal(agg.rejection_reasons.includes('worker dispatch failed: ENOENT spawning node'), false);
+  });
+
+  it('drops non-canonical failure_code values silently', () => {
+    writeWorkspace(tmp, [
+      {
+        tier: 1, wave_index: 0,
+        timestamp: '2026-05-30T00:01:00.000Z',
+        phases: ['phase-1', 'phase-2'],
+        selected_mode: 'parallel_failed',
+        parallel_requested: true,
+        worker_cap: 2,
+        worktree_slots: [],
+        failure_code: 'this_is_not_allowlisted',
+        failure_reason: 'arbitrary prose',
+      },
+    ]);
+    const agg = aggregateScheduler(tmp, fakeState());
+    assert.deepEqual(agg.failure_codes, []);
+    // The non-canonical code must not leak into rejection_reasons either.
+    assert.equal(agg.rejection_reasons.includes('this_is_not_allowlisted'), false);
+  });
+
+  it('collects failure_code only from parallel_failed events', () => {
+    writeWorkspace(tmp, [
+      {
+        tier: 1, wave_index: 0,
+        timestamp: '2026-05-30T00:01:00.000Z',
+        phases: ['phase-1', 'phase-2'],
+        selected_mode: 'parallel',
+        parallel_requested: true,
+        worker_cap: 2,
+        worktree_slots: [1, 2],
+        // Even if a non-failed event has a failure_code, ignore it.
+        failure_code: 'worker_dispatch_error',
+      },
+    ]);
+    const agg = aggregateScheduler(tmp, fakeState());
+    assert.deepEqual(agg.failure_codes, []);
+  });
+
+  it('preserves rejection_reasons / rejection_reasons_by_phase semantics (regression on PR #229)', () => {
+    writeWorkspace(tmp, [
+      {
+        tier: 1, wave_index: 0,
+        timestamp: '2026-05-30T00:01:00.000Z',
+        phases: ['phase-1', 'phase-2'],
+        selected_mode: 'parallel_failed',
+        parallel_requested: true,
+        worker_cap: 2,
+        worktree_slots: [],
+        rejection_reasons_by_phase: { 'phase-1': 'file_overlap' },
+        failure_code: 'worker_dispatch_error',
+        failure_reason: 'spawn EAGAIN',
+      },
+    ]);
+    const agg = aggregateScheduler(tmp, fakeState());
+    // The pre-attempt planning rejection still feeds rejection_reasons —
+    // the change is that failure_reason no longer does.
+    assert.ok(agg.rejection_reasons.includes('file_overlap'));
+    assert.deepEqual(agg.failure_codes, ['worker_dispatch_error']);
+    // explanation_required stays true (waves_parallel_failed > 0).
+    assert.equal(explanationRequiredFromAggregate(agg), true);
+  });
+
+  it('dedupes failure_codes across multiple parallel_failed waves', () => {
+    writeWorkspace(tmp, [
+      {
+        tier: 1, wave_index: 0,
+        timestamp: '2026-05-30T00:01:00.000Z',
+        phases: ['phase-1', 'phase-2'],
+        selected_mode: 'parallel_failed',
+        parallel_requested: true,
+        worker_cap: 2,
+        worktree_slots: [],
+        failure_code: 'worker_dispatch_error',
+      },
+      {
+        tier: 1, wave_index: 1,
+        timestamp: '2026-05-30T00:02:00.000Z',
+        phases: ['phase-1', 'phase-2'],
+        selected_mode: 'parallel_failed',
+        parallel_requested: true,
+        worker_cap: 2,
+        worktree_slots: [],
+        failure_code: 'worker_dispatch_error',
+      },
+    ]);
+    const agg = aggregateScheduler(tmp, fakeState());
+    assert.deepEqual(agg.failure_codes, ['worker_dispatch_error']);
+  });
+
+  it('surfaces multiple distinct failure_codes sorted', () => {
+    writeWorkspace(tmp, [
+      {
+        tier: 1, wave_index: 0,
+        timestamp: '2026-05-30T00:01:00.000Z',
+        phases: ['phase-1', 'phase-2'],
+        selected_mode: 'parallel_failed',
+        parallel_requested: true,
+        worker_cap: 2,
+        worktree_slots: [],
+        failure_code: 'worker_dispatch_error',
+      },
+      {
+        tier: 1, wave_index: 1,
+        timestamp: '2026-05-30T00:02:00.000Z',
+        phases: ['phase-1', 'phase-2'],
+        selected_mode: 'parallel_failed',
+        parallel_requested: true,
+        worker_cap: 2,
+        worktree_slots: [],
+        failure_code: 'merge_error',
+      },
+    ]);
+    const agg = aggregateScheduler(tmp, fakeState());
+    assert.deepEqual(agg.failure_codes, ['merge_error', 'worker_dispatch_error']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Finalize-gate dispatch — exercise the explanation requirement directly
+// against the validateNoParallelExplanationPresence helper by going
+// through the gate's public path: the gate's failure-code check uses
+// the same containsToken helper as the rejection-reasons check, so the
+// dispatch logic is exercised when we drive the gate file end-to-end.
+//
+// We do that via the existing finalize-artifacts test harness, but to
+// keep this test file focused we exercise the aggregator output in
+// combination with a hand-built explanation string and assert against
+// the contains-token semantics indirectly via the public
+// explanationRequiredFromAggregate signal.
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Finalize gate — end-to-end integration through mpl-require-finalize-artifacts
+// ---------------------------------------------------------------------------
+
+const __filename = fileURLToPath(import.meta.url);
+const FINALIZE_HOOK_PATH = join(dirname(__filename), '..', 'mpl-require-finalize-artifacts.mjs');
+
+function fullDecompositionYaml() {
+  return `
+recompose_count: 0
+execution_tiers:
+  - tier: 1
+    parallel: true
+    phases: [phase-1, phase-2]
+phases:
+  - id: phase-1
+  - id: phase-2
+`;
+}
+
+function fullGoalContract() {
+  return `
+source:
+  user_request: "Build app"
+  user_request_hash: "req"
+mission:
+  goal: "Test failure_code canonical vocabulary"
+  project_pivot: "no paraphrase bypass"
+  must_ship_outcomes:
+    - "x"
+ontology:
+  entities:
+    - app
+variation_axes:
+  - id: AX-1
+acceptance_criteria:
+  - id: AC-1
+e2e_policy:
+  real_runtime_required: false
+  mock_allowed: false
+  placeholder_assertions_allowed: false
+security_policy:
+  required: false
+completion_evidence:
+  required_artifacts:
+    - .mpl/mpl/audit-report.json
+    - .mpl/mpl/profile/run-summary.json
+    - .mpl/mpl/RUNBOOK.md
+  require_commit: false
+  require_finalize_timestamps: true
+`;
+}
+
+function setupFullWorkspace(tmp, { events, summary }) {
+  mkdirSync(join(tmp, '.mpl', 'mpl', 'profile'), { recursive: true });
+  writeFileSync(join(tmp, '.mpl', 'state.json'), JSON.stringify({
+    schema_version: CURRENT_SCHEMA_VERSION,
+    current_phase: 'phase5-finalize',
+    pipeline_id: PIPELINE_ID,
+    started_at: STARTED_AT,
+    phase_scheduler_history: events.map((e, i) => ({
+      pipeline_id: PIPELINE_ID,
+      run_started_at: STARTED_AT,
+      recompose_count: 0,
+      wave_index: i,
+      timestamp: `2026-05-30T00:00:${String(10 + i).padStart(2, '0')}.000Z`,
+      ...e,
+    })),
+  }));
+  writeFileSync(join(tmp, '.mpl', 'goal-contract.yaml'), fullGoalContract());
+  writeFileSync(join(tmp, '.mpl', 'mpl', 'decomposition.yaml'), fullDecompositionYaml());
+  writeFileSync(join(tmp, '.mpl', 'mpl', 'audit-report.json'), JSON.stringify({ verdict: 'pass' }));
+  writeFileSync(join(tmp, '.mpl', 'mpl', 'profile', 'run-summary.json'),
+    JSON.stringify({ run_id: 'r1', scheduler: summary }));
+  writeFileSync(join(tmp, '.mpl', 'mpl', 'RUNBOOK.md'),
+    '# MPL Pipeline RUNBOOK\n\n## Pipeline Complete\n');
+  // Also persist the events to the JSONL profile so the aggregator picks them up.
+  writeFileSync(
+    join(tmp, '.mpl', 'mpl', 'profile', 'phase-scheduler.jsonl'),
+    events.map((e, i) => JSON.stringify({
+      pipeline_id: PIPELINE_ID,
+      run_started_at: STARTED_AT,
+      recompose_count: 0,
+      wave_index: i,
+      timestamp: `2026-05-30T00:00:${String(10 + i).padStart(2, '0')}.000Z`,
+      ...e,
+    })).join('\n') + '\n',
+  );
+}
+
+function runFinalizeHook(tmp) {
+  const stateContent = JSON.stringify({
+    current_phase: 'phase5-finalize',
+    finalize_done: true,
+    completed_at: '2026-05-30T00:01:00.000Z',
+    finalized_at: '2026-05-30T00:01:01.000Z',
+  });
+  return JSON.parse(execFileSync('node', [FINALIZE_HOOK_PATH], {
+    input: JSON.stringify({
+      cwd: tmp,
+      tool_name: 'Write',
+      tool_input: {
+        file_path: '.mpl/state.json',
+        content: stateContent,
+      },
+    }),
+    encoding: 'utf-8',
+  }));
+}
+
+describe('#230 finalize gate — failure_code requirement', () => {
+  let tmp;
+  beforeEach(() => { tmp = mkdtempSync(join(tmpdir(), 'mpl-230-gate-')); });
+  afterEach(() => rmSync(tmp, { recursive: true, force: true }));
+
+  it('blocks when explanation paraphrases the failure_reason but omits the canonical failure_code', () => {
+    // The exact paraphrase-bypass shape from the #230 issue body.
+    setupFullWorkspace(tmp, {
+      events: [{
+        tier: 1,
+        phases: ['phase-1', 'phase-2'],
+        selected_mode: 'parallel_failed',
+        parallel_requested: true,
+        worker_cap: 2,
+        worktree_slots: [],
+        failure_code: 'worker_dispatch_error',
+        failure_reason: 'worker dispatch failed',
+      }],
+      summary: {
+        tiers_total: 1,
+        tiers_parallel_requested: 1,
+        tiers_parallel_executed: 0,
+        tiers_parallel_rejected: 1,
+        tiers_with_missing_telemetry: [],
+        waves_parallel_rejected: 0,
+        waves_parallel_failed: 1,
+        tiers_with_partial_rejection: [],
+        rejection_reasons: [],
+        failure_codes: ['worker_dispatch_error'],
+        no_parallel_explanation: 'tier 1: worker dispatch failed (parallel_failed_without_reason: false)',
+      },
+    });
+    const r = runFinalizeHook(tmp);
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason, /no_parallel_explanation_missing_failure_code:expected=worker_dispatch_error/);
+  });
+
+  it('passes when explanation names the canonical failure_code verbatim', () => {
+    setupFullWorkspace(tmp, {
+      events: [{
+        tier: 1,
+        phases: ['phase-1', 'phase-2'],
+        selected_mode: 'parallel_failed',
+        parallel_requested: true,
+        worker_cap: 2,
+        worktree_slots: [],
+        failure_code: 'worker_dispatch_error',
+        failure_reason: 'spawn EAGAIN under pool pressure',
+      }],
+      summary: {
+        tiers_total: 1,
+        tiers_parallel_requested: 1,
+        tiers_parallel_executed: 0,
+        tiers_parallel_rejected: 1,
+        tiers_with_missing_telemetry: [],
+        waves_parallel_rejected: 0,
+        waves_parallel_failed: 1,
+        tiers_with_partial_rejection: [],
+        rejection_reasons: [],
+        failure_codes: ['worker_dispatch_error'],
+        no_parallel_explanation:
+          'tier 1 hit worker_dispatch_error during the wave; ' +
+          'parallel_failed_without_reason did not apply (failure_reason captured).',
+      },
+    });
+    const r = runFinalizeHook(tmp);
+    assert.equal(r.continue, true,
+      `expected continue:true with full vocabulary, got ${JSON.stringify(r)}`);
+  });
+
+  it('blocks when masked runtime cause: pre-attempt token present but failure_code omitted', () => {
+    // The second issue-body repro: a wave with both file_overlap
+    // (pre-attempt deferred) AND worker_dispatch_error (runtime) — an
+    // explanation that names ONLY file_overlap was the masked-cause
+    // bypass.
+    setupFullWorkspace(tmp, {
+      events: [{
+        tier: 1,
+        phases: ['phase-1', 'phase-2'],
+        selected_mode: 'parallel_failed',
+        parallel_requested: true,
+        worker_cap: 2,
+        worktree_slots: [],
+        rejection_reasons_by_phase: { 'phase-1': 'file_overlap' },
+        failure_code: 'worker_dispatch_error',
+        failure_reason: 'pool exhaustion',
+      }],
+      summary: {
+        tiers_total: 1,
+        tiers_parallel_requested: 1,
+        tiers_parallel_executed: 0,
+        tiers_parallel_rejected: 1,
+        tiers_with_missing_telemetry: [],
+        waves_parallel_rejected: 0,
+        waves_parallel_failed: 1,
+        tiers_with_partial_rejection: [],
+        rejection_reasons: ['file_overlap'],
+        failure_codes: ['worker_dispatch_error'],
+        no_parallel_explanation:
+          'tier 1 lost parallelism: file_overlap deferred phase-1',
+      },
+    });
+    const r = runFinalizeHook(tmp);
+    assert.equal(r.decision, 'block');
+    assert.match(r.reason, /no_parallel_explanation_missing_failure_code:expected=worker_dispatch_error/);
+  });
+
+  it('passes when masked runtime cause is resolved by naming BOTH tokens', () => {
+    setupFullWorkspace(tmp, {
+      events: [{
+        tier: 1,
+        phases: ['phase-1', 'phase-2'],
+        selected_mode: 'parallel_failed',
+        parallel_requested: true,
+        worker_cap: 2,
+        worktree_slots: [],
+        rejection_reasons_by_phase: { 'phase-1': 'file_overlap' },
+        failure_code: 'worker_dispatch_error',
+        failure_reason: 'pool exhaustion',
+      }],
+      summary: {
+        tiers_total: 1,
+        tiers_parallel_requested: 1,
+        tiers_parallel_executed: 0,
+        tiers_parallel_rejected: 1,
+        tiers_with_missing_telemetry: [],
+        waves_parallel_rejected: 0,
+        waves_parallel_failed: 1,
+        tiers_with_partial_rejection: [],
+        rejection_reasons: ['file_overlap'],
+        failure_codes: ['worker_dispatch_error'],
+        no_parallel_explanation:
+          'tier 1: file_overlap deferred phase-1, then the wave hit ' +
+          'worker_dispatch_error during dispatch.',
+      },
+    });
+    const r = runFinalizeHook(tmp);
+    assert.equal(r.continue, true,
+      `expected continue:true with both tokens, got ${JSON.stringify(r)}`);
+  });
+
+  it('hyphen / space variants of the failure_code satisfy the gate', () => {
+    setupFullWorkspace(tmp, {
+      events: [{
+        tier: 1,
+        phases: ['phase-1', 'phase-2'],
+        selected_mode: 'parallel_failed',
+        parallel_requested: true,
+        worker_cap: 2,
+        worktree_slots: [],
+        failure_code: 'worktree_setup_error',
+      }],
+      summary: {
+        tiers_total: 1,
+        tiers_parallel_requested: 1,
+        tiers_parallel_executed: 0,
+        tiers_parallel_rejected: 1,
+        tiers_with_missing_telemetry: [],
+        waves_parallel_rejected: 0,
+        waves_parallel_failed: 1,
+        tiers_with_partial_rejection: [],
+        rejection_reasons: [],
+        failure_codes: ['worktree_setup_error'],
+        // Hyphenated variant — same canonical token, different separator.
+        no_parallel_explanation:
+          'tier 1 lost parallelism: worktree-setup-error before any worker dispatched.',
+      },
+    });
+    const r = runFinalizeHook(tmp);
+    assert.equal(r.continue, true,
+      `expected continue:true for hyphen variant, got ${JSON.stringify(r)}`);
+  });
+});
+
+describe('#230 explanationRequired', () => {
+  it('stays true when a parallel_failed event is present (failure_code feeds the gate)', () => {
+    const agg = {
+      tiers_total: 1,
+      tiers_parallel_requested: 1,
+      tiers_parallel_executed: 0,
+      tiers_parallel_rejected: 1,
+      tiers_with_missing_telemetry: [],
+      waves_parallel_rejected: 0,
+      waves_parallel_failed: 1,
+      waves_parallel_rejected_without_reason: 0,
+      waves_parallel_failed_without_reason: 0,
+      tiers_with_partial_rejection: [],
+      rejection_reasons: [],
+      failure_codes: ['worker_dispatch_error'],
+      affected_tier_ids: [1],
+    };
+    assert.equal(explanationRequiredFromAggregate(agg), true);
+  });
+});

--- a/hooks/__tests__/mpl-require-finalize-artifacts.test.mjs
+++ b/hooks/__tests__/mpl-require-finalize-artifacts.test.mjs
@@ -793,7 +793,14 @@ phases:
     writeArtifacts();
     writeDecompositionWithParallelTier();
     writeSchedulerEvents([
-      { tier: 1, selected_mode: 'parallel_failed', timestamp: '2026-05-27T00:00:02Z', failure_reason: 'worker_dispatch_error' },
+      // #230: parallel_failed events now carry a canonical
+      // `failure_code` (allowlisted) alongside the free-form
+      // `failure_reason`. The aggregator no longer unions
+      // failure_reason into rejection_reasons, so the runtime cause
+      // must be expressed via failure_code.
+      { tier: 1, selected_mode: 'parallel_failed', timestamp: '2026-05-27T00:00:02Z',
+        failure_code: 'worker_dispatch_error',
+        failure_reason: 'spawn ENOSPC under pool pressure' },
     ]);
     writeSummaryScheduler({
       tiers_total: 1,
@@ -804,11 +811,11 @@ phases:
       waves_parallel_rejected: 0,
       waves_parallel_failed: 1,
       tiers_with_partial_rejection: [],
-      rejection_reasons: ['worker_dispatch_error'],
-      // #214: explanation must use the canonical reason token
-      // (worker_dispatch_error / worker-dispatch-error / worker dispatch error),
-      // not a paraphrase. Updated from the original "worker dispatch failed"
-      // wording to satisfy the new content-strength check.
+      rejection_reasons: [],
+      // #230: failure_codes carries the canonical runtime cause
+      // separately from rejection_reasons. EACH code must appear in
+      // the explanation verbatim (snake_case / hyphen / space).
+      failure_codes: ['worker_dispatch_error'],
       no_parallel_explanation: 'tier 1 hit worker_dispatch_error during parallel execution; fell back to sequential retry',
     });
     const r = runHook();

--- a/hooks/lib/mpl-scheduler-aggregate.mjs
+++ b/hooks/lib/mpl-scheduler-aggregate.mjs
@@ -16,6 +16,8 @@
 import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 
+import { isCanonicalFailureCode } from './mpl-scheduler-failure-codes.mjs';
+
 /**
  * Minimal YAML peek over `execution_tiers:` and top-level
  * `recompose_count:` in decomposition.yaml. We only need the parallel
@@ -330,6 +332,17 @@ export function aggregateScheduler(cwd, state) {
   const tiersWithRejectedEvent = new Set();
   const tiersSeen = new Set();
   const rejectionReasonSet = new Set();
+  // #230: canonical failure_code tokens from parallel_failed events.
+  // Collected SEPARATELY from rejection_reasons because (1) free-form
+  // failure_reason values were paraphrase-bypassing the canonical
+  // vocabulary gate, and (2) a wave with both pre-attempt
+  // rejection_reasons_by_phase and a runtime failure_code was being
+  // explained by the planning token alone, hiding the runtime cause.
+  // Only allowlisted codes (mpl-scheduler-failure-codes.mjs) are
+  // surfaced; anything else is dropped at this boundary so the
+  // finalize gate cannot be tricked by an executor emitting an
+  // arbitrary string in `failure_code`.
+  const failureCodeSet = new Set();
   let wavesParallelRejected = 0;
   let wavesParallelFailed = 0;
   // Codex r4 on PR #229 [logic]: per-event reasonless counters so the
@@ -350,9 +363,16 @@ export function aggregateScheduler(cwd, state) {
         else if (Array.isArray(v)) for (const r of v) if (typeof r === 'string' && r) rejectionReasonSet.add(r);
       }
     }
-    if (typeof e?.failure_reason === 'string' && e.failure_reason) {
-      rejectionReasonSet.add(e.failure_reason);
-    }
+    // #230: do NOT union event.failure_reason into rejection_reasons.
+    // That free-form prose message was the paraphrase-bypass surface
+    // (codex r6 on PR #229). It stays alongside the canonical
+    // failure_code for operator readability but no longer feeds the
+    // gate's required-token set.
+  }
+
+  function collectFailureCode(e) {
+    if (e?.selected_mode !== 'parallel_failed') return;
+    if (isCanonicalFailureCode(e?.failure_code)) failureCodeSet.add(e.failure_code);
   }
 
   // Codex r5 on PR #229 [logic]: the reasonless check must be
@@ -375,7 +395,18 @@ export function aggregateScheduler(cwd, state) {
     return false;
   }
   function failedEventHasReason(e) {
-    return typeof e?.failure_reason === 'string' && e.failure_reason.length > 0;
+    // #230: a parallel_failed wave is "reasoned" when EITHER the
+    // free-form failure_reason carries a message OR a canonical
+    // failure_code is present. Codex r6 on PR #229 originally counted
+    // only failure_reason, which made `parallel_failed_without_reason`
+    // a load-bearing degraded token. With #230, canonical
+    // failure_codes carry the runtime cause and the gate requires
+    // each code in the explanation independently — so a wave with a
+    // canonical code is no longer "reasonless".
+    const reasoned =
+      (typeof e?.failure_reason === 'string' && e.failure_reason.length > 0) ||
+      isCanonicalFailureCode(e?.failure_code);
+    return reasoned;
   }
   for (const e of events) {
     tiersSeen.add(Number(e.tier));
@@ -395,6 +426,10 @@ export function aggregateScheduler(cwd, state) {
     // deferred phases. Limiting this to non-parallel events would wedge a
     // correctly generated summary that mentions wave-split block reasons.
     collectRejectionReasons(e);
+    // #230: canonical failure_code is only emitted on parallel_failed
+    // events. Collected separately so the gate can require it as an
+    // independent axis from rejection_reasons.
+    collectFailureCode(e);
   }
 
   const tiersParallelExecuted = [...expectedParallel].filter((t) =>
@@ -431,6 +466,13 @@ export function aggregateScheduler(cwd, state) {
     waves_parallel_failed_without_reason: wavesParallelFailedWithoutReason,
     tiers_with_partial_rejection: tiersWithPartialRejection,
     rejection_reasons: [...rejectionReasonSet].sort(),
+    // #230: canonical failure_code tokens — surfaced separately from
+    // rejection_reasons so the finalize gate can require each one
+    // independently. Empty when no parallel_failed event carried a
+    // canonical code (the executor will set 'unknown_runtime_error'
+    // when it cannot classify, so this is empty only when no wave
+    // failed at all).
+    failure_codes: [...failureCodeSet].sort(),
     affected_tier_ids,
   };
 }

--- a/hooks/lib/mpl-scheduler-failure-codes.mjs
+++ b/hooks/lib/mpl-scheduler-failure-codes.mjs
@@ -1,0 +1,47 @@
+/**
+ * #230 — Canonical `failure_code` allowlist for parallel_failed events.
+ *
+ * Before this module, `parallel_failed` events carried a free-form
+ * `failure_reason: err.message` string and the scheduler aggregator
+ * unioned that string into `rejection_reasons`. A free-form prose
+ * paraphrase of an error could satisfy the finalize gate's
+ * canonical-vocabulary check (#214) just by repeating the same words
+ * the executor happened to emit (e.g. `"worker dispatch failed"`),
+ * and a wave with both pre-attempt `rejection_reasons_by_phase`
+ * (planning) AND runtime `failure_reason` could be explained by the
+ * planning token alone, masking the runtime cause.
+ *
+ * This module enumerates the only `failure_code` values that
+ * parallel_failed events may carry. The aggregator collects these
+ * SEPARATELY from `rejection_reasons`, and the finalize gate
+ * requires each computed code to appear in `no_parallel_explanation`
+ * independently of the existing rejection-reason check.
+ *
+ * Producer contract (commands/mpl-run-execute.md Step 4.0):
+ *   - Pool / worktree setup failure  → 'worktree_setup_error'
+ *   - Worker dispatch / spawn failure → 'worker_dispatch_error'
+ *   - Per-phase execution failure inside the wave → 'wave_execution_error'
+ *   - Sequential merge-after-wave failure → 'merge_error'
+ *   - Anything not classifiable → 'unknown_runtime_error'
+ *
+ * Codes outside the allowlist are dropped at the aggregator boundary —
+ * they cannot forge their way into the explanation's required-token
+ * set. The free-form `failure_reason` message stays alongside the code
+ * for operator readability but no longer feeds the gate.
+ */
+
+export const FAILURE_CODE_ALLOWLIST = Object.freeze(new Set([
+  'worker_dispatch_error',
+  'worktree_setup_error',
+  'wave_execution_error',
+  'merge_error',
+  'unknown_runtime_error',
+]));
+
+/**
+ * Returns `true` when `code` is a recognized canonical failure code.
+ * `false` for null/undefined/non-string/non-allowlisted values.
+ */
+export function isCanonicalFailureCode(code) {
+  return typeof code === 'string' && FAILURE_CODE_ALLOWLIST.has(code);
+}

--- a/hooks/mpl-require-finalize-artifacts.mjs
+++ b/hooks/mpl-require-finalize-artifacts.mjs
@@ -322,6 +322,23 @@ function schedulerExplanationMissing(cwd, state) {
     }
   }
 
+  // #230 axis 1b — canonical failure_code per parallel_failed wave.
+  // Free-form `failure_reason` is no longer unioned into rejection_reasons
+  // (see mpl-scheduler-aggregate.mjs), so a wave with a runtime failure
+  // surfaces a canonical token in `computed.failure_codes` instead.
+  // EACH code must appear in the explanation independently — naming the
+  // pre-attempt rejection token (e.g. `file_overlap`) is not enough when
+  // the wave also failed at runtime. Use `every`, not `some`, so a mixed
+  // batch of failure codes cannot be satisfied by mentioning only one.
+  const computedFailureCodes = Array.isArray(computed?.failure_codes)
+    ? computed.failure_codes.filter((c) => typeof c === 'string' && c)
+    : [];
+  for (const code of computedFailureCodes) {
+    if (!containsToken(code)) {
+      return `scheduler:no_parallel_explanation_missing_failure_code:expected=${code}`;
+    }
+  }
+
   // #214 + codex r1/r2 [logic]: degraded-telemetry axis is INDEPENDENT
   // of the rejection-reasons axis. Codex r2 showed a mixed run (one
   // missing-telemetry tier + one tier with file_overlap) bypassed the
@@ -355,7 +372,20 @@ function schedulerExplanationMissing(cwd, state) {
     // Catch-all: aggregate still requires an explanation but no
     // specific degraded shape was identified (and no concrete reasons
     // were recorded).
-    if (requiredDegraded.length === 0 && computedReasons.length === 0) {
+    //
+    // #230: a canonical failure_code IS a recorded reason — when
+    // computed.failure_codes is non-empty, the runtime cause is
+    // already required as an independent axis (axis 1b above). Adding
+    // `no_recorded_reason` on top would force the operator to say both
+    // `worker_dispatch_error` AND `no_recorded_reason`, which is
+    // contradictory. Skip the fallback when failure_codes is non-empty.
+    const hasFailureCode = Array.isArray(computed?.failure_codes)
+      && computed.failure_codes.length > 0;
+    if (
+      requiredDegraded.length === 0 &&
+      computedReasons.length === 0 &&
+      !hasFailureCode
+    ) {
       requiredDegraded.push('no_recorded_reason');
     }
   }


### PR DESCRIPTION
## Summary

Closes #230. Two attack shapes survived PR #229's canonical-vocabulary gate; this PR closes both with a separate canonical `failure_code` allowlist surfaced as an independent axis from `rejection_reasons`.

## What

**New canonical allowlist (`hooks/lib/mpl-scheduler-failure-codes.mjs`)**:
- `worker_dispatch_error` — worker spawn / dispatch failure
- `worktree_setup_error` — pool / worktree creation failed before any worker dispatched
- `wave_execution_error` — one or more workers failed during the wave
- `merge_error` — sequential merge after the wave failed
- `unknown_runtime_error` — catch-all when the error cannot be classified

**Aggregator (`hooks/lib/mpl-scheduler-aggregate.mjs`)** — collects `failure_codes` from `parallel_failed` events into a separate set; non-allowlisted codes are silently dropped at this boundary. The free-form `event.failure_reason` is **no longer unioned** into `rejection_reasons` (paraphrase-bypass surface closed). `failedEventHasReason` now counts a canonical `failure_code` as a recorded reason so a wave with only a `failure_code` does not trip the `parallel_failed_without_reason` degraded axis.

**Finalize gate (`hooks/mpl-require-finalize-artifacts.mjs`)** — every token in `computed.failure_codes` must appear in `no_parallel_explanation` verbatim (snake_case / hyphen / space variants), independently of the existing rejection-reason check. The `no_recorded_reason` fallback skips when `failure_codes` is non-empty (codes already drive their own axis).

**Producer docs**:
- `commands/mpl-run-execute.md` Step 4.0 parallel_failed catch branch emits `failure_code` alongside `failure_reason` and enumerates the allowlist inline.
- `commands/mpl-run-finalize.md` documents the `failure_codes` aggregate field separately from `rejection_reasons` and adds a Canonical-failure_codes block to the `no_parallel_explanation` contract.

**Tests** — 14 new tests in `hooks/__tests__/mpl-issue-230-failure-code-canonical.test.mjs` covering both attack shapes (paraphrase bypass, masked runtime cause), the allowlist surface, the aggregator's separate-axis collection, the gate's per-code requirement, and hyphen/space variant acceptance. Existing PR #229 regression in `mpl-require-finalize-artifacts.test.mjs` updated to use the new `failure_code` field.

## Why

The issue body lists both paraphrase bypass and masked runtime cause as real surfaces that PR #229's union-into-rejection_reasons design cannot block. The chosen fix (separate canonical field) was preferred over the alternative (validate every `rejection_reasons` element against a strict canonical-token grammar) because it preserves the existing rejection-reason semantics for planning-time tokens (`file_overlap`, `single_ready_phase`) while adding a per-event runtime-cause requirement that cannot be conflated with planning tokens.

## Test plan

- [x] `node --test hooks/__tests__/mpl-issue-230-failure-code-canonical.test.mjs` → 14/14 pass
- [x] `node --test hooks/__tests__/*.test.mjs` → 1570/1570 pass (no regression in #229 / #214 / #205 suites; one #229 test updated to the new field).
- [x] Issue-body repros covered:
  - `failure_reason: "worker dispatch failed"` paraphrased in explanation alone → block.
  - Wave with both `file_overlap` (pre-attempt) AND `worker_dispatch_error` (runtime) → both tokens required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)