### PR TITLE
feat: add scheduler tier wave planning

### DIFF
--- a/commands/mpl-run-execute.md
+++ b/commands/mpl-run-execute.md
@@ -21,7 +21,7 @@ algorithm. Skipping the CLI calls is detectable by the finalize gate
 (no `selected_mode:"parallel"` event in `.mpl/mpl/profile/phase-scheduler.jsonl`).
 
 The CLIs:
-- `hooks/lib/policy/scheduler-cli.mjs` — `plan-wave`, `record-event`, `classify-wave-failure`
+- `hooks/lib/policy/scheduler-cli.mjs` — `plan-tier`, `plan-wave`, `record-event`, `classify-wave-failure`
 - `hooks/lib/policy/isolation-cli.mjs` — `assert-clean`, `acquire-slot`, `release-slot`, `detect-drift`
 - `hooks/lib/state/wave-reducer-cli.mjs` — `merge`
 
@@ -97,15 +97,16 @@ echo '{"cwd":"'$cwd'"}' \
   | node hooks/lib/policy/isolation-cli.mjs assert-clean
 // → { "ok": true } or exit non-zero + announce + halt this tier.
 
-// 1. Plan the wave via the Node scheduler. plan-wave runs
-//    validateWaveComposition + buildWaveState in one call. The CLI
-//    emits the queue with overlap/HIGH-risk losers pruned, plus the
-//    ready_but_blocked list for the rejection telemetry.
+// 1. Plan every reachable wave in this tier via the Node scheduler.
+//    plan-tier repeatedly calls the same validateWaveComposition +
+//    buildWaveState composite as plan-wave, treating earlier accepted
+//    waves as completed for later dependency-frontier planning. File
+//    overlap losers can therefore move into a later same-tier wave instead
+//    of forcing the orchestrator to manually recompose the tier.
 plan_input = {
   cwd: cwd,
   run_id: state.started_at,
   tier: tier.tier,
-  wave_index: 0,   // single-pass; the plan returns one wave_state
   phase_ids: phase_ids,
   phases: decomposition.phases
     .filter(p => phase_ids.includes(p.id))
@@ -119,21 +120,20 @@ plan_input = {
     .filter(p => p.status === "COMPLETED").map(p => p.id),
   config: config
 }
-plan_result = `echo '$plan_input' | node hooks/lib/policy/scheduler-cli.mjs plan-wave`
-wave_state = plan_result.wave_state
-wave_index = wave_state.wave_index   // mirror for telemetry
+plan_result = `echo '$plan_input' | node hooks/lib/policy/scheduler-cli.mjs plan-tier`
+waves = plan_result.waves
 
-announce: "[MPL] Tier {tier.tier}: planning wave (queue={wave_state.queue.length}, blocked={plan_result.ready_but_blocked.length})"
+announce: "[MPL] Tier {tier.tier}: planned {waves.length} wave(s), blocked={plan_result.ready_but_blocked.length}, unplanned={plan_result.unplanned_phase_ids.length}"
 
-// 2. Branch on wave size.
-if wave_state.queue.length == 0:
-  // Every phase blocked by the composer → emit parallel_rejected + run sequentially.
+// 2. Branch on tier plan size.
+if waves.length == 0:
+  // Every phase blocked by the composer/frontier → emit parallel_rejected + run sequentially.
   emit_event({
     pipeline_id: state.pipeline_id,
     run_started_at: state.started_at,
     recompose_count: decomposition.recompose_count,
     tier: tier.tier,
-    wave_index: wave_index,
+    wave_index: 0,
     phases: phase_ids,
     selected_mode: "parallel_rejected",
     parallel_requested: true,
@@ -145,143 +145,150 @@ if wave_state.queue.length == 0:
     execute_single_phase(phase_id)
   continue
 
-if wave_state.queue.length == 1:
-  // Singleton wave (post-overlap pruning) → emit parallel_rejected:single_ready_phase, run sequentially.
-  only_phase = wave_state.queue[0]
-  emit_event({
-    pipeline_id: state.pipeline_id,
-    run_started_at: state.started_at,
-    recompose_count: decomposition.recompose_count,
-    tier: tier.tier,
-    wave_index: wave_index,
-    phases: phase_ids,
-    selected_mode: "parallel_rejected",
-    parallel_requested: true,
-    worker_cap: max_phase_workers,
-    rejection_reasons_by_phase: [{phase_id: only_phase, code: "single_ready_phase"}],
-    worktree_slots: []
-  })
-  execute_single_phase(only_phase)
-  continue
+for each planned_wave in waves:
+  wave_state = planned_wave.wave_state
+  wave_index = wave_state.wave_index   // mirror for telemetry
+
+  if wave_state.queue.length == 1:
+    // Singleton wave (post-overlap pruning) → emit parallel_rejected:single_ready_phase, run sequentially.
+    only_phase = wave_state.queue[0]
+    emit_event({
+      pipeline_id: state.pipeline_id,
+      run_started_at: state.started_at,
+      recompose_count: decomposition.recompose_count,
+      tier: tier.tier,
+      wave_index: wave_index,
+      phases: wave_state.queue,
+      selected_mode: "parallel_rejected",
+      parallel_requested: true,
+      worker_cap: max_phase_workers,
+      rejection_reasons_by_phase: [{phase_id: only_phase, code: "single_ready_phase"}],
+      worktree_slots: []
+    })
+    execute_single_phase(only_phase)
+    continue wave loop
+
+  run_parallel_wave(wave_state, planned_wave)
 
 // 3. Parallel wave — acquire slots, dispatch one phase-runner per slot.
-acquired_slots = []
-try:
-  for slot_id in range(min(wave_state.max_phase_workers, wave_state.queue.length)):
-    phase_id = wave_state.queue[slot_id]
-    acq_input = {
-      cwd: cwd, phase_id: phase_id, slot_id: slot_id,
-      run_id: state.started_at, base_ref: base_sha
-    }
-    acq = `echo '$acq_input' | node hooks/lib/policy/isolation-cli.mjs acquire-slot`
-    if not acq.ok:
-      throw new Error("worktree_setup_error: " + acq.error)
-    acquired_slots.append({
-      slot_id: slot_id,
-      phase_id: phase_id,
-      worktree_root: acq.worktree_root,
-      branch: acq.branch,
-      base_sha: acq.acquired_base_sha  // captured by acquireSlot
+function run_parallel_wave(wave_state, planned_wave):
+  acquired_slots = []
+  try:
+    for slot_id in range(min(wave_state.max_phase_workers, wave_state.queue.length)):
+      phase_id = wave_state.queue[slot_id]
+      acq_input = {
+        cwd: cwd, phase_id: phase_id, slot_id: slot_id,
+        run_id: state.started_at, base_ref: base_sha
+      }
+      acq = `echo '$acq_input' | node hooks/lib/policy/isolation-cli.mjs acquire-slot`
+      if not acq.ok:
+        throw new Error("worktree_setup_error: " + acq.error)
+      acquired_slots.append({
+        slot_id: slot_id,
+        phase_id: phase_id,
+        worktree_root: acq.worktree_root,
+        branch: acq.branch,
+        base_sha: acq.acquired_base_sha  // captured by acquireSlot
+      })
+      // Mirror to state.worktree_pool_history (replaces in-prompt append).
+      mpl_state_write({
+        worktree_pool_history: [
+          ...prev_history,
+          {
+            tier: tier.tier, phase_id: phase_id, slot_id: slot_id,
+            worktree_path: acq.worktree_root, base_ref: base_sha,
+            started_at: now_iso(), completed_at: null
+          }
+        ]
+      })
+
+    // Dispatch phase-runner subagents in parallel (one Task per slot, run_in_background=true).
+    task_handles = []
+    for slot in acquired_slots:
+      handle = Task(
+        subagent_type="mpl-phase-runner", model="sonnet",
+        prompt=assemble_context(slot.phase_id, isolation_root=slot.worktree_root),
+        run_in_background=true
+      )
+      task_handles.append({slot: slot, handle: handle})
+
+    // Wait for all handles to finish (BashOutput polling loop already documented).
+    results = wait_all(task_handles)
+    if any(r.failed for r in results):
+      throw new Error("wave_execution_error: " + first_failure_message(results))
+
+    // 4. Wave reduce — merge shards via wave-reducer-cli (inside the try so
+    //    merge_error flows through the canonical failure_code path).
+    merge_result = `echo '{"cwd":"$cwd","wave_id":"$wave_state.wave_id"}' | node hooks/lib/state/wave-reducer-cli.mjs merge`
+    if not merge_result.ok:
+      throw new Error(merge_result.failure_code + ": " + merge_result.error_message)
+
+    // 5. Per-slot drift check (declared vs git diff inside the slot).
+    for slot in acquired_slots:
+      declared = state.execution.phase_details.find(p => p.id == slot.phase_id).impact
+      drift_input = {
+        worktree_root: slot.worktree_root,
+        base_ref: slot.base_sha,
+        declared: declared
+      }
+      drift = `echo '$drift_input' | node hooks/lib/policy/isolation-cli.mjs detect-drift`
+      if drift.drift:
+        // NON-FATAL by default (declarations are forward commitments — see
+        // detectImpactDrift contract in scheduler.mjs). Append to the
+        // join-reconciliation artifact's undeclared_writes_by_phase and continue.
+        // A future config.scheduler.drift_policy = "block" can flip this.
+        append join_reconciliation.undeclared_writes_by_phase[slot.phase_id] = drift.undeclared
+
+    // 6. Emit proof-of-execution event. selected_mode:"parallel" means the
+    //    wave actually ran in parallel (writer side; finalize counts only
+    //    this toward tiers_parallel_executed).
+    emit_event({
+      pipeline_id: state.pipeline_id,
+      run_started_at: state.started_at,
+      recompose_count: decomposition.recompose_count,
+      tier: tier.tier,
+      wave_index: wave_index,
+      phases: wave_state.queue,
+      selected_mode: "parallel",
+      parallel_requested: true,
+      worker_cap: max_phase_workers,
+      rejection_reasons_by_phase: planned_wave.ready_but_blocked,
+      worktree_slots: acquired_slots.map(s => s.slot_id)
     })
-    // Mirror to state.worktree_pool_history (replaces in-prompt append).
-    mpl_state_write({
-      worktree_pool_history: [
-        ...prev_history,
-        {
-          tier: tier.tier, phase_id: phase_id, slot_id: slot_id,
-          worktree_path: acq.worktree_root, base_ref: base_sha,
-          started_at: now_iso(), completed_at: null
-        }
-      ]
+
+    // 7. Release slots.
+    for slot in acquired_slots:
+      `echo '{"cwd":"$cwd","worktree_root":"$slot.worktree_root","branch":"$slot.branch","delete_branch":true}' | node hooks/lib/policy/isolation-cli.mjs release-slot`
+      // Update worktree_pool_history[].completed_at for this slot.
+
+  catch err:
+    // 8. Classified failure path — every error_message routes through
+    //    classify-wave-failure so the canonical failure_code lands in the
+    //    parallel_failed event. The aggregator surfaces failure_codes as an
+    //    independent axis from rejection_reasons (paraphrase-resistant).
+    classify = `echo '{"error_message":"$err.message"}' | node hooks/lib/policy/scheduler-cli.mjs classify-wave-failure`
+    failure_code = classify.failure_code
+
+    // Force-release any acquired slots so the pool doesn't leak.
+    for slot in acquired_slots:
+      `echo '{"cwd":"$cwd","worktree_root":"$slot.worktree_root","force":true,"delete_branch":true,"branch":"$slot.branch"}' | node hooks/lib/policy/isolation-cli.mjs release-slot`
+
+    emit_event({
+      pipeline_id: state.pipeline_id,
+      run_started_at: state.started_at,
+      recompose_count: decomposition.recompose_count,
+      tier: tier.tier,
+      wave_index: wave_index,
+      phases: wave_state.queue,
+      selected_mode: "parallel_failed",
+      parallel_requested: true,
+      worker_cap: max_phase_workers,
+      rejection_reasons_by_phase: planned_wave.ready_but_blocked,
+      worktree_slots: [],
+      failure_code: failure_code,
+      failure_reason: err.message
     })
-
-  // Dispatch phase-runner subagents in parallel (one Task per slot, run_in_background=true).
-  task_handles = []
-  for slot in acquired_slots:
-    handle = Task(
-      subagent_type="mpl-phase-runner", model="sonnet",
-      prompt=assemble_context(slot.phase_id, isolation_root=slot.worktree_root),
-      run_in_background=true
-    )
-    task_handles.append({slot: slot, handle: handle})
-
-  // Wait for all handles to finish (BashOutput polling loop already documented).
-  results = wait_all(task_handles)
-  if any(r.failed for r in results):
-    throw new Error("wave_execution_error: " + first_failure_message(results))
-
-  // 4. Wave reduce — merge shards via wave-reducer-cli (inside the try so
-  //    merge_error flows through the canonical failure_code path).
-  merge_result = `echo '{"cwd":"$cwd","wave_id":"$wave_state.wave_id"}' | node hooks/lib/state/wave-reducer-cli.mjs merge`
-  if not merge_result.ok:
-    throw new Error(merge_result.failure_code + ": " + merge_result.error_message)
-
-  // 5. Per-slot drift check (declared vs git diff inside the slot).
-  for slot in acquired_slots:
-    declared = state.execution.phase_details.find(p => p.id == slot.phase_id).impact
-    drift_input = {
-      worktree_root: slot.worktree_root,
-      base_ref: slot.base_sha,
-      declared: declared
-    }
-    drift = `echo '$drift_input' | node hooks/lib/policy/isolation-cli.mjs detect-drift`
-    if drift.drift:
-      // NON-FATAL by default (declarations are forward commitments — see
-      // detectImpactDrift contract in scheduler.mjs). Append to the
-      // join-reconciliation artifact's undeclared_writes_by_phase and continue.
-      // A future config.scheduler.drift_policy = "block" can flip this.
-      append join_reconciliation.undeclared_writes_by_phase[slot.phase_id] = drift.undeclared
-
-  // 6. Emit proof-of-execution event. selected_mode:"parallel" means the
-  //    wave actually ran in parallel (writer side; finalize counts only
-  //    this toward tiers_parallel_executed).
-  emit_event({
-    pipeline_id: state.pipeline_id,
-    run_started_at: state.started_at,
-    recompose_count: decomposition.recompose_count,
-    tier: tier.tier,
-    wave_index: wave_index,
-    phases: phase_ids,
-    selected_mode: "parallel",
-    parallel_requested: true,
-    worker_cap: max_phase_workers,
-    rejection_reasons_by_phase: plan_result.ready_but_blocked,
-    worktree_slots: acquired_slots.map(s => s.slot_id)
-  })
-
-  // 7. Release slots.
-  for slot in acquired_slots:
-    `echo '{"cwd":"$cwd","worktree_root":"$slot.worktree_root","branch":"$slot.branch","delete_branch":true}' | node hooks/lib/policy/isolation-cli.mjs release-slot`
-    // Update worktree_pool_history[].completed_at for this slot.
-
-catch err:
-  // 8. Classified failure path — every error_message routes through
-  //    classify-wave-failure so the canonical failure_code lands in the
-  //    parallel_failed event. The aggregator surfaces failure_codes as an
-  //    independent axis from rejection_reasons (paraphrase-resistant).
-  classify = `echo '{"error_message":"$err.message"}' | node hooks/lib/policy/scheduler-cli.mjs classify-wave-failure`
-  failure_code = classify.failure_code
-
-  // Force-release any acquired slots so the pool doesn't leak.
-  for slot in acquired_slots:
-    `echo '{"cwd":"$cwd","worktree_root":"$slot.worktree_root","force":true,"delete_branch":true,"branch":"$slot.branch"}' | node hooks/lib/policy/isolation-cli.mjs release-slot`
-
-  emit_event({
-    pipeline_id: state.pipeline_id,
-    run_started_at: state.started_at,
-    recompose_count: decomposition.recompose_count,
-    tier: tier.tier,
-    wave_index: wave_index,
-    phases: phase_ids,
-    selected_mode: "parallel_failed",
-    parallel_requested: true,
-    worker_cap: max_phase_workers,
-    rejection_reasons_by_phase: plan_result.ready_but_blocked,
-    worktree_slots: [],
-    failure_code: failure_code,
-    failure_reason: err.message
-  })
-  raise
+    raise
 
 // emit_event(row) is the canonical shorthand for:
 //   `echo '{"cwd":"$cwd","event":$row}' | node hooks/lib/policy/scheduler-cli.mjs record-event`

--- a/docs/v2-remaining-work.md
+++ b/docs/v2-remaining-work.md
@@ -30,8 +30,8 @@ v2 정책 엔진 통합 완료, 병렬 인프라 활성화 완료, 알려진 gap
 - ✅ **detectImpactDrift를 git diff로 wire** — detectImpactDriftFromGit이 spawnSync('git', ['diff', '--name-only', base_ref])를 worktree 안에서 실행. (commit 3321f69)
 - ✅ **config.scheduler / .isolation 활성화** — yaml-mini parse 해결로 runtime에서 정의됨. (commit 37a0f6b)
 
-### 알려진 P2b 후속 (작음)
-- ⚠️ **multi-wave-per-tier**: 현재 plan-wave가 tier당 단일 wave만 emit. orchestrator가 completed_phase_ids를 반영해 plan-wave 재호출하면 multi-wave 됨. 작은 follow-up.
+### 알려진 P2b 후속
+- ✅ **multi-wave-per-tier**: `scheduler-cli plan-tier`가 tier 안의 dependency frontier를 반복 계획하고 file-overlap loser를 후속 wave로 재계획한다. `commands/mpl-run-execute.md` Step 4.0은 `plan-tier`를 production call-site로 사용한다.
 
 ---
 
@@ -109,6 +109,7 @@ cmux-control smoke로 검증된 것 (2026-06-01, `~/playground/ygg-exp23`):
 post-merge local smoke로 검증된 것 (2026-06-07, PR #266 merge 후 `main`):
 - ✅ statusline (`cli/mpl-hud.mjs`) 실 렌더링: temp `.mpl/state.json` + Claude statusline stdin shape에서 phase, TODO, gate, fix loop, token, context 표시 확인
 - ✅ MCP 도구 직접 호출: stdio server `dist/index.js`에서 `mpl_state_read`/`mpl_state_write` 호출 성공, I13 artifact guard 거부 케이스도 확인
+- ✅ scheduler stdio 직접 호출: `scheduler-cli plan-tier`가 dependency frontier multi-wave와 file-overlap 후속 wave를 계획하는 black-box stdin/stdout 경로 확인
 
 남은 미검증 (Production smoke 확대 필요):
 ```
@@ -154,7 +155,7 @@ post-merge local smoke로 검증된 것 (2026-06-07, PR #266 merge 후 `main`):
 |---|---|---|
 | ~~🔴 P1~~ | ~~§9 local harness regression — macOS tmpdir vs isolation safe-path~~ | ✅ closed 2026-06-02 |
 | 🟠 P1 | §5 production smoke 확대 — 작은 task로 `/mpl run` 사이클 한 바퀴 | 시간 (수동) |
-| 🟢 P3 | §1 P2b multi-wave-per-tier follow-up | 작음 |
+| ~~🟢 P3~~ | ~~§1 P2b multi-wave-per-tier follow-up~~ | ✅ closed 2026-06-07 |
 | 🟢 P3 | §4 #6 phase_seed_required dispatcher 빌드 (Pass 3) | 중간 |
 | 🟢 P3 | §4 #8 gate-recorder bridge careful port (회귀 위험 있음) | 중간 |
 | 🟢 P3 | §4 #9 wave-reducer RFC-6902 move/copy (사용 시점에) | 작음 |

--- a/hooks/__tests__/scheduler-cli.test.mjs
+++ b/hooks/__tests__/scheduler-cli.test.mjs
@@ -125,6 +125,28 @@ describe('scheduler-cli — plan-tier', () => {
     assert.deepEqual(r.waves[1].wave_state.queue, ['p2']);
     assert.ok(r.ready_but_blocked.some((x) => x.phase_id === 'p2' && x.code === 'file_overlap'));
   });
+
+  it('drops HIGH-risk phases while continuing to plan retryable blocked phases', () => {
+    const r = subPlanTier({
+      cwd: '/repo',
+      run_id: '2026-06-01T00:00:00Z',
+      tier: 1,
+      phase_ids: ['p1', 'p2', 'p3', 'p4'],
+      phases: [
+        { id: 'p1', risk_level: 'HIGH', dependencies: [], impact: { create: ['src/high.ts'] } },
+        { id: 'p2', risk_level: 'LOW', dependencies: [], impact: { create: ['src/a.ts'] } },
+        { id: 'p3', risk_level: 'LOW', dependencies: [], impact: { create: ['src/a.ts'] } },
+        { id: 'p4', risk_level: 'LOW', dependencies: ['p2'], impact: { create: ['src/b.ts'] } },
+      ],
+      completed_phase_ids: [],
+      config: { parallelism: { max_phase_workers: 2 } },
+    });
+    assert.equal(r.ok, true);
+    assert.deepEqual(r.waves.map((w) => w.wave_state.queue), [['p2'], ['p3', 'p4']]);
+    assert.deepEqual(r.unplanned_phase_ids, []);
+    assert.ok(r.ready_but_blocked.some((x) => x.phase_id === 'p1' && x.code === 'high_risk_phase_rejected'));
+    assert.ok(r.ready_but_blocked.some((x) => x.phase_id === 'p3' && x.code === 'file_overlap'));
+  });
 });
 
 describe('scheduler-cli — validate-wave', () => {

--- a/hooks/__tests__/scheduler-cli.test.mjs
+++ b/hooks/__tests__/scheduler-cli.test.mjs
@@ -21,6 +21,7 @@ import { fileURLToPath } from 'node:url';
 
 import {
   subPlanWave,
+  subPlanTier,
   subValidateWave,
   subBuildWaveState,
   subClaim,
@@ -80,6 +81,49 @@ describe('scheduler-cli — plan-wave', () => {
     assert.equal(r.ok, true);
     assert.equal(r.wave_state.queue.length, 0);
     assert.ok(r.ready_but_blocked.some((x) => x.code === 'high_risk_phase_rejected'));
+  });
+});
+
+describe('scheduler-cli — plan-tier', () => {
+  it('plans multiple waves as dependencies close within the same tier', () => {
+    const r = subPlanTier({
+      cwd: '/repo',
+      run_id: '2026-06-01T00:00:00Z',
+      tier: 2,
+      phase_ids: ['p1', 'p2', 'p3'],
+      phases: [
+        { id: 'p1', risk_level: 'LOW', dependencies: [], impact: { create: ['src/a.ts'] } },
+        { id: 'p2', risk_level: 'LOW', dependencies: ['p1'], impact: { create: ['src/b.ts'] } },
+        { id: 'p3', risk_level: 'LOW', dependencies: ['p2'], impact: { create: ['src/c.ts'] } },
+      ],
+      completed_phase_ids: [],
+      config: { parallelism: { max_phase_workers: 2 } },
+    });
+    assert.equal(r.ok, true);
+    assert.equal(r.waves.length, 3);
+    assert.deepEqual(r.waves.map((w) => w.wave_state.queue), [['p1'], ['p2'], ['p3']]);
+    assert.deepEqual(r.unplanned_phase_ids, []);
+  });
+
+  it('replans file-overlap losers into a later wave', () => {
+    const r = subPlanTier({
+      cwd: '/repo',
+      run_id: '2026-06-01T00:00:00Z',
+      tier: 1,
+      phase_ids: ['p1', 'p2', 'p3'],
+      phases: [
+        { id: 'p1', risk_level: 'LOW', dependencies: [], impact: { create: ['src/a.ts'] } },
+        { id: 'p2', risk_level: 'LOW', dependencies: [], impact: { create: ['src/a.ts'] } },
+        { id: 'p3', risk_level: 'LOW', dependencies: [], impact: { create: ['src/b.ts'] } },
+      ],
+      completed_phase_ids: [],
+      config: { parallelism: { max_phase_workers: 2 } },
+    });
+    assert.equal(r.ok, true);
+    assert.equal(r.waves.length, 2);
+    assert.deepEqual(r.waves[0].wave_state.queue, ['p1', 'p3']);
+    assert.deepEqual(r.waves[1].wave_state.queue, ['p2']);
+    assert.ok(r.ready_but_blocked.some((x) => x.phase_id === 'p2' && x.code === 'file_overlap'));
   });
 });
 
@@ -253,6 +297,23 @@ describe('scheduler-cli — black-box stdin/stdout', () => {
     const out = JSON.parse(r.stdout);
     assert.equal(out.ok, true);
     assert.deepEqual(out.wave_state.queue, ['p1']);
+  });
+
+  it('plan-tier invokable via Bash', () => {
+    const r = runCli('plan-tier', {
+      run_id: 'r1', tier: 1,
+      phase_ids: ['p1', 'p2'],
+      phases: [
+        { id: 'p1', risk_level: 'LOW', dependencies: [], impact: { create: ['a.ts'] } },
+        { id: 'p2', risk_level: 'LOW', dependencies: ['p1'], impact: { create: ['b.ts'] } },
+      ],
+      completed_phase_ids: [],
+      config: {},
+    });
+    assert.equal(r.status, 0, r.stderr);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.ok, true);
+    assert.deepEqual(out.waves.map((w) => w.wave_state.queue), [['p1'], ['p2']]);
   });
 
   it('malformed stdin → exit 64 with structured envelope', () => {

--- a/hooks/__tests__/scheduler-cli.test.mjs
+++ b/hooks/__tests__/scheduler-cli.test.mjs
@@ -148,6 +148,24 @@ describe('scheduler-cli — plan-tier', () => {
     assert.ok(r.ready_but_blocked.some((x) => x.phase_id === 'p1' && x.code === 'high_risk_phase_rejected'));
     assert.ok(r.ready_but_blocked.some((x) => x.phase_id === 'p3' && x.code === 'file_overlap'));
   });
+
+  it('leaves phase ids missing from the phase payload unplanned', () => {
+    const r = subPlanTier({
+      cwd: '/repo',
+      run_id: '2026-06-01T00:00:00Z',
+      tier: 1,
+      phase_ids: ['p1', 'missing-phase'],
+      phases: [
+        { id: 'p1', risk_level: 'LOW', dependencies: [], impact: { create: ['src/a.ts'] } },
+      ],
+      completed_phase_ids: [],
+      config: { parallelism: { max_phase_workers: 2 } },
+    });
+    assert.equal(r.ok, true);
+    assert.deepEqual(r.waves.map((w) => w.wave_state.queue), [['p1']]);
+    assert.deepEqual(r.rejected_phase_ids, []);
+    assert.deepEqual(r.unplanned_phase_ids, ['missing-phase']);
+  });
 });
 
 describe('scheduler-cli — validate-wave', () => {

--- a/hooks/__tests__/scheduler-cli.test.mjs
+++ b/hooks/__tests__/scheduler-cli.test.mjs
@@ -143,6 +143,7 @@ describe('scheduler-cli — plan-tier', () => {
     });
     assert.equal(r.ok, true);
     assert.deepEqual(r.waves.map((w) => w.wave_state.queue), [['p2'], ['p3', 'p4']]);
+    assert.deepEqual(r.rejected_phase_ids, ['p1']);
     assert.deepEqual(r.unplanned_phase_ids, []);
     assert.ok(r.ready_but_blocked.some((x) => x.phase_id === 'p1' && x.code === 'high_risk_phase_rejected'));
     assert.ok(r.ready_but_blocked.some((x) => x.phase_id === 'p3' && x.code === 'file_overlap'));

--- a/hooks/lib/policy/scheduler-cli.mjs
+++ b/hooks/lib/policy/scheduler-cli.mjs
@@ -178,7 +178,10 @@ function subPlanTier(input) {
   let wave_index = Number.isInteger(start_wave_index) ? start_wave_index : 0;
 
   for (let i = 0; i < maxIterations && remaining.size > 0; i++) {
-    const readyIds = [...remaining].filter((id) => phaseDepsClosed(phaseById.get(id), completed));
+    const readyIds = [...remaining].filter((id) => {
+      if (!phaseById.has(id)) return false;
+      return phaseDepsClosed(phaseById.get(id), completed);
+    });
 
     if (readyIds.length === 0) break;
 

--- a/hooks/lib/policy/scheduler-cli.mjs
+++ b/hooks/lib/policy/scheduler-cli.mjs
@@ -171,6 +171,7 @@ function subPlanTier(input) {
   const phaseById = new Map(phases.filter((p) => p && typeof p.id === 'string').map((p) => [p.id, p]));
   const completed = new Set(completed_phase_ids || []);
   const remaining = new Set(phase_ids);
+  const rejected = new Set();
   const waves = [];
   const ready_but_blocked = [];
   const maxIterations = phase_ids.length + 1;
@@ -195,6 +196,7 @@ function subPlanTier(input) {
       // HIGH-risk phases cannot become parallel-ready in a later wave.
       if (row.code === WAVE_REJECTION_CODES.HIGH_RISK_PHASE && row.phase_id) {
         remaining.delete(row.phase_id);
+        rejected.add(row.phase_id);
       }
     }
 
@@ -224,6 +226,9 @@ function subPlanTier(input) {
     ok: true,
     waves,
     ready_but_blocked,
+    rejected_phase_ids: [...rejected],
+    // Phases still in `remaining` are blocked by unresolved dependency
+    // frontier, not permanently rejected from parallel planning.
     unplanned_phase_ids,
     completed_phase_ids_after_plan: [...completed],
   };

--- a/hooks/lib/policy/scheduler-cli.mjs
+++ b/hooks/lib/policy/scheduler-cli.mjs
@@ -21,6 +21,8 @@
  *
  * Subcommands:
  *   plan-wave            — validateWaveComposition + buildWaveState composite
+ *   plan-tier            — repeatedly plan waves for one tier until the
+ *                          dependency frontier is exhausted
  *   validate-wave        — pure validateWaveComposition
  *   build-wave-state     — pure buildWaveState
  *   claim                — claim
@@ -148,6 +150,82 @@ function subPlanWave(input) {
     wave_state,
     rejection_reasons: validation.reasons || [],
     ready_but_blocked,
+  };
+}
+
+function phaseDepsClosed(phase, completed) {
+  const deps = Array.isArray(phase?.dependencies) ? phase.dependencies : [];
+  return deps.every((dep) => typeof dep !== 'string' || completed.has(dep));
+}
+
+function subPlanTier(input) {
+  const {
+    run_id, tier, phase_ids, phases,
+    completed_phase_ids, config, start_wave_index,
+  } = input || {};
+
+  if (!Array.isArray(phase_ids) || !Array.isArray(phases)) {
+    return fail('InvalidInput', 'phase_ids and phases must be arrays', { phase_ids, phases });
+  }
+
+  const phaseById = new Map(phases.filter((p) => p && typeof p.id === 'string').map((p) => [p.id, p]));
+  const completed = new Set(completed_phase_ids || []);
+  const remaining = new Set(phase_ids);
+  const waves = [];
+  const ready_but_blocked = [];
+  const maxIterations = phase_ids.length + 1;
+  let wave_index = Number.isInteger(start_wave_index) ? start_wave_index : 0;
+
+  for (let i = 0; i < maxIterations && remaining.size > 0; i++) {
+    const readyIds = [...remaining].filter((id) => phaseDepsClosed(phaseById.get(id), completed));
+
+    if (readyIds.length === 0) break;
+
+    const planned = subPlanWave({
+      ...input,
+      wave_index,
+      phase_ids: readyIds,
+      phases: readyIds.map((id) => phaseById.get(id)).filter(Boolean),
+      completed_phase_ids: [...completed],
+      config: config || {},
+    });
+
+    for (const row of planned.ready_but_blocked || []) {
+      ready_but_blocked.push({ wave_index, ...row });
+      // HIGH-risk phases cannot become parallel-ready in a later wave.
+      if (row.code === WAVE_REJECTION_CODES.HIGH_RISK_PHASE && row.phase_id) {
+        remaining.delete(row.phase_id);
+      }
+    }
+
+    const queued = planned.wave_state?.queue || [];
+    if (queued.length === 0) {
+      // Avoid spinning forever on a frontier where every ready phase was
+      // rejected by a non-retryable reason.
+      break;
+    }
+
+    waves.push({
+      wave_index,
+      wave_state: planned.wave_state,
+      rejection_reasons: planned.rejection_reasons || [],
+      ready_but_blocked: planned.ready_but_blocked || [],
+    });
+
+    for (const id of queued) {
+      remaining.delete(id);
+      completed.add(id);
+    }
+    wave_index += 1;
+  }
+
+  const unplanned_phase_ids = [...remaining];
+  return {
+    ok: true,
+    waves,
+    ready_but_blocked,
+    unplanned_phase_ids,
+    completed_phase_ids_after_plan: [...completed],
   };
 }
 
@@ -353,6 +431,7 @@ function main() {
   try {
     switch (subcommand) {
       case 'plan-wave':            result = subPlanWave(input); break;
+      case 'plan-tier':            result = subPlanTier(input); break;
       case 'validate-wave':        result = subValidateWave(input); break;
       case 'build-wave-state':     result = subBuildWaveState(input); break;
       case 'claim':                result = subClaim(input); break;
@@ -381,6 +460,7 @@ function main() {
 // shelling out for every assertion. The CLI binary path stays the same.
 export {
   subPlanWave,
+  subPlanTier,
   subValidateWave,
   subBuildWaveState,
   subClaim,


### PR DESCRIPTION
## Summary
- Add `scheduler-cli plan-tier` to plan multiple waves within one execution tier
- Replan file-overlap losers into later waves and advance dependency-frontier waves as prior planned waves close
- Update `/mpl run` Step 4.0 protocol to call `plan-tier` as the production scheduler planning surface
- Update remaining-work docs: multi-wave-per-tier follow-up closed; scheduler stdio smoke recorded

## Verification
- `node --test hooks/__tests__/scheduler-cli.test.mjs`
- `git diff --check`
- `npm test` — 2240 pass / 0 fail

## Notes
- Direct slash-command `/mpl run` full-cycle execution is still a manual production smoke item because this environment can exercise repo CLIs/hooks/MCP, but cannot invoke the host slash command directly.