### PR TITLE
Close recorder semantic gaps: exit-code masking + I12 round-trip (#232)

### DIFF
--- a/hooks/__tests__/mpl-issue-232-recorder-semantic-gaps.test.mjs
+++ b/hooks/__tests__/mpl-issue-232-recorder-semantic-gaps.test.mjs
@@ -88,6 +88,27 @@ describe('#232 (1) compositeRejectReason detection — unit', () => {
     assert.equal(compositeRejectReason('npm test &> log.txt'), null);
   });
 
+  // Hermes r4 on PR #265: fd duplication (`n>&m`, `n<&m`, `>&-`)
+  // is a redirect operator, not a background-`&`. `2>&1` is the
+  // canonical "merge stderr into stdout" pattern, and the recorder
+  // must NOT drop legitimate logging shapes.
+  it('keeps `2>&1` and other fd-duplication forms (NOT background)', () => {
+    assert.equal(compositeRejectReason('npm test 2>&1'), null);
+    assert.equal(compositeRejectReason('npm test > log.txt 2>&1'), null);
+    assert.equal(compositeRejectReason('npm test 1>&2'), null);
+    assert.equal(compositeRejectReason('npm test 3>&1'), null);
+    assert.equal(compositeRejectReason('npm test >&-'), null);
+    assert.equal(compositeRejectReason('npm test <&3'), null);
+  });
+  it('keeps `bash -lc "npm test 2>&1"` — fd dup inside wrapper payload', () => {
+    assert.equal(compositeRejectReason('bash -lc "npm test 2>&1"'), null);
+  });
+  it('still flags bare `&` background even when redirect operators are also present', () => {
+    // `&` between redirects-and-command is still background.
+    assert.equal(compositeRejectReason('npm test > log.txt &'), 'background');
+    assert.equal(compositeRejectReason('npm test 2>&1 &'), 'background');
+  });
+
   it('keeps trailing comment shapes — `#` is shell-discarded', () => {
     assert.equal(compositeRejectReason('npm test # smoke'), null);
   });

--- a/hooks/__tests__/mpl-issue-232-recorder-semantic-gaps.test.mjs
+++ b/hooks/__tests__/mpl-issue-232-recorder-semantic-gaps.test.mjs
@@ -134,6 +134,12 @@ describe('#232 (1) compositeRejectReason detection — unit', () => {
   it('flags `+o errexit -c` style (off-option flag) too', () => {
     assert.equal(compositeRejectReason('bash +o errexit -c "npm test || true"'), 'or_or');
   });
+  it('flags `-O extglob -c` style (shopt option flag with value)', () => {
+    // Hermes r3 on PR #265: bash also exposes shopt via -O / +O,
+    // structurally identical to -o / +o.
+    assert.equal(compositeRejectReason('bash -O extglob -c "npm test || true"'), 'or_or');
+    assert.equal(compositeRejectReason('bash +O nullglob -c "npm test ; true"'), 'semicolon');
+  });
   it('flags `--rcfile <path> -c` (rcfile flag takes value)', () => {
     assert.equal(compositeRejectReason('bash --rcfile /tmp/rc -c "npm test ; true"'), 'semicolon');
   });

--- a/hooks/__tests__/mpl-issue-232-recorder-semantic-gaps.test.mjs
+++ b/hooks/__tests__/mpl-issue-232-recorder-semantic-gaps.test.mjs
@@ -97,6 +97,30 @@ describe('#232 (1) compositeRejectReason detection — unit', () => {
     assert.equal(compositeRejectReason('pytest -k "login || logout"'), null);
   });
 
+  // Hermes review on PR #265: shell wrappers (`bash -c`, `sh -c`,
+  // `bash -lc`, ...) hide the payload from the outer quote-aware
+  // scan. The wrapper itself evaluates the masking operator
+  // internally, so the bypass surface must extend into the wrapped
+  // payload.
+  it('flags `bash -lc "npm test || true"` — masking inside shell wrapper payload', () => {
+    assert.equal(compositeRejectReason('bash -lc "npm test || true"'), 'or_or');
+  });
+  it('flags `sh -c "npx playwright test | tee out.log"` — pipe inside wrapped payload', () => {
+    assert.equal(compositeRejectReason('sh -c "npx playwright test | tee out.log"'), 'pipe');
+  });
+  it('flags `bash -c \'npm test ; true\'` — semicolon inside wrapped payload', () => {
+    assert.equal(compositeRejectReason("bash -c 'npm test ; true'"), 'semicolon');
+  });
+  it('flags `/usr/local/bin/bash -lc "npm test || true"` — path-qualified shell head', () => {
+    assert.equal(compositeRejectReason('/usr/local/bin/bash -lc "npm test || true"'), 'or_or');
+  });
+  it('keeps `bash -lc "npm test && echo done"` — `&&` in payload still safe', () => {
+    assert.equal(compositeRejectReason('bash -lc "npm test && echo done"'), null);
+  });
+  it('keeps `bash -lc "npm test"` — no composite in payload', () => {
+    assert.equal(compositeRejectReason('bash -lc "npm test"'), null);
+  });
+
   it('classifier still resolves leading family on composite shapes — PR #220 contract preserved', () => {
     // The classifier is unchanged for these shapes (the recorder is
     // where rejection happens). Asserting here so a future refactor
@@ -321,5 +345,26 @@ describe('#232 (1) recorder integration — masking composites do not produce ga
     const state = postToolUse('docker compose run app npm test', { exit_code: 0 });
     assert.equal(state.gate_results?.hard2_coverage?.source, 'recorder',
       'recorder must tag every entry with source: \'recorder\' so I12 can skip strict re-validation');
+  });
+
+  // Hermes review on PR #265 found this bypass: the masking
+  // operator is hidden inside the shell wrapper's quoted payload, so
+  // the outer compositeRejectReason scan let it through. The
+  // wrapper-payload re-scan now catches it.
+  it('`bash -lc "npm test || true"` (shell-wrapper masking) does NOT produce a hard2_coverage entry', () => {
+    const state = postToolUse('bash -lc "npm test || true"', { exit_code: 0 });
+    assert.equal(state.gate_results?.hard2_coverage, undefined,
+      `recorder must drop wrapper-hidden masking composites, got: ${JSON.stringify(state.gate_results)}`);
+  });
+
+  it('`sh -c "npx playwright test | tee out.log"` (wrapped pipe) does NOT produce a hard3_resilience entry', () => {
+    const state = postToolUse('sh -c "npx playwright test | tee out.log"', { exit_code: 0 });
+    assert.equal(state.gate_results?.hard3_resilience, undefined,
+      `recorder must drop wrapper-hidden pipes, got: ${JSON.stringify(state.gate_results)}`);
+  });
+
+  it('`bash -lc "npm test"` (no payload composite) DOES still record', () => {
+    const state = postToolUse('bash -lc "npm test"', { exit_code: 0 });
+    assert.equal(state.gate_results?.hard2_coverage?.command, 'bash -lc "npm test"');
   });
 });

--- a/hooks/__tests__/mpl-issue-232-recorder-semantic-gaps.test.mjs
+++ b/hooks/__tests__/mpl-issue-232-recorder-semantic-gaps.test.mjs
@@ -1,0 +1,325 @@
+/**
+ * #232 — Recorder semantic gaps after PR #231.
+ *
+ * Two structurally-distinct surfaces remained from the strict / recorder
+ * unification work:
+ *
+ *  (1) The recorder cut at the first control operator and classified
+ *      only the leading simple command, BUT it still stored the OVERALL
+ *      shell exit code from the composite. So:
+ *        - `npm test || true`             → leading=npm test (hard2),
+ *                                            shell exit = 0 from `true`
+ *        - `npm test ; true`              → leading=npm test (hard2),
+ *                                            shell exit = 0 from `true`
+ *        - `npx playwright test | tee X`  → leading=npx playwright (hard3),
+ *                                            shell exit = tee's (typically 0)
+ *      Result: a failing gate command could record as a PASS row in
+ *      `state.gate_results`. The fix rejects composite shapes at the
+ *      recorder classifier so the recorder drops the event entirely.
+ *
+ *  (2) The recorder accepts execution-wrapper heads (`docker`, `bash -lc`,
+ *      `kubectl exec`) because they are legitimate gate evidence; the
+ *      strict allowlist deliberately rejects them. A recorder write of
+ *      `docker compose run app npm test` therefore re-classified as `null`
+ *      on the next I12 STATE_WRITE check, firing a family mismatch on
+ *      legitimate recorder evidence. The fix tags every recorder entry
+ *      with `source: 'recorder'` and I12 skips strict re-validation for
+ *      those entries.
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { tmpdir } from 'os';
+
+import {
+  classifyRecordedCommand,
+  classifyGateCommand,
+  compositeRejectReason,
+} from '../lib/mpl-gate-classify.mjs';
+import { CURRENT_SCHEMA_VERSION } from '../lib/mpl-state.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const STATE_INVARIANT_HOOK = join(dirname(__filename), '..', 'mpl-state-invariant.mjs');
+
+// ---------------------------------------------------------------------------
+// (1) Exit-code masking — composite shapes rejected at the recorder
+// ---------------------------------------------------------------------------
+
+describe('#232 (1) compositeRejectReason detection — unit', () => {
+  // The classifier itself preserves PR #220's leading-command family
+  // assignment so legitimate consumers (manual gate-evidence writes
+  // with a redirect, structured-write tests probing family) still
+  // resolve. The recorder hook (mpl-gate-recorder.mjs) consumes
+  // compositeRejectReason() to refuse the write when the shell exit
+  // would be unreliable; that integration is exercised in the next
+  // suite via the live recorder.
+  it('flags `||` as or_or — `||` swallows the failure', () => {
+    assert.equal(compositeRejectReason('npm test || true'), 'or_or');
+  });
+
+  it('flags `;` as semicolon — `;` runs both, shell exit = last', () => {
+    assert.equal(compositeRejectReason('npm test ; true'), 'semicolon');
+  });
+
+  it('flags bare `|` as pipe — exit = rightmost', () => {
+    assert.equal(compositeRejectReason('npx playwright test | tee output.log'), 'pipe');
+  });
+
+  it('flags bare `&` as background', () => {
+    assert.equal(compositeRejectReason('npm test &'), 'background');
+  });
+
+  it('flags newline / CR as newline', () => {
+    assert.equal(compositeRejectReason('npm test\ntrue'), 'newline');
+    assert.equal(compositeRejectReason('npm test\rtrue'), 'newline');
+  });
+
+  it('keeps `&&` (short-circuits — leading failure propagates)', () => {
+    assert.equal(compositeRejectReason('npm test && echo ok'), null);
+  });
+
+  it('keeps redirects (`>`, `>>`, `&>`) — they do not mask exit codes', () => {
+    assert.equal(compositeRejectReason('npm test > log.txt'), null);
+    assert.equal(compositeRejectReason('npm test >> log.txt'), null);
+    assert.equal(compositeRejectReason('npm test &> log.txt'), null);
+  });
+
+  it('keeps trailing comment shapes — `#` is shell-discarded', () => {
+    assert.equal(compositeRejectReason('npm test # smoke'), null);
+  });
+
+  it('ignores operators inside single / double quotes (pytest -k filters)', () => {
+    assert.equal(compositeRejectReason("pytest -k 'login || logout'"), null);
+    assert.equal(compositeRejectReason('pytest -k "login || logout"'), null);
+  });
+
+  it('classifier still resolves leading family on composite shapes — PR #220 contract preserved', () => {
+    // The classifier is unchanged for these shapes (the recorder is
+    // where rejection happens). Asserting here so a future refactor
+    // that moves rejection back into the classifier flags the
+    // regression against PR #220's intent.
+    assert.equal(classifyRecordedCommand('npm test || echo playwright'), 'hard2_coverage');
+    assert.equal(classifyRecordedCommand('npm test > playwright'), 'hard2_coverage');
+    assert.equal(classifyRecordedCommand('docker compose run app npm test'), 'hard2_coverage');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (2) Strict / recorder allowlist divergence — round-trip via source marker
+// ---------------------------------------------------------------------------
+
+describe('#232 (2) I12 skips strict re-validation for recorder-sourced entries', () => {
+  let tmp;
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'mpl-232-i12-'));
+    mkdirSync(join(tmp, '.mpl'), { recursive: true });
+    writeFileSync(join(tmp, '.mpl', 'state.json'), JSON.stringify({
+      schema_version: CURRENT_SCHEMA_VERSION,
+      current_phase: 'phase3-gate',
+      gate_results: {},
+    }));
+  });
+  afterEach(() => rmSync(tmp, { recursive: true, force: true }));
+
+  function runStateInvariant(stateDelta) {
+    // Drive checkI12 by issuing a Task tool input that triggers
+    // STATE_WRITE on state.json. The simplest path is to invoke the
+    // hook with a Write of state.json containing the delta.
+    const fullState = {
+      schema_version: CURRENT_SCHEMA_VERSION,
+      current_phase: 'phase3-gate',
+      ...stateDelta,
+    };
+    const input = {
+      cwd: tmp,
+      // deriveTrigger() requires hook_event_name to map tool_name to a
+      // STATE_WRITE trigger; without it the hook resolves to STOP and
+      // skips the I12 check entirely.
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Write',
+      tool_input: {
+        file_path: '.mpl/state.json',
+        content: JSON.stringify(fullState),
+      },
+    };
+    return JSON.parse(execFileSync('node', [STATE_INVARIANT_HOOK], {
+      input: JSON.stringify(input),
+      encoding: 'utf-8',
+    }));
+  }
+
+  it('a recorder-sourced wrapper entry (`docker compose run app npm test`) does NOT surface I12', () => {
+    // Pre-#232, this would have classified as `null` under strict
+    // (head `docker` not in STRICT_GATE_HEAD_ALLOWLIST) and fired
+    // GATE_COMMAND_FAMILY_MISMATCH. The `source: 'recorder'` marker
+    // now causes I12 to skip the strict re-check for this entry.
+    //
+    // Other invariants (I6 missing hard1/hard3 evidence on this
+    // minimal fixture, I13 phase0 artifact requirement) may still
+    // surface — they are unrelated to #232. The narrow assertion is
+    // that the surfaced reason MUST NOT mention I12 / family mismatch.
+    const r = runStateInvariant({
+      gate_results: {
+        hard2_coverage: {
+          command: 'docker compose run app npm test',
+          exit_code: 0,
+          timestamp: '2026-05-30T00:00:00.000Z',
+          source: 'recorder',
+        },
+      },
+    });
+    const surfaced = r.reason || r.systemMessage || '';
+    assert.doesNotMatch(
+      surfaced,
+      /I12|gate_command_family_mismatch|GATE_COMMAND_FAMILY_MISMATCH/i,
+      `recorder-sourced wrapper entry must not trip I12, got: ${surfaced}`,
+    );
+  });
+
+  it('a manually-written wrapper entry (no source marker) still surfaces I12', () => {
+    // The carve-out is narrowly scoped to entries that claim recorder
+    // provenance. Manual writes that try to pass a wrapper without
+    // the marker stay flagged by the I12 invariant — strict default
+    // policy is `warn` (ENFORCEMENT_DEFAULTS.state_invariant_violation
+    // = 'warn'), so the hook returns continue:true with a systemMessage
+    // naming I12 / GATE_COMMAND_FAMILY_MISMATCH. The carve-out must
+    // not suppress that surfacing.
+    const r = runStateInvariant({
+      gate_results: {
+        hard2_coverage: {
+          command: 'docker compose run app npm test',
+          exit_code: 0,
+          timestamp: '2026-05-30T00:00:00.000Z',
+        },
+      },
+    });
+    // Either decision === 'block' (strict mode) or warn with the
+    // I12 / family-mismatch text — both prove the strict path remains
+    // load-bearing for the hand-edit shape.
+    const surfaced = r.decision === 'block' || typeof r.systemMessage === 'string';
+    assert.ok(surfaced, `expected I12 to surface for manual write, got ${JSON.stringify(r)}`);
+    const message = r.reason || r.systemMessage || '';
+    assert.match(message, /I12|gate_command_family_mismatch|GATE_COMMAND_FAMILY_MISMATCH/i,
+      `expected I12 message, got ${message}`);
+  });
+
+  it('a recorder-sourced slot-mismatch (npm test in hard3 slot) does NOT surface I12 (other invariants may still fire)', () => {
+    // The source-marker carve-out trusts the classification the
+    // recorder produced; it does NOT trust that an arbitrary command
+    // was placed in the right family slot. Today the recorder writes
+    // each command into the slot it classified into, so a slot/family
+    // mismatch is a manual-edit / drift shape — out of #232's scope.
+    //
+    // The relevant assertion is therefore narrow: the I12
+    // GATE_COMMAND_FAMILY_MISMATCH text MUST NOT appear in the
+    // surfaced reason for a source:'recorder' entry. Other
+    // invariants (I6 — missing structured gate evidence for the
+    // other Hard slots) still fire on this minimal fixture and may
+    // produce a block; that is intentional and unrelated to #232.
+    const r = runStateInvariant({
+      gate_results: {
+        hard3_resilience: {
+          command: 'npm test',
+          exit_code: 0,
+          timestamp: '2026-05-30T00:00:00.000Z',
+          source: 'recorder',
+        },
+      },
+    });
+    const surfaced = r.reason || r.systemMessage || '';
+    assert.doesNotMatch(
+      surfaced,
+      /I12|gate_command_family_mismatch|GATE_COMMAND_FAMILY_MISMATCH/i,
+      `I12 must not surface for source:'recorder' entries, got: ${surfaced}`,
+    );
+  });
+
+  it('strict allowlist is unaffected for manual writes — wrapper still rejected', () => {
+    // Direct unit-level check that strict classification is unchanged.
+    assert.equal(classifyGateCommand('docker compose run app npm test'), null);
+    assert.equal(classifyGateCommand('bash -lc "npm test"'), null);
+    assert.equal(classifyGateCommand('kubectl exec pod -- npm test'), null);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Combined surface — both fixes are needed together
+// ---------------------------------------------------------------------------
+
+describe('#232 (1) recorder integration — masking composites do not produce gate_results entries', () => {
+  let tmp;
+  const RECORDER_HOOK = join(dirname(__filename), '..', 'mpl-gate-recorder.mjs');
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'mpl-232-recorder-'));
+    mkdirSync(join(tmp, '.mpl'), { recursive: true });
+    writeFileSync(join(tmp, '.mpl', 'state.json'), JSON.stringify({
+      schema_version: CURRENT_SCHEMA_VERSION,
+      current_phase: 'phase3-gate',
+    }));
+  });
+  afterEach(() => rmSync(tmp, { recursive: true, force: true }));
+
+  function postToolUse(command, { exit_code = 0, stdout = '' } = {}) {
+    const input = {
+      cwd: tmp,
+      hook_event_name: 'PostToolUse',
+      tool_name: 'Bash',
+      tool_input: { command },
+      tool_response: {
+        exit_code,
+        stdout,
+      },
+    };
+    execFileSync('node', [RECORDER_HOOK], {
+      input: JSON.stringify(input),
+      encoding: 'utf-8',
+      timeout: 5000,
+    });
+    return JSON.parse(readFileSync(join(tmp, '.mpl', 'state.json'), 'utf-8'));
+  }
+
+  it('`npm test || true` with shell exit 0 does NOT produce a hard2_coverage entry', () => {
+    // The classic paraphrase: `|| true` swallows the npm test failure,
+    // so the shell exit is 0 even when npm test failed. Pre-#232 the
+    // recorder happily wrote a passing hard2_coverage entry. Now it
+    // refuses to record any masking-composite shape.
+    const state = postToolUse('npm test || true', { exit_code: 0 });
+    assert.equal(state.gate_results?.hard2_coverage, undefined,
+      `recorder must drop `||` composites, got: ${JSON.stringify(state.gate_results)}`);
+  });
+
+  it('`npx playwright test | tee output.log` does NOT produce a hard3_resilience entry', () => {
+    const state = postToolUse('npx playwright test | tee output.log', { exit_code: 0 });
+    assert.equal(state.gate_results?.hard3_resilience, undefined,
+      `recorder must drop pipes, got: ${JSON.stringify(state.gate_results)}`);
+  });
+
+  it('`npm test ; true` does NOT produce a hard2_coverage entry', () => {
+    const state = postToolUse('npm test ; true', { exit_code: 0 });
+    assert.equal(state.gate_results?.hard2_coverage, undefined);
+  });
+
+  it('`npm test && echo done` DOES produce a hard2_coverage entry (safe shape)', () => {
+    // `&&` short-circuits → leading failure propagates to the shell
+    // exit. Recording this shape is safe.
+    const state = postToolUse('npm test && echo done', { exit_code: 0 });
+    assert.equal(state.gate_results?.hard2_coverage?.command, 'npm test && echo done');
+    assert.equal(state.gate_results?.hard2_coverage?.exit_code, 0);
+  });
+
+  it('`npm test > log.txt` DOES produce a hard2_coverage entry (redirect is safe)', () => {
+    const state = postToolUse('npm test > log.txt', { exit_code: 0 });
+    assert.equal(state.gate_results?.hard2_coverage?.command, 'npm test > log.txt');
+  });
+
+  it('recorder writes carry `source: \'recorder\'` for #232 (2) round-trip', () => {
+    const state = postToolUse('docker compose run app npm test', { exit_code: 0 });
+    assert.equal(state.gate_results?.hard2_coverage?.source, 'recorder',
+      'recorder must tag every entry with source: \'recorder\' so I12 can skip strict re-validation');
+  });
+});

--- a/hooks/__tests__/mpl-issue-232-recorder-semantic-gaps.test.mjs
+++ b/hooks/__tests__/mpl-issue-232-recorder-semantic-gaps.test.mjs
@@ -121,6 +121,35 @@ describe('#232 (1) compositeRejectReason detection — unit', () => {
     assert.equal(compositeRejectReason('bash -lc "npm test"'), null);
   });
 
+  // Hermes follow-up review on PR #265 (HEAD 4caf885): two more
+  // wrapper bypasses surfaced. The flag-with-value `-o pipefail`
+  // consumed the loop's `-c` skip; nested wrappers needed iterative
+  // peeling instead of one-shot.
+  it('flags `bash -o pipefail -c "npm test || true"` — option flag with value precedes -c', () => {
+    assert.equal(compositeRejectReason('bash -o pipefail -c "npm test || true"'), 'or_or');
+  });
+  it("flags `bash -lc \"bash -c 'npm test || true'\"` — nested shell wrapper", () => {
+    assert.equal(compositeRejectReason(`bash -lc "bash -c 'npm test || true'"`), 'or_or');
+  });
+  it('flags `+o errexit -c` style (off-option flag) too', () => {
+    assert.equal(compositeRejectReason('bash +o errexit -c "npm test || true"'), 'or_or');
+  });
+  it('flags `--rcfile <path> -c` (rcfile flag takes value)', () => {
+    assert.equal(compositeRejectReason('bash --rcfile /tmp/rc -c "npm test ; true"'), 'semicolon');
+  });
+  it('keeps `bash -o pipefail -c "npm test"` — no payload composite', () => {
+    assert.equal(compositeRejectReason('bash -o pipefail -c "npm test"'), null);
+  });
+  it('bounded depth: pathological nesting eventually falls open, recorder records', () => {
+    // Past the bound, the helper falls open. This is documented behavior:
+    // the bound is a runaway-loop backstop, not a real bypass surface (any
+    // realistic command is well under 5 levels of wrapping).
+    let nested = 'npm test || true';
+    for (let i = 0; i < 10; i++) nested = `bash -c "${nested.replace(/"/g, '\\"')}"`;
+    // No assertion that this returns null — only that it doesn't throw or hang.
+    assert.doesNotThrow(() => compositeRejectReason(nested));
+  });
+
   it('classifier still resolves leading family on composite shapes — PR #220 contract preserved', () => {
     // The classifier is unchanged for these shapes (the recorder is
     // where rejection happens). Asserting here so a future refactor

--- a/hooks/lib/mpl-gate-classify.mjs
+++ b/hooks/lib/mpl-gate-classify.mjs
@@ -825,6 +825,16 @@ const SHELL_WRAPPER_HEADS = new Set([
   'sh', 'bash', 'zsh', 'fish', 'dash', 'ksh', 'csh', 'tcsh',
 ]);
 
+// Shell-wrapper flags that take a SEPARATE value token, so the loop
+// must consume two tokens instead of one when it sees them. `-o <opt>`
+// (e.g. `bash -o pipefail -c ...`) is the canonical Hermes-found case;
+// `--rcfile <path>` and `--init-file <path>` are the documented bash
+// long-form equivalents. GNU-style `--flag=value` is single-token and
+// handled by the `includes('=')` branch in the main loop.
+const SHELL_WRAPPER_FLAGS_WITH_VALUE = new Set([
+  '-o', '+o', '--rcfile', '--init-file',
+]);
+
 function extractShellWrapperPayload(command) {
   const tokens = command.trim().split(/\s+/);
   if (tokens.length < 3) return null;
@@ -833,14 +843,21 @@ function extractShellWrapperPayload(command) {
   const baseHead = head.includes('/') ? head.slice(head.lastIndexOf('/') + 1) : head;
   if (!SHELL_WRAPPER_HEADS.has(baseHead)) return null;
   // Walk past leading flags until we find one whose final char is `c`
-  // (`-c`, `-lc`, `-ic`, ...). Skip plain flags that take a value
-  // conservatively; if we hit the end without a `-c`-family flag,
-  // bail out (this isn't a `-c` invocation).
+  // (`-c`, `-lc`, `-ic`, ...). Consume value tokens for flags that
+  // take a value (`-o pipefail`); skip GNU-style `--flag=value`
+  // single-token. If we hit the end without a `-c`-family flag, bail
+  // out (this isn't a `-c` invocation).
   let i = 1;
   while (i < tokens.length) {
     const t = tokens[i];
-    if (!t.startsWith('-')) break;
+    // Bash accepts both `-`-prefixed and `+`-prefixed option flags
+    // (`-o option` enables, `+o option` disables). Either kind sits
+    // between the head and `-c`; treat them the same way.
+    if (!t.startsWith('-') && !t.startsWith('+')) break;
     if (/^-[a-z]*c$/i.test(t)) { i++; break; }
+    if (SHELL_WRAPPER_FLAGS_WITH_VALUE.has(t)) { i += 2; continue; }
+    // Single-token forms: `--rcfile=path`, `--noprofile`, `-p`, `-i`,
+    // etc. Treat as flag-only and continue.
     i++;
   }
   if (i >= tokens.length) return null;
@@ -854,22 +871,28 @@ function extractShellWrapperPayload(command) {
   return m ? m[2] : rest;
 }
 
+// Bounded loop count: a pathological nested wrapper
+// (`bash -c "bash -c \"bash -c ...\""`) would otherwise run away.
+// Five levels covers any real-world wrapper composition; past that,
+// the helper falls open and the recorder records (no false-block
+// surface). Convergence: every iteration either reports a masking
+// operator (exit) or strips a wrapper level (i shrinks until the
+// non-wrapper base command is reached).
+const COMPOSITE_REJECT_MAX_PEEL_DEPTH = 5;
+
 export function compositeRejectReason(command) {
-  // First, scan the command as-is. Operators outside of quotes are
-  // legitimate composites and surface immediately.
-  const outer = scanForMaskingOperator(command);
-  if (outer !== null) return outer;
-  // Second pass — if the command is a shell wrapper, the payload was
-  // hidden inside the wrapper's quoted argument. Re-scan that payload
-  // so `bash -lc "npm test || true"` no longer slips through. One
-  // level of unwrapping is sufficient: a nested wrapper
-  // (`bash -lc "bash -c 'npm test || true'"`) would itself contain
-  // the outer wrapper's quotes, and a payload-level scan inside the
-  // first peel reaches the inner `||` directly.
-  const payload = extractShellWrapperPayload(command);
-  if (payload !== null) {
-    const inner = scanForMaskingOperator(payload);
-    if (inner !== null) return inner;
+  // Iteratively peel shell-wrapper layers, scanning each layer for a
+  // masking operator. The outer scan handles plain composites; the
+  // peel handles wrappers; nested wrappers (Hermes follow-up:
+  // `bash -lc "bash -c 'npm test || true'"`) are exposed level by
+  // level so the inner `||` surfaces correctly.
+  let current = command;
+  for (let depth = 0; depth < COMPOSITE_REJECT_MAX_PEEL_DEPTH; depth++) {
+    const reason = scanForMaskingOperator(current);
+    if (reason !== null) return reason;
+    const payload = extractShellWrapperPayload(current);
+    if (payload === null) return null;
+    current = payload;
   }
   return null;
 }

--- a/hooks/lib/mpl-gate-classify.mjs
+++ b/hooks/lib/mpl-gate-classify.mjs
@@ -754,8 +754,72 @@ function stripNonExecutedSuffix(command) {
   return command.slice(0, cut);
 }
 
+// #232 (1) [data-integrity]: composite shapes that mask the leading
+// command's exit code in the overall shell exit. The recorder reads
+// the shell's exit code, so any composite where the gate command's
+// failure does NOT propagate to the shell exit is a false-PASS
+// surface:
+//   - `npm test || true`   — `||` swallows the failure (right side runs
+//                            on left's failure and its exit becomes the
+//                            shell exit)
+//   - `npm test ; true`    — `;` runs both, shell exit = `true` (0)
+//   - `npm test | tee log` — pipe exit = rightmost (tee's exit)
+//   - `npm test &`         — background; shell returns 0 immediately
+//   - newline / carriage return — multi-command shape, shell exit = last
+//
+// `&&` is genuinely safe (short-circuits on failure → leading
+// command's exit propagates). Redirects `>`, `>>`, `<`, `<<`, `&>`
+// move bytes/file descriptors, not exit codes. Comments `#` are
+// discarded by the shell.
+//
+// Detection runs on the ORIGINAL command, not on the
+// stripNonExecutedSuffix output (the suffix-strip would have already
+// hidden the offending operator). Returning `null` here drops the
+// recorder event entirely — better than letting a false-PASS row land
+// in `state.gate_results`.
+//
+// The walker is quote-aware at the level of single / double quotes so
+// operators inside `pytest -k 'a || b'` are ignored. Backticks and
+// `$(...)` are subshell openers — stripNonExecutedSuffix already cuts
+// at them on the strict side, but here we treat them as quotes during
+// the scan so the operator inside the subshell does not double-count.
+export function compositeRejectReason(command) {
+  let inSingle = false;
+  let inDouble = false;
+  for (let i = 0; i < command.length; i++) {
+    const ch = command[i];
+    if (ch === "'" && !inDouble) { inSingle = !inSingle; continue; }
+    if (ch === '"' && !inSingle) { inDouble = !inDouble; continue; }
+    if (inSingle || inDouble) continue;
+    if (ch === '|') {
+      // `||` — exit-code-masking (left's failure runs the right; shell
+      // exit becomes the right side's exit).
+      // bare `|` — pipe; exit = rightmost segment.
+      return command[i + 1] === '|' ? 'or_or' : 'pipe';
+    }
+    if (ch === ';') return 'semicolon';
+    if (ch === '\n' || ch === '\r') return 'newline';
+    if (ch === '&') {
+      const next = command[i + 1];
+      if (next === '&') { i++; continue; }    // `&&` safe — skip both chars
+      if (next === '>') { i++; continue; }    // `&>` redirect safe
+      return 'background';                     // bare `&` — background
+    }
+  }
+  return null;
+}
+
 export function classifyRecordedCommand(command) {
   if (typeof command !== 'string' || !command.trim()) return null;
+  // #232 (1) [data-integrity]: the recorder hook (not this classifier)
+  // is responsible for refusing to record evidence when the command
+  // shape would let a misleading shell exit code stamp a passing
+  // entry. The classifier preserves PR #220's leading-command family
+  // assignment so legitimate consumers (manual gate-evidence writes
+  // that include a redirect, structured-write tests that pass a
+  // composite for family probing) still resolve. See
+  // `compositeRejectReason` — exported above for the recorder hook
+  // to consume at write time.
   const trimmed = stripNonExecutedSuffix(command);
   if (!trimmed.trim()) return null;
   return matchFamilyRegex(trimmed);

--- a/hooks/lib/mpl-gate-classify.mjs
+++ b/hooks/lib/mpl-gate-classify.mjs
@@ -786,6 +786,13 @@ function stripNonExecutedSuffix(command) {
 function scanForMaskingOperator(command) {
   let inSingle = false;
   let inDouble = false;
+  // Track the most recent non-whitespace significant character so the
+  // `&` branch can distinguish bare background-`&` from fd-duplication
+  // forms like `2>&1`, `1>&2`, `>&-`, `<&-`, `n<&m`. In all those
+  // cases the `&` is preceded by `>` or `<` (possibly across a digit),
+  // never bare. Quotes are not significant here; they're consumed
+  // above before this update.
+  let prevSig = '';
   for (let i = 0; i < command.length; i++) {
     const ch = command[i];
     if (ch === "'" && !inDouble) { inSingle = !inSingle; continue; }
@@ -801,10 +808,27 @@ function scanForMaskingOperator(command) {
     if (ch === '\n' || ch === '\r') return 'newline';
     if (ch === '&') {
       const next = command[i + 1];
-      if (next === '&') { i++; continue; }    // `&&` safe — skip both chars
-      if (next === '>') { i++; continue; }    // `&>` redirect safe
-      return 'background';                     // bare `&` — background
+      if (next === '&') { i++; prevSig = '&'; continue; }   // `&&` safe — skip both chars
+      if (next === '>') { i++; prevSig = '>'; continue; }   // `&>` redirect safe
+      // Hermes r4 on PR #265: fd duplication `n>&m` / `n<&m` /
+      // `>&-` / `<&-` puts `&` AFTER a redirect operator. The
+      // preceding significant char is `>` or `<` (possibly with a
+      // digit between, which we treat as still-redirect because
+      // `2>` is one logical token). Detect by walking backward
+      // past digits to the operator.
+      let j = i - 1;
+      while (j >= 0 && command[j] >= '0' && command[j] <= '9') j--;
+      if (j >= 0 && (command[j] === '>' || command[j] === '<')) {
+        // fd duplication — the `&` is part of the redirect token,
+        // not a background marker. Skip the next token target too
+        // (`-`, a digit, or a word) but lazy: just continue, the
+        // following chars will be re-classified by the loop.
+        prevSig = '&';
+        continue;
+      }
+      return 'background';                                   // bare `&` — background
     }
+    if (ch !== ' ' && ch !== '\t') prevSig = ch;
   }
   return null;
 }

--- a/hooks/lib/mpl-gate-classify.mjs
+++ b/hooks/lib/mpl-gate-classify.mjs
@@ -859,8 +859,9 @@ const SHELL_WRAPPER_HEADS = new Set([
 //                                   (extglob, nullglob, …)
 //   `--rcfile <path>` / `--init-file <path>` — bash startup file
 //   `--noediting` is single-token, NOT here; `--login` ditto.
-// GNU-style `--flag=value` is single-token and handled by the
-// includes('=') branch in the main loop.
+// GNU-style `--flag=value` is single-token: it doesn't appear in this
+// set and naturally falls through the "single-token, advance by 1"
+// branch in extractShellWrapperPayload below.
 const SHELL_WRAPPER_FLAGS_WITH_VALUE = new Set([
   '-o', '+o', '-O', '+O', '--rcfile', '--init-file',
 ]);

--- a/hooks/lib/mpl-gate-classify.mjs
+++ b/hooks/lib/mpl-gate-classify.mjs
@@ -783,7 +783,7 @@ function stripNonExecutedSuffix(command) {
 // `$(...)` are subshell openers — stripNonExecutedSuffix already cuts
 // at them on the strict side, but here we treat them as quotes during
 // the scan so the operator inside the subshell does not double-count.
-export function compositeRejectReason(command) {
+function scanForMaskingOperator(command) {
   let inSingle = false;
   let inDouble = false;
   for (let i = 0; i < command.length; i++) {
@@ -805,6 +805,71 @@ export function compositeRejectReason(command) {
       if (next === '>') { i++; continue; }    // `&>` redirect safe
       return 'background';                     // bare `&` — background
     }
+  }
+  return null;
+}
+
+// #232 follow-up (Hermes review on PR #265): shell wrappers conceal
+// the payload from the outer quote-aware scan. `bash -lc "npm test
+// || true"` passes the outer scan because the `||` lives inside the
+// double-quoted argument, but the shell DOES evaluate the `||`
+// internally — the wrapper executes the composite as one shell
+// session and emits the bypass-shaped exit code. Detect the wrapper
+// shape and re-scan the unwrapped payload so the masking operator
+// surfaces.
+//
+// Recognized wrappers: posix shells (bash/sh/zsh/dash/ksh/csh/tcsh/
+// fish) with a `-c` family flag (`-c`, `-lc`, `-ic`, `-ilc`, etc. —
+// any `-` flag whose final character is `c`).
+const SHELL_WRAPPER_HEADS = new Set([
+  'sh', 'bash', 'zsh', 'fish', 'dash', 'ksh', 'csh', 'tcsh',
+]);
+
+function extractShellWrapperPayload(command) {
+  const tokens = command.trim().split(/\s+/);
+  if (tokens.length < 3) return null;
+  const head = tokens[0].toLowerCase();
+  // Reduce path-qualified head to basename so /bin/bash matches.
+  const baseHead = head.includes('/') ? head.slice(head.lastIndexOf('/') + 1) : head;
+  if (!SHELL_WRAPPER_HEADS.has(baseHead)) return null;
+  // Walk past leading flags until we find one whose final char is `c`
+  // (`-c`, `-lc`, `-ic`, ...). Skip plain flags that take a value
+  // conservatively; if we hit the end without a `-c`-family flag,
+  // bail out (this isn't a `-c` invocation).
+  let i = 1;
+  while (i < tokens.length) {
+    const t = tokens[i];
+    if (!t.startsWith('-')) break;
+    if (/^-[a-z]*c$/i.test(t)) { i++; break; }
+    i++;
+  }
+  if (i >= tokens.length) return null;
+  // Re-join the remainder so a multi-token quoted payload survives the
+  // initial whitespace split, then peel one wrapping pair of single
+  // or double quotes if present. The recursive scan will run on the
+  // peeled text; nested quotes inside the payload behave normally
+  // because the recursive call uses scanForMaskingOperator unchanged.
+  const rest = tokens.slice(i).join(' ');
+  const m = rest.match(/^(['"])([\s\S]*)\1$/);
+  return m ? m[2] : rest;
+}
+
+export function compositeRejectReason(command) {
+  // First, scan the command as-is. Operators outside of quotes are
+  // legitimate composites and surface immediately.
+  const outer = scanForMaskingOperator(command);
+  if (outer !== null) return outer;
+  // Second pass — if the command is a shell wrapper, the payload was
+  // hidden inside the wrapper's quoted argument. Re-scan that payload
+  // so `bash -lc "npm test || true"` no longer slips through. One
+  // level of unwrapping is sufficient: a nested wrapper
+  // (`bash -lc "bash -c 'npm test || true'"`) would itself contain
+  // the outer wrapper's quotes, and a payload-level scan inside the
+  // first peel reaches the inner `||` directly.
+  const payload = extractShellWrapperPayload(command);
+  if (payload !== null) {
+    const inner = scanForMaskingOperator(payload);
+    if (inner !== null) return inner;
   }
   return null;
 }

--- a/hooks/lib/mpl-gate-classify.mjs
+++ b/hooks/lib/mpl-gate-classify.mjs
@@ -826,13 +826,19 @@ const SHELL_WRAPPER_HEADS = new Set([
 ]);
 
 // Shell-wrapper flags that take a SEPARATE value token, so the loop
-// must consume two tokens instead of one when it sees them. `-o <opt>`
-// (e.g. `bash -o pipefail -c ...`) is the canonical Hermes-found case;
-// `--rcfile <path>` and `--init-file <path>` are the documented bash
-// long-form equivalents. GNU-style `--flag=value` is single-token and
-// handled by the `includes('=')` branch in the main loop.
+// must consume two tokens instead of one when it sees them. The canon
+// list (from `man bash` SHELL INVOCATION + Hermes review iterations
+// on PR #265):
+//   `-o <option>` / `+o <option>` — set/unset shell option
+//                                   (pipefail, errexit, …)
+//   `-O <shopt>`  / `+O <shopt>`  — set/unset shopt option
+//                                   (extglob, nullglob, …)
+//   `--rcfile <path>` / `--init-file <path>` — bash startup file
+//   `--noediting` is single-token, NOT here; `--login` ditto.
+// GNU-style `--flag=value` is single-token and handled by the
+// includes('=') branch in the main loop.
 const SHELL_WRAPPER_FLAGS_WITH_VALUE = new Set([
-  '-o', '+o', '--rcfile', '--init-file',
+  '-o', '+o', '-O', '+O', '--rcfile', '--init-file',
 ]);
 
 function extractShellWrapperPayload(command) {

--- a/hooks/lib/mpl-state-invariant.mjs
+++ b/hooks/lib/mpl-state-invariant.mjs
@@ -392,6 +392,20 @@ function checkGateFamilyForBlock(block, label, cwd) {
       });
       continue;
     }
+    // #232 (2) [contract-break]: strict re-classification is for
+    // MANUAL state.gate_results writes — it deliberately rejects
+    // execution wrappers (`docker`, `kubectl exec`, `bash -lc`) because
+    // a hand-typed wrapper command is not credible gate evidence.
+    // But the recorder LEGITIMATELY accepts those wrappers; without
+    // this carve-out, every recorder write of a wrapper-shaped command
+    // would re-classify as `null` here and fire I12 family mismatch.
+    // `source: 'recorder'` is the entry's own attestation; recorder
+    // writes are authoritative for what they observed at execution
+    // time. Manual writes that try to forge `source: 'recorder'` are
+    // out of scope — the broader anti-forgery layer is upstream
+    // (mpl-write-guard rejects direct edits to state.gate_results
+    // outside the gate-recorder).
+    if (entry.source === 'recorder') continue;
     const family = classifyGateCommand(command, { cwd });
     if (family !== expectedFamily) {
       issues.push({

--- a/hooks/mpl-gate-recorder.mjs
+++ b/hooks/mpl-gate-recorder.mjs
@@ -55,7 +55,7 @@ const {
 const { buildBlockedHookPatch } = await import(
   pathToFileURL(join(__dirname, 'lib', 'mpl-blocked-hook.mjs')).href
 );
-const { classifyRecordedCommand } = await import(
+const { classifyRecordedCommand, compositeRejectReason } = await import(
   pathToFileURL(join(__dirname, 'lib', 'mpl-gate-classify.mjs')).href
 );
 
@@ -254,6 +254,22 @@ try {
       }
     }
 
+    // #232 (1) [data-integrity]: refuse to record evidence when the
+    // command shape would let a misleading shell exit code stamp a
+    // passing entry. The classifier still strips and returns the
+    // leading family (so legitimate consumers like manual gate-evidence
+    // writes that include a redirect are unaffected — PR #220), but the
+    // recorder cannot trust the shell exit when the gate command's
+    // failure does not propagate (`npm test || true`, `npm test ; true`,
+    // `npx playwright test | tee log`, `npm test &`). Drop the event;
+    // `&&` and pure redirects (`>` / `>>` / `&>` / `#` comment) remain
+    // safe and are allowed through.
+    const maskReason = compositeRejectReason(command);
+    if (maskReason !== null) {
+      ok();
+      process.exit(0);
+    }
+
     const gateName = classifyGate(command);
     if (!gateName) {
       ok();
@@ -291,6 +307,18 @@ try {
       exit_code: recordedExit,
       stdout_tail: tailOf(stdout, 500),
       timestamp: new Date().toISOString(),
+      // #232 (2) [contract-break]: tag every recorder-produced entry
+      // with its provenance. The strict / recorder allowlists are
+      // deliberately asymmetric (strict rejects wrapper heads like
+      // `docker`/`kubectl`/`bash`; recorder accepts them because real
+      // execution wrappers are legitimate gate evidence). Without this
+      // marker, a recorder write of `docker compose run app npm test`
+      // would re-classify as `null` under strict at the next I12
+      // STATE_WRITE check (manual-write rules wrongly applied to
+      // recorder evidence). I12 now skips strict re-validation for
+      // entries carrying `source: 'recorder'`; the recorder is
+      // authoritative for what it observed.
+      source: 'recorder',
     };
 
     function buildPatch(updatedGate) {


### PR DESCRIPTION
## Summary

Closes #232. Both surfaces from the issue body are resolved.

## What

**(1) Exit-code masking — `npm test || true` no longer records a passing entry.**

PR #231 stripped the suffix at the classifier so the leading command drove the family classification. The recorder, however, still stored the OVERALL shell exit code from the composite, so a failure that the shell swallowed (`|| true`, `;`, `|`, `&`, newline) would be written as a passing hard2/3 entry. PR #220 deliberately preserved leading-family classification for legitimate consumers (manual gate-evidence writes with redirects, structured-write family probes), so this PR moves the rejection into the RECORDER instead of the classifier:

- `hooks/lib/mpl-gate-classify.mjs` exports a new `compositeRejectReason()` helper. The classifier itself is unchanged — PR #220's contract is preserved.
- `hooks/mpl-gate-recorder.mjs` calls `compositeRejectReason()` before recording any `state.gate_results` entry. Non-null reason → drop the event entirely. `&&` (short-circuits — leading failure propagates) and pure redirects / comments (`>`, `>>`, `&>`, `#`) remain allowed.

**(2) Strict / recorder allowlist divergence — recorder evidence is authoritative.**

The recorder accepts execution-wrapper heads (`docker`, `bash -lc`, `kubectl exec`) that the strict allowlist deliberately rejects. A recorder write of `docker compose run app npm test` re-classified as `null` on the next I12 `STATE_WRITE` check and fired `GATE_COMMAND_FAMILY_MISMATCH` on legitimate recorder evidence.

- `hooks/mpl-gate-recorder.mjs` tags every entry it writes with `source: 'recorder'`. The recorder is authoritative for what it observed at execution time.
- `hooks/lib/mpl-state-invariant.mjs` I12 skips strict re-validation for entries carrying `source: 'recorder'`. Carve-out is narrowly scoped: manual writes that try to pass a wrapper without the marker still get flagged. `mpl-write-guard` already rejects direct edits to `state.gate_results` outside the recorder, so forging the marker would require breaching the broader write surface.

## Why

The issue body acceptance criteria explicitly listed both shapes:

- `npm test || true` does not produce a passing hard2 entry when `npm test` actually failed.
- `docker compose run app npm test` recorder write does not trigger an I12 family mismatch on subsequent `STATE_WRITE` checks (round-trip holds OR I12 treats recorder writes as authoritative).

The chosen approach (recorder-side rejection + provenance marker) preserves the asymmetry called out by codex r6 / r7 on PR #231 — strict and recorder are deliberately different — and adds a per-entry attestation so the asymmetry survives a round trip.

## Test plan

- [x] `node --test hooks/__tests__/mpl-issue-232-recorder-semantic-gaps.test.mjs` → 20/20 pass
- [x] `node --test hooks/__tests__/*.test.mjs` → 1610/1610 pass (no regression in PR #220 / #229 / #231 suites)
- [x] Issue-body repros covered:
  - `npm test || true` (shell exit 0) → no `gate_results.hard2_coverage` entry
  - `npx playwright test | tee output.log` → no `gate_results.hard3_resilience` entry
  - `npm test ; true` → no `gate_results.hard2_coverage` entry
  - `npm test && echo done` (safe) → entry recorded
  - `npm test > log.txt` (redirect safe) → entry recorded
  - `docker compose run app npm test` recorder write → no I12 mismatch (carries `source: 'recorder'`)
  - Manual wrapper write without `source` marker → I12 still surfaces (carve-out is narrow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)